### PR TITLE
Change for cl2000 compiler

### DIFF
--- a/tests/CppUTestExt/TestMockFailure.cpp
+++ b/tests/CppUTestExt/TestMockFailure.cpp
@@ -31,6 +31,12 @@
 #include "CppUTestExt/MockExpectedFunctionsList.h"
 #include "TestMockFailure.h"
 
+MockFailureReporterForTest* MockFailureReporterForTest::getReporter()
+{
+    static MockFailureReporterForTest reporter;
+    return &reporter;
+}
+
 TEST_GROUP(MockFailureTest)
 {
 	MockFailureReporter reporter;

--- a/tests/CppUTestExt/TestMockFailure.h
+++ b/tests/CppUTestExt/TestMockFailure.h
@@ -44,11 +44,7 @@ public:
 		mockFailureString = failure.getMessage();
 	}
 
-	static MockFailureReporterForTest* getReporter()
-	{
-		static MockFailureReporterForTest reporter;
-		return &reporter;
-	}
+	static MockFailureReporterForTest* getReporter();
 };
 
 inline UtestShell* mockFailureTest()


### PR DESCRIPTION
Moved definition of MockFailureReporterForTest::getReporter() from .h to .cpp
