### PR TITLE
Handling the 64 bit test case in a cleaner way

### DIFF
--- a/tests/SimpleStringTest.cpp
+++ b/tests/SimpleStringTest.cpp
@@ -573,10 +573,11 @@ TEST(SimpleString, _64BitAddressPrintsCorrectly)
 
 #else
 /*
- * The above test case should also pass on 64 bit systems with 32 bit longs, 
- * but would actually fail due to implementation problems. Right now, the 64  
- * bit pointers are casted to 32bit as the %p is causing different formats
- * on different platforms. However, this will need to be fixed in the future.
+ * This test case should pass on 64 bit systems with 32 bit longs, 
+ * but actually fails due to an implementation problem: Right now,
+ * the 64 bit pointers are casted to 32bit as the %p is causing 
+ * different formats on different platforms. However, this will
+ * need to be fixed in the future.
  */
 
 IGNORE_TEST(SimpleString, _64BitAddressPrintsCorrectly)
@@ -586,7 +587,7 @@ IGNORE_TEST(SimpleString, _64BitAddressPrintsCorrectly)
 #endif
 #else
 /*
- * The above test case would necessarily fail on 32 bit systems.
+ * This test case necessarily fails on 32 bit systems.
  */
 IGNORE_TEST(SimpleString, _64BitAddressPrintsCorrectly)
 {

--- a/tests/SimpleStringTest.cpp
+++ b/tests/SimpleStringTest.cpp
@@ -565,9 +565,9 @@ TEST(SimpleString, CollectionWritingToEmptyString)
 
 TEST(SimpleString, _64BitAddressPrintsCorrectly)
 {
-    char* p = (char*) 0xffffffff;
-    SimpleString expected("0x100000000");
-    SimpleString actual = StringFrom((void*)++p);
+    char* p = (char*) 0x0012345678901234;
+    SimpleString expected("0x12345678901234");
+    SimpleString actual = StringFrom((void*)p);
     STRCMP_EQUAL(expected.asCharString(), actual.asCharString());
 }
 
@@ -582,6 +582,10 @@ TEST(SimpleString, _64BitAddressPrintsCorrectly)
 
 IGNORE_TEST(SimpleString, _64BitAddressPrintsCorrectly)
 {
+    char* p = (char*) 0xffffffff;
+    SimpleString expected("0x123456789");
+    SimpleString actual = StringFrom((void*)&p[0x2345678A]);
+    STRCMP_EQUAL(expected.asCharString(), actual.asCharString());
 }
 
 #endif

--- a/tests/SimpleStringTest.cpp
+++ b/tests/SimpleStringTest.cpp
@@ -587,7 +587,7 @@ IGNORE_TEST(SimpleString, _64BitAddressPrintsCorrectly)
 #endif
 #else
 /*
- * This test case necessarily fails on 32 bit systems.
+ * This test case cannot pass on 32 bit systems.
  */
 IGNORE_TEST(SimpleString, _64BitAddressPrintsCorrectly)
 {

--- a/tests/SimpleStringTest.cpp
+++ b/tests/SimpleStringTest.cpp
@@ -560,25 +560,36 @@ TEST(SimpleString, CollectionWritingToEmptyString)
     STRCMP_EQUAL("", col[3].asCharString());
 }
 
-#if !defined(CPPUTEST_64BIT) || \
-     defined(CPPUTEST_64BIT_32BIT_LONGS)
+#ifdef CPPUTEST_64BIT
+#ifndef CPPUTEST_64BIT_32BIT_LONGS
 
+TEST(SimpleString, _64BitAddressPrintsCorrectly)
+{
+    char* p = (char*) 0xffffffff;
+    SimpleString expected("0x100000000");
+    SimpleString actual = StringFrom((void*)++p);
+    STRCMP_EQUAL(expected.asCharString(), actual.asCharString());
+}
+
+#else
 /*
- * Right now, the 64 bit pointers are casted to 32bit as the %p is causing different formats on
- * different platforms. However, this will need to be fixed in the future.
+ * The above test case should also pass on 64 bit systems with 32 bit longs, 
+ * but would actually fail due to implementation problems. Right now, the 64  
+ * bit pointers are casted to 32bit as the %p is causing different formats
+ * on different platforms. However, this will need to be fixed in the future.
  */
+
 IGNORE_TEST(SimpleString, _64BitAddressPrintsCorrectly)
 {
 }
 
+#endif
 #else
-
-TEST(SimpleString, _64BitAddressPrintsCorrectly)
+/*
+ * The above test case would necessarily fail on 32 bit systems.
+ */
+IGNORE_TEST(SimpleString, _64BitAddressPrintsCorrectly)
 {
-    char* p = (char*) 0x0012345678901234;
-    SimpleString expected("0x12345678901234");
-    SimpleString actual = StringFrom((void*)p);
-    STRCMP_EQUAL(expected.asCharString(), actual.asCharString());
 }
 
 #endif


### PR DESCRIPTION
Rewrote test so it will compile on all 32 bit and 64 bit systems.

We now have the following distinct scenarios:
1. Test will pass on 64 bit systems with 64 bit longs
   -> TEST().
2. Test should pass on 64 bit systems with 32 bit longs, but fails
   due to a known implementation problem. Needs to be fixed.
   -> IGNORE_TEST() for now.
3. Test cannot pass on 32 bit systems
   -> IGNORE_TEST() always.