### PR TITLE
Instance() fix the second...

### DIFF
--- a/include/CppUTestExt/MockFunctionCall.h
+++ b/include/CppUTestExt/MockFunctionCall.h
@@ -123,7 +123,7 @@ public:
 
 	virtual MockFunctionCall& onObject(void* ) { return *this; }
 
-	static MockFunctionCall& instance() { static MockIgnoredCall call; return call; }
+	static MockFunctionCall& instance();
 };
 
 class MockFunctionCallTrace : public MockFunctionCall

--- a/src/CppUTestExt/MockFunctionCall.cpp
+++ b/src/CppUTestExt/MockFunctionCall.cpp
@@ -192,7 +192,12 @@ MockFunctionCall& MockFunctionCallComposite::onObject(void* object)
 	return *this;
 }
 
-
+MockFunctionCall& MockIgnoredCall::instance()
+{
+    static MockIgnoredCall call;
+    return call;
+}
+ 
 MockFunctionCallTrace::MockFunctionCallTrace()
 {
 }


### PR DESCRIPTION
... MockFunctionCall.cpp

to fix problem with TI cl2000 compiler, which creates several copies of call, leading to linker error.
