### PR TITLE
Fix "unused variable" warning when CPPUTEST_USE_MALLOC_MACROS not defined

### DIFF
--- a/tests/TestHarness_cTest.cpp
+++ b/tests/TestHarness_cTest.cpp
@@ -218,8 +218,10 @@ TEST(TestHarness_c, cpputest_realloc_larger)
 
 TEST(TestHarness_c, macros)
 {
+#if CPPUTEST_USE_MALLOC_MACROS
 	MemoryLeakDetector* memLeakDetector = MemoryLeakWarningPlugin::getGlobalDetector();
 	int memLeaks = memLeakDetector->totalMemoryLeaks(mem_leak_period_checking);
+#endif
 	void* mem1 = malloc(10);
 	void* mem2 = calloc(10, 20);
 	void* mem3 = realloc(mem2, 100);


### PR DESCRIPTION
This time it should be clean. I don't know why I ran into this; it does trip the compiler up with -Werror on. I have CPPUTEST_USE_MEM_LEAK_DETECTION defined via compiler switch, nothing else. Feel free to use or to reject.
