### PR TITLE
Make all tests that checks if something throws use the EXPECT_THROWS

### DIFF
--- a/tests/MemoryLeakOperatorOverloadsTest.cpp
+++ b/tests/MemoryLeakOperatorOverloadsTest.cpp
@@ -262,22 +262,12 @@ TEST_GROUP(OutOfMemoryTestsForOperatorNew)
 
 TEST(OutOfMemoryTestsForOperatorNew, FailingNewOperatorThrowsAnExceptionWhenUsingStdCppNew)
 {
-	try {
-		new char;
-		FAIL("Should have thrown an exception!")
-	}
-	catch (std::bad_alloc&) {
-	}
+	CHECK_THROWS(std::bad_alloc, new char);
 }
 
 TEST(OutOfMemoryTestsForOperatorNew, FailingNewArrayOperatorThrowsAnExceptionWhenUsingStdCppNew)
 {
-	try {
-		new char[10];
-		FAIL("Should have thrown an exception!")
-	}
-	catch (std::bad_alloc&) {
-	}
+	CHECK_THROWS(std::bad_alloc, new char[10]);
 }
 
 class ClassThatThrowsAnExceptionInTheConstructor
@@ -294,18 +284,12 @@ TEST_GROUP(TestForExceptionsInConstructor)
 
 TEST(TestForExceptionsInConstructor,ConstructorThrowsAnException)
 {
-	try {
-		new ClassThatThrowsAnExceptionInTheConstructor();
-	}catch(...){
-	}
+	CHECK_THROWS(int, new ClassThatThrowsAnExceptionInTheConstructor);
 }
 
 TEST(TestForExceptionsInConstructor,ConstructorThrowsAnExceptionAllocatedAsArray)
 {
-	try {
-		new ClassThatThrowsAnExceptionInTheConstructor[10];
-	}catch(...){
-	}
+	CHECK_THROWS(int, new ClassThatThrowsAnExceptionInTheConstructor[10]);
 }
 
 #else
@@ -356,22 +340,12 @@ static char* some_memory;
 
 TEST(OutOfMemoryTestsForOperatorNew, FailingNewOperatorThrowsAnExceptionWhenUsingStdCppNewWithoutOverride)
 {
-	try {
-		some_memory = new char;
-		FAIL("Should have thrown an exception!")
-	}
-	catch (std::bad_alloc&) {
-	}
+	CHECK_THROWS(std::bad_alloc, some_memory = new char);
 }
 
 TEST(OutOfMemoryTestsForOperatorNew, FailingNewArrayOperatorThrowsAnExceptionWhenUsingStdCppNewWithoutOverride)
 {
-	try {
-		some_memory = new char[10];
-		FAIL("Should have thrown an exception!")
-	}
-	catch (std::bad_alloc&) {
-	}
+	CHECK_THROWS(std::bad_alloc, some_memory = new char[10]);
 }
 
 TEST(OutOfMemoryTestsForOperatorNew, FailingNewOperatorReturnsNullWithoutOverride)


### PR DESCRIPTION
There is no reason explicitly using try/catch when we have a macro that does the same.
