### PR TITLE
Use IGNORE_TEST() on incompatible systems.

### DIFF
--- a/tests/SimpleStringTest.cpp
+++ b/tests/SimpleStringTest.cpp
@@ -560,20 +560,15 @@ TEST(SimpleString, CollectionWritingToEmptyString)
     STRCMP_EQUAL("", col[3].asCharString());
 }
 
-#ifdef CPPUTEST_64BIT
-#ifdef CPPUTEST_64BIT_32BIT_LONGS
+#if !defined(CPPUTEST_64BIT) || \
+     defined(CPPUTEST_64BIT_32BIT_LONGS)
 
 /*
  * Right now, the 64 bit pointers are casted to 32bit as the %p is causing different formats on
- * different platforms. However, this will need to be fixed in the future and then this test ought
- * to be deleted.
+ * different platforms. However, this will need to be fixed in the future.
  */
-TEST(SimpleString, _64BitAddressPrintsCorrectly)
+IGNORE_TEST(SimpleString, _64BitAddressPrintsCorrectly)
 {
-    char* p = (char*) 0xffffffffu;
-    SimpleString expected("0x23456789");
-    SimpleString actual = StringFrom((void*)&p[0x2345678A]);
-    STRCMP_EQUAL(expected.asCharString(), actual.asCharString());
 }
 
 #else
@@ -586,7 +581,6 @@ TEST(SimpleString, _64BitAddressPrintsCorrectly)
     STRCMP_EQUAL(expected.asCharString(), actual.asCharString());
 }
 
-#endif
 #endif
 
 TEST(SimpleString, BuildStringFromUnsignedInteger)


### PR DESCRIPTION
Up to now, the 64 bit pointer printing test would have been silently omitted on 32-bit systems.

I suggest replacing this with an empty IGNORE_TEST() on incompatible systems.

Note: This drops my hack for 64 bit Windows. I consider it a hack, rather than a test of anything useful. So I am rather glad to see it gone.

The number of testcases should now be identical (with regard to this particular conditional compilation), regardless of target system.