### PR TITLE
Fixes for cl2000 compiler

### DIFF
--- a/project/CCStudio/tests/CppUTestExt/AllTestsForTarget.cpp
+++ b/project/CCStudio/tests/CppUTestExt/AllTestsForTarget.cpp
@@ -30,7 +30,6 @@
 #include "CppUTest/TestRegistry.h"
 #include "CppUTestExt/MemoryReporterPlugin.h"
 #include "CppUTestExt/MockSupportPlugin.h"
-#include "CppUTestExt/GTestConvertor.h"
 
 int main(int ac, char** av)
 {
@@ -44,11 +43,6 @@ int main(int ac, char** av)
 	};
 
     ac = sizeof(argv) / sizeof(char*);
-
-#ifdef CPPUTEST_USE_REAL_GTEST
-    GTestConvertor convertor;
-    convertor.addAllGTestToTestRegistry();
-#endif
 
     MemoryReporterPlugin plugin;
     MockSupportPlugin mockPlugin;

--- a/tests/CppUTestExt/TestMockSupport.cpp
+++ b/tests/CppUTestExt/TestMockSupport.cpp
@@ -280,7 +280,7 @@ TEST(MockSupportTest, expectOneCallHoweverMultipleHappened)
 
 TEST(MockSupportTest, expectOneUnsignedIntegerParameterAndValue)
 {
-    unsigned int value = 144000;
+    unsigned int value = 14400;
 	mock().expectOneCall("foo").withParameter("parameter", value);
 	mock().actualCall("foo").withParameter("parameter", value);
 	mock().checkExpectations();


### PR DESCRIPTION
1. On 16 bit platforms, a 32 bit unsigned constant will
   cause warnings / errors
2. Removed GTest stuff from AllTestsForTarget.cpp.
   GTest is neither supported nor tested.
