### PR TITLE
Coverage

### DIFF
--- a/src/CppUTest/Utest.cpp
+++ b/src/CppUTest/Utest.cpp
@@ -49,9 +49,6 @@ public:
     {
         return defaultTestResult;
     }
-    virtual void exitCurrentTest()
-    {
-    }
     virtual ~OutsideTestRunnerUTest()
     {
     }

--- a/tests/SetPluginTest.cpp
+++ b/tests/SetPluginTest.cpp
@@ -82,6 +82,22 @@ TEST(SetPointerPluginTest, testUnoverridden_testBody)
     delete tst;
 }
 
+class defaultCreateTestUtestShell: public UtestShell
+{
+public:
+};
+
+TEST(SetPointerPluginTest, testUnoverridden_createTest)
+{
+    defaultCreateTestUtestShell *tst = new defaultCreateTestUtestShell();
+    ;
+    myRegistry_->addTest(tst);
+    myRegistry_->runAllTests(*result_);
+    LONGS_EQUAL(0, result_->getFailureCount());
+    LONGS_EQUAL(0, result_->getCheckCount());
+    delete tst;
+}
+
 class FunctionPointerUtest : public Utest
 {
 public:

--- a/tests/SetPluginTest.cpp
+++ b/tests/SetPluginTest.cpp
@@ -49,28 +49,36 @@ TEST_GROUP(SetPointerPluginTest)
     }
 };
 
-class nonoverriddenTestBodyUtest : public Utest
+class defaultTestBodyUtest : public Utest
 {
 public:
+    void setup() _override 
+    {
+        CHECK(true);
+    }
+    void teardown() _override
+    {
+        CHECK(true);
+    }
 };
 
-class nonoverriddenTestBodyUtestUtestShell: public UtestShell
+class defaultTestBodyUtestUtestShell: public UtestShell
 {
 public:
    virtual Utest* createTest() _override
    {
-      return new nonoverriddenTestBodyUtest();
+      return new defaultTestBodyUtest();
    }
 };
 
 TEST(SetPointerPluginTest, testUnoverridden_testBody)
 {
-    nonoverriddenTestBodyUtestUtestShell *tst = new nonoverriddenTestBodyUtestUtestShell();
+    defaultTestBodyUtestUtestShell *tst = new defaultTestBodyUtestUtestShell();
     ;
     myRegistry_->addTest(tst);
     myRegistry_->runAllTests(*result_);
     LONGS_EQUAL(0, result_->getFailureCount());
-    LONGS_EQUAL(0, result_->getCheckCount());
+    LONGS_EQUAL(2, result_->getCheckCount());
     delete tst;
 }
 

--- a/tests/SetPluginTest.cpp
+++ b/tests/SetPluginTest.cpp
@@ -49,16 +49,41 @@ TEST_GROUP(SetPointerPluginTest)
     }
 };
 
+class nonoverriddenTestBodyUtest : public Utest
+{
+public:
+};
+
+class nonoverriddenTestBodyUtestUtestShell: public UtestShell
+{
+public:
+   virtual Utest* createTest() _override
+   {
+      return new nonoverriddenTestBodyUtest();
+   }
+};
+
+TEST(SetPointerPluginTest, testUnoverridden_testBody)
+{
+    nonoverriddenTestBodyUtestUtestShell *tst = new nonoverriddenTestBodyUtestUtestShell();
+    ;
+    myRegistry_->addTest(tst);
+    myRegistry_->runAllTests(*result_);
+    LONGS_EQUAL(0, result_->getFailureCount());
+    LONGS_EQUAL(0, result_->getCheckCount());
+    delete tst;
+}
+
 class FunctionPointerUtest : public Utest
 {
 public:
-   void setup()
+   void setup() _override
    {
       UT_PTR_SET(fp1, stub_func1);
       UT_PTR_SET(fp2, stub_func2);
       UT_PTR_SET(fp2, stub_func2);
    }
-   void testBody()
+   void testBody() _override
    {
       CHECK(fp1 == stub_func1);
       CHECK(fp2 == stub_func2);

--- a/tests/TestUTestMacro.cpp
+++ b/tests/TestUTestMacro.cpp
@@ -692,4 +692,14 @@ TEST(IgnoreTest, doesIgnoreCount)
     delete ignoreTest;
 }
 
+TEST(IgnoreTest, printsIGNORE_TESTwhenVerbose)
+{
+    IgnoredUtestShell * ignoreTest = new IgnoredUtestShell();
+    fixture.addTest(ignoreTest);
+    fixture.output_->verbose();
+    fixture.runAllTests();
+    fixture.assertPrintContains("IGNORE_TEST");
+    delete ignoreTest;
+}
+
 

--- a/tests/TestUTestMacro.cpp
+++ b/tests/TestUTestMacro.cpp
@@ -681,25 +681,25 @@ TEST(UnitTestMacros, MultipleCHECK_THROWS_inOneScope)
 TEST_GROUP(IgnoreTest)
 {
     TestTestingFixture fixture;
+    IgnoredUtestShell ignoreTest;
+    
+    void setup() _override
+    {
+        fixture.addTest(&ignoreTest);
+    }
 };
 
 TEST(IgnoreTest, doesIgnoreCount)
 {
-    IgnoredUtestShell * ignoreTest = new IgnoredUtestShell();
-    fixture.addTest(ignoreTest);
     fixture.runAllTests();
     LONGS_EQUAL(1, fixture.getIgnoreCount());
-    delete ignoreTest;
 }
 
 TEST(IgnoreTest, printsIGNORE_TESTwhenVerbose)
 {
-    IgnoredUtestShell * ignoreTest = new IgnoredUtestShell();
-    fixture.addTest(ignoreTest);
     fixture.output_->verbose();
     fixture.runAllTests();
     fixture.assertPrintContains("IGNORE_TEST");
-    delete ignoreTest;
 }
 
 

--- a/tests/TestUTestMacro.cpp
+++ b/tests/TestUTestMacro.cpp
@@ -92,6 +92,138 @@ IGNORE_TEST(UnitTestMacros, FAILworksInAnIgnoredTest)
     FAIL("die!");
 }
 
+static void _STRCMP_EQUALWithActualIsNULLTestMethod()
+{
+    STRCMP_EQUAL("ok", NULL);
+}
+
+TEST(UnitTestMacros, FailureWithSTRCMP_EQUALAndActualIsNULL)
+{
+    runTestWithMethod(_STRCMP_EQUALWithActualIsNULLTestMethod);
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <(null)>");
+}
+
+static void _STRCMP_EQUALWithExpectedIsNULLTestMethod()
+{
+    STRCMP_EQUAL(NULL, "ok");
+}
+
+TEST(UnitTestMacros, FailureWithSTRCMP_EQUALAndExpectedIsNULL)
+{
+    runTestWithMethod(_STRCMP_EQUALWithExpectedIsNULLTestMethod);
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <(null)>");
+}
+
+static void _STRCMP_CONTAINSWithActualIsNULLTestMethod()
+{
+    STRCMP_CONTAINS("ok", NULL);
+}
+
+TEST(UnitTestMacros, FailureWithSTRCMP_CONTAINSAndActualIsNULL)
+{
+    runTestWithMethod(_STRCMP_CONTAINSWithActualIsNULLTestMethod);
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("did not contain  <ok>");
+}
+
+static void _STRCMP_CONTAINSWithExpectedIsNULLTestMethod()
+{
+    STRCMP_CONTAINS(NULL, "ok");
+}
+
+TEST(UnitTestMacros, FailureWithSTRCMP_CONTAINSAndExpectedIsNULL)
+{
+    runTestWithMethod(_STRCMP_CONTAINSWithExpectedIsNULLTestMethod);
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("did not contain  <>");
+}
+
+static void _STRNCMP_EQUALWithActualIsNULLTestMethod()
+{
+    STRNCMP_EQUAL("ok", NULL, 2);
+}
+
+TEST(UnitTestMacros, FailureWithSTRNCMP_EQUALAndActualIsNULL)
+{
+    runTestWithMethod(_STRNCMP_EQUALWithActualIsNULLTestMethod);
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <(null)>");
+}
+
+static void _STRNCMP_EQUALWithExpectedIsNULLTestMethod()
+{
+    STRNCMP_EQUAL(NULL, "ok", 2);
+}
+
+TEST(UnitTestMacros, FailureWithSTRNCMP_EQUALAndExpectedIsNULL)
+{
+    runTestWithMethod(_STRNCMP_EQUALWithExpectedIsNULLTestMethod);
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <(null)>");
+}
+
+static void _STRCMP_NOCASE_EQUALWithActualIsNULLTestMethod()
+{
+    STRCMP_NOCASE_EQUAL("ok", NULL);
+}
+
+TEST(UnitTestMacros, FailureWithSTRCMP_NOCASE_EQUALAndActualIsNULL)
+{
+    runTestWithMethod(_STRCMP_NOCASE_EQUALWithActualIsNULLTestMethod);
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <(null)>");
+}
+
+static void _STRCMP_NOCASE_EQUALWithExpectedIsNULLTestMethod()
+{
+    STRCMP_NOCASE_EQUAL(NULL, "ok");
+}
+
+TEST(UnitTestMacros, FailureWithSTRCMP_NOCASE_EQUALAndExpectedIsNULL)
+{
+    runTestWithMethod(_STRCMP_NOCASE_EQUALWithExpectedIsNULLTestMethod);
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <(null)>");
+}
+
+static void _STRCMP_NOCASE_EQUALWithUnequalInputTestMethod()
+{
+    STRCMP_NOCASE_EQUAL("no", "ok");
+}
+
+TEST(UnitTestMacros, FailureWithSTRCMP_NOCASE_EQUALAndUnequalInput)
+{
+    runTestWithMethod(_STRCMP_NOCASE_EQUALWithUnequalInputTestMethod);
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <ok>");
+}
+
+static void _STRCMP_NOCASE_CONTAINSWithActualIsNULLTestMethod()
+{
+    STRCMP_NOCASE_CONTAINS("ok", NULL);
+}
+
+TEST(UnitTestMacros, FailureWithSTRCMP_NOCASE_CONTAINSAndActualIsNULL)
+{
+    runTestWithMethod(_STRCMP_NOCASE_CONTAINSWithActualIsNULLTestMethod);
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("did not contain  <ok>");
+}
+
+static void _STRCMP_NOCASE_CONTAINSWithExpectedIsNULLTestMethod()
+{
+    STRCMP_NOCASE_CONTAINS(NULL, "ok");
+}
+
+TEST(UnitTestMacros, FailureWithSTRCMP_NOCASE_CONTAINSAndExpectedIsNULL)
+{
+    runTestWithMethod(_STRCMP_NOCASE_CONTAINSWithExpectedIsNULLTestMethod);
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("did not contain  <>");
+}
+
+static void _UNSIGNED_LONGS_EQUALFailMethod()
+{
+    UNSIGNED_LONGS_EQUAL(1, 0);
+}
+
+TEST(UnitTestMacros, FailureWithUNSIGNED_LONGS_EQUAL)
+{
+    runTestWithMethod(_UNSIGNED_LONGS_EQUALFailMethod);
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <0 (0x0) 0x0>");
+}
+
 static void _failingTestMethodWithCHECK()
 {
     CHECK(false);

--- a/tests/TestUTestMacro.cpp
+++ b/tests/TestUTestMacro.cpp
@@ -213,14 +213,15 @@ TEST(UnitTestMacros, FailureWithSTRCMP_NOCASE_CONTAINSAndExpectedIsNULL)
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("did not contain  <>");
 }
 
-static void _UNSIGNED_LONGS_EQUALFailMethod()
+static void _UNSIGNED_LONGS_EQUALTestMethod()
 {
+    UNSIGNED_LONGS_EQUAL(1, 1);
     UNSIGNED_LONGS_EQUAL(1, 0);
 }
 
-TEST(UnitTestMacros, FailureWithUNSIGNED_LONGS_EQUAL)
+TEST(UnitTestMacros, TestUNSIGNED_LONGS_EQUAL)
 {
-    runTestWithMethod(_UNSIGNED_LONGS_EQUALFailMethod);
+    runTestWithMethod(_UNSIGNED_LONGS_EQUALTestMethod);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <0 (0x0) 0x0>");
 }
 


### PR DESCRIPTION
Bring up statement coverage to 95+ % by adding missing tests and removing some dead code.

Another small improvement will be achieved when I add tests for running tests in a separate process.

However, 100% cannot be reached because of some methods failing unconditionally.

Also, defaultCrashMethod cannot be exercised without, well, crashing ;-).