### PR TITLE
Fix clang build

### DIFF
--- a/include/CppUTest/CppUTestConfig.h
+++ b/include/CppUTest/CppUTestConfig.h
@@ -137,6 +137,12 @@
   #define UT_THROW(exception)
 #endif
 
+#if defined(__cplusplus) && __cplusplus >= 201103L
+	#define DEFAULT_COPY_CONSTRUCTOR(classname) classname(const classname &) = default;
+#else
+	#define DEFAULT_COPY_CONSTRUCTOR(classname)
+#endif
+
 /*
  * g++-4.7 with stdc++11 enabled On MacOSX! will have a different exception specifier for operator new (and thank you!)
  * I assume they'll fix this in the future, but for now, we'll change that here.

--- a/include/CppUTest/TestResult.h
+++ b/include/CppUTest/TestResult.h
@@ -42,6 +42,7 @@ class TestResult
 {
 public:
 	TestResult(TestOutput&);
+	DEFAULT_COPY_CONSTRUCTOR(TestResult)
 	virtual ~TestResult();
 
 	virtual void testsStarted();

--- a/include/CppUTestExt/MockNamedValue.h
+++ b/include/CppUTestExt/MockNamedValue.h
@@ -71,6 +71,7 @@ class MockNamedValue
 {
 public:
 	MockNamedValue(const SimpleString& name);
+	DEFAULT_COPY_CONSTRUCTOR(MockNamedValue)
 	virtual ~MockNamedValue();
 
 	virtual void setValue(int value);


### PR DESCRIPTION
CppUTest doesn't want to compile with clang 3.4 and C++11 due to these issues.

Not completely happy with the macro solution for default copy ctor, but not sure how to do it cleaner. Suggestion would be really welcome. 
