### PR TITLE
Fix cpputest.pc instalation when using autotools

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -101,6 +101,8 @@ include_cpputestext_HEADERS = \
 	include/CppUTestExt/MemoryReportAllocator.h \
 	include/CppUTestExt/MockExpectedFunctionsList.h \
 	include/CppUTestExt/MockSupportPlugin.h \
+	include/CppUTestExt/MockSupport.h \
+	include/CppUTestExt/MockExpectedFunctionCall.h \
 	include/CppUTestExt/MemoryReportFormatter.h \
 	include/CppUTestExt/MockFailure.h \
 	include/CppUTestExt/MockSupport_c.h \


### PR DESCRIPTION
The cpputest.pc file is being generated correctly but it is not being installed on the system. I just added the minimal required information on the Makefile.am to make it work.

I also added some missing headers from CppUTestExt that where not being installed on the Makefile.am
