### PR TITLE
Fix setting of CPPUTEST_HOME.

### DIFF
--- a/scripts/InstallScripts.sh
+++ b/scripts/InstallScripts.sh
@@ -1,5 +1,10 @@
 #!/bin/bash -x
-CPPUTEST_HOME=$(pwd)/..
+FirstLetter=${0:0:1}
+if [[ $FirstLetter == "/" ]] ;  then
+	CPPUTEST_HOME=${0%/scripts/*}
+else
+	CPPUTEST_HOME="$(pwd)/${0%/scripts/*}"
+fi
 
 EXE_DIR=${EXE_DIR:-/usr/local/bin}
 test -f ${EXE_DIR} || mkdir -p ${EXE_DIR}


### PR DESCRIPTION
Before CPPUTEST_HOME was set using "$(pwd)/..", which creates
a bad link. Now CPPUTEST_HOME is set without using .. which
allows for a successful link.
