### PR TITLE
Moved definition of MockIgnoredCall::instance() to MockFunctionCall.cpp

### DIFF
--- a/include/CppUTestExt/MockFunctionCall.h
+++ b/include/CppUTestExt/MockFunctionCall.h
@@ -123,7 +123,7 @@ public:
 
 	virtual MockFunctionCall& onObject(void* ) { return *this; }
 
-	static MockFunctionCall& instance() { static MockIgnoredCall call; return call; }
+	static MockFunctionCall& instance();
 };
 
 class MockFunctionCallTrace : public MockFunctionCall


### PR DESCRIPTION
TI cl2000 compiler cannot handle it in the header file; it generates multiple copies of call, which lead to linker errors.
