### PR TITLE
Inhibit normal ar output to stderr

### DIFF
--- a/build/MakefileWorker.mk
+++ b/build/MakefileWorker.mk
@@ -395,6 +395,9 @@ CPPFLAGS = $(CPPUTEST_CPPFLAGS) $(CPPUTEST_ADDITIONAL_CPPFLAGS)
 CXXFLAGS = $(CPPUTEST_CXXFLAGS) $(CPPUTEST_ADDITIONAL_CXXFLAGS)
 LDFLAGS = $(CPPUTEST_LDFLAGS) $(CPPUTEST_ADDITIONAL_LDFLAGS)
 
+# Don't consider creating the archive a warning condition that does STDERR output
+ARFLAGS := $(ARFLAGS)c
+
 DEP_FLAGS=-MMD -MP
 
 # Some macros for programs to be overridden. For some reason, these are not in Make defaults


### PR DESCRIPTION
Inhibiting AR warning on archive creation that goes to STDERR. Lame!
