### PR TITLE
Explicit cast conforms to standard

### DIFF
--- a/tests/SimpleStringTest.cpp
+++ b/tests/SimpleStringTest.cpp
@@ -440,7 +440,7 @@ TEST(SimpleString, StringFromFormat)
 TEST(SimpleString, StringFromFormatpointer)
 {
 	//this is not a great test. but %p is odd on mingw and even more odd on Solaris.
-	SimpleString h1 = StringFromFormat("%p", 1);
+	SimpleString h1 = StringFromFormat("%p", (void*) 1);
 	if (h1.size() == 3)
 		STRCMP_EQUAL("0x1", h1.asCharString())
 	else if (h1.size() == 8)


### PR DESCRIPTION
Hi Bas, the code compiled with the cl2000 compiler actually produced an interesting result such as "1AD76", which went away after the explicit cast.
