### PR TITLE
Adding returnIntValue to MockActualCall

### DIFF
--- a/include/CppUTestExt/MockActualCall.h
+++ b/include/CppUTestExt/MockActualCall.h
@@ -66,6 +66,7 @@ public:
 	virtual bool hasReturnValue()=0;
 	virtual MockNamedValue returnValue()=0;
 	virtual int returnIntValueOrDefault(int default_value)=0;
+	virtual int returnIntValue()=0;
 
 	virtual MockActualCall& onObject(void* objectPtr)=0;
 };

--- a/include/CppUTestExt/MockCheckedActualCall.h
+++ b/include/CppUTestExt/MockCheckedActualCall.h
@@ -53,6 +53,7 @@ public:
 	virtual bool hasReturnValue() _override;
 	virtual MockNamedValue returnValue() _override;
 	virtual int returnIntValueOrDefault(int default_value) _override;
+	virtual int returnIntValue() _override;
 
 	virtual MockActualCall& onObject(void* objectPtr) _override;
 
@@ -132,6 +133,7 @@ public:
 	virtual bool hasReturnValue() _override;
 	virtual MockNamedValue returnValue() _override;
 	virtual int returnIntValueOrDefault(int default_value) _override;
+	virtual int returnIntValue() _override;
 
 	virtual MockActualCall& onObject(void* objectPtr) _override;
 
@@ -164,6 +166,7 @@ public:
 	virtual bool hasReturnValue() _override { return false; }
 	virtual MockNamedValue returnValue() _override { return MockNamedValue(""); }
     virtual int returnIntValueOrDefault(int) { return 0; }
+    virtual int returnIntValue() { return 0; }
 
 	virtual MockActualCall& onObject(void* ) _override { return *this; }
 

--- a/src/CppUTestExt/MockActualCall.cpp
+++ b/src/CppUTestExt/MockActualCall.cpp
@@ -317,6 +317,11 @@ int MockCheckedActualCall::returnIntValueOrDefault(int default_value)
     if (!hasReturnValue()) {
         return default_value;
     }
+    return returnIntValue();
+}
+
+int MockCheckedActualCall::returnIntValue()
+{
     return returnValue().getIntValue();
 }
 
@@ -482,6 +487,11 @@ bool MockActualCallTrace::hasReturnValue()
 MockNamedValue MockActualCallTrace::returnValue()
 {
 	return MockNamedValue("");
+}
+
+int MockActualCallTrace::returnIntValue()
+{
+	return 0;
 }
 
 int MockActualCallTrace::returnIntValueOrDefault(int)

--- a/tests/CppUTestExt/MockSupportTest.cpp
+++ b/tests/CppUTestExt/MockSupportTest.cpp
@@ -1212,7 +1212,11 @@ TEST(MockSupportTest, IntegerReturnValue)
 {
 	int expected_value = 1;
 	mock().expectOneCall("foo").andReturnValue(1);
-	LONGS_EQUAL(expected_value, mock().actualCall("foo").returnValue().getIntValue());
+	MockActualCall& actual_call = mock().actualCall("foo");
+
+	LONGS_EQUAL(expected_value, actual_call.returnValue().getIntValue());
+	LONGS_EQUAL(expected_value, actual_call.returnIntValue());
+
 	LONGS_EQUAL(expected_value, mock().returnValue().getIntValue());
 	LONGS_EQUAL(expected_value, mock().intReturnValue());
 }


### PR DESCRIPTION
Just adding the returnIntValue method on MockActualCall. I don't fancy the:

```
LONGS_EQUAL(expected_value, actual_call.returnValue().getIntValue());
```

But didn't wanted to break anything yet.
