### PR TITLE
SimpleString::StrCmp()

### DIFF
--- a/include/CppUTest/PlatformSpecificFunctions_c.h
+++ b/include/CppUTest/PlatformSpecificFunctions_c.h
@@ -52,7 +52,6 @@ extern const char* (*GetPlatformSpecificTimeString)(void);
 
 /* String operations */
 int PlatformSpecificAtoI(const char*str);
-int PlatformSpecificStrCmp(const char* s1, const char* s2);
 int PlatformSpecificStrNCmp(const char* s1, const char* s2, size_t size);
 char* PlatformSpecificStrStr(const char* s1, const char* s2);
 

--- a/include/CppUTest/SimpleString.h
+++ b/include/CppUTest/SimpleString.h
@@ -90,6 +90,7 @@ public:
     static void setStringAllocator(TestMemoryAllocator* allocator);
 
     static char* allocStringBuffer(size_t size);
+    static int StrCmp(const char* s1, const char* s2);
     static size_t StrLen(const char*);
     static char* StrNCpy(char* s1, const char* s2, size_t n);
     static void deallocStringBuffer(char* str);

--- a/src/CppUTest/MemoryLeakDetector.cpp
+++ b/src/CppUTest/MemoryLeakDetector.cpp
@@ -127,7 +127,7 @@ void MemoryLeakOutputStringBuffer::reportMemoryLeak(MemoryLeakDetectorNode* leak
     outputBuffer_.add("Alloc num (%u) Leak size: %lu Allocated at: %s and line: %d. Type: \"%s\"\n\t Memory: <%p> Content: \"%.15s\"\n",
             leak->number_, (unsigned long) leak->size_, leak->file_, leak->line_, leak->allocator_->alloc_name(), leak->memory_, leak->memory_);
 
-    if (PlatformSpecificStrCmp(leak->allocator_->alloc_name(), "malloc") == 0)
+    if (SimpleString::StrCmp(leak->allocator_->alloc_name(), (const char*) "malloc") == 0)
         giveWarningOnUsingMalloc_ = true;
 }
 

--- a/src/CppUTest/SimpleString.cpp
+++ b/src/CppUTest/SimpleString.cpp
@@ -63,6 +63,16 @@ char* SimpleString::getEmptyString() const
     return empty;
 }
 
+int SimpleString::StrCmp(const char* s1, const char* s2)
+{
+    for(;;)
+    {
+        if (!*s1) return(0 - *s2);
+        if (*s1++ != *s2++)
+            return(*--s1 - *--s2);
+    }
+}
+
 size_t SimpleString::StrLen(const char* str)
 {
     size_t n = (size_t)-1;
@@ -147,7 +157,7 @@ bool SimpleString::endsWith(const SimpleString& other) const
     if (other_buffer_length == 0) return true;
     if (buffer_length == 0) return false;
     if (buffer_length < other_buffer_length) return false;
-    return PlatformSpecificStrCmp(buffer_ + buffer_length - other_buffer_length, other.buffer_) == 0;
+    return StrCmp(buffer_ + buffer_length - other_buffer_length, other.buffer_) == 0;
 }
 
 size_t SimpleString::count(const SimpleString& substr) const
@@ -255,7 +265,7 @@ SimpleString::~SimpleString()
 
 bool operator==(const SimpleString& left, const SimpleString& right)
 {
-    return 0 == PlatformSpecificStrCmp(left.asCharString(), right.asCharString());
+    return 0 == SimpleString::StrCmp(left.asCharString(), right.asCharString());
 }
 
 bool SimpleString::equalsNoCase(const SimpleString& str) const

--- a/src/CppUTest/TestMemoryAllocator.cpp
+++ b/src/CppUTest/TestMemoryAllocator.cpp
@@ -127,7 +127,7 @@ bool TestMemoryAllocator::hasBeenDestroyed()
 
 bool TestMemoryAllocator::isOfEqualType(TestMemoryAllocator* allocator)
 {
-    return PlatformSpecificStrCmp(this->name(), allocator->name()) == 0;
+    return SimpleString::StrCmp(this->name(), allocator->name()) == 0;
 }
 
 char* TestMemoryAllocator::allocMemoryLeakNode(size_t size)

--- a/src/CppUTest/Utest.cpp
+++ b/src/CppUTest/Utest.cpp
@@ -347,7 +347,7 @@ void UtestShell::assertCstrEqual(const char* expected, const char* actual, const
     if (actual == 0 && expected == 0) return;
     if (actual == 0 || expected == 0)
         failWith(StringEqualFailure(this, fileName, lineNumber, expected, actual), testTerminator);
-    if (PlatformSpecificStrCmp(expected, actual) != 0)
+    if (SimpleString::StrCmp(expected, actual) != 0)
         failWith(StringEqualFailure(this, fileName, lineNumber, expected, actual), testTerminator);
 }
 

--- a/src/CppUTestExt/CodeMemoryReportFormatter.cpp
+++ b/src/CppUTestExt/CodeMemoryReportFormatter.cpp
@@ -105,7 +105,7 @@ SimpleString CodeMemoryReportFormatter::createVariableNameFromFileLineInfo(const
 
 bool CodeMemoryReportFormatter::isNewAllocator(TestMemoryAllocator* allocator)
 {
-    return PlatformSpecificStrCmp(allocator->alloc_name(), defaultNewAllocator()->alloc_name()) == 0 || PlatformSpecificStrCmp(allocator->alloc_name(), defaultNewArrayAllocator()->alloc_name()) == 0;
+    return SimpleString::StrCmp(allocator->alloc_name(), defaultNewAllocator()->alloc_name()) == 0 || SimpleString::StrCmp(allocator->alloc_name(), defaultNewArrayAllocator()->alloc_name()) == 0;
 }
 
 bool CodeMemoryReportFormatter::variableExists(const SimpleString& variableName)

--- a/src/CppUTestExt/MockSupport_c.cpp
+++ b/src/CppUTestExt/MockSupport_c.cpp
@@ -327,35 +327,35 @@ MockExpectedCall_c* andReturnConstPointerValue_c(const void* value)
 static MockValue_c getMockValueCFromNamedValue(const MockNamedValue& namedValue)
 {
     MockValue_c returnValue;
-    if (PlatformSpecificStrCmp(namedValue.getType().asCharString(), "int") == 0) {
+    if (SimpleString::StrCmp(namedValue.getType().asCharString(), "int") == 0) {
         returnValue.type = MOCKVALUETYPE_INTEGER;
         returnValue.value.intValue = namedValue.getIntValue();
     }
-    else if (PlatformSpecificStrCmp(namedValue.getType().asCharString(), "unsigned int") == 0) {
+    else if (SimpleString::StrCmp(namedValue.getType().asCharString(), "unsigned int") == 0) {
         returnValue.type = MOCKVALUETYPE_UNSIGNED_INTEGER;
         returnValue.value.unsignedIntValue = namedValue.getUnsignedIntValue();
     }
-    else if (PlatformSpecificStrCmp(namedValue.getType().asCharString(), "long int") == 0) {
+    else if (SimpleString::StrCmp(namedValue.getType().asCharString(), "long int") == 0) {
         returnValue.type = MOCKVALUETYPE_LONG_INTEGER;
         returnValue.value.longIntValue = namedValue.getLongIntValue();
     }
-    else if (PlatformSpecificStrCmp(namedValue.getType().asCharString(), "unsigned long int") == 0) {
+    else if (SimpleString::StrCmp(namedValue.getType().asCharString(), "unsigned long int") == 0) {
         returnValue.type = MOCKVALUETYPE_UNSIGNED_LONG_INTEGER;
         returnValue.value.unsignedLongIntValue = namedValue.getUnsignedLongIntValue();
     }
-    else if (PlatformSpecificStrCmp(namedValue.getType().asCharString(), "double") == 0) {
+    else if (SimpleString::StrCmp(namedValue.getType().asCharString(), "double") == 0) {
         returnValue.type = MOCKVALUETYPE_DOUBLE;
         returnValue.value.doubleValue = namedValue.getDoubleValue();
     }
-    else if (PlatformSpecificStrCmp(namedValue.getType().asCharString(), "const char*") == 0) {
+    else if (SimpleString::StrCmp(namedValue.getType().asCharString(), "const char*") == 0) {
         returnValue.type = MOCKVALUETYPE_STRING;
         returnValue.value.stringValue = namedValue.getStringValue();
     }
-    else if (PlatformSpecificStrCmp(namedValue.getType().asCharString(), "void*") == 0) {
+    else if (SimpleString::StrCmp(namedValue.getType().asCharString(), "void*") == 0) {
         returnValue.type = MOCKVALUETYPE_POINTER;
         returnValue.value.pointerValue = namedValue.getPointerValue();
     }
-    else if (PlatformSpecificStrCmp(namedValue.getType().asCharString(), "const void*") == 0) {
+    else if (SimpleString::StrCmp(namedValue.getType().asCharString(), "const void*") == 0) {
         returnValue.type = MOCKVALUETYPE_CONST_POINTER;
         returnValue.value.constPointerValue = namedValue.getConstPointerValue();
     }

--- a/src/Platforms/C2000/UtestPlatform.cpp
+++ b/src/Platforms/C2000/UtestPlatform.cpp
@@ -127,16 +127,6 @@ int PlatformSpecificAtoI(const char* str)
    return atoi(str);
 }
 
-int PlatformSpecificStrCmp(const char* s1, const char* s2)
-{
-    for(;;)
-    {
-        if (!*s1) return(0 - *s2);
-        if (*s1++ != *s2++)
-            return(*--s1 - *--s2);
-    }
-}
-
 int PlatformSpecificStrNCmp(const char* s1, const char* s2, size_t n)
 {
     unsigned int   ch1, diff;

--- a/src/Platforms/Gcc/UtestPlatform.cpp
+++ b/src/Platforms/Gcc/UtestPlatform.cpp
@@ -139,11 +139,6 @@ int PlatformSpecificAtoI(const char*str)
    return atoi(str);
 }
 
-int PlatformSpecificStrCmp(const char* s1, const char* s2)
-{
-   return strcmp(s1, s2);
-}
-
 int PlatformSpecificStrNCmp(const char* s1, const char* s2, size_t size)
 {
    return strncmp(s1, s2, size);

--- a/src/Platforms/GccNoStdC/UtestPlatform.cpp
+++ b/src/Platforms/GccNoStdC/UtestPlatform.cpp
@@ -76,14 +76,6 @@ int PlatformSpecificAtoI(const char*str)
     return 0;
 }
 
-int PlatformSpecificStrCmp(const char* s1, const char* s2)
-{
-    /* To be implemented */
-    (void) s1;
-    (void) s2;
-    return 0;
-}
-
 int PlatformSpecificStrNCmp(const char* s1, const char* s2, size_t size)
 {
     /* To be implemented */

--- a/src/Platforms/Iar/UtestPlatform.cpp
+++ b/src/Platforms/Iar/UtestPlatform.cpp
@@ -105,11 +105,6 @@ int PlatformSpecificAtoI(const char*str)
     return atoi(str);
 }
 
-int PlatformSpecificStrCmp(const char* s1, const char* s2)
-{
-    return strcmp(s1, s2);
-}
-
 int PlatformSpecificStrNCmp(const char* s1, const char* s2, size_t size)
 {
     return strncmp(s1, s2, size);

--- a/src/Platforms/Symbian/UtestPlatform.cpp
+++ b/src/Platforms/Symbian/UtestPlatform.cpp
@@ -109,10 +109,6 @@ char* PlatformSpecificStrStr(const char* s1, const char* s2) {
     return strstr(s1, s2);
 }
 
-int PlatformSpecificStrCmp(const char* s1, const char* s2) {
-    return strcmp(s1, s2);
-}
-
 int PlatformSpecificStrNCmp(const char* s1, const char* s2, size_t size) {
     return strncmp(s1, s2, size);
 }

--- a/src/Platforms/VisualCpp/UtestPlatform.cpp
+++ b/src/Platforms/VisualCpp/UtestPlatform.cpp
@@ -87,11 +87,6 @@ int PlatformSpecificAtoI(const char*str)
    return atoi(str);
 }
 
-int PlatformSpecificStrCmp(const char* s1, const char* s2)
-{
-   return strcmp(s1, s2);
-}
-
 int PlatformSpecificStrNCmp(const char* s1, const char* s2, size_t size)
 {
    return strncmp(s1, s2, size);

--- a/src/Platforms/armcc/UtestPlatform.cpp
+++ b/src/Platforms/armcc/UtestPlatform.cpp
@@ -108,11 +108,6 @@ int PlatformSpecificAtoI(const char* str)
     return atoi(str);
 }
 
-int PlatformSpecificStrCmp(const char* s1, const char* s2)
-{
-    return strcmp(s1, s2);
-}
-
 int PlatformSpecificStrNCmp(const char* s1, const char* s2, size_t size)
 {
     return strncmp(s1, s2, size);


### PR DESCRIPTION
Moved to SimpleString from PlatformSpecificStrCmp().

Any specific test cases we should add, in addition to being tested indirectly through existing tests?
