### PR TITLE
Consistent use of size_t for casting pointers to integer type.

### DIFF
--- a/src/CppUTest/SimpleString.cpp
+++ b/src/CppUTest/SimpleString.cpp
@@ -384,6 +384,11 @@ SimpleString HexStringFrom(long value)
 	return StringFromFormat("%lx", value);
 }
 
+SimpleString HexStringFrom(unsigned long value)
+{
+	return StringFromFormat("%lx", value);
+}
+
 SimpleString StringFrom(double value, int precision)
 {
 	return StringFromFormat("%.*g", precision, value);


### PR DESCRIPTION
Second attempt finally yields a decent diff.
