### PR TITLE
Added the option to silence the output from the linker.

### DIFF
--- a/build/MakefileWorker.mk
+++ b/build/MakefileWorker.mk
@@ -435,7 +435,7 @@ test-deps: $(TEST_DEPS)
 
 $(TEST_TARGET): $(TEST_DEPS)
 	@echo Linking $@
-	$(LINK.o) -o $@ $^ $(LD_LIBRARIES)
+	$(SILENCE)$(LINK.o) -o $@ $^ $(LD_LIBRARIES)
 
 $(TARGET_LIB): $(OBJ)
 	@echo Building archive $@


### PR DESCRIPTION
For some reason the link rule did not have the silence option like every
other command in the MakefileWorker.
