### PR TITLE
Moved definition of MockIgnoredCall::instance() from MockFunctionCall.h

### DIFF
--- a/src/CppUTestExt/MockFunctionCall.cpp
+++ b/src/CppUTestExt/MockFunctionCall.cpp
@@ -192,6 +192,11 @@ MockFunctionCall& MockFunctionCallComposite::onObject(void* object)
 	return *this;
 }
 
+MockFunctionCall& MockIgnoredCall::instance()
+{
+    static MockIgnoredCall call;
+    return call;
+}
 
 MockFunctionCallTrace::MockFunctionCallTrace()
 {


### PR DESCRIPTION
TI cl2000 compiler cannot handle it in the header file; it generates multiple copies of call, which lead to linker errors.
