### PR TITLE
Added support for outputting skipped tests to junit

### DIFF
--- a/include/CppUTest/TestResult.h
+++ b/include/CppUTest/TestResult.h
@@ -59,7 +59,6 @@ public:
     virtual void countIgnored();
     virtual void addFailure(const TestFailure& failure);
     virtual void print(const char* text);
-    virtual void setProgressIndicator(const char*);
 
     int getTestCount() const
     {

--- a/include/CppUTest/Utest.h
+++ b/include/CppUTest/Utest.h
@@ -101,7 +101,7 @@ public:
     virtual SimpleString getFormattedName() const;
     const SimpleString getFile() const;
     int getLineNumber() const;
-    virtual const char *getProgressIndicator() const;
+    virtual bool willRun() const;
     virtual bool hasFailed() const;
 
     virtual void assertTrue(bool condition, const char *checkString, const char *conditionString, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
@@ -216,7 +216,7 @@ public:
     virtual ~IgnoredUtestShell();
     explicit IgnoredUtestShell(const char* groupName, const char* testName,
             const char* fileName, int lineNumber);
-    virtual const char* getProgressIndicator() const;
+    virtual bool willRun() const;
     protected:  virtual SimpleString getMacroName() const _override;
     virtual void runOneTest(TestPlugin* plugin, TestResult& result) _override;
 

--- a/src/CppUTest/JUnitTestOutput.cpp
+++ b/src/CppUTest/JUnitTestOutput.cpp
@@ -136,7 +136,7 @@ void JUnitTestOutput::printCurrentTestStarted(const UtestShell& test)
         impl_->results_.tail_ = impl_->results_.tail_->next_;
     }
     impl_->results_.tail_->name_ = test.getName();
-    if (*(test.getProgressIndicator()) == '!') {
+    if (!test.willRun()) {
         impl_->results_.tail_->ignored_ = true;
     }
 }

--- a/src/CppUTest/JUnitTestOutput.cpp
+++ b/src/CppUTest/JUnitTestOutput.cpp
@@ -34,13 +34,14 @@
 struct JUnitTestCaseResultNode
 {
     JUnitTestCaseResultNode() :
-        execTime_(0), failure_(0), next_(0)
+        execTime_(0), failure_(0), ignored_(false), next_(0)
     {
     }
 
     SimpleString name_;
     long execTime_;
     TestFailure* failure_;
+    bool ignored_;
     JUnitTestCaseResultNode* next_;
 };
 
@@ -135,6 +136,9 @@ void JUnitTestOutput::printCurrentTestStarted(const UtestShell& test)
         impl_->results_.tail_ = impl_->results_.tail_->next_;
     }
     impl_->results_.tail_->name_ = test.getName();
+    if (*(test.getProgressIndicator()) == '!') {
+        impl_->results_.tail_->ignored_ = true;
+    }
 }
 
 SimpleString JUnitTestOutput::createFileName(const SimpleString& group)
@@ -192,6 +196,9 @@ void JUnitTestOutput::writeTestCases()
 
         if (cur->failure_) {
             writeFailure(cur);
+        }
+        else if (cur->ignored_) {
+            writeToFile("<skipped />\n");
         }
         writeToFile("</testcase>\n");
         cur = cur->next_;

--- a/src/CppUTest/TestOutput.cpp
+++ b/src/CppUTest/TestOutput.cpp
@@ -98,6 +98,13 @@ TestOutput& operator<<(TestOutput& p, long int i)
 void TestOutput::printCurrentTestStarted(const UtestShell& test)
 {
     if (verbose_) print(test.getFormattedName().asCharString());
+
+    if (test.willRun()) {
+       setProgressIndicator(".");
+    }
+    else {
+       setProgressIndicator("!");
+    }
 }
 
 void TestOutput::printCurrentTestEnded(const TestResult& res)

--- a/src/CppUTest/TestRegistry.cpp
+++ b/src/CppUTest/TestRegistry.cpp
@@ -56,7 +56,6 @@ void TestRegistry::runAllTests(TestResult& result)
             groupStart = false;
         }
 
-        result.setProgressIndicator(test->getProgressIndicator());
         result.countTest();
         if (testShouldRun(test, result)) {
             result.currentTestStarted(test);

--- a/src/CppUTest/TestResult.cpp
+++ b/src/CppUTest/TestResult.cpp
@@ -37,11 +37,6 @@ TestResult::TestResult(TestOutput& p) :
 {
 }
 
-void TestResult::setProgressIndicator(const char* indicator)
-{
-    output_.setProgressIndicator(indicator);
-}
-
 TestResult::~TestResult()
 {
 }

--- a/src/CppUTest/Utest.cpp
+++ b/src/CppUTest/Utest.cpp
@@ -596,6 +596,11 @@ IgnoredUtestShell::IgnoredUtestShell()
 {
 }
 
+IgnoredUtestShell::IgnoredUtestShell(const char* groupName, const char* testName, const char* fileName, int lineNumber) :
+   UtestShell(groupName, testName, fileName, lineNumber)
+{
+}
+
 IgnoredUtestShell::~IgnoredUtestShell()
 {
 }

--- a/src/CppUTest/Utest.cpp
+++ b/src/CppUTest/Utest.cpp
@@ -258,9 +258,9 @@ bool UtestShell::hasFailed() const
     return hasFailed_;
 }
 
-const char* UtestShell::getProgressIndicator() const
+bool UtestShell::willRun() const
 {
-    return ".";
+    return true;
 }
 
 bool UtestShell::isRunInSeperateProcess() const
@@ -605,9 +605,9 @@ IgnoredUtestShell::~IgnoredUtestShell()
 {
 }
 
-const char* IgnoredUtestShell::getProgressIndicator() const
+bool IgnoredUtestShell::willRun() const
 {
-    return "!";
+    return false;
 }
 
 SimpleString IgnoredUtestShell::getMacroName() const

--- a/tests/JUnitOutputTest.cpp
+++ b/tests/JUnitOutputTest.cpp
@@ -239,6 +239,15 @@ public:
         return *this;
     }
 
+    JUnitTestOutputTestRunner& withIgnoredTest(const char* testName)
+    {
+        runPreviousTest();
+        delete currentTest_;
+
+        currentTest_ = new IgnoredUtestShell(currentGroupName_, testName, "file", 1);
+        return *this;
+    }
+
     void runPreviousTest()
     {
         if (currentTest_ == 0) return;
@@ -583,3 +592,16 @@ TEST(JUnitOutputTest, TestCaseBlockWithAPackageName)
     STRCMP_EQUAL("</testcase>\n", outputFile->line(6));
 }
 
+TEST(JUnitOutputTest, TestCaseBlockForIgnoredTest)
+{
+   junitOutput->setPackageName("packagename");
+   testCaseRunner->start()
+      .withGroup("groupname").withIgnoredTest("testname")
+      .end();
+
+   outputFile = fileSystem.file("cpputest_groupname.xml");
+
+   STRCMP_EQUAL("<testcase classname=\"packagename.groupname\" name=\"testname\" time=\"0.000\">\n", outputFile->line(5));
+   STRCMP_EQUAL("<skipped />\n", outputFile->line(6));
+   STRCMP_EQUAL("</testcase>\n", outputFile->line(7));
+}

--- a/tests/TestOutputTest.cpp
+++ b/tests/TestOutputTest.cpp
@@ -119,11 +119,11 @@ TEST(TestOutput, PrintTestALot)
 
 TEST(TestOutput, SetProgressIndicator)
 {
-    result->setProgressIndicator(".");
+    printer->setProgressIndicator(".");
     printer->printCurrentTestEnded(*result);
-    result->setProgressIndicator("!");
+    printer->setProgressIndicator("!");
     printer->printCurrentTestEnded(*result);
-    result->setProgressIndicator(".");
+    printer->setProgressIndicator(".");
     printer->printCurrentTestEnded(*result);
 
     STRCMP_EQUAL(".!.", mock->getOutput().asCharString());


### PR DESCRIPTION
Fixes #462.  It's not a very good solution, just checks what character the progress indicator is, but it works.  It looks to me like there is some unneeded coupling going on between the TestOutput logic and the UTestShell class since it knows the character that gets printed.  I think that it should probably just know it's status and let the TestOutput class decide which character that means gets printed, or in the case of JUnit Output, what to put into the file.