### PR TITLE
clang doesn't have __WORDSIZE defined.

### DIFF
--- a/include/CppUTest/CppUTestConfig.h
+++ b/include/CppUTest/CppUTestConfig.h
@@ -147,7 +147,7 @@
  * Detection of different 64 bit environments
  */
 
-#if defined(__LP64__) || defined(_LP64) || (__WORDSIZE == 64 ) || defined(__x86_64) || defined(_WIN64)
+#if defined(__LP64__) || defined(_LP64) || (defined(__WORDSIZE) && (__WORDSIZE == 64 )) || defined(__x86_64) || defined(_WIN64)
 #define CPPUTEST_64BIT
 #if defined(_WIN64)
 #define CPPUTEST_64BIT_32BIT_LONGS


### PR DESCRIPTION
As requested. It seems that __WORDSIZE didn't give any trouble with clang++ on either Mac or Travis? If that is indeed so, then the commit message should read:

```
clang doesn't have __WORDSIZE defined on Windows.
```
