### PR TITLE
Removed ignoreOtherParameters() from MockActualCall.

### DIFF
--- a/include/CppUTestExt/MockActualCall.h
+++ b/include/CppUTestExt/MockActualCall.h
@@ -50,7 +50,6 @@ public:
 	MockActualCall& withParameter(const SimpleString& name, void* value) { return withPointerParameter(name, value); }
 	MockActualCall& withParameter(const SimpleString& name, const void* value) { return withConstPointerParameter(name, value); }
 	virtual MockActualCall& withParameterOfType(const SimpleString& typeName, const SimpleString& name, const void* value)=0;
-	virtual MockActualCall& ignoreOtherParameters() { return *this;}
 
 	virtual MockActualCall& withIntParameter(const SimpleString& name, int value)=0;
 	virtual MockActualCall& withUnsignedIntParameter(const SimpleString& name, unsigned int value)=0;

--- a/include/CppUTestExt/MockCheckedActualCall.h
+++ b/include/CppUTestExt/MockCheckedActualCall.h
@@ -104,7 +104,6 @@ public:
 	virtual MockActualCall& withPointerParameter(const SimpleString& name, void* value) _override;
 	virtual MockActualCall& withConstPointerParameter(const SimpleString& name, const void* value) _override;
 	virtual MockActualCall& withParameterOfType(const SimpleString& typeName, const SimpleString& name, const void* value) _override;
-	virtual MockActualCall& ignoreOtherParameters() _override;
 
 	virtual bool hasReturnValue() _override;
 	virtual MockNamedValue returnValue() _override;

--- a/src/CppUTestExt/MockActualCall.cpp
+++ b/src/CppUTestExt/MockActualCall.cpp
@@ -361,11 +361,6 @@ MockActualCall& MockActualCallTrace::withParameterOfType(const SimpleString& typ
 	return *this;
 }
 
-MockActualCall& MockActualCallTrace::ignoreOtherParameters()
-{
-	return *this;
-}
-
 bool MockActualCallTrace::hasReturnValue()
 {
 	return false;


### PR DESCRIPTION
What would be the point of calling ignoreOtherParameters() on MockActualCall?

I couldn't find any; if you don't want a parameter to be checked, you just simply omit the corresponding call to withParameter().
