### PR TITLE
Add missing \ in the CppUTest headers so all will be installed.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -57,7 +57,7 @@ include_cpputest_HEADERS = \
 	include/CppUTest/TestRegistry.h \
 	include/CppUTest/MemoryLeakDetector.h \
 	include/CppUTest/TestFailure.h \
-	include/CppUTest/TestResult.h
+	include/CppUTest/TestResult.h \
 	include/CppUTest/MemoryLeakDetectorMallocMacros.h \
 	include/CppUTest/TestFilter.h \
 	include/CppUTest/TestTestingFixture.h \


### PR DESCRIPTION
Not having this missing \ will cause some headers to not be installed.
