### PR TITLE
Consistent use of size_t for casting pointers to integer type.

### DIFF
--- a/src/CppUTest/MemoryLeakDetector.cpp
+++ b/src/CppUTest/MemoryLeakDetector.cpp
@@ -323,7 +323,7 @@ bool MemoryLeakDetectorList::hasLeaks(MemLeakPeriod period)
 
 unsigned long MemoryLeakDetectorTable::hash(char* memory)
 {
-	return ((size_t) memory) % hash_prime;
+	return (unsigned long)((size_t)memory % hash_prime);
 }
 
 void MemoryLeakDetectorTable::clearAllAccounting(MemLeakPeriod period)


### PR DESCRIPTION
Have to start with the second change; the first one has a broken diff.
