### PR TITLE
Fixed an issue with unexpected call error reporting

### DIFF
--- a/include/CppUTestExt/MockCheckedActualCall.h
+++ b/include/CppUTestExt/MockCheckedActualCall.h
@@ -97,7 +97,6 @@ protected:
     };
     virtual const char* stringFromState(ActualCallState state);
     virtual void setState(ActualCallState state);
-    virtual void checkStateConsistency(ActualCallState oldState, ActualCallState newState);
 
 private:
     SimpleString functionName_;

--- a/src/CppUTestExt/MockActualCall.cpp
+++ b/src/CppUTestExt/MockActualCall.cpp
@@ -72,8 +72,10 @@ UtestShell* MockCheckedActualCall::getTest() const
 
 void MockCheckedActualCall::failTest(const MockFailure& failure)
 {
-    setState(CALL_FAILED);
-    reporter_->failTest(failure);
+    if (!hasFailed()) {
+        setState(CALL_FAILED);
+        reporter_->failTest(failure);
+    }
 }
 
 void MockCheckedActualCall::finalizeOutputParameters()
@@ -290,17 +292,8 @@ const char* MockCheckedActualCall::stringFromState(ActualCallState state)
 #endif
 }
 
-void MockCheckedActualCall::checkStateConsistency(ActualCallState oldState, ActualCallState newState)
-{
-    if (oldState == newState)
-        FAIL(StringFromFormat("State change to the same state: %s.", stringFromState(newState)).asCharString());
-    if (oldState == CALL_FAILED)
-        FAIL("State was already failed. Cannot change state again.");
-}
-
 void MockCheckedActualCall::setState(ActualCallState state)
 {
-    checkStateConsistency(state_, state);
     state_ = state;
 }
 

--- a/tests/CppUTestExt/MockActualCallTest.cpp
+++ b/tests/CppUTestExt/MockActualCallTest.cpp
@@ -62,6 +62,15 @@ TEST(MockCheckedActualCall, unExpectedCall)
     CHECK_EXPECTED_MOCK_FAILURE(expectedFailure);
 }
 
+TEST(MockCheckedActualCall, unExpectedCallWithAParameter)
+{
+    MockCheckedActualCall actualCall(1, reporter, *emptyList);
+    actualCall.withName("unexpected").withParameter("bar", 0);
+
+    MockUnexpectedCallHappenedFailure expectedFailure(mockFailureTest(), "unexpected", *list);
+    CHECK_EXPECTED_MOCK_FAILURE(expectedFailure);
+}
+
 TEST(MockCheckedActualCall, unExpectedParameterName)
 {
     MockCheckedExpectedCall call1;


### PR DESCRIPTION
The issue is that when a call was unexpected and had a parameter it was tripping some error inside of CppUTest.  This caused mock to report two errors, one of which could do nothing but confuse a user.  The code that was causing the extra error was untested and so I removed it with due force and used a simple guard to protect against reporting more than one failure.
