### PR TITLE
Correct C++-style comment in header file (-pedantic).

### DIFF
--- a/include/CppUTest/MemoryLeakDetectorNewMacros.h
+++ b/include/CppUTest/MemoryLeakDetectorNewMacros.h
@@ -21,7 +21,7 @@
 
 #include "CppUTestConfig.h"
 
-// Make sure that mem leak detection is on and that this is being included from a C++ file
+/* Make sure that mem leak detection is on and that this is being included from a C++ file */
 #if CPPUTEST_USE_MEM_LEAK_DETECTION && defined(__cplusplus)
 
 /* This #ifndef prevents <new> from being included twice and enables the file to be included anywhere */


### PR DESCRIPTION
Ironically, the comment occurs before we make sure that we are included from a C++ file ;-)

Strange this hasn't occurred before. I set the -pedantic switch yesterday mainly because I realized it's set for gcc on Travis, and it promptly complained about this line. 

Ah, now I realize why. I compiled with Code::Blocks, which cannot easily differentiate between C and C++ where it's command line is concerned. So this file gets #included for C files as well.

In any case, the safe thing is to use a C-style comment here.
