### PR TITLE
cmake: Make ctest run tests from EXECUTABLE_OUTPUT_DIR

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,7 +39,7 @@ endif (MSVC)
 
 add_executable(CppUTestTests ${CppUTestTests_src})
 target_link_libraries(CppUTestTests CppUTest)
-add_test(CppUTestTests CppUTestTests)
+add_test(CppUTestTests ${EXECUTABLE_OUTPUT_PATH}/CppUTestTests)
 
 if (TESTS)
     add_subdirectory(CppUTestExt)

--- a/tests/CppUTestExt/CMakeLists.txt
+++ b/tests/CppUTestExt/CMakeLists.txt
@@ -20,4 +20,4 @@ set(CppUTestExtTests_src
 
 add_executable(CppUTestExtTests ${CppUTestExtTests_src})
 target_link_libraries(CppUTestExtTests CppUTest CppUTestExt ${CPPUNIT_EXTERNAL_LIBRARIES})
-add_test(CppUTestExtTests CppUTestExtTests)
+add_test(CppUTestExtTests ${EXECUTABLE_OUTPUT_PATH}/CppUTestExtTests)


### PR DESCRIPTION
This makes it possible to use it as a submodule in other projects,
that dont necessarily put exeutables directly under the build folder.
