### PR TITLE
removed non-exsisting macro from example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,6 @@ TEST(ClassName, Create)
 {
   CHECK(0 != className);
   CHECK(true);
-  CHECK_EQUALS(1,1);
   LONGS_EQUAL(1,1);
   DOUBLES_EQUAL(1.000, 1.001, .01);
   STRCMP_EQUAL("hello", "hello");


### PR DESCRIPTION
I tried Example Test in README.md, and compile failed.
I found `CHECK_EQUALS` doesn't exist in `include/CppUTest/UtestMacros.h` and any other files. 

just removed `CHECK_EQUALS` row in `README.md`
