### PR TITLE
These tests will bring up statement coverage for UTestPlatform.cpp (GCC) to 100%

### DIFF
--- a/tests/UtestPlatformTest.cpp
+++ b/tests/UtestPlatformTest.cpp
@@ -30,6 +30,23 @@
 #include "CppUTest/TestTestingFixture.h"
 #include "CppUTest/PlatformSpecificFunctions.h"
 
+TEST_GROUP(UTestPlatformsTest)
+{
+};
+
+TEST(UTestPlatformsTest, PlatformSpecificFileFunctionsDontCrash)
+{
+    PlatformSpecificFile file;
+    file = PlatformSpecificFOpen("/dev/null", "rw");
+    PlatformSpecificFPuts("Hello", file);
+    PlatformSpecificFClose(file);
+}
+
+TEST(UTestPlatformsTest, GetPlatformSpecificTimeStringIsCalledOnce)
+{
+    GetPlatformSpecificTimeString();
+}
+
 TEST_GROUP(UTestPlatformsTest_PlatformSpecificRunTestInASeperateProcess)
 {
     TestTestingFixture fixture;

--- a/tests/UtestPlatformTest.cpp
+++ b/tests/UtestPlatformTest.cpp
@@ -42,9 +42,17 @@ TEST(UTestPlatformsTest, PlatformSpecificFileFunctionsDontCrash)
     PlatformSpecificFClose(file);
 }
 
-TEST(UTestPlatformsTest, GetPlatformSpecificTimeStringIsCalledOnce)
+TEST(UTestPlatformsTest, GetPlatformSpecificTimeStringIsCovered)
 {
     GetPlatformSpecificTimeString();
+}
+
+TEST(UTestPlatformsTest, PlatformSpecificMutexLockAndUnlockDontCrash)
+{
+    PlatformSpecificMutex mutex = PlatformSpecificMutexCreate();
+    PlatformSpecificMutexLock(mutex);
+    PlatformSpecificMutexUnlock(mutex);
+    PlatformSpecificMutexDestroy(mutex);
 }
 
 TEST_GROUP(UTestPlatformsTest_PlatformSpecificRunTestInASeperateProcess)


### PR DESCRIPTION
They are rather simple-minded and don't do any checking (yet?). Some observations:

1. `PlatformSpecificFOpen()`, `PlatformSpecificFPuts()` - it seems like those functions probably don't get used anywhere in CppUTest. One could write some stuff in an actual temp file, read it back and have the test compare it. However, temporary files (that get automatically unlinked) are not supported under Cygwin, as far as I know.

2. `GetPlatformSpecificTimeString()` - this doesn't seem to be used, either. The interface does not allow for any kind of sensible test.

3. `PlatformSpecificMutexLock` and `PlatformSpecificMutexLock` - better tests might be possible for this. Personally, I have no experience so I left it at this.