### PR TITLE
cmake: Include modules directly instead of using CMAKE_MODULE_PATH.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,15 +18,13 @@ option(GMOCK "Enable using GMock" OFF)
 
 option(TESTS "Compile and make tests for the code?" ON)
 
-set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/Modules" CACHE STRING "Path to cmake modules")
-
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "What kind of build this is" FORCE)
 endif(NOT CMAKE_BUILD_TYPE)
 
 set(CppUTestRootDirectory ${PROJECT_SOURCE_DIR})
 
-include(CppUTestConfigurationOptions)
+include("${CppUTestRootDirectory}/cmake/Modules/CppUTestConfigurationOptions.cmake")
 include(CTest)
 
 configure_file (

--- a/cmake/Modules/CppUTestConfigurationOptions.cmake
+++ b/cmake/Modules/CppUTestConfigurationOptions.cmake
@@ -12,7 +12,7 @@ else (MSVC)
     set(CPP_PLATFORM GccNoStdC)
 endif (MSVC)
 
-include(CppUTestWarningFlags)
+include("${CppUTestRootDirectory}/cmake/Modules/CppUTestWarningFlags.cmake")
 
 if (NOT STD_CPP)
     set(CPPUTEST_STD_CPP_LIB_DISABLED 1)


### PR DESCRIPTION
Specifying CMAKE_MODULE_PATH won't work, if cpputest is used as a
git submodule.
