### PR TITLE
Fix check count if CHECK_EQUAL evaluates to 'true'

### DIFF
--- a/include/CppUTest/UtestMacros.h
+++ b/include/CppUTest/UtestMacros.h
@@ -122,6 +122,10 @@
 	  if ((expected) != (expected)) \
 	  	  UtestShell::getCurrent()->print("WARNING:\n\tThe \"Expected Parameter\" parameter is evaluated multiple times resulting in different values.\n\tThus the value in the error message is probably incorrect.", file, line); \
 	  UtestShell::getCurrent()->assertEquals(true, StringFrom(expected).asCharString(), StringFrom(actual).asCharString(), file, line); \
+  } \
+  else \
+  { \
+    UtestShell::getCurrent()->assertLongsEqual((long)0, (long)0, file, line); \
   } }
 
 //This check checks for char* string equality using strcmp.

--- a/tests/UtestTest.cpp
+++ b/tests/UtestTest.cpp
@@ -45,6 +45,11 @@ static void _passingTestMethod()
 	CHECK(true);
 }
 
+static void _passingCheckEqualTestMethod()
+{
+	CHECK_EQUAL(1, 1);
+}
+
 TEST(UtestShell, compareDoubles)
 {
 	double zero = 0.0;
@@ -62,6 +67,13 @@ TEST(UtestShell, compareDoubles)
 TEST(UtestShell, FailWillIncreaseTheAmountOfChecks)
 {
 	fixture.setTestFunction(_failMethod);
+	fixture.runAllTests();
+	LONGS_EQUAL(1, fixture.getCheckCount());
+}
+
+TEST(UtestShell, PassedCheckEqualWillIncreaseTheAmountOfChecks)
+{
+	fixture.setTestFunction(_passingCheckEqualTestMethod);
 	fixture.runAllTests();
 	LONGS_EQUAL(1, fixture.getCheckCount());
 }


### PR DESCRIPTION
CHECK_EQUAL() does not increment the check count if it evaluates to true because the
effective check function is called in the fail case only (to avoid multiple evaluations of expected/actual).
The (quick) solution is to call an arbitrary passing check if CHECK_EQUAL passes.

By the way: this would be a great place to have a template function. While I fully support the
decision against using STL, 'plain' templates should be OK for post-2005 embedded C++ compiler.
