### PR TITLE
not for merging - erroneous

### DIFF
--- a/examples/AllTests/HelloStub.c
+++ b/examples/AllTests/HelloStub.c
@@ -3,5 +3,5 @@
 
 void printHelloWorld()
 {
-    printf("dlroW olleH!\n");
+    PrintFormated("Stub the World!\n");
 }

--- a/examples/AllTests/HelloTest.cpp
+++ b/examples/AllTests/HelloTest.cpp
@@ -56,5 +56,5 @@ void teardown()
 TEST(HelloWorld, PrintOk)
 {
     printHelloWorld();
-    STRCMP_EQUAL("Hello World!\n", buffer->asCharString());
+    STRCMP_EQUAL("Stub the World!\n", buffer->asCharString());
 }

--- a/examples/ApplicationLib/hello.h
+++ b/examples/ApplicationLib/hello.h
@@ -32,7 +32,7 @@
 extern "C" {
 #endif
 
-extern void printHelloWorld(void);
+__attribute__((weak)) extern void printHelloWorld(void);
 
 extern int (*PrintFormated)(const char*, ...);
 


### PR DESCRIPTION
Her my quick and dirty attempt to use linker substitution fails both in GCC and in VS2008.

This is the linker command line:

g++.exe -Lcpputest/lib -Lcpputest/lib -L. -o AllTests.exe out/cpputest/examples/AllTests/AllTests.o out/cpputest/examples/AllTests/CircularBufferTest.o out/cpputest/examples/AllTests/EventDispatcherTest.o out/cpputest/examples/AllTests/HelloTest.o out/cpputest/examples/AllTests/MockDocumentationTest.o out/cpputest/examples/AllTests/PrinterTest.o out/cpputest/src/CppUTestExt/MockActualCall.o out/cpputest/src/CppUTestExt/MockExpectedCall.o   -lCppUTest -lCppUTestExt -lApplicationLib

./libApplicationLib.a(hello.o): In function `printHelloWorld':
C:/data/00_Dev/05_CppUTest/cpputest/examples/ApplicationLib/hello.c:32: multiple definition of`printHelloWorld'

It was my understanding that the linker should only take the offending function from ApplicationLib if it wasn't defined already?
