### PR TITLE
Fix compilation error on Mac OS X.

### DIFF
--- a/tests/MemoryLeakOperatorOverloadsTest.cpp
+++ b/tests/MemoryLeakOperatorOverloadsTest.cpp
@@ -283,7 +283,7 @@ TEST(OutOfMemoryTestsForOperatorNew, FailingNewArrayOperatorThrowsAnExceptionWhe
 class ClassThatThrowsAnExceptionInTheConstructor
 {
 public:
-	ClassThatThrowsAnExceptionInTheConstructor(){
+	ClassThatThrowsAnExceptionInTheConstructor() __attribute__((noreturn)){
 		throw 1;
 	}
 };


### PR DESCRIPTION
The missing noreturn attribute on the ClassThatThrowsAnExceptionInTheConstructor cause compilation to fail on Mac OS X.

Signed-off-by: Trond Danielsen trond.danielsen@norbit.no
