### PR TITLE
Applied change from #494 to Visual C++

### DIFF
--- a/src/Platforms/VisualCpp/UtestPlatform.cpp
+++ b/src/Platforms/VisualCpp/UtestPlatform.cpp
@@ -46,11 +46,14 @@ void PlatformSpecificRestoreJumpBuffer()
     jmp_buf_index--;
 }
 
-void PlatformSpecificRunTestInASeperateProcess(UtestShell* shell, TestPlugin* plugin, TestResult* result)
+static void VisualCppPlatformSpecificRunTestInASeperateProcess(UtestShell* shell, TestPlugin* plugin, TestResult* result)
 {
    printf("-p doesn't work on this platform as it is not implemented. Running inside the process\b");
    shell->runOneTest(plugin, *result);
 }
+
+void (*PlatformSpecificRunTestInASeperateProcess)(UtestShell* shell, TestPlugin* plugin, TestResult* result) =
+        VisualCppPlatformSpecificRunTestInASeperateProcess;
 
 TestOutput::WorkingEnvironment PlatformSpecificGetWorkingEnvironment()
 {


### PR DESCRIPTION
PlatformSpecificRunTestInASeperateProcess was modified to be a function pointer as part of pull request #494.  That change wasn't also applied to the VisualCpp copy of UtestPlatform.cpp, so I applied it to this file as well.