### PR TITLE
Add TEST_IN_SEPARATE_PROCESS() macro

### DIFF
--- a/include/CppUTest/UtestMacros.h
+++ b/include/CppUTest/UtestMacros.h
@@ -69,6 +69,26 @@
   static TestInstaller TEST_##testGroup##_##testName##_Installer(TEST_##testGroup##_##testName##_TestShell_instance, #testGroup, #testName, __FILE__,__LINE__); \
     void TEST_##testGroup##_##testName##_Test::testBody()
 
+#if !defined(__MINGW32__) && !defined(_MSC_VER)
+
+#define TEST_IN_SEPARATE_PROCESS(testGroup, testName) \
+  /* External declarations for strict compilers */ \
+  class TEST_##testGroup##_##testName##_TestShell; \
+  extern TEST_##testGroup##_##testName##_TestShell TEST_##testGroup##_##testName##_TestShell_instance; \
+  \
+  class TEST_##testGroup##_##testName##_Test : public TEST_GROUP_##CppUTestGroup##testGroup \
+{ public: TEST_##testGroup##_##testName##_Test () : TEST_GROUP_##CppUTestGroup##testGroup () {} \
+       void testBody(); }; \
+  class TEST_##testGroup##_##testName##_TestShell : public UtestShell { \
+      public: \
+      TEST_##testGroup##_##testName##_TestShell() : UtestShell() { setRunInSeperateProcess(); } \
+      virtual Utest* createTest() _override { return new TEST_##testGroup##_##testName##_Test; } \
+  } TEST_##testGroup##_##testName##_TestShell_instance; \
+  static TestInstaller TEST_##testGroup##_##testName##_Installer(TEST_##testGroup##_##testName##_TestShell_instance, #testGroup, #testName, __FILE__,__LINE__); \
+    void TEST_##testGroup##_##testName##_Test::testBody()
+
+#endif
+
 #define IGNORE_TEST(testGroup, testName)\
   /* External declarations for strict compilers */ \
   class IGNORE##testGroup##_##testName##_TestShell; \

--- a/tests/TestUTestMacro.cpp
+++ b/tests/TestUTestMacro.cpp
@@ -639,6 +639,22 @@ TEST(UnitTestMacros, CompareNFirstCharsWithLastCharDifferent)
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("difference starts at position 16");
 }
 
+#if defined(__MINGW32__) || defined(MSC_VER)
+
+IGNORE_TEST(UnitTestMacros, TEST_IN_SEPARATE_PROCESSWorks)
+{
+}
+
+#else
+
+TEST_IN_SEPARATE_PROCESS(UnitTestMacros, TEST_IN_SEPARATE_PROCESSWorks)
+{
+    CHECK(true);
+}
+
+#endif
+
+
 #if CPPUTEST_USE_STD_CPP_LIB
 static void _failingTestMethod_NoThrowWithCHECK_THROWS()
 {
@@ -682,7 +698,7 @@ TEST_GROUP(IgnoreTest)
 {
     TestTestingFixture fixture;
     IgnoredUtestShell ignoreTest;
-    
+
     void setup() _override
     {
         fixture.addTest(&ignoreTest);
@@ -701,5 +717,3 @@ TEST(IgnoreTest, printsIGNORE_TESTwhenVerbose)
     fixture.runAllTests();
     fixture.assertPrintContains("IGNORE_TEST");
 }
-
-

--- a/tests/UtestPlatformTest.cpp
+++ b/tests/UtestPlatformTest.cpp
@@ -30,6 +30,23 @@
 #include "CppUTest/TestTestingFixture.h"
 #include "CppUTest/PlatformSpecificFunctions.h"
 
+TEST_GROUP(UTestPlatformsTest)
+{
+};
+
+TEST(UTestPlatformsTest, PlatformSpecificFileFunctionsDontCrash)
+{
+    PlatformSpecificFile file;
+    file = PlatformSpecificFOpen("/dev/null", "rw");
+    PlatformSpecificFPuts("Hello", file);
+    PlatformSpecificFClose(file);
+}
+
+TEST(UTestPlatformsTest, GetPlatformSpecificTimeStringIsCalledOnce)
+{
+    GetPlatformSpecificTimeString();
+}
+
 TEST_GROUP(UTestPlatformsTest_PlatformSpecificRunTestInASeperateProcess)
 {
     TestTestingFixture fixture;

--- a/tests/UtestPlatformTest.cpp
+++ b/tests/UtestPlatformTest.cpp
@@ -42,9 +42,17 @@ TEST(UTestPlatformsTest, PlatformSpecificFileFunctionsDontCrash)
     PlatformSpecificFClose(file);
 }
 
-TEST(UTestPlatformsTest, GetPlatformSpecificTimeStringIsCalledOnce)
+TEST(UTestPlatformsTest, GetPlatformSpecificTimeStringIsCovered)
 {
     GetPlatformSpecificTimeString();
+}
+
+TEST(UTestPlatformsTest, PlatformSpecificMutexLockAndUnlockDontCrash)
+{
+    PlatformSpecificMutex mutex = PlatformSpecificMutexCreate();
+    PlatformSpecificMutexLock(mutex);
+    PlatformSpecificMutexUnlock(mutex);
+    PlatformSpecificMutexDestroy(mutex);
 }
 
 TEST_GROUP(UTestPlatformsTest_PlatformSpecificRunTestInASeperateProcess)


### PR DESCRIPTION
Using this macro, a single test can easily be run in a separate process on platforms that support fork() including Cygwin.

In this way, a branch that crashes can be safely tested without terminating the tests.

It seems less useful than I thought, though, because an anticipated crash would still cause the test to fail.