### PR TITLE
A CHECK_NO_THROWS macro for checking that given expression does not throw an exception.

### DIFF
--- a/include/CppUTest/UtestMacros.h
+++ b/include/CppUTest/UtestMacros.h
@@ -215,6 +215,21 @@
 		UtestShell::getCurrent()->fail(msg.asCharString(), __FILE__, __LINE__); \
 	} \
 	}
+	
+#define CHECK_NO_THROWS(expression) \
+	{ \
+	SimpleString msg("Expected to throw nothing, but threw an exception"); \
+	bool caught_exception = false; \
+	try { \
+		(expression); \
+	} catch(...) { \
+		msg = "Expected to throw nothing, but threw an exception"; \
+		caught_exception = true; \
+	} \
+	if (caught_exception) { \
+		UtestShell::getCurrent()->fail(msg.asCharString(), __FILE__, __LINE__); \
+	} \
+	}
 #endif /* CPPUTEST_USE_STD_CPP_LIB */
 
 #define UT_CRASH() { UtestShell::crash(); }


### PR DESCRIPTION
I added a CHECK_NO_THROWS macro that checks that the given expression does not throw an exception to root out unwanted exceptions.
