### PR TITLE
[WIP] Remove old c style casts

### DIFF
--- a/src/CppUTest/JUnitTestOutput.cpp
+++ b/src/CppUTest/JUnitTestOutput.cpp
@@ -167,7 +167,7 @@ void JUnitTestOutput::writeTestSuiteSummery()
                             impl_->results_.failureCount_,
                             impl_->results_.group_.asCharString(),
                             impl_->results_.testCount_,
-                            (int) (impl_->results_.groupExecTime_ / 1000), (int) (impl_->results_.groupExecTime_ % 1000),
+                            static_cast<int>(impl_->results_.groupExecTime_ / 1000), static_cast<int>(impl_->results_.groupExecTime_ % 1000),
                             GetPlatformSpecificTimeString());
     writeToFile(buf.asCharString());
 }
@@ -187,7 +187,7 @@ void JUnitTestOutput::writeTestCases()
                 impl_->package_.asCharString(),
                 impl_->package_.isEmpty() == true ? "" : ".",
                 impl_->results_.group_.asCharString(),
-                cur->name_.asCharString(), (int) (cur->execTime_ / 1000), (int)(cur->execTime_ % 1000));
+                cur->name_.asCharString(), static_cast<int>(cur->execTime_ / 1000), static_cast<int>(cur->execTime_ % 1000));
         writeToFile(buf.asCharString());
 
         if (cur->failure_) {

--- a/src/CppUTest/MemoryLeakWarningPlugin.cpp
+++ b/src/CppUTest/MemoryLeakWarningPlugin.cpp
@@ -42,13 +42,13 @@ static void* mem_leak_malloc(size_t size, const char* file, int line)
 
 static void mem_leak_free(void* buffer, const char* file, int line)
 {
-    MemoryLeakWarningPlugin::getGlobalDetector()->invalidateMemory((char*) buffer);
-    MemoryLeakWarningPlugin::getGlobalDetector()->deallocMemory(getCurrentMallocAllocator(), (char*) buffer, file, line, true);
+    MemoryLeakWarningPlugin::getGlobalDetector()->invalidateMemory(static_cast<char*>(buffer));
+    MemoryLeakWarningPlugin::getGlobalDetector()->deallocMemory(getCurrentMallocAllocator(), static_cast<char*>(buffer), file, line, true);
 }
 
 static void* mem_leak_realloc(void* memory, size_t size, const char* file, int line)
 {
-    return MemoryLeakWarningPlugin::getGlobalDetector()->reallocMemory(getCurrentMallocAllocator(), (char*) memory, size, file, line, true);
+    return MemoryLeakWarningPlugin::getGlobalDetector()->reallocMemory(getCurrentMallocAllocator(), static_cast<char*>(memory), size, file, line, true);
 }
 
 #endif
@@ -118,7 +118,7 @@ static void* mem_leak_operator_new_nothrow (size_t size) UT_NOTHROW
 
 static void* mem_leak_operator_new_debug (size_t size, const char* file, int line) UT_THROW(std::bad_alloc)
 {
-    void *memory = MemoryLeakWarningPlugin::getGlobalDetector()->allocMemory(getCurrentNewAllocator(), size, (char*) file, line);
+    void *memory = MemoryLeakWarningPlugin::getGlobalDetector()->allocMemory(getCurrentNewAllocator(), size, const_cast<char*>(file), line);
     UT_THROW_BAD_ALLOC_WHEN_NULL(memory);
     return memory;
 }
@@ -137,21 +137,21 @@ static void* mem_leak_operator_new_array_nothrow (size_t size) UT_NOTHROW
 
 static void* mem_leak_operator_new_array_debug (size_t size, const char* file, int line) UT_THROW(std::bad_alloc)
 {
-    void* memory = MemoryLeakWarningPlugin::getGlobalDetector()->allocMemory(getCurrentNewArrayAllocator(), size, (char*) file, line);
+    void* memory = MemoryLeakWarningPlugin::getGlobalDetector()->allocMemory(getCurrentNewArrayAllocator(), size, const_cast<char*>(file), line);
     UT_THROW_BAD_ALLOC_WHEN_NULL(memory);
     return memory;
 }
 
 static void mem_leak_operator_delete (void* mem) UT_NOTHROW
 {
-    MemoryLeakWarningPlugin::getGlobalDetector()->invalidateMemory((char*) mem);
-    MemoryLeakWarningPlugin::getGlobalDetector()->deallocMemory(getCurrentNewAllocator(), (char*) mem);
+    MemoryLeakWarningPlugin::getGlobalDetector()->invalidateMemory(static_cast<char*>(mem));
+    MemoryLeakWarningPlugin::getGlobalDetector()->deallocMemory(getCurrentNewAllocator(), static_cast<char*>(mem));
 }
 
 static void mem_leak_operator_delete_array (void* mem) UT_NOTHROW
 {
-    MemoryLeakWarningPlugin::getGlobalDetector()->invalidateMemory((char*) mem);
-    MemoryLeakWarningPlugin::getGlobalDetector()->deallocMemory(getCurrentNewArrayAllocator(), (char*) mem);
+    MemoryLeakWarningPlugin::getGlobalDetector()->invalidateMemory(static_cast<char*>(mem));
+    MemoryLeakWarningPlugin::getGlobalDetector()->deallocMemory(getCurrentNewArrayAllocator(), static_cast<char*>(mem));
 }
 
 static void* normal_operator_new (size_t size) UT_THROW(std::bad_alloc)

--- a/src/CppUTest/SimpleString.cpp
+++ b/src/CppUTest/SimpleString.cpp
@@ -82,12 +82,12 @@ int SimpleString::StrCmp(const char* s1, const char* s2)
 {
    while(*s1 && *s1 == *s2)
        s1++, s2++;
-   return *(unsigned char *) s1 - *(unsigned char *) s2;
+   return *reinterpret_cast<unsigned char *>(const_cast<char *>(s1)) - *reinterpret_cast<unsigned char *>(const_cast<char *>(s2));
 }
 
 size_t SimpleString::StrLen(const char* str)
 {
-    size_t n = (size_t)-1;
+    size_t n = static_cast<size_t>(-1);
     do n++; while (*str++);
     return n;
 }
@@ -97,7 +97,7 @@ int SimpleString::StrNCmp(const char* s1, const char* s2, size_t n)
     while (n && *s1 && *s1 == *s2) {
         n--, s1++, s2++;
     }
-    return n ? *(unsigned char *) s1 - *(unsigned char *) s2 : 0;
+    return n ? *reinterpret_cast<unsigned char *>(const_cast<char *>(s1)) - *reinterpret_cast<unsigned char *>(const_cast<char *>(s2)) : 0;
 }
 
 char* SimpleString::StrNCpy(char* s1, const char* s2, size_t n)
@@ -113,16 +113,16 @@ char* SimpleString::StrNCpy(char* s1, const char* s2, size_t n)
 
 char* SimpleString::StrStr(const char* s1, const char* s2)
 {
-    if(!*s2) return (char*) s1;
+    if(!*s2) return const_cast<char*>(s1);
     for (; *s1; s1++)
         if (StrNCmp(s1, s2, StrLen(s2)) == 0)
-            return (char*) s1;
+            return const_cast<char*>(s1);
     return NULL;
 }
 
 char SimpleString::ToLower(char ch)
 {
-    return isUpper(ch) ? (char)((int)ch + ('a' - 'A')) : ch;
+    return isUpper(ch) ? static_cast<char>((static_cast<int>(ch) + ('a' - 'A'))) : ch;
 }
 
 SimpleString::SimpleString(const char *otherBuffer)
@@ -212,7 +212,7 @@ void SimpleString::split(const SimpleString& delimiter, SimpleStringCollection& 
     for (size_t i = 0; i < num; ++i) {
         prev = str;
         str = StrStr(str, delimiter.buffer_) + 1;
-        size_t len = (size_t) (str - prev) + 1;
+        size_t len = static_cast<size_t>(str - prev) + 1;
         col[i].buffer_ = copyToNewBuffer(prev, len);
     }
     if (extraEndToken) {
@@ -372,7 +372,7 @@ int SimpleString::findFrom(size_t starting_position, char ch) const
 {
     size_t length = size();
     for (size_t i = starting_position; i < length; i++)
-        if (buffer_[i] == ch) return (int) i;
+        if (buffer_[i] == ch) return static_cast<int>(i);
     return -1;
 }
 
@@ -381,10 +381,10 @@ SimpleString SimpleString::subStringFromTill(char startChar, char lastExcludedCh
     int beginPos = find(startChar);
     if (beginPos < 0) return "";
 
-    int endPos = findFrom((size_t)beginPos, lastExcludedChar);
-    if (endPos == -1) return subString((size_t)beginPos, size());
+    int endPos = findFrom(static_cast<size_t>(beginPos), lastExcludedChar);
+    if (endPos == -1) return subString(static_cast<size_t>(beginPos), size());
 
-    return subString((size_t)beginPos, (size_t) (endPos - beginPos));
+    return subString(static_cast<size_t>(beginPos), static_cast<size_t>(endPos - beginPos));
 }
 
 char* SimpleString::copyToNewBuffer(const char* bufferToCopy, size_t bufferSize)
@@ -469,7 +469,7 @@ static long convertPointerToLongValue(const void* value)
      * This isn't the right way to convert pointers values and need to change by implementing a
      * proper portable way to convert pointers to strings.
      */
-    long* long_value = (long*) &value;
+    long* long_value = reinterpret_cast<long*>(&value);
     return *long_value;
 }
 
@@ -541,7 +541,7 @@ SimpleString VStringFromFormat(const char* format, va_list args)
     char defaultBuffer[sizeOfdefaultBuffer];
     SimpleString resultString;
 
-    size_t size = (size_t)PlatformSpecificVSNprintf(defaultBuffer, sizeOfdefaultBuffer, format, args);
+    size_t size = static_cast<size_t>(PlatformSpecificVSNprintf(defaultBuffer, sizeOfdefaultBuffer, format, args));
     if (size < sizeOfdefaultBuffer) {
         resultString = SimpleString(defaultBuffer);
     }

--- a/src/CppUTest/TestFailure.cpp
+++ b/src/CppUTest/TestFailure.cpp
@@ -34,7 +34,7 @@
 static SimpleString removeAllPrintableCharactersFrom(const SimpleString& str)
 {
     size_t bufferSize = str.size()+1;
-    char* buffer = (char*) PlatformSpecificMalloc(bufferSize);
+    char* buffer = static_cast<char*>(PlatformSpecificMalloc(bufferSize));
     str.copyToBuffer(buffer, bufferSize);
 
     for (size_t i = 0; i < bufferSize-1; i++)
@@ -49,7 +49,7 @@ static SimpleString removeAllPrintableCharactersFrom(const SimpleString& str)
 static SimpleString addMarkerToString(const SimpleString& str, int markerPos)
 {
     size_t bufferSize = str.size()+1;
-    char* buffer = (char*) PlatformSpecificMalloc(bufferSize);
+    char* buffer = static_cast<char*>(PlatformSpecificMalloc(bufferSize));
     str.copyToBuffer(buffer, bufferSize);
 
     buffer[markerPos] = '^';
@@ -138,7 +138,7 @@ SimpleString TestFailure::createDifferenceAtPosString(const SimpleString& actual
 
     SimpleString paddingForPreventingOutOfBounds (" ", halfOfExtraCharactersWindow);
     SimpleString actualString = paddingForPreventingOutOfBounds + actual + paddingForPreventingOutOfBounds;
-    SimpleString differentString = StringFromFormat("difference starts at position %lu at: <", (unsigned long) position);
+    SimpleString differentString = StringFromFormat("difference starts at position %lu at: <", static_cast<unsigned long>(position));
 
     result += "\n";
     result += StringFromFormat("\t%s%s>\n", differentString.asCharString(), actualString.subString(position, extraCharactersWindow).asCharString());

--- a/src/CppUTest/TestHarness_c.cpp
+++ b/src/CppUTest/TestHarness_c.cpp
@@ -37,7 +37,7 @@ extern "C"
 
 void CHECK_EQUAL_C_INT_LOCATION(int expected, int actual, const char* fileName, int lineNumber)
 {
-    UtestShell::getCurrent()->assertLongsEqual((long)expected, (long)actual,  fileName, lineNumber, TestTerminatorWithoutExceptions());
+    UtestShell::getCurrent()->assertLongsEqual(static_cast<long>(expected), static_cast<long>(actual),  fileName, lineNumber, TestTerminatorWithoutExceptions());
 }
 
 void CHECK_EQUAL_C_REAL_LOCATION(double expected, double actual, double threshold, const char* fileName, int lineNumber)

--- a/src/CppUTest/TestMemoryAllocator.cpp
+++ b/src/CppUTest/TestMemoryAllocator.cpp
@@ -32,7 +32,7 @@
 
 static char* checkedMalloc(size_t size)
 {
-    char* mem = (char*) PlatformSpecificMalloc(size);
+    char* mem = static_cast<char*>(PlatformSpecificMalloc(size));
     if (mem == 0)
     FAIL("malloc returned null pointer");
     return mem;

--- a/src/CppUTest/TestPlugin.cpp
+++ b/src/CppUTest/TestPlugin.cpp
@@ -147,7 +147,7 @@ void CppUTestStore(void**function)
 void SetPointerPlugin::postTestAction(UtestShell& /*test*/, TestResult& /*result*/)
 {
     for (int i = pointerTableIndex - 1; i >= 0; i--)
-        *((void**) setlist[i].orig) = setlist[i].orig_value;
+        *static_cast<void**>(setlist[i].orig) = setlist[i].orig_value;
     pointerTableIndex = 0;
 }
 

--- a/src/CppUTest/Utest.cpp
+++ b/src/CppUTest/Utest.cpp
@@ -81,17 +81,17 @@ extern "C" {
 
     static void helperDoTestSetup(void* data)
     {
-        ((Utest*)data)->setup();
+        (static_cast<Utest*>(data))->setup();
     }
 
     static void helperDoTestBody(void* data)
     {
-        ((Utest*)data)->testBody();
+        (static_cast<Utest*>(data))->testBody();
     }
 
     static void helperDoTestTeardown(void* data)
     {
-        ((Utest*)data)->teardown();
+        (static_cast<Utest*>(data))->teardown();
     }
 
     struct HelperTestRunInfo
@@ -105,7 +105,7 @@ extern "C" {
 
     static void helperDoRunOneTestInCurrentProcess(void* data)
     {
-        HelperTestRunInfo* runInfo = (HelperTestRunInfo*) data;
+        HelperTestRunInfo* runInfo = static_cast<HelperTestRunInfo*>(data);
 
         UtestShell* shell = runInfo->shell_;
         TestPlugin* plugin = runInfo->plugin_;
@@ -116,7 +116,7 @@ extern "C" {
 
     static void helperDoRunOneTestSeperateProcess(void* data)
     {
-        HelperTestRunInfo* runInfo = (HelperTestRunInfo*) data;
+        HelperTestRunInfo* runInfo = static_cast<HelperTestRunInfo*>(data);
 
         UtestShell* shell = runInfo->shell_;
         TestPlugin* plugin = runInfo->plugin_;
@@ -149,7 +149,7 @@ UtestShell::~UtestShell()
 
 static void defaultCrashMethod()
 {
-    UtestShell* ptr = (UtestShell*) 0x0; ptr->countTests();
+    UtestShell* ptr = static_cast<UtestShell*>(0x0); ptr->countTests();
 }
 
 static void (*pleaseCrashMeRightNow) () = defaultCrashMethod;

--- a/src/Platforms/Gcc/UtestPlatform.cpp
+++ b/src/Platforms/Gcc/UtestPlatform.cpp
@@ -119,7 +119,7 @@ static long TimeInMillisImplementation()
     struct timeval tv;
     struct timezone tz;
     gettimeofday(&tv, &tz);
-    return (tv.tv_sec * 1000) + (long)((double)tv.tv_usec * 0.001);
+    return (tv.tv_sec * 1000) + static_cast<long>(static_cast<double>(tv.tv_usec) * 0.001);
 }
 
 long (*GetPlatformSpecificTimeInMillis)() = TimeInMillisImplementation;
@@ -153,12 +153,12 @@ PlatformSpecificFile PlatformSpecificFOpen(const char* filename, const char* fla
 
 void PlatformSpecificFPuts(const char* str, PlatformSpecificFile file)
 {
-   fputs(str, (FILE*)file);
+   fputs(str, static_cast<FILE*>(file));
 }
 
 void PlatformSpecificFClose(PlatformSpecificFile file)
 {
-   fclose((FILE*)file);
+   fclose(static_cast<FILE*>(file));
 }
 
 void PlatformSpecificFlush()
@@ -204,7 +204,7 @@ double PlatformSpecificFabs(double d)
 
 static int IsNanImplementation(double d)
 {
-    return isnan((float)d);
+    return isnan(static_cast<float>(d));
 }
 
 int (*PlatformSpecificIsNan)(double) = IsNanImplementation;
@@ -216,22 +216,22 @@ static PlatformSpecificMutex PThreadMutexCreate(void)
     
     pthread_mutex_init(mutex, NULL);
     
-    return (PlatformSpecificMutex)mutex;
+    return static_cast<PlatformSpecificMutex>(mutex);
 }
 
 static void PThreadMutexLock(PlatformSpecificMutex mtx)
 {
-    pthread_mutex_lock((pthread_mutex_t *)mtx);
+    pthread_mutex_lock(static_cast<pthread_mutex_t *>(mtx));
 }
 
 static void PThreadMutexUnlock(PlatformSpecificMutex mtx)
 {
-    pthread_mutex_unlock((pthread_mutex_t *)mtx);
+    pthread_mutex_unlock(static_cast<pthread_mutex_t *>(mtx));
 }
 
 static void PThreadMutexDestroy(PlatformSpecificMutex mtx)
 {
-    pthread_mutex_t *mutex = (pthread_mutex_t *)mtx;
+    pthread_mutex_t *mutex = static_cast<pthread_mutex_t *>(mtx);
     pthread_mutex_destroy(mutex);
     delete mutex;
 }


### PR DESCRIPTION
The Apple clang 4.0 seems to include Wold-style-cast in Weverything.
A lot of old c style casts like `(int)var` resides in CppUTest, producing Wold-style-cast.
Since Werror is given, CppUTest cannot be built on at least my Mac OS X Mavericks.

To remove Wold-style-cast, the old c style casts should be replaced with c++ style casts like `static_cast<int>(var)`.
Renewing existing casts is a hard task because there is no way to do automatically.
Therefore, please tell me whether this casting renewal is acceptable.

Thanks.
