### PR TITLE
Fixed compiler error when writing multiple CHECK_THROWS in one scope

### DIFF
--- a/include/CppUTest/UtestMacros.h
+++ b/include/CppUTest/UtestMacros.h
@@ -191,6 +191,7 @@
 
 #if CPPUTEST_USE_STD_CPP_LIB
 #define CHECK_THROWS(expected, expression) \
+	{ \
 	SimpleString msg("expected to throw "#expected "\nbut threw nothing"); \
 	bool caught_expected = false; \
 	try { \
@@ -202,6 +203,7 @@
 	} \
 	if (!caught_expected) { \
 		UtestShell::getCurrent()->fail(msg.asCharString(), __FILE__, __LINE__); \
+	} \
 	}
 #endif /* CPPUTEST_USE_STD_CPP_LIB */
 

--- a/tests/TestUTestMacro.cpp
+++ b/tests/TestUTestMacro.cpp
@@ -432,4 +432,10 @@ TEST(UnitTestMacros, FailureWithCHECK_THROWS_whenWrongThrow)
 	CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected to throw int");
 	CHECK_TEST_FAILS_PROPER_WITH_TEXT("but threw a different type");
 }
+
+TEST(UnitTestMacros, MultipleCHECK_THROWS_inOneScope)
+{
+	CHECK_THROWS(int, throw 4);
+	CHECK_THROWS(int, throw 4);
+}
 #endif


### PR DESCRIPTION
Writing multiple CHECK_THROWS() in one scope
=> compile error because of duplicated "SimpleString msg".
CHECK_THROWS needs one more {}.
