### PR TITLE
Added the release folders to the ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,9 @@ ErrorLogs
 testResults
 .metadata
 Debug
+Release
 */Debug/*
+*/Release/*
 *.exe
 *.obj
 *.ncb


### PR DESCRIPTION
When building the VS201x projects, I noticed that git status shows the release folders as being changes, so I added them to the ignore list.

@arstrube I don't see your linker warnings, I built both Debug and Release configurations of CppUTest and the Examples.  One thing I did just remember, there was a known issue with VS2010 and VS2012 coexisting that was fixed in VS2010SP1, so if you didn't have the service pack installed before installing VS2012, that may be why you had problems.  One possible way to clean things up may be to install Service Pack 1 if you don't already have it installed.