### PR TITLE
cmake: Disabled -Werror and -pedantic-errors if gmock or gtest integration is enabled

### DIFF
--- a/cmake/Modules/CppUTestWarningFlags.cmake
+++ b/cmake/Modules/CppUTestWarningFlags.cmake
@@ -6,7 +6,6 @@ else (MSVC)
     include(CheckCXXCompilerFlag)
 
     set(WARNING_C_FLAGS
-        Werror
         Weverything
         Wall
         Wextra
@@ -14,11 +13,14 @@ else (MSVC)
         Wswitch-default
         Wswitch-enum
         Wconversion
-        pedantic-errors
         Wsign-conversion
         Woverloaded-virtual
         Wno-padded
         )
+
+    if (NOT GMOCK AND NOT REAL_GTEST)
+      list(APPEND WARNING_C_FLAGS Werror pedantic-errors)
+    endif (NOT GMOCK AND NOT REAL_GTEST)
 
     set(WARNING_C_ONLY_FLAGS
         Wstrict-prototypes


### PR DESCRIPTION
Because gtest and gmock headers cause some compiler warning with gcc and clang.
