### PR TITLE
Fix 'unused parameter' warnings

### DIFF
--- a/src/Platforms/GccNoStdC/UtestPlatform.cpp
+++ b/src/Platforms/GccNoStdC/UtestPlatform.cpp
@@ -190,16 +190,19 @@ static PlatformSpecificMutex DummyMutexCreate(void)
 
 static void DummyMutexLock(PlatformSpecificMutex mtx)
 {
+    (void)mtx;
     FAIL("PlatformSpecificMutexLock is not implemented");
 }
 
 static void DummyMutexUnlock(PlatformSpecificMutex mtx)
 {
+    (void)mtx;
     FAIL("PlatformSpecificMutexUnlock is not implemented");
 }
 
 static void DummyMutexDestroy(PlatformSpecificMutex mtx)
 {
+    (void)mtx;
     FAIL("PlatformSpecificMutexDestroy is not implemented");
 }
 


### PR DESCRIPTION
in src/Platforms/GccNoStdC.
