### PR TITLE
MinGW-w64 use ANSI STDIO

### DIFF
--- a/include/CppUTest/CppUTestConfig.h
+++ b/include/CppUTest/CppUTestConfig.h
@@ -176,6 +176,9 @@
 #define _override
 #endif
 
+/* MinGW-w64 prefers to act like Visual C++, but we want the ANSI behaviors instead */
+#define __USE_MINGW_ANSI_STDIO 1
+
 /* Should be the only #include here. Standard C library wrappers */
 #include "StandardCLibrary.h"
 


### PR DESCRIPTION
Took me a while to get it done, but here's a change to fix issue #315.  I wasn't able to put the #define in PlatformSpecific.cpp since the forced includes for the new macros ends up pulling in stdio.h eventually (the include tree for that was a pain to chase).  I can try to find some #ifdef's to wrap around the #define if you want, but it seemed like that shouldn't really be necessary since the #define is pretty specific to just enabling a behavior that we pretty much always want on anyways.
