### PR TITLE
Adding call-checking when tracing is on.

### DIFF
--- a/include/CppUTestExt/MockCheckedActualCall.h
+++ b/include/CppUTestExt/MockCheckedActualCall.h
@@ -103,6 +103,10 @@ protected:
     };
     virtual const char* stringFromState(ActualCallState state);
     virtual void setState(ActualCallState state);
+    ActualCallState getState() { return state_; }
+    void setFulfilledExpectation( MockCheckedExpectedCall *expectation ) { fulfilledExpectation_ = expectation; }
+    MockExpectedCallsList *getUnfulfilledExpectations() { return &unfulfilledExpectations_; }
+    const MockExpectedCallsList& getAllExpectations() { return allExpectations_; }
 
 private:
     SimpleString functionName_;
@@ -188,6 +192,42 @@ private:
     SimpleString traceBuffer_;
 
     void addParameterName(const SimpleString& name);
+};
+
+class MockCheckedActualCallTrace : public MockCheckedActualCall
+{
+public:
+	MockCheckedActualCallTrace(int callOrder, MockFailureReporter* reporter, const MockExpectedCallsList& expectations);
+    virtual ~MockCheckedActualCallTrace();
+
+    virtual MockActualCall& withName(const SimpleString&) _override;
+    virtual MockActualCall& withCallOrder(int) _override;
+    virtual MockActualCall& withIntParameter(const SimpleString&, int) _override;
+    virtual MockActualCall& withUnsignedIntParameter(const SimpleString&, unsigned int) _override;
+    virtual MockActualCall& withLongIntParameter(const SimpleString&, long int) _override;
+    virtual MockActualCall& withUnsignedLongIntParameter(const SimpleString&, unsigned long int) _override;
+    virtual MockActualCall& withDoubleParameter(const SimpleString&, double) _override;
+    virtual MockActualCall& withStringParameter(const SimpleString&, const char*) _override;
+    virtual MockActualCall& withPointerParameter(const SimpleString& , void*) _override;
+    virtual MockActualCall& withConstPointerParameter(const SimpleString& , const void*) _override;
+    virtual MockActualCall& withParameterOfType(const SimpleString&, const SimpleString&, const void*) _override;
+    virtual MockActualCall& withOutputParameter(const SimpleString&, void*) _override;
+
+    static const char* getTraceOutput();
+    static void clearTraceOutput();
+
+    virtual void checkExpectations();
+
+protected:
+    virtual void failTest(const MockFailure& failure);
+
+private:
+    static SimpleString traceBuffer_;
+    static SimpleString testName_;
+    MockFailureReporter* reporter_; // Need own copy to use for generating trace messages.
+
+    void addParameterName(const SimpleString& name);
+    void announceTestIfNew();
 };
 
 class MockIgnoredActualCall: public MockActualCall

--- a/src/CppUTestExt/MockNamedValue.cpp
+++ b/src/CppUTestExt/MockNamedValue.cpp
@@ -37,7 +37,7 @@ void MockNamedValue::setDefaultComparatorRepository(MockNamedValueComparatorRepo
     defaultRepository_ = repository;
 }
 
-MockNamedValue::MockNamedValue(const SimpleString& name) : name_(name), type_("int"), comparator_(NULL)
+MockNamedValue::MockNamedValue(const SimpleString& name) : name_(name), type_("int"), size_(sizeof(int)), comparator_(NULL)
 {
     value_.intValue_ = 0;
 }

--- a/src/CppUTestExt/MockSupport.cpp
+++ b/src/CppUTestExt/MockSupport.cpp
@@ -111,6 +111,7 @@ void MockSupport::clear()
 
     tracing_ = false;
     MockActualCallTrace::instance().clear();
+    MockCheckedActualCallTrace::clearTraceOutput();
 
     expectations_.deleteAllExpectationsAndClearList();
     compositeCalls_.clear();
@@ -158,7 +159,11 @@ MockExpectedCall& MockSupport::expectNCalls(int amount, const SimpleString& func
 
 MockCheckedActualCall* MockSupport::createActualFunctionCall()
 {
-    lastActualFunctionCall_ = new MockCheckedActualCall(++callOrder_, activeReporter_, expectations_);
+	if (tracing_)
+		lastActualFunctionCall_ = new MockCheckedActualCallTrace(++callOrder_, activeReporter_, expectations_);
+	else
+		lastActualFunctionCall_ = new MockCheckedActualCall(++callOrder_, activeReporter_, expectations_);
+
     return lastActualFunctionCall_;
 }
 
@@ -171,8 +176,6 @@ MockActualCall& MockSupport::actualCall(const SimpleString& functionName)
     }
 
     if (!enabled_) return MockIgnoredActualCall::instance();
-    if (tracing_) return MockActualCallTrace::instance().withName(functionName);
-
 
     if (!expectations_.hasExpectationWithName(functionName) && ignoreOtherCalls_) {
         return MockIgnoredActualCall::instance();
@@ -217,7 +220,7 @@ void MockSupport::tracing(bool enabled)
 
 const char* MockSupport::getTraceOutput()
 {
-    return MockActualCallTrace::instance().getTraceOutput();
+    return MockCheckedActualCallTrace::getTraceOutput();
 }
 
 bool MockSupport::expectedCallsLeft()


### PR DESCRIPTION
Added an alternative tracing class, MockCheckedActualCallTrace, derived
from MockCheckedActualCall. (The class, MockActualCallTrace, is still
present, but its use with the tracing feature is disabled.) Access to a
few attributes of MockCheckedActualCall were given to the new class
through protected methods, to support the feature.

The MockSupport class was modified to use the new trace class in place
of the former one.

Tests in MockSupportTest.cpp were enhanced to cover the tracing feature
more completely.

A small correction to MockNamedValue (completing initialization) was
done; as far as I know this is not related to the tracing feature, but was found
during code analysis and appeared to be generally beneficial.
