### PR TITLE
Workaround to improve junit test count

### DIFF
--- a/tests/MemoryLeakOperatorOverloadsTest.cpp
+++ b/tests/MemoryLeakOperatorOverloadsTest.cpp
@@ -260,6 +260,20 @@ TEST_GROUP(OutOfMemoryTestsForOperatorNew)
 
 #if CPPUTEST_USE_STD_CPP_LIB
 
+TEST_GROUP(TestForExceptionsInConstructor)
+{
+};
+
+TEST(TestForExceptionsInConstructor, ConstructorThrowsAnException)
+{
+   CHECK_THROWS(int, new ClassThatThrowsAnExceptionInTheConstructor);
+}
+
+TEST(TestForExceptionsInConstructor, ConstructorThrowsAnExceptionAllocatedAsArray)
+{
+   CHECK_THROWS(int, new ClassThatThrowsAnExceptionInTheConstructor[10]);
+}
+
 TEST(OutOfMemoryTestsForOperatorNew, FailingNewOperatorThrowsAnExceptionWhenUsingStdCppNew)
 {
     CHECK_THROWS(std::bad_alloc, new char);
@@ -268,20 +282,6 @@ TEST(OutOfMemoryTestsForOperatorNew, FailingNewOperatorThrowsAnExceptionWhenUsin
 TEST(OutOfMemoryTestsForOperatorNew, FailingNewArrayOperatorThrowsAnExceptionWhenUsingStdCppNew)
 {
     CHECK_THROWS(std::bad_alloc, new char[10]);
-}
-
-TEST_GROUP(TestForExceptionsInConstructor)
-{
-};
-
-TEST(TestForExceptionsInConstructor,ConstructorThrowsAnException)
-{
-    CHECK_THROWS(int, new ClassThatThrowsAnExceptionInTheConstructor);
-}
-
-TEST(TestForExceptionsInConstructor,ConstructorThrowsAnExceptionAllocatedAsArray)
-{
-    CHECK_THROWS(int, new ClassThatThrowsAnExceptionInTheConstructor[10]);
 }
 
 #else


### PR DESCRIPTION
I swapped the order of a few tests around to working around issue #168 and get the junit test count closer to the actual test count.  There's still one test that I cannot easily get because of the `ORDERED_TEST` macros.