### PR TITLE
Files to purge item in .travis_github_deployer.yml 

### DIFF
--- a/.travis_github_deployer.yml
+++ b/.travis_github_deployer.yml
@@ -2,9 +2,9 @@ destination_repository: https://github.com/cpputest/cpputest.github.io.git
 
 files_to_deploy:
   cpputest_build/unit_test_report/*: unit_test_report
-  cpputest_build/cpputest-3.7dev.tar.gz: releases
-  cpputest_build/cpputest-3.7dev.zip: releases
-
-files_to_purge_from_history:
-  *dev.tar.gz
-  *dev.zip
+  cpputest_build/cpputest-3.7dev.tar.gz:
+    destination: releases
+    purge: yes
+  cpputest_build/cpputest-3.7dev.zip:
+    destination: releases
+    purge: yes


### PR DESCRIPTION
The new yml format. Purging history not functional; will work as before.
Should be merged with the corresponding pull on travis_github_deployer.
