### PR TITLE
No throwing without exceptions; no exceptions without C++ lib.

### DIFF
--- a/tests/AllocationInCppFile.cpp
+++ b/tests/AllocationInCppFile.cpp
@@ -27,8 +27,11 @@ char* newArrayAllocationWithoutMacro()
 	return new char[100];
 }
 
+#if CPPUTEST_USE_STD_CPP_LIB
+
 ClassThatThrowsAnExceptionInTheConstructor::ClassThatThrowsAnExceptionInTheConstructor()
 {
   throw 1;
 }
 
+#endif

--- a/tests/AllocationInCppFile.h
+++ b/tests/AllocationInCppFile.h
@@ -7,10 +7,14 @@ char* newArrayAllocation();
 char* newAllocationWithoutMacro();
 char* newArrayAllocationWithoutMacro();
 
+#if CPPUTEST_USE_STD_CPP_LIB
+
 class ClassThatThrowsAnExceptionInTheConstructor
 {
 public:
   ClassThatThrowsAnExceptionInTheConstructor() __no_return__;
 };
+
+#endif
 
 #endif


### PR DESCRIPTION
Is this the correct way to fix the problem I mentioned in the corresponding issue?

Why do clang or gcc not pick this up? e.g. is exception handling still enabled, even without std c++ library? 

The cl2000 has an option to switch off exception handling, and libraries that - optionally - contain no exception handling code at all.
