### PR TITLE
Make #include scheme for examples consistant

### DIFF
--- a/examples/AllTests/AllTests.cpp
+++ b/examples/AllTests/AllTests.cpp
@@ -54,4 +54,4 @@ int main(int ac, char** av)
 	return CommandLineTestRunner::RunAllTests(ac, av);
 }
 
-#include "ApplicationLib/AllTests.h"
+#include "AllTests.h"


### PR DESCRIPTION
Reasoning: Either this, or all #includes in ./examples should have "ApplicationLib/". However, the latter makes little sense in my opinion because there is no real common root (like in "CppUTest/include").

Compiles OK locally - let's see what Travis has to say...
