### PR TITLE
Make a CHECK_THROWS macro, which tests that we throw an exception.

### DIFF
--- a/include/CppUTest/UtestMacros.h
+++ b/include/CppUTest/UtestMacros.h
@@ -189,6 +189,22 @@
 #define UT_PRINT(text) \
    UT_PRINT_LOCATION(text, __FILE__, __LINE__)
 
+#if CPPUTEST_USE_STD_CPP_LIB
+#define CHECK_THROWS(expected, expression) \
+	SimpleString msg("expected to throw "#expected "\nbut threw nothing"); \
+	bool caught_expected = false; \
+	try { \
+		(expression); \
+	} catch(const expected & e) { \
+		caught_expected = true; \
+	} catch(...) { \
+		msg = "expected to throw " #expected "\nbut threw a different type"; \
+	} \
+	if (!caught_expected) { \
+		UtestShell::getCurrent()->fail(msg.asCharString(), __FILE__, __LINE__); \
+	}
+#endif /* CPPUTEST_USE_STD_CPP_LIB */
+
 #define UT_CRASH() { UtestShell::crash(); }
 #define RUN_ALL_TESTS(ac, av) CommandLineTestRunner::RunAllTests(ac, av)
 

--- a/tests/TestUTestMacro.cpp
+++ b/tests/TestUTestMacro.cpp
@@ -400,3 +400,36 @@ TEST(UnitTestMacros, allMacrosFromFunctionThatReturnsAValue)
 {
 	functionThatReturnsAValue();
 }
+
+#if CPPUTEST_USE_STD_CPP_LIB
+static void _failingTestMethod_NoThrowWithCHECK_THROWS()
+{
+	CHECK_THROWS(int, (void) (1+2));
+	lineOfCodeExecutedAfterCheck = true;
+}
+
+TEST(UnitTestMacros, FailureWithCHECK_THROWS_whenDoesntThrow)
+{
+	runTestWithMethod(_failingTestMethod_NoThrowWithCHECK_THROWS);
+	CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected to throw int");
+	CHECK_TEST_FAILS_PROPER_WITH_TEXT("but threw nothing");
+}
+
+TEST(UnitTestMacros, SuccessWithCHECK_THROWS)
+{
+	CHECK_THROWS(int, throw 4);
+}
+
+static void _failingTestMethod_WrongThrowWithCHECK_THROWS()
+{
+	CHECK_THROWS(int, throw 4.3);
+	lineOfCodeExecutedAfterCheck = true;
+}
+
+TEST(UnitTestMacros, FailureWithCHECK_THROWS_whenWrongThrow)
+{
+	runTestWithMethod(_failingTestMethod_WrongThrowWithCHECK_THROWS);
+	CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected to throw int");
+	CHECK_TEST_FAILS_PROPER_WITH_TEXT("but threw a different type");
+}
+#endif


### PR DESCRIPTION
I needed a CHECK_THROWS macro in my project, and though it would be something others needed as well, so I ported it to CppUTest. Not sure about the message I'm writing, but I'm happy to fix any issues you might find about it.
