### PR TITLE
Fixed fake memory leak when throwing exception in constructor.

### DIFF
--- a/include/CppUTest/MemoryLeakDetectorNewMacros.h
+++ b/include/CppUTest/MemoryLeakDetectorNewMacros.h
@@ -37,6 +37,11 @@
 	void* operator new(size_t size) UT_THROW(std::bad_alloc);
 	void* operator new[](size_t size) UT_THROW(std::bad_alloc);
 
+    void operator delete(void* mem) UT_NOTHROW;
+    void operator delete[](void* mem) UT_NOTHROW;
+    void operator delete(void* mem, const char* file, int line) UT_NOTHROW;
+    void operator delete[](void* mem, const char* file, int line) UT_NOTHROW;
+
 #endif
 
 #define new new(__FILE__, __LINE__)

--- a/include/CppUTest/MemoryLeakWarningPlugin.h
+++ b/include/CppUTest/MemoryLeakWarningPlugin.h
@@ -29,26 +29,10 @@
 #define D_MemoryLeakWarningPlugin_h
 
 #include "TestPlugin.h"
+#include "MemoryLeakDetectorNewMacros.h"
 
 #define IGNORE_ALL_LEAKS_IN_TEST() MemoryLeakWarningPlugin::getFirstPlugin()->ignoreAllLeaksInTest();
 #define EXPECT_N_LEAKS(n)          MemoryLeakWarningPlugin::getFirstPlugin()->expectLeaksInTest(n);
-
-#if CPPUTEST_USE_MEM_LEAK_DETECTION
-
-#if !CPPUTEST_USE_NEW_MACROS
-	#include <new>
-	void* operator new(size_t size) UT_THROW(std::bad_alloc);
-	void* operator new[](size_t size) UT_THROW(std::bad_alloc);
-	void* operator new(size_t size, const std::nothrow_t&) UT_NOTHROW;
-	void* operator new[](size_t size, const std::nothrow_t&) UT_NOTHROW;
-#endif
-
-void operator delete(void* mem) UT_NOTHROW;
-void operator delete[](void* mem) UT_NOTHROW;
-void operator delete(void* mem, const char* file, int line) UT_NOTHROW;
-void operator delete[](void* mem, const char* file, int line) UT_NOTHROW;
-
-#endif
 
 extern void crash_on_allocation_number(unsigned alloc_number);
 

--- a/tests/AllocationInCppFile.cpp
+++ b/tests/AllocationInCppFile.cpp
@@ -26,3 +26,9 @@ char* newArrayAllocationWithoutMacro()
 {
 	return new char[100];
 }
+
+ClassThatThrowsAnExceptionInTheConstructor::ClassThatThrowsAnExceptionInTheConstructor()
+{
+  throw 1;
+}
+

--- a/tests/AllocationInCppFile.h
+++ b/tests/AllocationInCppFile.h
@@ -7,4 +7,10 @@ char* newArrayAllocation();
 char* newAllocationWithoutMacro();
 char* newArrayAllocationWithoutMacro();
 
+class ClassThatThrowsAnExceptionInTheConstructor
+{
+public:
+  ClassThatThrowsAnExceptionInTheConstructor() __no_return__;
+};
+
 #endif

--- a/tests/MemoryLeakOperatorOverloadsTest.cpp
+++ b/tests/MemoryLeakOperatorOverloadsTest.cpp
@@ -270,14 +270,6 @@ TEST(OutOfMemoryTestsForOperatorNew, FailingNewArrayOperatorThrowsAnExceptionWhe
 	CHECK_THROWS(std::bad_alloc, new char[10]);
 }
 
-class ClassThatThrowsAnExceptionInTheConstructor
-{
-public:
-	ClassThatThrowsAnExceptionInTheConstructor() __no_return__ {
-		throw 1;
-	}
-};
-
 TEST_GROUP(TestForExceptionsInConstructor)
 {
 };


### PR DESCRIPTION
It has been submitted as issue #73, but I've found out that the fix is only partial. It does not work when throw is performed in different translation unit. To solve this, the delete operator declarations with additional parameters (**FILE** and__LINE__) must be included by every file. If their are not, the default delete is called, and the detector doesn't know that the memory has been freed.
1. I changed the tests to show that - I moved ClassThatThrowsAnExceptionInTheConstructor to different translation unit.
2. I moved declarations to MemoryLeakDetectorNewMacros.h, which is included everywhere
3. I've removed redundant declarations by including MemoryLeakDetectorNewMacros.h in MemoryLeakWarningPlugin.h
