### PR TITLE
Disable clang's Wmissing-variable-declarations.

### DIFF
--- a/cmake/Modules/CppUTestWarningFlags.cmake
+++ b/cmake/Modules/CppUTestWarningFlags.cmake
@@ -35,6 +35,7 @@ else (MSVC)
         Woverloaded-virtual
         Wno-padded
         Wno-disabled-macro-expansion
+        Wno-missing-variable-declarations
         )
 
     if (NOT GMOCK AND NOT REAL_GTEST)


### PR DESCRIPTION
Wmissing-variable-declarations forces 'extern' declarations before all
global variable definitions.
It is hard to shut up all of warnings because UtestMacros.h has
global variable definitions in its macros.
