### PR TITLE
IGNORE_TEST correctly output in JUnit output

### DIFF
--- a/src/CppUTest/JUnitTestOutput.cpp
+++ b/src/CppUTest/JUnitTestOutput.cpp
@@ -34,27 +34,25 @@
 struct JUnitTestCaseResultNode
 {
 	JUnitTestCaseResultNode() :
-		execTime_(0), failure_(0), skipped_(0), next_(0)
+		execTime_(0), failure_(0), next_(0)
 	{
 	}
 	;
 	SimpleString name_;
 	long execTime_;
 	TestFailure* failure_;
-	int skipped_;
 	JUnitTestCaseResultNode* next_;
 };
 
 struct JUnitTestGroupResult
 {
 	JUnitTestGroupResult() :
-		testCount_(0), failureCount_(0), skippedCount_(0), groupExecTime_(0), head_(0), tail_(0)
+		testCount_(0), failureCount_(0), groupExecTime_(0), head_(0), tail_(0)
 	{
 	}
 	;
 	int testCount_;
 	int failureCount_;
-	int skippedCount_;
 	long startTime_;
 	long groupExecTime_;
 	SimpleString group_;
@@ -83,7 +81,6 @@ void JUnitTestOutput::resetTestGroupResult()
 {
 	impl_->results_.testCount_ = 0;
 	impl_->results_.failureCount_ = 0;
-	impl_->results_.skippedCount_ = 0;
 	impl_->results_.group_ = "";
 	JUnitTestCaseResultNode* cur = impl_->results_.head_;
 	while (cur) {
@@ -109,8 +106,6 @@ void JUnitTestOutput::printCurrentTestEnded(const TestResult& result)
 {
 	impl_->results_.tail_->execTime_
 			= result.getCurrentTestTotalExecutionTime();
-	impl_->results_.tail_->skipped_
-      = result.getIgnoredCount();
 }
 
 void JUnitTestOutput::printTestsEnded(const TestResult& /*result*/)
@@ -120,7 +115,6 @@ void JUnitTestOutput::printTestsEnded(const TestResult& /*result*/)
 void JUnitTestOutput::printCurrentGroupEnded(const TestResult& result)
 {
 	impl_->results_.groupExecTime_ = result.getCurrentGroupTotalExecutionTime();
-	impl_->results_.skippedCount_ = result.getIgnoredCount();
 	writeTestGroupToFile();
 	resetTestGroupResult();
 }
@@ -161,10 +155,9 @@ void JUnitTestOutput::writeTestSuiteSummery()
 	SimpleString
 			buf =
 					StringFromFormat(
-							"<testsuite errors=\"0\" failures=\"%d\" hostname=\"localhost\" name=\"%s\" skips=\"%d\" tests=\"%d\" time=\"%d.%03d\" timestamp=\"%s\">\n",
+							"<testsuite errors=\"0\" failures=\"%d\" hostname=\"localhost\" name=\"%s\" tests=\"%d\" time=\"%d.%03d\" timestamp=\"%s\">\n",
 							impl_->results_.failureCount_,
 							impl_->results_.group_.asCharString(),
-							impl_->results_.skippedCount_,
 							impl_->results_.testCount_,
 							(int) (impl_->results_.groupExecTime_ / 1000), (int) (impl_->results_.groupExecTime_ % 1000),
 							GetPlatformSpecificTimeString());
@@ -189,10 +182,6 @@ void JUnitTestOutput::writeTestCases()
 
 		if (cur->failure_) {
 			writeFailure(cur);
-		}
-		else if(cur->skipped_)
-		{
-			writeToFile("<skipped />\n");
 		}
 		writeToFile("</testcase>\n");
 		cur = cur->next_;

--- a/src/CppUTest/JUnitTestOutput.cpp
+++ b/src/CppUTest/JUnitTestOutput.cpp
@@ -34,25 +34,27 @@
 struct JUnitTestCaseResultNode
 {
 	JUnitTestCaseResultNode() :
-		execTime_(0), failure_(0), next_(0)
+		execTime_(0), failure_(0), skipped_(0), next_(0)
 	{
 	}
 	;
 	SimpleString name_;
 	long execTime_;
 	TestFailure* failure_;
+	int skipped_;
 	JUnitTestCaseResultNode* next_;
 };
 
 struct JUnitTestGroupResult
 {
 	JUnitTestGroupResult() :
-		testCount_(0), failureCount_(0), groupExecTime_(0), head_(0), tail_(0)
+		testCount_(0), failureCount_(0), skippedCount_(0), groupExecTime_(0), head_(0), tail_(0)
 	{
 	}
 	;
 	int testCount_;
 	int failureCount_;
+	int skippedCount_;
 	long startTime_;
 	long groupExecTime_;
 	SimpleString group_;
@@ -81,6 +83,7 @@ void JUnitTestOutput::resetTestGroupResult()
 {
 	impl_->results_.testCount_ = 0;
 	impl_->results_.failureCount_ = 0;
+	impl_->results_.skippedCount_ = 0;
 	impl_->results_.group_ = "";
 	JUnitTestCaseResultNode* cur = impl_->results_.head_;
 	while (cur) {
@@ -106,6 +109,8 @@ void JUnitTestOutput::printCurrentTestEnded(const TestResult& result)
 {
 	impl_->results_.tail_->execTime_
 			= result.getCurrentTestTotalExecutionTime();
+	impl_->results_.tail_->skipped_
+			= result.getIgnoredCount();
 }
 
 void JUnitTestOutput::printTestsEnded(const TestResult& /*result*/)
@@ -115,6 +120,7 @@ void JUnitTestOutput::printTestsEnded(const TestResult& /*result*/)
 void JUnitTestOutput::printCurrentGroupEnded(const TestResult& result)
 {
 	impl_->results_.groupExecTime_ = result.getCurrentGroupTotalExecutionTime();
+	impl_->results_.skippedCount_ = result.getIgnoredCount();
 	writeTestGroupToFile();
 	resetTestGroupResult();
 }
@@ -155,9 +161,10 @@ void JUnitTestOutput::writeTestSuiteSummery()
 	SimpleString
 			buf =
 					StringFromFormat(
-							"<testsuite errors=\"0\" failures=\"%d\" hostname=\"localhost\" name=\"%s\" tests=\"%d\" time=\"%d.%03d\" timestamp=\"%s\">\n",
+							"<testsuite errors=\"0\" failures=\"%d\" hostname=\"localhost\" name=\"%s\" skips=\"%d\" tests=\"%d\" time=\"%d.%03d\" timestamp=\"%s\">\n",
 							impl_->results_.failureCount_,
 							impl_->results_.group_.asCharString(),
+							impl_->results_.skippedCount_,
 							impl_->results_.testCount_,
 							(int) (impl_->results_.groupExecTime_ / 1000), (int) (impl_->results_.groupExecTime_ % 1000),
 							GetPlatformSpecificTimeString());
@@ -182,6 +189,10 @@ void JUnitTestOutput::writeTestCases()
 
 		if (cur->failure_) {
 			writeFailure(cur);
+		}
+		else if(cur->skipped_)
+		{
+			writeToFile("<skipped />\n");
 		}
 		writeToFile("</testcase>\n");
 		cur = cur->next_;

--- a/src/CppUTest/JUnitTestOutput.cpp
+++ b/src/CppUTest/JUnitTestOutput.cpp
@@ -34,25 +34,27 @@
 struct JUnitTestCaseResultNode
 {
 	JUnitTestCaseResultNode() :
-		execTime_(0), failure_(0), next_(0)
+		execTime_(0), failure_(0), skipped_(0), next_(0)
 	{
 	}
 	;
 	SimpleString name_;
 	long execTime_;
 	TestFailure* failure_;
+	int skipped_;
 	JUnitTestCaseResultNode* next_;
 };
 
 struct JUnitTestGroupResult
 {
 	JUnitTestGroupResult() :
-		testCount_(0), failureCount_(0), groupExecTime_(0), head_(0), tail_(0)
+		testCount_(0), failureCount_(0), skippedCount_(0), groupExecTime_(0), head_(0), tail_(0)
 	{
 	}
 	;
 	int testCount_;
 	int failureCount_;
+	int skippedCount_;
 	long startTime_;
 	long groupExecTime_;
 	SimpleString group_;
@@ -81,6 +83,7 @@ void JUnitTestOutput::resetTestGroupResult()
 {
 	impl_->results_.testCount_ = 0;
 	impl_->results_.failureCount_ = 0;
+	impl_->results_.skippedCount_ = 0;
 	impl_->results_.group_ = "";
 	JUnitTestCaseResultNode* cur = impl_->results_.head_;
 	while (cur) {
@@ -106,6 +109,8 @@ void JUnitTestOutput::printCurrentTestEnded(const TestResult& result)
 {
 	impl_->results_.tail_->execTime_
 			= result.getCurrentTestTotalExecutionTime();
+	impl_->results_.tail_->skipped_
+      = result.getIgnoredCount();
 }
 
 void JUnitTestOutput::printTestsEnded(const TestResult& /*result*/)
@@ -115,6 +120,7 @@ void JUnitTestOutput::printTestsEnded(const TestResult& /*result*/)
 void JUnitTestOutput::printCurrentGroupEnded(const TestResult& result)
 {
 	impl_->results_.groupExecTime_ = result.getCurrentGroupTotalExecutionTime();
+	impl_->results_.skippedCount_ = result.getIgnoredCount();
 	writeTestGroupToFile();
 	resetTestGroupResult();
 }
@@ -155,9 +161,10 @@ void JUnitTestOutput::writeTestSuiteSummery()
 	SimpleString
 			buf =
 					StringFromFormat(
-							"<testsuite errors=\"0\" failures=\"%d\" hostname=\"localhost\" name=\"%s\" tests=\"%d\" time=\"%d.%03d\" timestamp=\"%s\">\n",
+							"<testsuite errors=\"0\" failures=\"%d\" hostname=\"localhost\" name=\"%s\" skips=\"%d\" tests=\"%d\" time=\"%d.%03d\" timestamp=\"%s\">\n",
 							impl_->results_.failureCount_,
 							impl_->results_.group_.asCharString(),
+							impl_->results_.skippedCount_,
 							impl_->results_.testCount_,
 							(int) (impl_->results_.groupExecTime_ / 1000), (int) (impl_->results_.groupExecTime_ % 1000),
 							GetPlatformSpecificTimeString());
@@ -182,6 +189,10 @@ void JUnitTestOutput::writeTestCases()
 
 		if (cur->failure_) {
 			writeFailure(cur);
+		}
+		else if(cur->skipped_)
+		{
+			writeToFile("<skipped />\n");
 		}
 		writeToFile("</testcase>\n");
 		cur = cur->next_;

--- a/tests/JUnitOutputTest.cpp
+++ b/tests/JUnitOutputTest.cpp
@@ -68,25 +68,27 @@ TEST_GROUP(JUnitOutputTest)
 		struct TestData
 		{
 			TestData() :
-				tst_(0), testName_(0), failure_(0)
+				tst_(0), testName_(0), failure_(0), skipped_(0)
 			{
 			}
 			;
 			UtestShell* tst_;
 			SimpleString* testName_;
 			TestFailure* failure_;
+			size_t skipped_;
 		};
 
 		struct TestGroupData
 		{
 			TestGroupData() :
-				numberTests_(0), totalFailures_(0), name_(""), testData_(0)
+				numberTests_(0), totalFailures_(0), totalSkipped_(0), name_(""), testData_(0)
 			{
 			}
 			;
 
 			size_t numberTests_;
 			size_t totalFailures_;
+			size_t totalSkipped_;
 			SimpleString name_;
 
 			TestData* testData_;
@@ -110,6 +112,7 @@ TEST_GROUP(JUnitOutputTest)
 			for (int i = 0; i < testGroupSize; i++) {
 				testGroupData_[i].numberTests_ = 0;
 				testGroupData_[i].totalFailures_ = 0;
+				testGroupData_[i].totalSkipped_ = 0;
 			}
 		}
 		;
@@ -204,8 +207,8 @@ TEST_GROUP(JUnitOutputTest)
 		void CHECK_TEST_SUITE_START(SimpleString out)
 		{
 			TestGroupData& group = currentGroup();
-			SimpleString buf = StringFromFormat("<testsuite errors=\"0\" failures=\"%d\" hostname=\"localhost\" name=\"%s\" tests=\"%d\" time=\"0.050\" timestamp=\"%s\">\n", group.totalFailures_,
-					group.name_.asCharString(), group.numberTests_, theTime);
+			SimpleString buf = StringFromFormat("<testsuite errors=\"0\" failures=\"%d\" hostname=\"localhost\" name=\"%s\" skips=\"%d\" tests=\"%d\" time=\"0.050\" timestamp=\"%s\">\n", group.totalFailures_,
+					group.name_.asCharString(), group.totalSkipped_, group.numberTests_, theTime);
 			CHECK_EQUAL(buf, out);
 		}
 
@@ -376,4 +379,4 @@ TEST(JUnitOutputTest, escapeSlashesInFilenames)
 	STRCMP_EQUAL("cpputest_group_weird_name.xml", output->createFileName("group/weird/name").asCharString());
 }
 
-
+//TODO: Add tests for skipped tests (IGNORE_TEST).


### PR DESCRIPTION
When using IGNORE_TEST and output as JUnit, the output will be "skipped"
to make such test cases show up correctly in CI systems, e.g. Jenkins.