### PR TITLE
Windows timeGetTime() returns milli-seconds.

### DIFF
--- a/src/Platforms/VisualCpp/UtestPlatform.cpp
+++ b/src/Platforms/VisualCpp/UtestPlatform.cpp
@@ -62,7 +62,7 @@ TestOutput::WorkingEnvironment PlatformSpecificGetWorkingEnvironment()
 
 static long TimeInMillisImplementation()
 {
-    return timeGetTime()/1000;
+    return timeGetTime();
 }
 
 static long (*timeInMillisFp) () = TimeInMillisImplementation;
@@ -157,7 +157,7 @@ int PlatformSpecificVSNprintf(char *str, size_t size, const char* format, va_lis
 		buf = (char*)malloc(sizeGuess);
 		result = _vsnprintf( buf, sizeGuess, format, args);
 	}
-	
+
 	if (buf != 0)
 		free(buf);
 	return result;


### PR DESCRIPTION
This bug just got discovered. 

What is actually the procedure for testing platform-specific VisualCpp code?  I don't have MSVC myself.

I will leave the whitespace change, my IDE trims it off and I don't think anybody wants it there.

Note that timeGetTime() will lead to incorrect timings, if your tests run longer than 49 days :-).
