### PR TITLE
(2) Remove redundant extern declarations

### DIFF
--- a/include/CppUTest/TestHarness_c.h
+++ b/include/CppUTest/TestHarness_c.h
@@ -81,10 +81,8 @@
 /* For use in C++ file */
 
 #define TEST_GROUP_C_WRAPPER(group_name) \
-    extern "C" { \
-        extern void group_##group_name##_setup_wrapper_c(void); \
-        extern void group_##group_name##_teardown_wrapper_c(void); \
-    } \
+    extern "C" void group_##group_name##_setup_wrapper_c(void); \
+    extern "C" void group_##group_name##_teardown_wrapper_c(void); \
     TEST_GROUP(group_name)
 
 #define TEST_GROUP_C_SETUP_WRAPPER(group_name) \
@@ -98,9 +96,7 @@
     }
 
 #define TEST_C_WRAPPER(group_name, test_name) \
-    extern "C" { \
-        extern void test_##group_name##_##test_name##_wrapper_c(); \
-    } \
+    extern "C" void test_##group_name##_##test_name##_wrapper_c(); \
     TEST(group_name, test_name) { \
         test_##group_name##_##test_name##_wrapper_c(); \
     }


### PR DESCRIPTION
It is not necessary to declare a function 'extern' again when it has already been declared 'extern "C"'.

In this particular instance it makes sense to roll the two into one and declare the functions as

```
extern "C" myFunc()
```
