### PR TITLE
Create a __no_return__ macro to flag a function as not returning.

### DIFF
--- a/include/CppUTest/CppUTestConfig.h
+++ b/include/CppUTest/CppUTestConfig.h
@@ -85,6 +85,20 @@
  #endif
 #endif
 
+/* Create a __no_return__ macro, which is used to flag a function as not returning.
+ * Used for functions that always throws for instance.
+ *
+ * This is needed for compiling with clang, without breaking other compilers.
+ */
+#ifndef __has_attribute
+  #define __has_attribute(x) 0
+#endif
+#if __has_attribute(noreturn)
+  #define __no_return__ __attribute__((noreturn))
+#else
+  #define __no_return__
+#endif
+
 /* Should be the only #include here. Standard C library wrappers */
 #include "StandardCLibrary.h"
 

--- a/src/Platforms/Gcc/UtestPlatform.cpp
+++ b/src/Platforms/Gcc/UtestPlatform.cpp
@@ -48,10 +48,6 @@
 
 #include "CppUTest/PlatformSpecificFunctions.h"
 
-#ifndef __has_attribute
-  #define __has_attribute(x) 0
-#endif
-
 static jmp_buf test_exit_jmp_buf[10];
 static int jmp_buf_index = 0;
 
@@ -98,9 +94,7 @@ int PlatformSpecificSetJmp(void (*function) (void* data), void* data)
 	return 0;
 }
 
-#if __has_attribute(noreturn)
-__attribute__((noreturn))
-#endif
+__no_return__
 void PlatformSpecificLongJmp()
 {
 	jmp_buf_index--;

--- a/tests/MemoryLeakOperatorOverloadsTest.cpp
+++ b/tests/MemoryLeakOperatorOverloadsTest.cpp
@@ -283,7 +283,7 @@ TEST(OutOfMemoryTestsForOperatorNew, FailingNewArrayOperatorThrowsAnExceptionWhe
 class ClassThatThrowsAnExceptionInTheConstructor
 {
 public:
-	ClassThatThrowsAnExceptionInTheConstructor(){
+	ClassThatThrowsAnExceptionInTheConstructor() __no_return__ {
 		throw 1;
 	}
 };


### PR DESCRIPTION
This commit is written by @martiert.

This is needed to compile with clang >= 3.1, as clang demands
functions that don't return to be marked as such. This is the case
for any function that always throws for instance, which we currently
have two off.

@martiert Please admit me to create this pull request instead of you.
It is a little more to reach successful build with clang-3.2 on travis-ci.
