### PR TITLE
Fixed typo of macro in example at README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ TEST(ClassName, Create)
 {
   CHECK(0 != className);
   CHECK(true);
-  CHECK_EQUALS(1,1);
+  CHECK_EQUAL(1,1);
   LONGS_EQUAL(1,1);
   DOUBLES_EQUAL(1.000, 1.001, .01);
   STRCMP_EQUAL("hello", "hello");


### PR DESCRIPTION
Hi John.
Thank you for replying :)
I made a new pull request and closed last one(https://github.com/cpputest/cpputest/pull/204).

I mistook LONGS_EQUAL for CHECK_EQUAL, and thought CHECK_EQUAL is duplicated.
I fixed typo.

Hope this helps you :thumbsup: 

Best.
Kawasaki
