### PR TITLE
Avoid the issue that ISO C++ forbids casting between pointer-to-function...

### DIFF
--- a/include/CppUTest/TestPlugin.h
+++ b/include/CppUTest/TestPlugin.h
@@ -92,7 +92,7 @@ private:
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-extern void CppUTestStore(void **location, void *value);
+extern void CppUTestStore(void **location);
 
 class SetPointerPlugin: public TestPlugin
 {
@@ -107,8 +107,7 @@ public:
 	};
 };
 
-/* C++ standard says we cannot cast function pointers to object pointers. Extra casting to fool the compiler */
-#define UT_PTR_SET(a, b) { CppUTestStore( (void**)&a, *((void**) &a)); a = b; }
+#define UT_PTR_SET(a, b) { CppUTestStore( (void**)&a ); a = b; }
 
 ///////////// Null Plugin
 

--- a/src/CppUTest/TestPlugin.cpp
+++ b/src/CppUTest/TestPlugin.cpp
@@ -134,12 +134,12 @@ SetPointerPlugin::~SetPointerPlugin()
 {
 }
 
-void CppUTestStore(void**function, void*value)
+void CppUTestStore(void**function)
 {
 	if (pointerTableIndex >= SetPointerPlugin::MAX_SET) {
 		FAIL("Maximum number of function pointers installed!");
 	}
-	setlist[pointerTableIndex].orig_value = value;
+	setlist[pointerTableIndex].orig_value = *function;
 	setlist[pointerTableIndex].orig = function;
 	pointerTableIndex++;
 }


### PR DESCRIPTION
... and pointer-to-object.

The previous work-around for it caused this warning when using gcc 4.5.3:
  dereferencing type-punned pointer will break strict-aliasing rules

Background: 

I've enabled -Werror, and got stuck at the UT_PTR_SET macro.

The warning was::

   error: dereferencing type-punned pointer will break strict-aliasing rules

And surely, reading the comment above the declaration for that macro,
it states that an attempt at fooling the compiler is taking place.

So, taking the fooling out of the equation shows the real issue, which the comment also pointed at::

   error: ISO C++ forbids casting between pointer-to-function and pointer-to-object

And I'm a bit worried here. Why try to fool the compiler?
OK, there may be test cases to see if the fooling actually works, or if it goes up in flames...
but that doesn't feel right. And more importantly, it puts sticks in my wheels when using -Werror.

OK, spent some time reading, and came up with a solution that circumvents this nicely.

Since the value arg passed to CppUTestStore is always that of the function deferenced,
the value arg could simply be dropped, and the dereferencing be done in the store function.
