### PR TITLE
Forward declaration for when PlatformSpecificFunctions.h is used stand-alone.

### DIFF
--- a/include/CppUTest/PlatformSpecificFunctions.h
+++ b/include/CppUTest/PlatformSpecificFunctions.h
@@ -31,6 +31,7 @@
 #include "CppUTest/TestOutput.h"
 TestOutput::WorkingEnvironment PlatformSpecificGetWorkingEnvironment();
 
+class TestPlugin;
 void PlatformSpecificRunTestInASeperateProcess(UtestShell* shell, TestPlugin* plugin, TestResult* result);
 
 /* Platform specific interface we use in order to minimize dependencies with LibC.


### PR DESCRIPTION
I found this by accident...
