### PR TITLE
Added new STRNCMP_EQUAL(expected, actual, length) macro used to compare ...

### DIFF
--- a/include/CppUTest/Utest.h
+++ b/include/CppUTest/Utest.h
@@ -108,6 +108,7 @@ public:
     virtual void assertTrue(bool condition, const char *checkString, const char *conditionString, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
     virtual void assertTrueText(bool condition, const char *checkString, const char *conditionString, const char* text, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
     virtual void assertCstrEqual(const char *expected, const char *actual, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
+    virtual void assertCstrNEqual(const char *expected, const char *actual, int length, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
     virtual void assertCstrNoCaseEqual(const char *expected, const char *actual, const char *fileName, int lineNumber);
     virtual void assertCstrContains(const char *expected, const char *actual, const char *fileName, int lineNumber);
     virtual void assertCstrNoCaseContains(const char *expected, const char *actual, const char *fileName, int lineNumber);

--- a/include/CppUTest/UtestMacros.h
+++ b/include/CppUTest/UtestMacros.h
@@ -136,6 +136,12 @@
 #define STRCMP_EQUAL_LOCATION(expected,actual, file, line)\
   { UtestShell::getCurrent()->assertCstrEqual(expected, actual, file, line); }
 
+#define STRNCMP_EQUAL(expected, actual, length)\
+  STRNCMP_EQUAL_LOCATION(expected, actual, length, __FILE__, __LINE__)
+
+#define STRNCMP_EQUAL_LOCATION(expected, actual, length, file, line)\
+  { UtestShell::getCurrent()->assertCstrNEqual(expected, actual, length, file, line); }
+
 #define STRCMP_NOCASE_EQUAL(expected,actual)\
   STRCMP_NOCASE_EQUAL_LOCATION(expected, actual, __FILE__, __LINE__)
 

--- a/src/CppUTest/Utest.cpp
+++ b/src/CppUTest/Utest.cpp
@@ -356,6 +356,16 @@ void UtestShell::assertCstrEqual(const char* expected, const char* actual, const
         failWith(StringEqualFailure(this, fileName, lineNumber, expected, actual), testTerminator);
 }
 
+void UtestShell::assertCstrNEqual(const char* expected, const char* actual, int length, const char* fileName, int lineNumber, const TestTerminator& testTerminator)
+{
+    getTestResult()->countCheck();
+    if (actual == 0 && expected == 0) return;
+    if (actual == 0 || expected == 0)
+        failWith(StringEqualFailure(this, fileName, lineNumber, expected, actual), testTerminator);
+    if (PlatformSpecificStrNCmp(expected, actual, length) != 0)
+        failWith(StringEqualFailure(this, fileName, lineNumber, expected, actual), testTerminator);
+}
+
 void UtestShell::assertCstrNoCaseEqual(const char* expected, const char* actual, const char* fileName, int lineNumber)
 {
     getTestResult()->countCheck();


### PR DESCRIPTION
...up to 'length' characters from 'expected' and 'actual' strings.
