### PR TITLE
Silence -Wold-style-cast to build with Apple clang 4.0

### DIFF
--- a/cmake/Modules/CppUTestWarningFlags.cmake
+++ b/cmake/Modules/CppUTestWarningFlags.cmake
@@ -34,7 +34,6 @@ else (MSVC)
         Wsign-conversion
         Wno-padded
         Wno-disabled-macro-expansion
-        Wno-old-style-cast
         )
 
     if (NOT GMOCK AND NOT REAL_GTEST)
@@ -51,6 +50,7 @@ else (MSVC)
         Wno-global-constructors
         Wno-exit-time-destructors
         Wno-weak-vtables
+        Wno-old-style-cast
         )
 
     check_and_append_c_warning_flags(${WARNING_C_FLAGS})


### PR DESCRIPTION
Avoiding to use C++ style casts to keep backward compatibility.
