### PR TITLE
Bringing README_InstallCppUTest.txt uptodate

### DIFF
--- a/README_InstallCppUTest.txt
+++ b/README_InstallCppUTest.txt
@@ -8,10 +8,10 @@
 2. Build CppUTest and examples
 
 2a. For unix/gcc (including cygwin)
- > cd <someDirectory>/CppUTest
- > configure
+ > cd <someDirectory>/CppUTest/cpputest_build
+ > ../configure
  > make
- > make check (This is to run the CppUTest unit tests)
+ > make tdd   # This is to run the CppUTest unit tests
   
 2b. For Microsoft Visual C++ V6
  Double click <someDirectory>/CppUTest/CppUTest.dsw


### PR DESCRIPTION
Obviously, the instructions here are for users of a release archive. I just fixed the build directory and what is obviously wrong.

How do we package instructions for potential contributors who want to build from a clone?

I think this Readme is cracking at the seems a bit because of all the different possibilities it covers. I am hesitant to add yet another one (and then, there is Eclipse, too).

Also, it is lacking

```
> make install   # for Linux and possibly Cygwin
```

Finally, why would I run make separately, unless I don't want to run the tests?

Suggestions? Maybe list the make targets with a brief description of what they do?
