### PR TITLE
Eliminate unintentional recursion for MinGW as well.

### DIFF
--- a/src/Platforms/Gcc/UtestPlatform.cpp
+++ b/src/Platforms/Gcc/UtestPlatform.cpp
@@ -55,7 +55,7 @@ void PlatformSpecificRunTestInASeperateProcess(UtestShell* shell, TestPlugin* pl
 {
 #ifdef __MINGW32__
    printf("-p doesn't work on MinGW as it is lacking fork. Running inside the process\b");
-   shell->runOneTest(plugin, *result);
+   shell->runOneTestInCurrentProcess(plugin, *result);
 #else
 
    int info;


### PR DESCRIPTION
This bug leads to mysterious failure with passing tests, among other problems.
