### PR TITLE
cmake: Add -Wno-c++98-compat if building for C++11.

### DIFF
--- a/cmake/Modules/CppUTestWarningFlags.cmake
+++ b/cmake/Modules/CppUTestWarningFlags.cmake
@@ -52,9 +52,14 @@ else (MSVC)
         Wno-weak-vtables
         )
 
-
     check_and_append_c_warning_flags(${WARNING_C_FLAGS})
     check_and_append_c_warning_flags(${WARNING_C_ONLY_FLAGS})
     check_and_append_cxx_warning_flags(${WARNING_CXX_FLAGS})
 
+    if (C++11)
+        check_cxx_compiler_flag("-Wno-c++98-compat" NO_WARNING_CXX_98_COMPAT_FLAG)
+        if (NO_WARNING_CXX_98_COMPAT_FLAG)
+            set(CPPUTEST_CXX_WARNING_FLAGS "${CPPUTEST_CXX_WARNING_FLAGS} -Wno-c++98-compat")
+        endif (NO_WARNING_CXX_98_COMPAT_FLAG)
+    endif (C++11)
 endif (MSVC)


### PR DESCRIPTION
On clang, this is default on, and with C++11 we use override, which
is not C++98 compatible.
