### PR TITLE
Fixed string case in include directive (building on linux)

### DIFF
--- a/tests/MemoryLeakOperatorOverloadsTest.cpp
+++ b/tests/MemoryLeakOperatorOverloadsTest.cpp
@@ -9,7 +9,7 @@
 
 extern "C"
 {
-#include "CppuTest/TestHarness_c.h"
+#include "CppUTest/TestHarness_c.h"
 #include "AllocationInCFile.h"
 }
 

--- a/tests/MemoryLeakWarningTest.cpp
+++ b/tests/MemoryLeakWarningTest.cpp
@@ -35,7 +35,7 @@
 
 extern "C"
 {
-#include "CppuTest/TestHarness_c.h"
+#include "CppUTest/TestHarness_c.h"
 }
 static char* leak1;
 static long* leak2;


### PR DESCRIPTION
Those tests could not be build on unix systems because the include
directives are handled case sensitive.
