### PR TITLE
Remove -D_CRT_SECURE_NO_WARNINGS again.

### DIFF
--- a/cmake/Modules/CppUTestConfigurationOptions.cmake
+++ b/cmake/Modules/CppUTestConfigurationOptions.cmake
@@ -1,6 +1,5 @@
 if (MSVC)
     set(CPP_PLATFORM VisualCpp)
-    add_definitions(-D_CRT_SECURE_NO_WARNINGS)
     include_directories(${CppUTestRootDirectory}/include/Platforms/${CPP_PLATFORM})
 elseif (STD_C)
     set(CPP_PLATFORM Gcc)


### PR DESCRIPTION
No longer needed since strncpy is now exempt via #pragma.

I tested this by running cmake for VS2008, then loading CppUTest.sln into VS. I compiled the ALL_BUILD and RUN_TESTS targets, which build and run as expected. There are a lot of other targets, like "Nightly" and "Experimental" -- does anyone know how to use these?
