### PR TITLE
fix ambiguous unsigned long resolving of StringFrom.

### DIFF
--- a/include/CppUTest/SimpleString.h
+++ b/include/CppUTest/SimpleString.h
@@ -138,6 +138,7 @@ SimpleString VStringFromFormat(const char* format, va_list args);
 #include <stdint.h>
 
 SimpleString StringFrom(const std::string& other);
+SimpleString StringFrom(unsigned long);
 SimpleString StringFrom(uint32_t);
 SimpleString StringFrom(uint16_t);
 SimpleString StringFrom(uint8_t);

--- a/src/CppUTest/SimpleString.cpp
+++ b/src/CppUTest/SimpleString.cpp
@@ -420,6 +420,11 @@ SimpleString StringFrom(const std::string& value)
 	return SimpleString(value.c_str());
 }
 
+SimpleString StringFrom(unsigned long i)
+{
+	return StringFromFormat("%lu (0x%lx)", i, i);
+}
+
 SimpleString StringFrom(uint32_t i)
 {
 	return StringFromFormat("%10u (0x%08x)", i, i);

--- a/tests/SimpleStringTest.cpp
+++ b/tests/SimpleStringTest.cpp
@@ -555,6 +555,12 @@ TEST(SimpleString, fromStdString)
 	STRCMP_EQUAL("hello", s1.asCharString());
 }
 
+TEST(SimpleString, CHECK_EQUAL_unsigned_long)
+{
+	unsigned long i = 0xffffffffUL;
+	CHECK_EQUAL(i, i);
+}
+
 TEST(SimpleString, CHECK_EQUAL_Uint32_t)
 {
 	uint32_t i = 0xffffffff;
@@ -571,6 +577,14 @@ TEST(SimpleString, CHECK_EQUAL_Uint8_t)
 {
 	uint8_t i = 0xff;
 	CHECK_EQUAL(i, i);
+}
+
+TEST(SimpleString, unsigned_long)
+{
+	unsigned long i = 0xffffffffUL;
+
+	SimpleString result = StringFrom(i);
+	CHECK_EQUAL("4294967295 (0xffffffff)", result);
 }
 
 TEST(SimpleString, Uint32_t)


### PR DESCRIPTION
Since 'unsigned long' is widely used, it's better to accept this type.

```
error: call of overloaded ‘StringFrom(long unsigned int)’ is ambiguous
```
