### PR TITLE
Add Eclipse CDT built-in gcc preprocessor include paths

### DIFF
--- a/.cproject
+++ b/.cproject
@@ -86,4 +86,5 @@
 			</target>
 		</buildTargets>
 	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.core.LanguageSettingsProviders"/>
 </cproject>


### PR DESCRIPTION
This is a tiny change, but it lets Eclipse parse everything (on Fedora and OS X, at least) without errors.  Without this it chokes on size_t, etc.

This results from:
Project Properties > C/C++ General > Preprocessor Include Paths > Providers > Check "CDT GCC Built-in Compiler Settings"
