### PR TITLE
More changes for compatibility with cl2000 compiler.

### DIFF
--- a/src/CppUTest/Utest.cpp
+++ b/src/CppUTest/Utest.cpp
@@ -82,7 +82,7 @@ static void helperDoTestSetup(void* data);
 static void helperDoTestBody(void* data);
 static void helperDoTestTeardown(void* data);
 static void helperDoRunOneTestSeperateProcess(void* data);
-} // extern "C"
+}
 
 static void helperDoTestSetup(void* data)
 {


### PR DESCRIPTION
Moved implementation of OutsideTestRunnerUTest::instance() outside class definition. 
Added extern "C" declarations to all helper functions.
