### PR TITLE
Remove the semicolon from the DEFAULT_COPY_CONSTRUCTOR macro.

### DIFF
--- a/include/CppUTest/CppUTestConfig.h
+++ b/include/CppUTest/CppUTestConfig.h
@@ -138,9 +138,9 @@
 #endif
 
 #if defined(__cplusplus) && __cplusplus >= 201103L
-	#define DEFAULT_COPY_CONSTRUCTOR(classname) classname(const classname &) = default;
+	#define DEFAULT_COPY_CONSTRUCTOR(classname) classname(const classname &) = default
 #else
-	#define DEFAULT_COPY_CONSTRUCTOR(classname)
+	#define DEFAULT_COPY_CONSTRUCTOR(classname) class _NoExtraSemi {}
 #endif
 
 /*

--- a/include/CppUTest/TestResult.h
+++ b/include/CppUTest/TestResult.h
@@ -42,7 +42,7 @@ class TestResult
 {
 public:
 	TestResult(TestOutput&);
-	DEFAULT_COPY_CONSTRUCTOR(TestResult)
+	DEFAULT_COPY_CONSTRUCTOR(TestResult);
 	virtual ~TestResult();
 
 	virtual void testsStarted();

--- a/include/CppUTestExt/MockNamedValue.h
+++ b/include/CppUTestExt/MockNamedValue.h
@@ -71,7 +71,7 @@ class MockNamedValue
 {
 public:
 	MockNamedValue(const SimpleString& name);
-	DEFAULT_COPY_CONSTRUCTOR(MockNamedValue)
+	DEFAULT_COPY_CONSTRUCTOR(MockNamedValue);
 	virtual ~MockNamedValue();
 
 	virtual void setValue(int value);


### PR DESCRIPTION
Let's see what Travis has to say...
