### PR TITLE
VC6

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,5 +9,7 @@
 *.bat text eol=crlf
 *.dsp text eol=crlf
 *.dsw text eol=crlf
+*.dep text eol=crlf
+*.mak text eol=crlf
 *.vcproj text eol=crlf
 *.vcxproj text eol=crlf

--- a/CppUTest.dep
+++ b/CppUTest.dep
@@ -1,0 +1,583 @@
+# Microsoft Developer Studio Generated Dependency File, included by CppUTest.mak
+
+.\src\CppUTestExt\CodeMemoryReportFormatter.cpp : \
+	".\include\CppUTest\CppUTestConfig.h"\
+	".\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	".\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	".\include\CppUTest\PlatformSpecificFunctions.h"\
+	".\include\CppUTest\PlatformSpecificFunctions_c.h"\
+	".\include\CppUTest\SimpleString.h"\
+	".\include\CppUTest\StandardCLibrary.h"\
+	".\include\CppUTest\TestFailure.h"\
+	".\include\CppUTest\TestHarness.h"\
+	".\include\CppUTest\TestMemoryAllocator.h"\
+	".\include\CppUTest\TestOutput.h"\
+	".\include\CppUTest\TestPlugin.h"\
+	".\include\CppUTest\TestResult.h"\
+	".\include\CppUTest\Utest.h"\
+	".\include\CppUTest\UtestMacros.h"\
+	".\include\CppUTestExt\CodeMemoryReportFormatter.h"\
+	".\include\CppUTestExt\MemoryReportAllocator.h"\
+	".\include\CppUTestExt\MemoryReportFormatter.h"\
+	".\include\platforms\visualcpp\stdint.h"\
+	
+
+.\SRC\CPPUTEST\CommandLineArguments.cpp : \
+	".\include\CppUTest\CommandLineArguments.h"\
+	".\include\CppUTest\CppUTestConfig.h"\
+	".\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	".\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	".\include\CppUTest\PlatformSpecificFunctions.h"\
+	".\include\CppUTest\PlatformSpecificFunctions_c.h"\
+	".\include\CppUTest\SimpleString.h"\
+	".\include\CppUTest\StandardCLibrary.h"\
+	".\include\CppUTest\TestFailure.h"\
+	".\include\CppUTest\TestFilter.h"\
+	".\include\CppUTest\TestHarness.h"\
+	".\include\CppUTest\TestOutput.h"\
+	".\include\CppUTest\TestPlugin.h"\
+	".\include\CppUTest\TestResult.h"\
+	".\include\CppUTest\Utest.h"\
+	".\include\CppUTest\UtestMacros.h"\
+	".\include\platforms\visualcpp\stdint.h"\
+	
+
+.\SRC\CPPUTEST\CommandLineTestRunner.cpp : \
+	".\include\CppUTest\CommandLineArguments.h"\
+	".\include\CppUTest\CommandLineTestRunner.h"\
+	".\include\CppUTest\CppUTestConfig.h"\
+	".\include\CppUTest\JunitTestOutput.h"\
+	".\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	".\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	".\include\CppUTest\SimpleString.h"\
+	".\include\CppUTest\StandardCLibrary.h"\
+	".\include\CppUTest\TestFailure.h"\
+	".\include\CppUTest\TestFilter.h"\
+	".\include\CppUTest\TestHarness.h"\
+	".\include\CppUTest\TestOutput.h"\
+	".\include\CppUTest\TestPlugin.h"\
+	".\include\CppUTest\TestRegistry.h"\
+	".\include\CppUTest\TestResult.h"\
+	".\include\CppUTest\Utest.h"\
+	".\include\CppUTest\UtestMacros.h"\
+	".\include\platforms\visualcpp\stdint.h"\
+	
+
+.\SRC\CPPUTEST\JUnitTestOutput.cpp : \
+	".\include\CppUTest\CppUTestConfig.h"\
+	".\include\CppUTest\JunitTestOutput.h"\
+	".\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	".\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	".\include\CppUTest\PlatformSpecificFunctions.h"\
+	".\include\CppUTest\PlatformSpecificFunctions_c.h"\
+	".\include\CppUTest\SimpleString.h"\
+	".\include\CppUTest\StandardCLibrary.h"\
+	".\include\CppUTest\TestFailure.h"\
+	".\include\CppUTest\TestHarness.h"\
+	".\include\CppUTest\TestOutput.h"\
+	".\include\CppUTest\TestPlugin.h"\
+	".\include\CppUTest\TestResult.h"\
+	".\include\CppUTest\Utest.h"\
+	".\include\CppUTest\UtestMacros.h"\
+	".\include\platforms\visualcpp\stdint.h"\
+	
+
+.\SRC\CPPUTEST\MemoryLeakDetector.cpp : \
+	".\include\CppUTest\CppUTestConfig.h"\
+	".\include\CppUTest\MemoryLeakDetector.h"\
+	".\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	".\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	".\include\CppUTest\PlatformSpecificFunctions.h"\
+	".\include\CppUTest\PlatformSpecificFunctions_c.h"\
+	".\include\CppUTest\SimpleMutex.h"\
+	".\include\CppUTest\SimpleString.h"\
+	".\include\CppUTest\StandardCLibrary.h"\
+	".\include\CppUTest\TestFailure.h"\
+	".\include\CppUTest\TestHarness.h"\
+	".\include\CppUTest\TestMemoryAllocator.h"\
+	".\include\CppUTest\TestOutput.h"\
+	".\include\CppUTest\TestPlugin.h"\
+	".\include\CppUTest\TestResult.h"\
+	".\include\CppUTest\Utest.h"\
+	".\include\CppUTest\UtestMacros.h"\
+	".\include\platforms\visualcpp\stdint.h"\
+	
+
+.\SRC\CPPUTEST\MemoryLeakWarningPlugin.cpp : \
+	".\include\CppUTest\CppUTestConfig.h"\
+	".\include\CppUTest\MemoryLeakDetector.h"\
+	".\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	".\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	".\include\CppUTest\PlatformSpecificFunctions.h"\
+	".\include\CppUTest\PlatformSpecificFunctions_c.h"\
+	".\include\CppUTest\SimpleMutex.h"\
+	".\include\CppUTest\SimpleString.h"\
+	".\include\CppUTest\StandardCLibrary.h"\
+	".\include\CppUTest\TestFailure.h"\
+	".\include\CppUTest\TestHarness.h"\
+	".\include\CppUTest\TestMemoryAllocator.h"\
+	".\include\CppUTest\TestOutput.h"\
+	".\include\CppUTest\TestPlugin.h"\
+	".\include\CppUTest\TestResult.h"\
+	".\include\CppUTest\Utest.h"\
+	".\include\CppUTest\UtestMacros.h"\
+	".\include\platforms\visualcpp\stdint.h"\
+	
+
+.\src\CppUTestExt\MemoryReportAllocator.cpp : \
+	".\include\CppUTest\CppUTestConfig.h"\
+	".\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	".\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	".\include\CppUTest\SimpleString.h"\
+	".\include\CppUTest\StandardCLibrary.h"\
+	".\include\CppUTest\TestFailure.h"\
+	".\include\CppUTest\TestHarness.h"\
+	".\include\CppUTest\TestMemoryAllocator.h"\
+	".\include\CppUTest\TestPlugin.h"\
+	".\include\CppUTest\TestResult.h"\
+	".\include\CppUTest\Utest.h"\
+	".\include\CppUTest\UtestMacros.h"\
+	".\include\CppUTestExt\MemoryReportAllocator.h"\
+	".\include\CppUTestExt\MemoryReportFormatter.h"\
+	".\include\platforms\visualcpp\stdint.h"\
+	
+
+.\src\CppUTestExt\MemoryReporterPlugin.cpp : \
+	".\include\CppUTest\CppUTestConfig.h"\
+	".\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	".\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	".\include\CppUTest\SimpleString.h"\
+	".\include\CppUTest\StandardCLibrary.h"\
+	".\include\CppUTest\TestFailure.h"\
+	".\include\CppUTest\TestHarness.h"\
+	".\include\CppUTest\TestMemoryAllocator.h"\
+	".\include\CppUTest\TestPlugin.h"\
+	".\include\CppUTest\TestResult.h"\
+	".\include\CppUTest\Utest.h"\
+	".\include\CppUTest\UtestMacros.h"\
+	".\include\CppUTestExt\CodeMemoryReportFormatter.h"\
+	".\include\CppUTestExt\MemoryReportAllocator.h"\
+	".\include\CppUTestExt\MemoryReporterPlugin.h"\
+	".\include\CppUTestExt\MemoryReportFormatter.h"\
+	".\include\platforms\visualcpp\stdint.h"\
+	
+
+.\src\CppUTestExt\MemoryReportFormatter.cpp : \
+	".\include\CppUTest\CppUTestConfig.h"\
+	".\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	".\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	".\include\CppUTest\SimpleString.h"\
+	".\include\CppUTest\StandardCLibrary.h"\
+	".\include\CppUTest\TestFailure.h"\
+	".\include\CppUTest\TestHarness.h"\
+	".\include\CppUTest\TestMemoryAllocator.h"\
+	".\include\CppUTest\TestPlugin.h"\
+	".\include\CppUTest\TestResult.h"\
+	".\include\CppUTest\Utest.h"\
+	".\include\CppUTest\UtestMacros.h"\
+	".\include\CppUTestExt\MemoryReportAllocator.h"\
+	".\include\CppUTestExt\MemoryReportFormatter.h"\
+	".\include\platforms\visualcpp\stdint.h"\
+	
+
+".\src\CppUTestExt\MockActualCall.cpp" : \
+	".\include\CppUTest\CppUTestConfig.h"\
+	".\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	".\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	".\include\CppUTest\PlatformSpecificFunctions.h"\
+	".\include\CppUTest\PlatformSpecificFunctions_c.h"\
+	".\include\CppUTest\SimpleString.h"\
+	".\include\CppUTest\StandardCLibrary.h"\
+	".\include\CppUTest\TestFailure.h"\
+	".\include\CppUTest\TestHarness.h"\
+	".\include\CppUTest\TestOutput.h"\
+	".\include\CppUTest\TestPlugin.h"\
+	".\include\CppUTest\TestResult.h"\
+	".\include\CppUTest\Utest.h"\
+	".\include\CppUTest\UtestMacros.h"\
+	".\include\cpputestext\mockactualcall.h"\
+	".\include\CppUTestExt\MockCheckedActualCall.h"\
+	".\include\CppUTestExt\MockCheckedExpectedCall.h"\
+	".\include\cpputestext\mockexpectedcall.h"\
+	".\include\CppUTestExt\MockExpectedCallsList.h"\
+	".\include\CppUTestExt\MockFailure.h"\
+	".\include\CppUTestExt\MockNamedValue.h"\
+	".\include\platforms\visualcpp\stdint.h"\
+	
+
+".\src\CppUTestExt\MockExpectedCall.cpp" : \
+	".\include\CppUTest\CppUTestConfig.h"\
+	".\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	".\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	".\include\CppUTest\SimpleString.h"\
+	".\include\CppUTest\StandardCLibrary.h"\
+	".\include\CppUTest\TestFailure.h"\
+	".\include\CppUTest\TestHarness.h"\
+	".\include\CppUTest\TestPlugin.h"\
+	".\include\CppUTest\TestResult.h"\
+	".\include\CppUTest\Utest.h"\
+	".\include\CppUTest\UtestMacros.h"\
+	".\include\CppUTestExt\MockCheckedExpectedCall.h"\
+	".\include\cpputestext\mockexpectedcall.h"\
+	".\include\CppUTestExt\MockNamedValue.h"\
+	".\include\platforms\visualcpp\stdint.h"\
+	
+
+".\src\CppUTestExt\MockExpectedCallsList.cpp" : \
+	".\include\CppUTest\CppUTestConfig.h"\
+	".\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	".\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	".\include\CppUTest\SimpleString.h"\
+	".\include\CppUTest\StandardCLibrary.h"\
+	".\include\CppUTest\TestFailure.h"\
+	".\include\CppUTest\TestHarness.h"\
+	".\include\CppUTest\TestPlugin.h"\
+	".\include\CppUTest\TestResult.h"\
+	".\include\CppUTest\Utest.h"\
+	".\include\CppUTest\UtestMacros.h"\
+	".\include\CppUTestExt\MockCheckedExpectedCall.h"\
+	".\include\cpputestext\mockexpectedcall.h"\
+	".\include\CppUTestExt\MockExpectedCallsList.h"\
+	".\include\CppUTestExt\MockNamedValue.h"\
+	".\include\platforms\visualcpp\stdint.h"\
+	
+
+".\src\CppUTestExt\MockFailure.cpp" : \
+	".\include\CppUTest\CppUTestConfig.h"\
+	".\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	".\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	".\include\CppUTest\SimpleString.h"\
+	".\include\CppUTest\StandardCLibrary.h"\
+	".\include\CppUTest\TestFailure.h"\
+	".\include\CppUTest\TestHarness.h"\
+	".\include\CppUTest\TestPlugin.h"\
+	".\include\CppUTest\TestResult.h"\
+	".\include\CppUTest\Utest.h"\
+	".\include\CppUTest\UtestMacros.h"\
+	".\include\cpputestext\mockexpectedcall.h"\
+	".\include\CppUTestExt\MockExpectedCallsList.h"\
+	".\include\CppUTestExt\MockFailure.h"\
+	".\include\CppUTestExt\MockNamedValue.h"\
+	".\include\platforms\visualcpp\stdint.h"\
+	
+
+".\src\CppUTestExt\MockNamedValue.cpp" : \
+	".\include\CppUTest\CppUTestConfig.h"\
+	".\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	".\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	".\include\CppUTest\PlatformSpecificFunctions.h"\
+	".\include\CppUTest\PlatformSpecificFunctions_c.h"\
+	".\include\CppUTest\SimpleString.h"\
+	".\include\CppUTest\StandardCLibrary.h"\
+	".\include\CppUTest\TestFailure.h"\
+	".\include\CppUTest\TestHarness.h"\
+	".\include\CppUTest\TestOutput.h"\
+	".\include\CppUTest\TestPlugin.h"\
+	".\include\CppUTest\TestResult.h"\
+	".\include\CppUTest\Utest.h"\
+	".\include\CppUTest\UtestMacros.h"\
+	".\include\CppUTestExt\MockNamedValue.h"\
+	".\include\platforms\visualcpp\stdint.h"\
+	
+
+".\src\CppUTestExt\MockSupport.cpp" : \
+	".\include\CppUTest\CppUTestConfig.h"\
+	".\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	".\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	".\include\CppUTest\SimpleString.h"\
+	".\include\CppUTest\StandardCLibrary.h"\
+	".\include\CppUTest\TestFailure.h"\
+	".\include\CppUTest\TestHarness.h"\
+	".\include\CppUTest\TestPlugin.h"\
+	".\include\CppUTest\TestResult.h"\
+	".\include\CppUTest\Utest.h"\
+	".\include\CppUTest\UtestMacros.h"\
+	".\include\cpputestext\mockactualcall.h"\
+	".\include\CppUTestExt\MockCheckedActualCall.h"\
+	".\include\CppUTestExt\MockCheckedExpectedCall.h"\
+	".\include\cpputestext\mockexpectedcall.h"\
+	".\include\CppUTestExt\MockExpectedCallsList.h"\
+	".\include\CppUTestExt\MockFailure.h"\
+	".\include\CppUTestExt\MockNamedValue.h"\
+	".\include\CppUTestExt\MockSupport.h"\
+	".\include\platforms\visualcpp\stdint.h"\
+	
+
+".\src\CppUTestExt\MockSupport_c.cpp" : \
+	".\include\CppUTest\CppUTestConfig.h"\
+	".\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	".\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	".\include\CppUTest\PlatformSpecificFunctions_c.h"\
+	".\include\CppUTest\SimpleString.h"\
+	".\include\CppUTest\StandardCLibrary.h"\
+	".\include\CppUTest\TestFailure.h"\
+	".\include\CppUTest\TestHarness.h"\
+	".\include\CppUTest\TestPlugin.h"\
+	".\include\CppUTest\TestResult.h"\
+	".\include\CppUTest\Utest.h"\
+	".\include\CppUTest\UtestMacros.h"\
+	".\include\cpputestext\mockactualcall.h"\
+	".\include\CppUTestExt\MockCheckedActualCall.h"\
+	".\include\CppUTestExt\MockCheckedExpectedCall.h"\
+	".\include\cpputestext\mockexpectedcall.h"\
+	".\include\CppUTestExt\MockExpectedCallsList.h"\
+	".\include\CppUTestExt\MockFailure.h"\
+	".\include\CppUTestExt\MockNamedValue.h"\
+	".\include\CppUTestExt\MockSupport.h"\
+	".\include\CppUTestExt\MockSupport_c.h"\
+	".\include\platforms\visualcpp\stdint.h"\
+	
+
+".\src\CppUTestExt\MockSupportPlugin.cpp" : \
+	".\include\CppUTest\CppUTestConfig.h"\
+	".\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	".\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	".\include\CppUTest\SimpleString.h"\
+	".\include\CppUTest\StandardCLibrary.h"\
+	".\include\CppUTest\TestFailure.h"\
+	".\include\CppUTest\TestHarness.h"\
+	".\include\CppUTest\TestPlugin.h"\
+	".\include\CppUTest\TestResult.h"\
+	".\include\CppUTest\Utest.h"\
+	".\include\CppUTest\UtestMacros.h"\
+	".\include\cpputestext\mockactualcall.h"\
+	".\include\CppUTestExt\MockCheckedActualCall.h"\
+	".\include\CppUTestExt\MockCheckedExpectedCall.h"\
+	".\include\cpputestext\mockexpectedcall.h"\
+	".\include\CppUTestExt\MockExpectedCallsList.h"\
+	".\include\CppUTestExt\MockFailure.h"\
+	".\include\CppUTestExt\MockNamedValue.h"\
+	".\include\CppUTestExt\MockSupport.h"\
+	".\include\CppUTestExt\MockSupportPlugin.h"\
+	".\include\platforms\visualcpp\stdint.h"\
+	
+
+".\src\CppUTestExt\OrderedTest.cpp" : \
+	".\include\CppUTest\CppUTestConfig.h"\
+	".\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	".\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	".\include\CppUTest\SimpleString.h"\
+	".\include\CppUTest\StandardCLibrary.h"\
+	".\include\CppUTest\TestFailure.h"\
+	".\include\CppUTest\TestFilter.h"\
+	".\include\CppUTest\TestHarness.h"\
+	".\include\CppUTest\TestPlugin.h"\
+	".\include\CppUTest\TestRegistry.h"\
+	".\include\CppUTest\TestResult.h"\
+	".\include\CppUTest\Utest.h"\
+	".\include\CppUTest\UtestMacros.h"\
+	".\include\CppUTestExt\OrderedTest.h"\
+	".\include\platforms\visualcpp\stdint.h"\
+	
+
+.\SRC\CPPUTEST\SimpleMutex.cpp : \
+	".\include\CppUTest\CppUTestConfig.h"\
+	".\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	".\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	".\include\CppUTest\PlatformSpecificFunctions.h"\
+	".\include\CppUTest\PlatformSpecificFunctions_c.h"\
+	".\include\CppUTest\SimpleMutex.h"\
+	".\include\CppUTest\SimpleString.h"\
+	".\include\CppUTest\StandardCLibrary.h"\
+	".\include\CppUTest\TestFailure.h"\
+	".\include\CppUTest\TestHarness.h"\
+	".\include\CppUTest\TestOutput.h"\
+	".\include\CppUTest\TestPlugin.h"\
+	".\include\CppUTest\TestResult.h"\
+	".\include\CppUTest\Utest.h"\
+	".\include\CppUTest\UtestMacros.h"\
+	".\include\platforms\visualcpp\stdint.h"\
+	
+
+.\SRC\CPPUTEST\SimpleString.cpp : \
+	".\include\CppUTest\CppUTestConfig.h"\
+	".\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	".\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	".\include\CppUTest\PlatformSpecificFunctions.h"\
+	".\include\CppUTest\PlatformSpecificFunctions_c.h"\
+	".\include\CppUTest\SimpleString.h"\
+	".\include\CppUTest\StandardCLibrary.h"\
+	".\include\CppUTest\TestFailure.h"\
+	".\include\CppUTest\TestHarness.h"\
+	".\include\CppUTest\TestMemoryAllocator.h"\
+	".\include\CppUTest\TestOutput.h"\
+	".\include\CppUTest\TestPlugin.h"\
+	".\include\CppUTest\TestResult.h"\
+	".\include\CppUTest\Utest.h"\
+	".\include\CppUTest\UtestMacros.h"\
+	".\include\platforms\visualcpp\stdint.h"\
+	
+
+.\SRC\CPPUTEST\TestFailure.cpp : \
+	".\include\CppUTest\CppUTestConfig.h"\
+	".\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	".\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	".\include\CppUTest\PlatformSpecificFunctions.h"\
+	".\include\CppUTest\PlatformSpecificFunctions_c.h"\
+	".\include\CppUTest\SimpleString.h"\
+	".\include\CppUTest\StandardCLibrary.h"\
+	".\include\CppUTest\TestFailure.h"\
+	".\include\CppUTest\TestHarness.h"\
+	".\include\CppUTest\TestOutput.h"\
+	".\include\CppUTest\TestPlugin.h"\
+	".\include\CppUTest\TestResult.h"\
+	".\include\CppUTest\Utest.h"\
+	".\include\CppUTest\UtestMacros.h"\
+	".\include\platforms\visualcpp\stdint.h"\
+	
+
+.\SRC\CPPUTEST\TestFilter.cpp : \
+	".\include\CppUTest\CppUTestConfig.h"\
+	".\include\CppUTest\SimpleString.h"\
+	".\include\CppUTest\StandardCLibrary.h"\
+	".\include\CppUTest\TestFilter.h"\
+	".\include\platforms\visualcpp\stdint.h"\
+	
+
+.\SRC\CPPUTEST\TestHarness_c.cpp : \
+	".\include\CppUTest\CppUTestConfig.h"\
+	".\include\CppUTest\MemoryLeakDetector.h"\
+	".\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	".\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	".\include\CppUTest\PlatformSpecificFunctions.h"\
+	".\include\CppUTest\PlatformSpecificFunctions_c.h"\
+	".\include\CppUTest\SimpleString.h"\
+	".\include\CppUTest\StandardCLibrary.h"\
+	".\include\CppUTest\TestFailure.h"\
+	".\include\CppUTest\TestHarness.h"\
+	".\include\CppUTest\TestHarness_c.h"\
+	".\include\CppUTest\TestMemoryAllocator.h"\
+	".\include\CppUTest\TestOutput.h"\
+	".\include\CppUTest\TestPlugin.h"\
+	".\include\CppUTest\TestResult.h"\
+	".\include\CppUTest\Utest.h"\
+	".\include\CppUTest\UtestMacros.h"\
+	".\include\platforms\visualcpp\stdint.h"\
+	
+
+.\SRC\CPPUTEST\TestMemoryAllocator.cpp : \
+	".\include\CppUTest\CppUTestConfig.h"\
+	".\include\CppUTest\MemoryLeakDetector.h"\
+	".\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	".\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	".\include\CppUTest\PlatformSpecificFunctions.h"\
+	".\include\CppUTest\PlatformSpecificFunctions_c.h"\
+	".\include\CppUTest\SimpleString.h"\
+	".\include\CppUTest\StandardCLibrary.h"\
+	".\include\CppUTest\TestFailure.h"\
+	".\include\CppUTest\TestHarness.h"\
+	".\include\CppUTest\TestMemoryAllocator.h"\
+	".\include\CppUTest\TestOutput.h"\
+	".\include\CppUTest\TestPlugin.h"\
+	".\include\CppUTest\TestResult.h"\
+	".\include\CppUTest\Utest.h"\
+	".\include\CppUTest\UtestMacros.h"\
+	".\include\platforms\visualcpp\stdint.h"\
+	
+
+.\SRC\CPPUTEST\TestOutput.cpp : \
+	".\include\CppUTest\CppUTestConfig.h"\
+	".\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	".\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	".\include\CppUTest\PlatformSpecificFunctions.h"\
+	".\include\CppUTest\PlatformSpecificFunctions_c.h"\
+	".\include\CppUTest\SimpleString.h"\
+	".\include\CppUTest\StandardCLibrary.h"\
+	".\include\CppUTest\TestFailure.h"\
+	".\include\CppUTest\TestHarness.h"\
+	".\include\CppUTest\TestOutput.h"\
+	".\include\CppUTest\TestPlugin.h"\
+	".\include\CppUTest\TestResult.h"\
+	".\include\CppUTest\Utest.h"\
+	".\include\CppUTest\UtestMacros.h"\
+	".\include\platforms\visualcpp\stdint.h"\
+	
+
+.\SRC\CPPUTEST\TestPlugin.cpp : \
+	".\include\CppUTest\CppUTestConfig.h"\
+	".\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	".\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	".\include\CppUTest\SimpleString.h"\
+	".\include\CppUTest\StandardCLibrary.h"\
+	".\include\CppUTest\TestFailure.h"\
+	".\include\CppUTest\TestHarness.h"\
+	".\include\CppUTest\TestPlugin.h"\
+	".\include\CppUTest\TestResult.h"\
+	".\include\CppUTest\Utest.h"\
+	".\include\CppUTest\UtestMacros.h"\
+	".\include\platforms\visualcpp\stdint.h"\
+	
+
+.\SRC\CPPUTEST\TestRegistry.cpp : \
+	".\include\CppUTest\CppUTestConfig.h"\
+	".\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	".\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	".\include\CppUTest\SimpleString.h"\
+	".\include\CppUTest\StandardCLibrary.h"\
+	".\include\CppUTest\TestFailure.h"\
+	".\include\CppUTest\TestFilter.h"\
+	".\include\CppUTest\TestHarness.h"\
+	".\include\CppUTest\TestPlugin.h"\
+	".\include\CppUTest\TestRegistry.h"\
+	".\include\CppUTest\TestResult.h"\
+	".\include\CppUTest\Utest.h"\
+	".\include\CppUTest\UtestMacros.h"\
+	".\include\platforms\visualcpp\stdint.h"\
+	
+
+.\SRC\CPPUTEST\TestResult.cpp : \
+	".\include\CppUTest\CppUTestConfig.h"\
+	".\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	".\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	".\include\CppUTest\PlatformSpecificFunctions.h"\
+	".\include\CppUTest\PlatformSpecificFunctions_c.h"\
+	".\include\CppUTest\SimpleString.h"\
+	".\include\CppUTest\StandardCLibrary.h"\
+	".\include\CppUTest\TestFailure.h"\
+	".\include\CppUTest\TestHarness.h"\
+	".\include\CppUTest\TestOutput.h"\
+	".\include\CppUTest\TestPlugin.h"\
+	".\include\CppUTest\TestResult.h"\
+	".\include\CppUTest\Utest.h"\
+	".\include\CppUTest\UtestMacros.h"\
+	".\include\platforms\visualcpp\stdint.h"\
+	
+
+.\SRC\CPPUTEST\Utest.cpp : \
+	".\include\CppUTest\CppUTestConfig.h"\
+	".\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	".\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	".\include\CppUTest\PlatformSpecificFunctions.h"\
+	".\include\CppUTest\PlatformSpecificFunctions_c.h"\
+	".\include\CppUTest\SimpleString.h"\
+	".\include\CppUTest\StandardCLibrary.h"\
+	".\include\CppUTest\TestFailure.h"\
+	".\include\CppUTest\TestFilter.h"\
+	".\include\CppUTest\TestHarness.h"\
+	".\include\CppUTest\TestOutput.h"\
+	".\include\CppUTest\TestPlugin.h"\
+	".\include\CppUTest\TestRegistry.h"\
+	".\include\CppUTest\TestResult.h"\
+	".\include\CppUTest\Utest.h"\
+	".\include\CppUTest\UtestMacros.h"\
+	".\include\platforms\visualcpp\stdint.h"\
+	
+
+.\src\Platforms\VisualCpp\UtestPlatform.cpp : \
+	".\include\CppUTest\CppUTestConfig.h"\
+	".\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	".\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	".\include\CppUTest\PlatformSpecificFunctions.h"\
+	".\include\CppUTest\PlatformSpecificFunctions_c.h"\
+	".\include\CppUTest\SimpleString.h"\
+	".\include\CppUTest\StandardCLibrary.h"\
+	".\include\CppUTest\TestFailure.h"\
+	".\include\CppUTest\TestHarness.h"\
+	".\include\CppUTest\TestOutput.h"\
+	".\include\CppUTest\TestPlugin.h"\
+	".\include\CppUTest\TestResult.h"\
+	".\include\CppUTest\Utest.h"\
+	".\include\CppUTest\UtestMacros.h"\
+	".\include\platforms\visualcpp\platform.h"\
+	".\include\platforms\visualcpp\stdint.h"\
+	

--- a/CppUTest.dsp
+++ b/CppUTest.dsp
@@ -41,7 +41,7 @@ RSC=rc.exe
 # PROP Intermediate_Dir "Release"
 # PROP Target_Dir ""
 # ADD BASE CPP /nologo /W3 /GX /O2 /D "WIN32" /D "NDEBUG" /D "_MBCS" /D "_LIB" /YX /FD /c
-# ADD CPP /nologo /W3 /GX /O2 /I ".\include\Platforms\VisualCpp" /I ".\include" /D "WIN32" /D "NDEBUG" /D "_MBCS" /D "_LIB" /YX /FD /c
+# ADD CPP /nologo /W3 /GX /O2 /I ".\include\Platforms\VisualCpp" /I ".\include" /D "WIN32" /D "NDEBUG" /D "_MBCS" /D "_LIB" /D "CPPUTEST_MEM_LEAK_DETECTION_DISABLED" /YX /FD /c
 # ADD BASE RSC /l 0x409 /d "NDEBUG"
 # ADD RSC /l 0x409 /d "NDEBUG"
 BSC32=bscmake.exe
@@ -64,7 +64,7 @@ LIB32=link.exe -lib
 # PROP Intermediate_Dir "Debug"
 # PROP Target_Dir ""
 # ADD BASE CPP /nologo /W3 /Gm /GX /ZI /Od /D "WIN32" /D "_DEBUG" /D "_MBCS" /D "_LIB" /YX /FD /GZ /c
-# ADD CPP /nologo /MDd /W3 /GX /ZI /Od /I ".\include\Platforms\VisualCpp" /I ".\include" /D "WIN32" /D "_DEBUG" /D "_MBCS" /D "_LIB" /FR /FD /GZ /c
+# ADD CPP /nologo /MDd /W3 /GX /ZI /Od /I ".\include\Platforms\VisualCpp" /I ".\include" /D "WIN32" /D "_DEBUG" /D "_MBCS" /D "_LIB" /D "CPPUTEST_MEM_LEAK_DETECTION_DISABLED" /FR /FD /GZ /c
 # SUBTRACT CPP /YX
 # ADD BASE RSC /l 0x409 /d "_DEBUG"
 # ADD RSC /l 0x409 /d "_DEBUG"

--- a/CppUTest.mak
+++ b/CppUTest.mak
@@ -25,6 +25,9 @@ NULL=
 NULL=nul
 !ENDIF 
 
+CPP=cl.exe
+RSC=rc.exe
+
 !IF  "$(CFG)" == "CppUTest - Win32 Release"
 
 OUTDIR=.\Release
@@ -73,40 +76,7 @@ CLEAN :
 "$(OUTDIR)" :
     if not exist "$(OUTDIR)/$(NULL)" mkdir "$(OUTDIR)"
 
-CPP=cl.exe
-CPP_PROJ=/nologo /ML /W3 /GX /O2 /I ".\include\Platforms\VisualCpp" /I ".\include" /D "WIN32" /D "NDEBUG" /D "_MBCS" /D "_LIB" /Fp"$(INTDIR)\CppUTest.pch" /YX /Fo"$(INTDIR)\\" /Fd"$(INTDIR)\\" /FD /c 
-
-.c{$(INTDIR)}.obj::
-   $(CPP) @<<
-   $(CPP_PROJ) $< 
-<<
-
-.cpp{$(INTDIR)}.obj::
-   $(CPP) @<<
-   $(CPP_PROJ) $< 
-<<
-
-.cxx{$(INTDIR)}.obj::
-   $(CPP) @<<
-   $(CPP_PROJ) $< 
-<<
-
-.c{$(INTDIR)}.sbr::
-   $(CPP) @<<
-   $(CPP_PROJ) $< 
-<<
-
-.cpp{$(INTDIR)}.sbr::
-   $(CPP) @<<
-   $(CPP_PROJ) $< 
-<<
-
-.cxx{$(INTDIR)}.sbr::
-   $(CPP) @<<
-   $(CPP_PROJ) $< 
-<<
-
-RSC=rc.exe
+CPP_PROJ=/nologo /ML /W3 /GX /O2 /I ".\include\Platforms\VisualCpp" /I ".\include" /D "WIN32" /D "NDEBUG" /D "_MBCS" /D "_LIB" /D "CPPUTEST_MEM_LEAK_DETECTION_DISABLED" /Fp"$(INTDIR)\CppUTest.pch" /YX /Fo"$(INTDIR)\\" /Fd"$(INTDIR)\\" /FD /c 
 BSC32=bscmake.exe
 BSC32_FLAGS=/nologo /o"$(OUTDIR)\CppUTest.bsc" 
 BSC32_SBRS= \
@@ -230,40 +200,7 @@ CLEAN :
 "$(OUTDIR)" :
     if not exist "$(OUTDIR)/$(NULL)" mkdir "$(OUTDIR)"
 
-CPP=cl.exe
-CPP_PROJ=/nologo /MDd /W3 /GX /ZI /Od /I ".\include\Platforms\VisualCpp" /I ".\include" /D "WIN32" /D "_DEBUG" /D "_MBCS" /D "_LIB" /FR"$(INTDIR)\\" /Fo"$(INTDIR)\\" /Fd"$(INTDIR)\\" /FD /GZ /c 
-
-.c{$(INTDIR)}.obj::
-   $(CPP) @<<
-   $(CPP_PROJ) $< 
-<<
-
-.cpp{$(INTDIR)}.obj::
-   $(CPP) @<<
-   $(CPP_PROJ) $< 
-<<
-
-.cxx{$(INTDIR)}.obj::
-   $(CPP) @<<
-   $(CPP_PROJ) $< 
-<<
-
-.c{$(INTDIR)}.sbr::
-   $(CPP) @<<
-   $(CPP_PROJ) $< 
-<<
-
-.cpp{$(INTDIR)}.sbr::
-   $(CPP) @<<
-   $(CPP_PROJ) $< 
-<<
-
-.cxx{$(INTDIR)}.sbr::
-   $(CPP) @<<
-   $(CPP_PROJ) $< 
-<<
-
-RSC=rc.exe
+CPP_PROJ=/nologo /MDd /W3 /GX /ZI /Od /I ".\include\Platforms\VisualCpp" /I ".\include" /D "WIN32" /D "_DEBUG" /D "_MBCS" /D "_LIB" /D "CPPUTEST_MEM_LEAK_DETECTION_DISABLED" /FR"$(INTDIR)\\" /Fo"$(INTDIR)\\" /Fd"$(INTDIR)\\" /FD /GZ /c 
 BSC32=bscmake.exe
 BSC32_FLAGS=/nologo /o"$(OUTDIR)\CppUTest.bsc" 
 BSC32_SBRS= \
@@ -343,6 +280,36 @@ LIB32_OBJS= \
 <<
 
 !ENDIF 
+
+.c{$(INTDIR)}.obj::
+   $(CPP) @<<
+   $(CPP_PROJ) $< 
+<<
+
+.cpp{$(INTDIR)}.obj::
+   $(CPP) @<<
+   $(CPP_PROJ) $< 
+<<
+
+.cxx{$(INTDIR)}.obj::
+   $(CPP) @<<
+   $(CPP_PROJ) $< 
+<<
+
+.c{$(INTDIR)}.sbr::
+   $(CPP) @<<
+   $(CPP_PROJ) $< 
+<<
+
+.cpp{$(INTDIR)}.sbr::
+   $(CPP) @<<
+   $(CPP_PROJ) $< 
+<<
+
+.cxx{$(INTDIR)}.sbr::
+   $(CPP) @<<
+   $(CPP_PROJ) $< 
+<<
 
 
 !IF "$(NO_EXTERNAL_DEPS)" != "1"

--- a/CppUTest.mak
+++ b/CppUTest.mak
@@ -25,9 +25,6 @@ NULL=
 NULL=nul
 !ENDIF 
 
-CPP=cl.exe
-RSC=rc.exe
-
 !IF  "$(CFG)" == "CppUTest - Win32 Release"
 
 OUTDIR=.\Release
@@ -40,15 +37,30 @@ ALL : "$(OUTDIR)\CppUTest.lib"
 
 
 CLEAN :
+	-@erase "$(INTDIR)\CodeMemoryReportFormatter.obj"
 	-@erase "$(INTDIR)\CommandLineArguments.obj"
 	-@erase "$(INTDIR)\CommandLineTestRunner.obj"
-	-@erase "$(INTDIR)\Failure.obj"
 	-@erase "$(INTDIR)\JUnitTestOutput.obj"
-	-@erase "$(INTDIR)\MemoryLeakAllocator.obj"
 	-@erase "$(INTDIR)\MemoryLeakDetector.obj"
 	-@erase "$(INTDIR)\MemoryLeakWarningPlugin.obj"
+	-@erase "$(INTDIR)\MemoryReportAllocator.obj"
+	-@erase "$(INTDIR)\MemoryReporterPlugin.obj"
+	-@erase "$(INTDIR)\MemoryReportFormatter.obj"
+	-@erase "$(INTDIR)\MockActualCall.obj"
+	-@erase "$(INTDIR)\MockExpectedCall.obj"
+	-@erase "$(INTDIR)\MockExpectedCallsList.obj"
+	-@erase "$(INTDIR)\MockFailure.obj"
+	-@erase "$(INTDIR)\MockNamedValue.obj"
+	-@erase "$(INTDIR)\MockSupport.obj"
+	-@erase "$(INTDIR)\MockSupport_c.obj"
+	-@erase "$(INTDIR)\MockSupportPlugin.obj"
+	-@erase "$(INTDIR)\OrderedTest.obj"
+	-@erase "$(INTDIR)\SimpleMutex.obj"
 	-@erase "$(INTDIR)\SimpleString.obj"
+	-@erase "$(INTDIR)\TestFailure.obj"
+	-@erase "$(INTDIR)\TestFilter.obj"
 	-@erase "$(INTDIR)\TestHarness_c.obj"
+	-@erase "$(INTDIR)\TestMemoryAllocator.obj"
 	-@erase "$(INTDIR)\TestOutput.obj"
 	-@erase "$(INTDIR)\TestPlugin.obj"
 	-@erase "$(INTDIR)\TestRegistry.obj"
@@ -61,96 +73,8 @@ CLEAN :
 "$(OUTDIR)" :
     if not exist "$(OUTDIR)/$(NULL)" mkdir "$(OUTDIR)"
 
-CPP_PROJ=/nologo /ML /W3 /GX /O2 /D "WIN32" /D "NDEBUG" /D "_MBCS" /D "_LIB" /Fp"$(INTDIR)\CppUTest.pch" /YX /Fo"$(INTDIR)\\" /Fd"$(INTDIR)\\" /FD /c 
-BSC32=bscmake.exe
-BSC32_FLAGS=/nologo /o"$(OUTDIR)\CppUTest.bsc" 
-BSC32_SBRS= \
-	
-LIB32=link.exe -lib
-LIB32_FLAGS=/nologo /out:"$(OUTDIR)\CppUTest.lib" 
-LIB32_OBJS= \
-	"$(INTDIR)\CommandLineArguments.obj" \
-	"$(INTDIR)\CommandLineTestRunner.obj" \
-	"$(INTDIR)\Failure.obj" \
-	"$(INTDIR)\JUnitTestOutput.obj" \
-	"$(INTDIR)\MemoryLeakAllocator.obj" \
-	"$(INTDIR)\MemoryLeakDetector.obj" \
-	"$(INTDIR)\MemoryLeakWarningPlugin.obj" \
-	"$(INTDIR)\SimpleString.obj" \
-	"$(INTDIR)\TestHarness_c.obj" \
-	"$(INTDIR)\TestOutput.obj" \
-	"$(INTDIR)\TestPlugin.obj" \
-	"$(INTDIR)\TestRegistry.obj" \
-	"$(INTDIR)\TestResult.obj" \
-	"$(INTDIR)\Utest.obj" \
-	"$(INTDIR)\UtestPlatform.obj"
-
-"$(OUTDIR)\CppUTest.lib" : "$(OUTDIR)" $(DEF_FILE) $(LIB32_OBJS)
-    $(LIB32) @<<
-  $(LIB32_FLAGS) $(DEF_FLAGS) $(LIB32_OBJS)
-<<
-
-!ELSEIF  "$(CFG)" == "CppUTest - Win32 Debug"
-
-OUTDIR=.\Debug
-INTDIR=.\Debug
-
-ALL : ".\lib\CppUTest.lib"
-
-
-CLEAN :
-	-@erase "$(INTDIR)\CommandLineArguments.obj"
-	-@erase "$(INTDIR)\CommandLineTestRunner.obj"
-	-@erase "$(INTDIR)\Failure.obj"
-	-@erase "$(INTDIR)\JUnitTestOutput.obj"
-	-@erase "$(INTDIR)\MemoryLeakAllocator.obj"
-	-@erase "$(INTDIR)\MemoryLeakDetector.obj"
-	-@erase "$(INTDIR)\MemoryLeakWarningPlugin.obj"
-	-@erase "$(INTDIR)\SimpleString.obj"
-	-@erase "$(INTDIR)\TestHarness_c.obj"
-	-@erase "$(INTDIR)\TestOutput.obj"
-	-@erase "$(INTDIR)\TestPlugin.obj"
-	-@erase "$(INTDIR)\TestRegistry.obj"
-	-@erase "$(INTDIR)\TestResult.obj"
-	-@erase "$(INTDIR)\Utest.obj"
-	-@erase "$(INTDIR)\UtestPlatform.obj"
-	-@erase "$(INTDIR)\vc60.idb"
-	-@erase "$(INTDIR)\vc60.pdb"
-	-@erase ".\lib\CppUTest.lib"
-
-"$(OUTDIR)" :
-    if not exist "$(OUTDIR)/$(NULL)" mkdir "$(OUTDIR)"
-
-CPP_PROJ=/nologo /MDd /W3 /GX /ZI /Od /I ".\include" /I ".\include\Platforms\VisualCpp" /D "_LIB" /D "WIN32" /D "_DEBUG" /D "_MBCS" /Fo"$(INTDIR)\\" /Fd"$(INTDIR)\\" /FD /GZ /c 
-BSC32=bscmake.exe
-BSC32_FLAGS=/nologo /o"$(OUTDIR)\CppUTest.bsc" 
-BSC32_SBRS= \
-	
-LIB32=link.exe -lib
-LIB32_FLAGS=/nologo /out:"lib\CppUTest.lib" 
-LIB32_OBJS= \
-	"$(INTDIR)\CommandLineArguments.obj" \
-	"$(INTDIR)\CommandLineTestRunner.obj" \
-	"$(INTDIR)\Failure.obj" \
-	"$(INTDIR)\JUnitTestOutput.obj" \
-	"$(INTDIR)\MemoryLeakAllocator.obj" \
-	"$(INTDIR)\MemoryLeakDetector.obj" \
-	"$(INTDIR)\MemoryLeakWarningPlugin.obj" \
-	"$(INTDIR)\SimpleString.obj" \
-	"$(INTDIR)\TestHarness_c.obj" \
-	"$(INTDIR)\TestOutput.obj" \
-	"$(INTDIR)\TestPlugin.obj" \
-	"$(INTDIR)\TestRegistry.obj" \
-	"$(INTDIR)\TestResult.obj" \
-	"$(INTDIR)\Utest.obj" \
-	"$(INTDIR)\UtestPlatform.obj"
-
-".\lib\CppUTest.lib" : "$(OUTDIR)" $(DEF_FILE) $(LIB32_OBJS)
-    $(LIB32) @<<
-  $(LIB32_FLAGS) $(DEF_FLAGS) $(LIB32_OBJS)
-<<
-
-!ENDIF 
+CPP=cl.exe
+CPP_PROJ=/nologo /ML /W3 /GX /O2 /I ".\include\Platforms\VisualCpp" /I ".\include" /D "WIN32" /D "NDEBUG" /D "_MBCS" /D "_LIB" /Fp"$(INTDIR)\CppUTest.pch" /YX /Fo"$(INTDIR)\\" /Fd"$(INTDIR)\\" /FD /c 
 
 .c{$(INTDIR)}.obj::
    $(CPP) @<<
@@ -182,6 +106,244 @@ LIB32_OBJS= \
    $(CPP_PROJ) $< 
 <<
 
+RSC=rc.exe
+BSC32=bscmake.exe
+BSC32_FLAGS=/nologo /o"$(OUTDIR)\CppUTest.bsc" 
+BSC32_SBRS= \
+	
+LIB32=link.exe -lib
+LIB32_FLAGS=/nologo /out:"$(OUTDIR)\CppUTest.lib" 
+LIB32_OBJS= \
+	"$(INTDIR)\CodeMemoryReportFormatter.obj" \
+	"$(INTDIR)\MemoryReportAllocator.obj" \
+	"$(INTDIR)\MemoryReporterPlugin.obj" \
+	"$(INTDIR)\MemoryReportFormatter.obj" \
+	"$(INTDIR)\MockActualCall.obj" \
+	"$(INTDIR)\MockExpectedCall.obj" \
+	"$(INTDIR)\MockExpectedCallsList.obj" \
+	"$(INTDIR)\MockFailure.obj" \
+	"$(INTDIR)\MockNamedValue.obj" \
+	"$(INTDIR)\MockSupport.obj" \
+	"$(INTDIR)\MockSupportPlugin.obj" \
+	"$(INTDIR)\MockSupport_c.obj" \
+	"$(INTDIR)\OrderedTest.obj" \
+	"$(INTDIR)\CommandLineArguments.obj" \
+	"$(INTDIR)\CommandLineTestRunner.obj" \
+	"$(INTDIR)\JUnitTestOutput.obj" \
+	"$(INTDIR)\MemoryLeakDetector.obj" \
+	"$(INTDIR)\MemoryLeakWarningPlugin.obj" \
+	"$(INTDIR)\SimpleMutex.obj" \
+	"$(INTDIR)\SimpleString.obj" \
+	"$(INTDIR)\TestFailure.obj" \
+	"$(INTDIR)\TestFilter.obj" \
+	"$(INTDIR)\TestHarness_c.obj" \
+	"$(INTDIR)\TestMemoryAllocator.obj" \
+	"$(INTDIR)\TestOutput.obj" \
+	"$(INTDIR)\TestPlugin.obj" \
+	"$(INTDIR)\TestRegistry.obj" \
+	"$(INTDIR)\TestResult.obj" \
+	"$(INTDIR)\Utest.obj" \
+	"$(INTDIR)\UtestPlatform.obj"
+
+"$(OUTDIR)\CppUTest.lib" : "$(OUTDIR)" $(DEF_FILE) $(LIB32_OBJS)
+    $(LIB32) @<<
+  $(LIB32_FLAGS) $(DEF_FLAGS) $(LIB32_OBJS)
+<<
+
+!ELSEIF  "$(CFG)" == "CppUTest - Win32 Debug"
+
+OUTDIR=.\Debug
+INTDIR=.\Debug
+# Begin Custom Macros
+OutDir=.\Debug
+# End Custom Macros
+
+ALL : ".\lib\CppUTest.lib" "$(OUTDIR)\CppUTest.bsc"
+
+
+CLEAN :
+	-@erase "$(INTDIR)\CodeMemoryReportFormatter.obj"
+	-@erase "$(INTDIR)\CodeMemoryReportFormatter.sbr"
+	-@erase "$(INTDIR)\CommandLineArguments.obj"
+	-@erase "$(INTDIR)\CommandLineArguments.sbr"
+	-@erase "$(INTDIR)\CommandLineTestRunner.obj"
+	-@erase "$(INTDIR)\CommandLineTestRunner.sbr"
+	-@erase "$(INTDIR)\JUnitTestOutput.obj"
+	-@erase "$(INTDIR)\JUnitTestOutput.sbr"
+	-@erase "$(INTDIR)\MemoryLeakDetector.obj"
+	-@erase "$(INTDIR)\MemoryLeakDetector.sbr"
+	-@erase "$(INTDIR)\MemoryLeakWarningPlugin.obj"
+	-@erase "$(INTDIR)\MemoryLeakWarningPlugin.sbr"
+	-@erase "$(INTDIR)\MemoryReportAllocator.obj"
+	-@erase "$(INTDIR)\MemoryReportAllocator.sbr"
+	-@erase "$(INTDIR)\MemoryReporterPlugin.obj"
+	-@erase "$(INTDIR)\MemoryReporterPlugin.sbr"
+	-@erase "$(INTDIR)\MemoryReportFormatter.obj"
+	-@erase "$(INTDIR)\MemoryReportFormatter.sbr"
+	-@erase "$(INTDIR)\MockActualCall.obj"
+	-@erase "$(INTDIR)\MockActualCall.sbr"
+	-@erase "$(INTDIR)\MockExpectedCall.obj"
+	-@erase "$(INTDIR)\MockExpectedCall.sbr"
+	-@erase "$(INTDIR)\MockExpectedCallsList.obj"
+	-@erase "$(INTDIR)\MockExpectedCallsList.sbr"
+	-@erase "$(INTDIR)\MockFailure.obj"
+	-@erase "$(INTDIR)\MockFailure.sbr"
+	-@erase "$(INTDIR)\MockNamedValue.obj"
+	-@erase "$(INTDIR)\MockNamedValue.sbr"
+	-@erase "$(INTDIR)\MockSupport.obj"
+	-@erase "$(INTDIR)\MockSupport.sbr"
+	-@erase "$(INTDIR)\MockSupport_c.obj"
+	-@erase "$(INTDIR)\MockSupport_c.sbr"
+	-@erase "$(INTDIR)\MockSupportPlugin.obj"
+	-@erase "$(INTDIR)\MockSupportPlugin.sbr"
+	-@erase "$(INTDIR)\OrderedTest.obj"
+	-@erase "$(INTDIR)\OrderedTest.sbr"
+	-@erase "$(INTDIR)\SimpleMutex.obj"
+	-@erase "$(INTDIR)\SimpleMutex.sbr"
+	-@erase "$(INTDIR)\SimpleString.obj"
+	-@erase "$(INTDIR)\SimpleString.sbr"
+	-@erase "$(INTDIR)\TestFailure.obj"
+	-@erase "$(INTDIR)\TestFailure.sbr"
+	-@erase "$(INTDIR)\TestFilter.obj"
+	-@erase "$(INTDIR)\TestFilter.sbr"
+	-@erase "$(INTDIR)\TestHarness_c.obj"
+	-@erase "$(INTDIR)\TestHarness_c.sbr"
+	-@erase "$(INTDIR)\TestMemoryAllocator.obj"
+	-@erase "$(INTDIR)\TestMemoryAllocator.sbr"
+	-@erase "$(INTDIR)\TestOutput.obj"
+	-@erase "$(INTDIR)\TestOutput.sbr"
+	-@erase "$(INTDIR)\TestPlugin.obj"
+	-@erase "$(INTDIR)\TestPlugin.sbr"
+	-@erase "$(INTDIR)\TestRegistry.obj"
+	-@erase "$(INTDIR)\TestRegistry.sbr"
+	-@erase "$(INTDIR)\TestResult.obj"
+	-@erase "$(INTDIR)\TestResult.sbr"
+	-@erase "$(INTDIR)\Utest.obj"
+	-@erase "$(INTDIR)\Utest.sbr"
+	-@erase "$(INTDIR)\UtestPlatform.obj"
+	-@erase "$(INTDIR)\UtestPlatform.sbr"
+	-@erase "$(INTDIR)\vc60.idb"
+	-@erase "$(INTDIR)\vc60.pdb"
+	-@erase "$(OUTDIR)\CppUTest.bsc"
+	-@erase ".\lib\CppUTest.lib"
+
+"$(OUTDIR)" :
+    if not exist "$(OUTDIR)/$(NULL)" mkdir "$(OUTDIR)"
+
+CPP=cl.exe
+CPP_PROJ=/nologo /MDd /W3 /GX /ZI /Od /I ".\include\Platforms\VisualCpp" /I ".\include" /D "WIN32" /D "_DEBUG" /D "_MBCS" /D "_LIB" /FR"$(INTDIR)\\" /Fo"$(INTDIR)\\" /Fd"$(INTDIR)\\" /FD /GZ /c 
+
+.c{$(INTDIR)}.obj::
+   $(CPP) @<<
+   $(CPP_PROJ) $< 
+<<
+
+.cpp{$(INTDIR)}.obj::
+   $(CPP) @<<
+   $(CPP_PROJ) $< 
+<<
+
+.cxx{$(INTDIR)}.obj::
+   $(CPP) @<<
+   $(CPP_PROJ) $< 
+<<
+
+.c{$(INTDIR)}.sbr::
+   $(CPP) @<<
+   $(CPP_PROJ) $< 
+<<
+
+.cpp{$(INTDIR)}.sbr::
+   $(CPP) @<<
+   $(CPP_PROJ) $< 
+<<
+
+.cxx{$(INTDIR)}.sbr::
+   $(CPP) @<<
+   $(CPP_PROJ) $< 
+<<
+
+RSC=rc.exe
+BSC32=bscmake.exe
+BSC32_FLAGS=/nologo /o"$(OUTDIR)\CppUTest.bsc" 
+BSC32_SBRS= \
+	"$(INTDIR)\CodeMemoryReportFormatter.sbr" \
+	"$(INTDIR)\MemoryReportAllocator.sbr" \
+	"$(INTDIR)\MemoryReporterPlugin.sbr" \
+	"$(INTDIR)\MemoryReportFormatter.sbr" \
+	"$(INTDIR)\MockActualCall.sbr" \
+	"$(INTDIR)\MockExpectedCall.sbr" \
+	"$(INTDIR)\MockExpectedCallsList.sbr" \
+	"$(INTDIR)\MockFailure.sbr" \
+	"$(INTDIR)\MockNamedValue.sbr" \
+	"$(INTDIR)\MockSupport.sbr" \
+	"$(INTDIR)\MockSupportPlugin.sbr" \
+	"$(INTDIR)\MockSupport_c.sbr" \
+	"$(INTDIR)\OrderedTest.sbr" \
+	"$(INTDIR)\CommandLineArguments.sbr" \
+	"$(INTDIR)\CommandLineTestRunner.sbr" \
+	"$(INTDIR)\JUnitTestOutput.sbr" \
+	"$(INTDIR)\MemoryLeakDetector.sbr" \
+	"$(INTDIR)\MemoryLeakWarningPlugin.sbr" \
+	"$(INTDIR)\SimpleMutex.sbr" \
+	"$(INTDIR)\SimpleString.sbr" \
+	"$(INTDIR)\TestFailure.sbr" \
+	"$(INTDIR)\TestFilter.sbr" \
+	"$(INTDIR)\TestHarness_c.sbr" \
+	"$(INTDIR)\TestMemoryAllocator.sbr" \
+	"$(INTDIR)\TestOutput.sbr" \
+	"$(INTDIR)\TestPlugin.sbr" \
+	"$(INTDIR)\TestRegistry.sbr" \
+	"$(INTDIR)\TestResult.sbr" \
+	"$(INTDIR)\Utest.sbr" \
+	"$(INTDIR)\UtestPlatform.sbr"
+
+"$(OUTDIR)\CppUTest.bsc" : "$(OUTDIR)" $(BSC32_SBRS)
+    $(BSC32) @<<
+  $(BSC32_FLAGS) $(BSC32_SBRS)
+<<
+
+LIB32=link.exe -lib
+LIB32_FLAGS=/nologo /out:"lib\CppUTest.lib" 
+LIB32_OBJS= \
+	"$(INTDIR)\CodeMemoryReportFormatter.obj" \
+	"$(INTDIR)\MemoryReportAllocator.obj" \
+	"$(INTDIR)\MemoryReporterPlugin.obj" \
+	"$(INTDIR)\MemoryReportFormatter.obj" \
+	"$(INTDIR)\MockActualCall.obj" \
+	"$(INTDIR)\MockExpectedCall.obj" \
+	"$(INTDIR)\MockExpectedCallsList.obj" \
+	"$(INTDIR)\MockFailure.obj" \
+	"$(INTDIR)\MockNamedValue.obj" \
+	"$(INTDIR)\MockSupport.obj" \
+	"$(INTDIR)\MockSupportPlugin.obj" \
+	"$(INTDIR)\MockSupport_c.obj" \
+	"$(INTDIR)\OrderedTest.obj" \
+	"$(INTDIR)\CommandLineArguments.obj" \
+	"$(INTDIR)\CommandLineTestRunner.obj" \
+	"$(INTDIR)\JUnitTestOutput.obj" \
+	"$(INTDIR)\MemoryLeakDetector.obj" \
+	"$(INTDIR)\MemoryLeakWarningPlugin.obj" \
+	"$(INTDIR)\SimpleMutex.obj" \
+	"$(INTDIR)\SimpleString.obj" \
+	"$(INTDIR)\TestFailure.obj" \
+	"$(INTDIR)\TestFilter.obj" \
+	"$(INTDIR)\TestHarness_c.obj" \
+	"$(INTDIR)\TestMemoryAllocator.obj" \
+	"$(INTDIR)\TestOutput.obj" \
+	"$(INTDIR)\TestPlugin.obj" \
+	"$(INTDIR)\TestRegistry.obj" \
+	"$(INTDIR)\TestResult.obj" \
+	"$(INTDIR)\Utest.obj" \
+	"$(INTDIR)\UtestPlatform.obj"
+
+".\lib\CppUTest.lib" : "$(OUTDIR)" $(DEF_FILE) $(LIB32_OBJS)
+    $(LIB32) @<<
+  $(LIB32_FLAGS) $(DEF_FLAGS) $(LIB32_OBJS)
+<<
+
+!ENDIF 
+
 
 !IF "$(NO_EXTERNAL_DEPS)" != "1"
 !IF EXISTS("CppUTest.dep")
@@ -193,95 +355,545 @@ LIB32_OBJS= \
 
 
 !IF "$(CFG)" == "CppUTest - Win32 Release" || "$(CFG)" == "CppUTest - Win32 Debug"
-SOURCE=.\src\CppUTest\CommandLineArguments.cpp
+SOURCE=.\src\CppUTestExt\CodeMemoryReportFormatter.cpp
+
+!IF  "$(CFG)" == "CppUTest - Win32 Release"
+
+
+"$(INTDIR)\CodeMemoryReportFormatter.obj" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ELSEIF  "$(CFG)" == "CppUTest - Win32 Debug"
+
+
+"$(INTDIR)\CodeMemoryReportFormatter.obj"	"$(INTDIR)\CodeMemoryReportFormatter.sbr" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ENDIF 
+
+SOURCE=.\SRC\CPPUTEST\CommandLineArguments.cpp
+
+!IF  "$(CFG)" == "CppUTest - Win32 Release"
+
 
 "$(INTDIR)\CommandLineArguments.obj" : $(SOURCE) "$(INTDIR)"
 	$(CPP) $(CPP_PROJ) $(SOURCE)
 
 
-SOURCE=.\src\CppUTest\CommandLineTestRunner.cpp
+!ELSEIF  "$(CFG)" == "CppUTest - Win32 Debug"
+
+
+"$(INTDIR)\CommandLineArguments.obj"	"$(INTDIR)\CommandLineArguments.sbr" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ENDIF 
+
+SOURCE=.\SRC\CPPUTEST\CommandLineTestRunner.cpp
+
+!IF  "$(CFG)" == "CppUTest - Win32 Release"
+
 
 "$(INTDIR)\CommandLineTestRunner.obj" : $(SOURCE) "$(INTDIR)"
 	$(CPP) $(CPP_PROJ) $(SOURCE)
 
 
-SOURCE=.\src\CppUTest\Failure.cpp
+!ELSEIF  "$(CFG)" == "CppUTest - Win32 Debug"
 
-"$(INTDIR)\Failure.obj" : $(SOURCE) "$(INTDIR)"
+
+"$(INTDIR)\CommandLineTestRunner.obj"	"$(INTDIR)\CommandLineTestRunner.sbr" : $(SOURCE) "$(INTDIR)"
 	$(CPP) $(CPP_PROJ) $(SOURCE)
 
 
-SOURCE=.\src\CppUTest\JUnitTestOutput.cpp
+!ENDIF 
+
+SOURCE=.\SRC\CPPUTEST\JUnitTestOutput.cpp
+
+!IF  "$(CFG)" == "CppUTest - Win32 Release"
+
 
 "$(INTDIR)\JUnitTestOutput.obj" : $(SOURCE) "$(INTDIR)"
 	$(CPP) $(CPP_PROJ) $(SOURCE)
 
 
-SOURCE=.\src\CppUTest\MemoryLeakAllocator.cpp
+!ELSEIF  "$(CFG)" == "CppUTest - Win32 Debug"
 
-"$(INTDIR)\MemoryLeakAllocator.obj" : $(SOURCE) "$(INTDIR)"
+
+"$(INTDIR)\JUnitTestOutput.obj"	"$(INTDIR)\JUnitTestOutput.sbr" : $(SOURCE) "$(INTDIR)"
 	$(CPP) $(CPP_PROJ) $(SOURCE)
 
 
-SOURCE=.\src\CppUTest\MemoryLeakDetector.cpp
+!ENDIF 
+
+SOURCE=.\SRC\CPPUTEST\MemoryLeakDetector.cpp
+
+!IF  "$(CFG)" == "CppUTest - Win32 Release"
+
 
 "$(INTDIR)\MemoryLeakDetector.obj" : $(SOURCE) "$(INTDIR)"
 	$(CPP) $(CPP_PROJ) $(SOURCE)
 
 
-SOURCE=.\src\CppUTest\MemoryLeakWarningPlugin.cpp
+!ELSEIF  "$(CFG)" == "CppUTest - Win32 Debug"
+
+
+"$(INTDIR)\MemoryLeakDetector.obj"	"$(INTDIR)\MemoryLeakDetector.sbr" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ENDIF 
+
+SOURCE=.\SRC\CPPUTEST\MemoryLeakWarningPlugin.cpp
+
+!IF  "$(CFG)" == "CppUTest - Win32 Release"
+
 
 "$(INTDIR)\MemoryLeakWarningPlugin.obj" : $(SOURCE) "$(INTDIR)"
 	$(CPP) $(CPP_PROJ) $(SOURCE)
 
 
-SOURCE=.\src\CppUTest\SimpleString.cpp
+!ELSEIF  "$(CFG)" == "CppUTest - Win32 Debug"
+
+
+"$(INTDIR)\MemoryLeakWarningPlugin.obj"	"$(INTDIR)\MemoryLeakWarningPlugin.sbr" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ENDIF 
+
+SOURCE=.\src\CppUTestExt\MemoryReportAllocator.cpp
+
+!IF  "$(CFG)" == "CppUTest - Win32 Release"
+
+
+"$(INTDIR)\MemoryReportAllocator.obj" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ELSEIF  "$(CFG)" == "CppUTest - Win32 Debug"
+
+
+"$(INTDIR)\MemoryReportAllocator.obj"	"$(INTDIR)\MemoryReportAllocator.sbr" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ENDIF 
+
+SOURCE=.\src\CppUTestExt\MemoryReporterPlugin.cpp
+
+!IF  "$(CFG)" == "CppUTest - Win32 Release"
+
+
+"$(INTDIR)\MemoryReporterPlugin.obj" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ELSEIF  "$(CFG)" == "CppUTest - Win32 Debug"
+
+
+"$(INTDIR)\MemoryReporterPlugin.obj"	"$(INTDIR)\MemoryReporterPlugin.sbr" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ENDIF 
+
+SOURCE=.\src\CppUTestExt\MemoryReportFormatter.cpp
+
+!IF  "$(CFG)" == "CppUTest - Win32 Release"
+
+
+"$(INTDIR)\MemoryReportFormatter.obj" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ELSEIF  "$(CFG)" == "CppUTest - Win32 Debug"
+
+
+"$(INTDIR)\MemoryReportFormatter.obj"	"$(INTDIR)\MemoryReportFormatter.sbr" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ENDIF 
+
+SOURCE=".\src\CppUTestExt\MockActualCall.cpp"
+
+!IF  "$(CFG)" == "CppUTest - Win32 Release"
+
+
+"$(INTDIR)\MockActualCall.obj" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ELSEIF  "$(CFG)" == "CppUTest - Win32 Debug"
+
+
+"$(INTDIR)\MockActualCall.obj"	"$(INTDIR)\MockActualCall.sbr" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ENDIF 
+
+SOURCE=".\src\CppUTestExt\MockExpectedCall.cpp"
+
+!IF  "$(CFG)" == "CppUTest - Win32 Release"
+
+
+"$(INTDIR)\MockExpectedCall.obj" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ELSEIF  "$(CFG)" == "CppUTest - Win32 Debug"
+
+
+"$(INTDIR)\MockExpectedCall.obj"	"$(INTDIR)\MockExpectedCall.sbr" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ENDIF 
+
+SOURCE=".\src\CppUTestExt\MockExpectedCallsList.cpp"
+
+!IF  "$(CFG)" == "CppUTest - Win32 Release"
+
+
+"$(INTDIR)\MockExpectedCallsList.obj" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ELSEIF  "$(CFG)" == "CppUTest - Win32 Debug"
+
+
+"$(INTDIR)\MockExpectedCallsList.obj"	"$(INTDIR)\MockExpectedCallsList.sbr" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ENDIF 
+
+SOURCE=".\src\CppUTestExt\MockFailure.cpp"
+
+!IF  "$(CFG)" == "CppUTest - Win32 Release"
+
+
+"$(INTDIR)\MockFailure.obj" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ELSEIF  "$(CFG)" == "CppUTest - Win32 Debug"
+
+
+"$(INTDIR)\MockFailure.obj"	"$(INTDIR)\MockFailure.sbr" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ENDIF 
+
+SOURCE=".\src\CppUTestExt\MockNamedValue.cpp"
+
+!IF  "$(CFG)" == "CppUTest - Win32 Release"
+
+
+"$(INTDIR)\MockNamedValue.obj" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ELSEIF  "$(CFG)" == "CppUTest - Win32 Debug"
+
+
+"$(INTDIR)\MockNamedValue.obj"	"$(INTDIR)\MockNamedValue.sbr" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ENDIF 
+
+SOURCE=".\src\CppUTestExt\MockSupport.cpp"
+
+!IF  "$(CFG)" == "CppUTest - Win32 Release"
+
+
+"$(INTDIR)\MockSupport.obj" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ELSEIF  "$(CFG)" == "CppUTest - Win32 Debug"
+
+
+"$(INTDIR)\MockSupport.obj"	"$(INTDIR)\MockSupport.sbr" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ENDIF 
+
+SOURCE=".\src\CppUTestExt\MockSupport_c.cpp"
+
+!IF  "$(CFG)" == "CppUTest - Win32 Release"
+
+
+"$(INTDIR)\MockSupport_c.obj" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ELSEIF  "$(CFG)" == "CppUTest - Win32 Debug"
+
+
+"$(INTDIR)\MockSupport_c.obj"	"$(INTDIR)\MockSupport_c.sbr" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ENDIF 
+
+SOURCE=".\src\CppUTestExt\MockSupportPlugin.cpp"
+
+!IF  "$(CFG)" == "CppUTest - Win32 Release"
+
+
+"$(INTDIR)\MockSupportPlugin.obj" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ELSEIF  "$(CFG)" == "CppUTest - Win32 Debug"
+
+
+"$(INTDIR)\MockSupportPlugin.obj"	"$(INTDIR)\MockSupportPlugin.sbr" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ENDIF 
+
+SOURCE=".\src\CppUTestExt\OrderedTest.cpp"
+
+!IF  "$(CFG)" == "CppUTest - Win32 Release"
+
+
+"$(INTDIR)\OrderedTest.obj" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ELSEIF  "$(CFG)" == "CppUTest - Win32 Debug"
+
+
+"$(INTDIR)\OrderedTest.obj"	"$(INTDIR)\OrderedTest.sbr" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ENDIF 
+
+SOURCE=.\SRC\CPPUTEST\SimpleMutex.cpp
+
+!IF  "$(CFG)" == "CppUTest - Win32 Release"
+
+
+"$(INTDIR)\SimpleMutex.obj" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ELSEIF  "$(CFG)" == "CppUTest - Win32 Debug"
+
+
+"$(INTDIR)\SimpleMutex.obj"	"$(INTDIR)\SimpleMutex.sbr" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ENDIF 
+
+SOURCE=.\SRC\CPPUTEST\SimpleString.cpp
+
+!IF  "$(CFG)" == "CppUTest - Win32 Release"
+
 
 "$(INTDIR)\SimpleString.obj" : $(SOURCE) "$(INTDIR)"
 	$(CPP) $(CPP_PROJ) $(SOURCE)
 
 
-SOURCE=.\src\CppUTest\TestHarness_c.cpp
+!ELSEIF  "$(CFG)" == "CppUTest - Win32 Debug"
+
+
+"$(INTDIR)\SimpleString.obj"	"$(INTDIR)\SimpleString.sbr" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ENDIF 
+
+SOURCE=.\SRC\CPPUTEST\TestFailure.cpp
+
+!IF  "$(CFG)" == "CppUTest - Win32 Release"
+
+
+"$(INTDIR)\TestFailure.obj" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ELSEIF  "$(CFG)" == "CppUTest - Win32 Debug"
+
+
+"$(INTDIR)\TestFailure.obj"	"$(INTDIR)\TestFailure.sbr" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ENDIF 
+
+SOURCE=.\SRC\CPPUTEST\TestFilter.cpp
+
+!IF  "$(CFG)" == "CppUTest - Win32 Release"
+
+
+"$(INTDIR)\TestFilter.obj" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ELSEIF  "$(CFG)" == "CppUTest - Win32 Debug"
+
+
+"$(INTDIR)\TestFilter.obj"	"$(INTDIR)\TestFilter.sbr" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ENDIF 
+
+SOURCE=.\SRC\CPPUTEST\TestHarness_c.cpp
+
+!IF  "$(CFG)" == "CppUTest - Win32 Release"
+
 
 "$(INTDIR)\TestHarness_c.obj" : $(SOURCE) "$(INTDIR)"
 	$(CPP) $(CPP_PROJ) $(SOURCE)
 
 
-SOURCE=.\src\CppUTest\TestOutput.cpp
+!ELSEIF  "$(CFG)" == "CppUTest - Win32 Debug"
+
+
+"$(INTDIR)\TestHarness_c.obj"	"$(INTDIR)\TestHarness_c.sbr" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ENDIF 
+
+SOURCE=.\SRC\CPPUTEST\TestMemoryAllocator.cpp
+
+!IF  "$(CFG)" == "CppUTest - Win32 Release"
+
+
+"$(INTDIR)\TestMemoryAllocator.obj" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ELSEIF  "$(CFG)" == "CppUTest - Win32 Debug"
+
+
+"$(INTDIR)\TestMemoryAllocator.obj"	"$(INTDIR)\TestMemoryAllocator.sbr" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ENDIF 
+
+SOURCE=.\SRC\CPPUTEST\TestOutput.cpp
+
+!IF  "$(CFG)" == "CppUTest - Win32 Release"
+
 
 "$(INTDIR)\TestOutput.obj" : $(SOURCE) "$(INTDIR)"
 	$(CPP) $(CPP_PROJ) $(SOURCE)
 
 
-SOURCE=.\src\CppUTest\TestPlugin.cpp
+!ELSEIF  "$(CFG)" == "CppUTest - Win32 Debug"
+
+
+"$(INTDIR)\TestOutput.obj"	"$(INTDIR)\TestOutput.sbr" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ENDIF 
+
+SOURCE=.\SRC\CPPUTEST\TestPlugin.cpp
+
+!IF  "$(CFG)" == "CppUTest - Win32 Release"
+
 
 "$(INTDIR)\TestPlugin.obj" : $(SOURCE) "$(INTDIR)"
 	$(CPP) $(CPP_PROJ) $(SOURCE)
 
 
-SOURCE=.\src\CppUTest\TestRegistry.cpp
+!ELSEIF  "$(CFG)" == "CppUTest - Win32 Debug"
+
+
+"$(INTDIR)\TestPlugin.obj"	"$(INTDIR)\TestPlugin.sbr" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ENDIF 
+
+SOURCE=.\SRC\CPPUTEST\TestRegistry.cpp
+
+!IF  "$(CFG)" == "CppUTest - Win32 Release"
+
 
 "$(INTDIR)\TestRegistry.obj" : $(SOURCE) "$(INTDIR)"
 	$(CPP) $(CPP_PROJ) $(SOURCE)
 
 
-SOURCE=.\src\CppUTest\TestResult.cpp
+!ELSEIF  "$(CFG)" == "CppUTest - Win32 Debug"
+
+
+"$(INTDIR)\TestRegistry.obj"	"$(INTDIR)\TestRegistry.sbr" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ENDIF 
+
+SOURCE=.\SRC\CPPUTEST\TestResult.cpp
+
+!IF  "$(CFG)" == "CppUTest - Win32 Release"
+
 
 "$(INTDIR)\TestResult.obj" : $(SOURCE) "$(INTDIR)"
 	$(CPP) $(CPP_PROJ) $(SOURCE)
 
 
-SOURCE=.\src\CppUTest\Utest.cpp
+!ELSEIF  "$(CFG)" == "CppUTest - Win32 Debug"
+
+
+"$(INTDIR)\TestResult.obj"	"$(INTDIR)\TestResult.sbr" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ENDIF 
+
+SOURCE=.\SRC\CPPUTEST\Utest.cpp
+
+!IF  "$(CFG)" == "CppUTest - Win32 Release"
+
 
 "$(INTDIR)\Utest.obj" : $(SOURCE) "$(INTDIR)"
 	$(CPP) $(CPP_PROJ) $(SOURCE)
 
 
+!ELSEIF  "$(CFG)" == "CppUTest - Win32 Debug"
+
+
+"$(INTDIR)\Utest.obj"	"$(INTDIR)\Utest.sbr" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ENDIF 
+
 SOURCE=.\src\Platforms\VisualCpp\UtestPlatform.cpp
+
+!IF  "$(CFG)" == "CppUTest - Win32 Release"
+
 
 "$(INTDIR)\UtestPlatform.obj" : $(SOURCE) "$(INTDIR)"
 	$(CPP) $(CPP_PROJ) $(SOURCE)
 
+
+!ELSEIF  "$(CFG)" == "CppUTest - Win32 Debug"
+
+
+"$(INTDIR)\UtestPlatform.obj"	"$(INTDIR)\UtestPlatform.sbr" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ENDIF 
 
 
 !ENDIF 

--- a/makeAndRun.bat
+++ b/makeAndRun.bat
@@ -1,0 +1,16 @@
+rem ****
+rem * for this command line build to work independent of where it was created
+rem * 
+rem * Generate Project/Export Makefiles
+rem *
+rem * then do these edits to the generated files
+rem * CppUTest.dep - change the relitive path to ....\program files to \program files
+rem * AllTests.mak - At the end of the makefile where the depended upon CppUTest is made
+rem*       Change cd "\absolute\path\CppUTest" to cd ..
+PATH=C:\Program Files\Microsoft Visual Studio\VC98\Bin;%PATH%
+rem nmake /f CppUTest.mak CFG="CppUTest - Win32 Debug" all
+cd tests
+nmake /f AllTests.mak all
+cd Debug
+AllTests -v
+cd ..\..

--- a/tests/AllTests.dep
+++ b/tests/AllTests.dep
@@ -3,12 +3,14 @@
 .\AllocationInCFile.c : \
 	"..\include\CppUTest\CppUTestConfig.h"\
 	"..\include\CppUTest\MemoryLeakDetectorMallocMacros.h"\
+	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
 	"..\include\CppUTest\StandardCLibrary.h"\
 	".\AllocationInCFile.h"\
 	
 
 .\AllocationInCppFile.cpp : \
 	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorMallocMacros.h"\
 	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
 	"..\include\CppUTest\StandardCLibrary.h"\
 	".\AllocationInCppFile.h"\
@@ -18,6 +20,7 @@
 	"..\include\CppUTest\CommandLineArguments.h"\
 	"..\include\CppUTest\CommandLineTestRunner.h"\
 	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorMallocMacros.h"\
 	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
 	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
 	"..\include\CppUTest\SimpleString.h"\
@@ -35,6 +38,7 @@
 
 .\CheatSheetTest.cpp : \
 	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorMallocMacros.h"\
 	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
 	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
 	"..\include\CppUTest\SimpleString.h"\
@@ -50,6 +54,7 @@
 
 .\CppUTestExt\CodeMemoryReportFormatterTest.cpp : \
 	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorMallocMacros.h"\
 	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
 	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
 	"..\include\CppUTest\SimpleString.h"\
@@ -71,6 +76,7 @@
 .\CommandLineArgumentsTest.cpp : \
 	"..\include\CppUTest\CommandLineArguments.h"\
 	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorMallocMacros.h"\
 	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
 	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
 	"..\include\CppUTest\SimpleString.h"\
@@ -91,6 +97,7 @@
 	"..\include\CppUTest\CommandLineArguments.h"\
 	"..\include\CppUTest\CommandLineTestRunner.h"\
 	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorMallocMacros.h"\
 	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
 	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
 	"..\include\CppUTest\SimpleString.h"\
@@ -108,8 +115,23 @@
 	"..\include\platforms\visualcpp\stdint.h"\
 	
 
+.\CppUTestExt\GMockTest.cpp : \
+	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorMallocMacros.h"\
+	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	"..\include\CppUTest\StandardCLibrary.h"\
+	
+
+.\CppUTestExt\GTest1Test.cpp : \
+	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorMallocMacros.h"\
+	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	"..\include\CppUTest\StandardCLibrary.h"\
+	
+
 .\CppUTestExt\GTest2ConvertorTest.cpp : \
 	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorMallocMacros.h"\
 	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
 	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
 	"..\include\CppUTest\SimpleString.h"\
@@ -130,6 +152,7 @@
 .\JUnitOutputTest.cpp : \
 	"..\include\CppUTest\CppUTestConfig.h"\
 	"..\include\CppUTest\JunitTestOutput.h"\
+	"..\include\CppUTest\MemoryLeakDetectorMallocMacros.h"\
 	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
 	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
 	"..\include\CppUTest\PlatformSpecificFunctions.h"\
@@ -149,6 +172,7 @@
 .\MemoryLeakDetectorTest.cpp : \
 	"..\include\CppUTest\CppUTestConfig.h"\
 	"..\include\CppUTest\MemoryLeakDetector.h"\
+	"..\include\CppUTest\MemoryLeakDetectorMallocMacros.h"\
 	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
 	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
 	"..\include\CppUTest\PlatformSpecificFunctions.h"\
@@ -166,8 +190,62 @@
 	"..\include\platforms\visualcpp\stdint.h"\
 	
 
+.\MemoryLeakOperatorOverloadsTest.cpp : \
+	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetector.h"\
+	"..\include\CppUTest\MemoryLeakDetectorMallocMacros.h"\
+	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	"..\include\CppUTest\PlatformSpecificFunctions.h"\
+	"..\include\CppUTest\PlatformSpecificFunctions_c.h"\
+	"..\include\CppUTest\SimpleString.h"\
+	"..\include\CppUTest\StandardCLibrary.h"\
+	"..\include\CppUTest\TestFailure.h"\
+	"..\include\CppUTest\TestFilter.h"\
+	"..\include\CppUTest\TestHarness.h"\
+	"..\include\CppUTest\TestHarness_c.h"\
+	"..\include\CppUTest\TestMemoryAllocator.h"\
+	"..\include\CppUTest\TestOutput.h"\
+	"..\include\CppUTest\TestPlugin.h"\
+	"..\include\CppUTest\TestRegistry.h"\
+	"..\include\CppUTest\TestResult.h"\
+	"..\include\CppUTest\TestTestingFixture.h"\
+	"..\include\CppUTest\Utest.h"\
+	"..\include\CppUTest\UtestMacros.h"\
+	"..\include\platforms\visualcpp\stdint.h"\
+	".\AllocationInCFile.h"\
+	".\AllocationInCppFile.h"\
+	
+
+.\MemoryLeakWarningTest.cpp : \
+	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetector.h"\
+	"..\include\CppUTest\MemoryLeakDetectorMallocMacros.h"\
+	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	"..\include\CppUTest\PlatformSpecificFunctions.h"\
+	"..\include\CppUTest\PlatformSpecificFunctions_c.h"\
+	"..\include\CppUTest\SimpleMutex.h"\
+	"..\include\CppUTest\SimpleString.h"\
+	"..\include\CppUTest\StandardCLibrary.h"\
+	"..\include\CppUTest\TestFailure.h"\
+	"..\include\CppUTest\TestFilter.h"\
+	"..\include\CppUTest\TestHarness.h"\
+	"..\include\CppUTest\TestHarness_c.h"\
+	"..\include\CppUTest\TestMemoryAllocator.h"\
+	"..\include\CppUTest\TestOutput.h"\
+	"..\include\CppUTest\TestPlugin.h"\
+	"..\include\CppUTest\TestRegistry.h"\
+	"..\include\CppUTest\TestResult.h"\
+	"..\include\CppUTest\TestTestingFixture.h"\
+	"..\include\CppUTest\Utest.h"\
+	"..\include\CppUTest\UtestMacros.h"\
+	"..\include\platforms\visualcpp\stdint.h"\
+	
+
 .\CppUTestExt\MemoryReportAllocatorTest.cpp : \
 	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorMallocMacros.h"\
 	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
 	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
 	"..\include\CppUTest\SimpleString.h"\
@@ -187,6 +265,7 @@
 
 .\CppUTestExt\MemoryReporterPluginTest.cpp : \
 	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorMallocMacros.h"\
 	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
 	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
 	"..\include\CppUTest\SimpleString.h"\
@@ -215,6 +294,7 @@
 
 .\CppUTestExt\MemoryReportFormatterTest.cpp : \
 	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorMallocMacros.h"\
 	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
 	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
 	"..\include\CppUTest\SimpleString.h"\
@@ -234,6 +314,7 @@
 
 .\CppUTestExt\MockActualCallTest.cpp : \
 	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorMallocMacros.h"\
 	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
 	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
 	"..\include\CppUTest\SimpleString.h"\
@@ -257,6 +338,7 @@
 
 .\CppUTestExt\MockCheatSheetTest.cpp : \
 	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorMallocMacros.h"\
 	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
 	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
 	"..\include\CppUTest\SimpleString.h"\
@@ -280,6 +362,7 @@
 
 .\CppUTestExt\MockExpectedCallTest.cpp : \
 	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorMallocMacros.h"\
 	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
 	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
 	"..\include\CppUTest\SimpleString.h"\
@@ -300,6 +383,7 @@
 
 .\CppUTestExt\MockExpectedFunctionsListTest.cpp : \
 	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorMallocMacros.h"\
 	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
 	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
 	"..\include\CppUTest\SimpleString.h"\
@@ -321,6 +405,7 @@
 
 .\CppUTestExt\MockFailureTest.cpp : \
 	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorMallocMacros.h"\
 	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
 	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
 	"..\include\CppUTest\SimpleString.h"\
@@ -342,6 +427,7 @@
 
 .\CppUTestExt\MockPluginTest.cpp : \
 	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorMallocMacros.h"\
 	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
 	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
 	"..\include\CppUTest\SimpleString.h"\
@@ -368,6 +454,7 @@
 
 .\CppUTestExt\MockSupport_cTest.cpp : \
 	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorMallocMacros.h"\
 	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
 	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
 	"..\include\CppUTest\SimpleString.h"\
@@ -390,6 +477,8 @@
 
 .\CppUTestExt\MockSupport_cTestCFile.c : \
 	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorMallocMacros.h"\
+	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
 	"..\include\CppUTest\StandardCLibrary.h"\
 	"..\include\CppUTestExt\MockSupport_c.h"\
 	".\CppUTestExt\MockSupport_cTestCFile.h"\
@@ -397,6 +486,7 @@
 
 .\CppUTestExt\MockSupportTest.cpp : \
 	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorMallocMacros.h"\
 	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
 	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
 	"..\include\CppUTest\SimpleString.h"\
@@ -421,6 +511,7 @@
 
 .\CppUTestExt\OrderedTestTest.cpp : \
 	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorMallocMacros.h"\
 	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
 	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
 	"..\include\CppUTest\SimpleString.h"\
@@ -441,6 +532,7 @@
 
 .\PluginTest.cpp : \
 	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorMallocMacros.h"\
 	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
 	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
 	"..\include\CppUTest\SimpleString.h"\
@@ -460,6 +552,7 @@
 
 .\PreprocessorTest.cpp : \
 	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorMallocMacros.h"\
 	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
 	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
 	"..\include\CppUTest\SimpleString.h"\
@@ -475,6 +568,7 @@
 
 .\SetPluginTest.cpp : \
 	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorMallocMacros.h"\
 	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
 	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
 	"..\include\CppUTest\SimpleString.h"\
@@ -493,6 +587,7 @@
 
 .\SimpleStringTest.cpp : \
 	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorMallocMacros.h"\
 	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
 	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
 	"..\include\CppUTest\PlatformSpecificFunctions.h"\
@@ -512,6 +607,7 @@
 
 .\TestFailureTest.cpp : \
 	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorMallocMacros.h"\
 	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
 	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
 	"..\include\CppUTest\SimpleString.h"\
@@ -528,6 +624,7 @@
 
 .\TestFilterTest.cpp : \
 	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorMallocMacros.h"\
 	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
 	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
 	"..\include\CppUTest\SimpleString.h"\
@@ -544,7 +641,7 @@
 
 .\TestHarness_cTest.cpp : \
 	"..\include\CppUTest\CppUTestConfig.h"\
-	"..\include\CppUTest\MemoryLeakDetector.h"\
+	"..\include\CppUTest\MemoryLeakDetectorMallocMacros.h"\
 	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
 	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
 	"..\include\CppUTest\PlatformSpecificFunctions.h"\
@@ -567,6 +664,8 @@
 
 .\TestHarness_cTestCFile.c : \
 	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorMallocMacros.h"\
+	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
 	"..\include\CppUTest\PlatformSpecificFunctions_c.h"\
 	"..\include\CppUTest\StandardCLibrary.h"\
 	"..\include\CppUTest\TestHarness_c.h"\
@@ -574,6 +673,7 @@
 
 .\TestInstallerTest.cpp : \
 	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorMallocMacros.h"\
 	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
 	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
 	"..\include\CppUTest\SimpleString.h"\
@@ -591,6 +691,7 @@
 
 .\TestMemoryAllocatorTest.cpp : \
 	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorMallocMacros.h"\
 	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
 	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
 	"..\include\CppUTest\PlatformSpecificFunctions.h"\
@@ -610,6 +711,7 @@
 
 .\TestOutputTest.cpp : \
 	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorMallocMacros.h"\
 	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
 	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
 	"..\include\CppUTest\PlatformSpecificFunctions.h"\
@@ -628,6 +730,7 @@
 
 .\TestRegistryTest.cpp : \
 	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorMallocMacros.h"\
 	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
 	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
 	"..\include\CppUTest\SimpleString.h"\
@@ -646,6 +749,7 @@
 
 .\TestResultTest.cpp : \
 	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorMallocMacros.h"\
 	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
 	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
 	"..\include\CppUTest\PlatformSpecificFunctions.h"\
@@ -664,6 +768,7 @@
 
 .\UtestTest.cpp : \
 	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorMallocMacros.h"\
 	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
 	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
 	"..\include\CppUTest\PlatformSpecificFunctions.h"\

--- a/tests/AllTests.dep
+++ b/tests/AllTests.dep
@@ -1,2 +1,684 @@
 # Microsoft Developer Studio Generated Dependency File, included by AllTests.mak
 
+.\AllocationInCFile.c : \
+	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorMallocMacros.h"\
+	"..\include\CppUTest\StandardCLibrary.h"\
+	".\AllocationInCFile.h"\
+	
+
+.\AllocationInCppFile.cpp : \
+	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	"..\include\CppUTest\StandardCLibrary.h"\
+	".\AllocationInCppFile.h"\
+	
+
+.\AllTests.cpp : \
+	"..\include\CppUTest\CommandLineArguments.h"\
+	"..\include\CppUTest\CommandLineTestRunner.h"\
+	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	"..\include\CppUTest\SimpleString.h"\
+	"..\include\CppUTest\StandardCLibrary.h"\
+	"..\include\CppUTest\TestFailure.h"\
+	"..\include\CppUTest\TestFilter.h"\
+	"..\include\CppUTest\TestHarness.h"\
+	"..\include\CppUTest\TestOutput.h"\
+	"..\include\CppUTest\TestPlugin.h"\
+	"..\include\CppUTest\TestResult.h"\
+	"..\include\CppUTest\Utest.h"\
+	"..\include\CppUTest\UtestMacros.h"\
+	"..\include\platforms\visualcpp\stdint.h"\
+	
+
+.\CheatSheetTest.cpp : \
+	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	"..\include\CppUTest\SimpleString.h"\
+	"..\include\CppUTest\StandardCLibrary.h"\
+	"..\include\CppUTest\TestFailure.h"\
+	"..\include\CppUTest\TestHarness.h"\
+	"..\include\CppUTest\TestPlugin.h"\
+	"..\include\CppUTest\TestResult.h"\
+	"..\include\CppUTest\Utest.h"\
+	"..\include\CppUTest\UtestMacros.h"\
+	"..\include\platforms\visualcpp\stdint.h"\
+	
+
+.\CppUTestExt\CodeMemoryReportFormatterTest.cpp : \
+	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	"..\include\CppUTest\SimpleString.h"\
+	"..\include\CppUTest\StandardCLibrary.h"\
+	"..\include\CppUTest\TestFailure.h"\
+	"..\include\CppUTest\TestHarness.h"\
+	"..\include\CppUTest\TestMemoryAllocator.h"\
+	"..\include\CppUTest\TestOutput.h"\
+	"..\include\CppUTest\TestPlugin.h"\
+	"..\include\CppUTest\TestResult.h"\
+	"..\include\CppUTest\Utest.h"\
+	"..\include\CppUTest\UtestMacros.h"\
+	"..\include\CppUTestExt\CodeMemoryReportFormatter.h"\
+	"..\include\CppUTestExt\MemoryReportAllocator.h"\
+	"..\include\CppUTestExt\MemoryReportFormatter.h"\
+	"..\include\platforms\visualcpp\stdint.h"\
+	
+
+.\CommandLineArgumentsTest.cpp : \
+	"..\include\CppUTest\CommandLineArguments.h"\
+	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	"..\include\CppUTest\SimpleString.h"\
+	"..\include\CppUTest\StandardCLibrary.h"\
+	"..\include\CppUTest\TestFailure.h"\
+	"..\include\CppUTest\TestFilter.h"\
+	"..\include\CppUTest\TestHarness.h"\
+	"..\include\CppUTest\TestOutput.h"\
+	"..\include\CppUTest\TestPlugin.h"\
+	"..\include\CppUTest\TestRegistry.h"\
+	"..\include\CppUTest\TestResult.h"\
+	"..\include\CppUTest\Utest.h"\
+	"..\include\CppUTest\UtestMacros.h"\
+	"..\include\platforms\visualcpp\stdint.h"\
+	
+
+.\CommandLineTestRunnerTest.cpp : \
+	"..\include\CppUTest\CommandLineArguments.h"\
+	"..\include\CppUTest\CommandLineTestRunner.h"\
+	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	"..\include\CppUTest\SimpleString.h"\
+	"..\include\CppUTest\StandardCLibrary.h"\
+	"..\include\CppUTest\TestFailure.h"\
+	"..\include\CppUTest\TestFilter.h"\
+	"..\include\CppUTest\TestHarness.h"\
+	"..\include\CppUTest\TestOutput.h"\
+	"..\include\CppUTest\TestPlugin.h"\
+	"..\include\CppUTest\TestRegistry.h"\
+	"..\include\CppUTest\TestResult.h"\
+	"..\include\CppUTest\TestTestingFixture.h"\
+	"..\include\CppUTest\Utest.h"\
+	"..\include\CppUTest\UtestMacros.h"\
+	"..\include\platforms\visualcpp\stdint.h"\
+	
+
+.\CppUTestExt\GTest2ConvertorTest.cpp : \
+	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	"..\include\CppUTest\SimpleString.h"\
+	"..\include\CppUTest\StandardCLibrary.h"\
+	"..\include\CppUTest\TestFailure.h"\
+	"..\include\CppUTest\TestFilter.h"\
+	"..\include\CppUTest\TestHarness.h"\
+	"..\include\CppUTest\TestOutput.h"\
+	"..\include\CppUTest\TestPlugin.h"\
+	"..\include\CppUTest\TestRegistry.h"\
+	"..\include\CppUTest\TestResult.h"\
+	"..\include\CppUTest\TestTestingFixture.h"\
+	"..\include\CppUTest\Utest.h"\
+	"..\include\CppUTest\UtestMacros.h"\
+	"..\include\platforms\visualcpp\stdint.h"\
+	
+
+.\JUnitOutputTest.cpp : \
+	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\JunitTestOutput.h"\
+	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	"..\include\CppUTest\PlatformSpecificFunctions.h"\
+	"..\include\CppUTest\PlatformSpecificFunctions_c.h"\
+	"..\include\CppUTest\SimpleString.h"\
+	"..\include\CppUTest\StandardCLibrary.h"\
+	"..\include\CppUTest\TestFailure.h"\
+	"..\include\CppUTest\TestHarness.h"\
+	"..\include\CppUTest\TestOutput.h"\
+	"..\include\CppUTest\TestPlugin.h"\
+	"..\include\CppUTest\TestResult.h"\
+	"..\include\CppUTest\Utest.h"\
+	"..\include\CppUTest\UtestMacros.h"\
+	"..\include\platforms\visualcpp\stdint.h"\
+	
+
+.\MemoryLeakDetectorTest.cpp : \
+	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetector.h"\
+	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	"..\include\CppUTest\PlatformSpecificFunctions.h"\
+	"..\include\CppUTest\PlatformSpecificFunctions_c.h"\
+	"..\include\CppUTest\SimpleString.h"\
+	"..\include\CppUTest\StandardCLibrary.h"\
+	"..\include\CppUTest\TestFailure.h"\
+	"..\include\CppUTest\TestHarness.h"\
+	"..\include\CppUTest\TestMemoryAllocator.h"\
+	"..\include\CppUTest\TestOutput.h"\
+	"..\include\CppUTest\TestPlugin.h"\
+	"..\include\CppUTest\TestResult.h"\
+	"..\include\CppUTest\Utest.h"\
+	"..\include\CppUTest\UtestMacros.h"\
+	"..\include\platforms\visualcpp\stdint.h"\
+	
+
+.\CppUTestExt\MemoryReportAllocatorTest.cpp : \
+	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	"..\include\CppUTest\SimpleString.h"\
+	"..\include\CppUTest\StandardCLibrary.h"\
+	"..\include\CppUTest\TestFailure.h"\
+	"..\include\CppUTest\TestHarness.h"\
+	"..\include\CppUTest\TestMemoryAllocator.h"\
+	"..\include\CppUTest\TestOutput.h"\
+	"..\include\CppUTest\TestPlugin.h"\
+	"..\include\CppUTest\TestResult.h"\
+	"..\include\CppUTest\Utest.h"\
+	"..\include\CppUTest\UtestMacros.h"\
+	"..\include\CppUTestExt\MemoryReportAllocator.h"\
+	"..\include\CppUTestExt\MemoryReportFormatter.h"\
+	"..\include\platforms\visualcpp\stdint.h"\
+	
+
+.\CppUTestExt\MemoryReporterPluginTest.cpp : \
+	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	"..\include\CppUTest\SimpleString.h"\
+	"..\include\CppUTest\StandardCLibrary.h"\
+	"..\include\CppUTest\TestFailure.h"\
+	"..\include\CppUTest\TestHarness.h"\
+	"..\include\CppUTest\TestMemoryAllocator.h"\
+	"..\include\CppUTest\TestOutput.h"\
+	"..\include\CppUTest\TestPlugin.h"\
+	"..\include\CppUTest\TestResult.h"\
+	"..\include\CppUTest\Utest.h"\
+	"..\include\CppUTest\UtestMacros.h"\
+	"..\include\CppUTestExt\MemoryReportAllocator.h"\
+	"..\include\CppUTestExt\MemoryReporterPlugin.h"\
+	"..\include\CppUTestExt\MemoryReportFormatter.h"\
+	"..\include\cpputestext\mockactualcall.h"\
+	"..\include\CppUTestExt\MockCheckedActualCall.h"\
+	"..\include\CppUTestExt\MockCheckedExpectedCall.h"\
+	"..\include\cpputestext\mockexpectedcall.h"\
+	"..\include\CppUTestExt\MockExpectedCallsList.h"\
+	"..\include\CppUTestExt\MockFailure.h"\
+	"..\include\CppUTestExt\MockNamedValue.h"\
+	"..\include\CppUTestExt\MockSupport.h"\
+	"..\include\platforms\visualcpp\stdint.h"\
+	
+
+.\CppUTestExt\MemoryReportFormatterTest.cpp : \
+	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	"..\include\CppUTest\SimpleString.h"\
+	"..\include\CppUTest\StandardCLibrary.h"\
+	"..\include\CppUTest\TestFailure.h"\
+	"..\include\CppUTest\TestHarness.h"\
+	"..\include\CppUTest\TestMemoryAllocator.h"\
+	"..\include\CppUTest\TestOutput.h"\
+	"..\include\CppUTest\TestPlugin.h"\
+	"..\include\CppUTest\TestResult.h"\
+	"..\include\CppUTest\Utest.h"\
+	"..\include\CppUTest\UtestMacros.h"\
+	"..\include\CppUTestExt\MemoryReportAllocator.h"\
+	"..\include\CppUTestExt\MemoryReportFormatter.h"\
+	"..\include\platforms\visualcpp\stdint.h"\
+	
+
+.\CppUTestExt\MockActualCallTest.cpp : \
+	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	"..\include\CppUTest\SimpleString.h"\
+	"..\include\CppUTest\StandardCLibrary.h"\
+	"..\include\CppUTest\TestFailure.h"\
+	"..\include\CppUTest\TestHarness.h"\
+	"..\include\CppUTest\TestPlugin.h"\
+	"..\include\CppUTest\TestResult.h"\
+	"..\include\CppUTest\Utest.h"\
+	"..\include\CppUTest\UtestMacros.h"\
+	"..\include\cpputestext\mockactualcall.h"\
+	"..\include\CppUTestExt\MockCheckedActualCall.h"\
+	"..\include\CppUTestExt\MockCheckedExpectedCall.h"\
+	"..\include\cpputestext\mockexpectedcall.h"\
+	"..\include\CppUTestExt\MockExpectedCallsList.h"\
+	"..\include\CppUTestExt\MockFailure.h"\
+	"..\include\CppUTestExt\MockNamedValue.h"\
+	"..\include\platforms\visualcpp\stdint.h"\
+	".\CppUTestExt\MockFailureTest.h"\
+	
+
+.\CppUTestExt\MockCheatSheetTest.cpp : \
+	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	"..\include\CppUTest\SimpleString.h"\
+	"..\include\CppUTest\StandardCLibrary.h"\
+	"..\include\CppUTest\TestFailure.h"\
+	"..\include\CppUTest\TestHarness.h"\
+	"..\include\CppUTest\TestPlugin.h"\
+	"..\include\CppUTest\TestResult.h"\
+	"..\include\CppUTest\Utest.h"\
+	"..\include\CppUTest\UtestMacros.h"\
+	"..\include\cpputestext\mockactualcall.h"\
+	"..\include\CppUTestExt\MockCheckedActualCall.h"\
+	"..\include\CppUTestExt\MockCheckedExpectedCall.h"\
+	"..\include\cpputestext\mockexpectedcall.h"\
+	"..\include\CppUTestExt\MockExpectedCallsList.h"\
+	"..\include\CppUTestExt\MockFailure.h"\
+	"..\include\CppUTestExt\MockNamedValue.h"\
+	"..\include\CppUTestExt\MockSupport.h"\
+	"..\include\platforms\visualcpp\stdint.h"\
+	
+
+.\CppUTestExt\MockExpectedCallTest.cpp : \
+	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	"..\include\CppUTest\SimpleString.h"\
+	"..\include\CppUTest\StandardCLibrary.h"\
+	"..\include\CppUTest\TestFailure.h"\
+	"..\include\CppUTest\TestHarness.h"\
+	"..\include\CppUTest\TestPlugin.h"\
+	"..\include\CppUTest\TestResult.h"\
+	"..\include\CppUTest\Utest.h"\
+	"..\include\CppUTest\UtestMacros.h"\
+	"..\include\CppUTestExt\MockCheckedExpectedCall.h"\
+	"..\include\cpputestext\mockexpectedcall.h"\
+	"..\include\CppUTestExt\MockFailure.h"\
+	"..\include\CppUTestExt\MockNamedValue.h"\
+	"..\include\platforms\visualcpp\stdint.h"\
+	".\CppUTestExt\MockFailureTest.h"\
+	
+
+.\CppUTestExt\MockExpectedFunctionsListTest.cpp : \
+	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	"..\include\CppUTest\SimpleString.h"\
+	"..\include\CppUTest\StandardCLibrary.h"\
+	"..\include\CppUTest\TestFailure.h"\
+	"..\include\CppUTest\TestHarness.h"\
+	"..\include\CppUTest\TestPlugin.h"\
+	"..\include\CppUTest\TestResult.h"\
+	"..\include\CppUTest\Utest.h"\
+	"..\include\CppUTest\UtestMacros.h"\
+	"..\include\CppUTestExt\MockCheckedExpectedCall.h"\
+	"..\include\cpputestext\mockexpectedcall.h"\
+	"..\include\CppUTestExt\MockExpectedCallsList.h"\
+	"..\include\CppUTestExt\MockFailure.h"\
+	"..\include\CppUTestExt\MockNamedValue.h"\
+	"..\include\platforms\visualcpp\stdint.h"\
+	".\CppUTestExt\MockFailureTest.h"\
+	
+
+.\CppUTestExt\MockFailureTest.cpp : \
+	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	"..\include\CppUTest\SimpleString.h"\
+	"..\include\CppUTest\StandardCLibrary.h"\
+	"..\include\CppUTest\TestFailure.h"\
+	"..\include\CppUTest\TestHarness.h"\
+	"..\include\CppUTest\TestPlugin.h"\
+	"..\include\CppUTest\TestResult.h"\
+	"..\include\CppUTest\Utest.h"\
+	"..\include\CppUTest\UtestMacros.h"\
+	"..\include\CppUTestExt\MockCheckedExpectedCall.h"\
+	"..\include\cpputestext\mockexpectedcall.h"\
+	"..\include\CppUTestExt\MockExpectedCallsList.h"\
+	"..\include\CppUTestExt\MockFailure.h"\
+	"..\include\CppUTestExt\MockNamedValue.h"\
+	"..\include\platforms\visualcpp\stdint.h"\
+	".\CppUTestExt\MockFailureTest.h"\
+	
+
+.\CppUTestExt\MockPluginTest.cpp : \
+	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	"..\include\CppUTest\SimpleString.h"\
+	"..\include\CppUTest\StandardCLibrary.h"\
+	"..\include\CppUTest\TestFailure.h"\
+	"..\include\CppUTest\TestHarness.h"\
+	"..\include\CppUTest\TestOutput.h"\
+	"..\include\CppUTest\TestPlugin.h"\
+	"..\include\CppUTest\TestResult.h"\
+	"..\include\CppUTest\Utest.h"\
+	"..\include\CppUTest\UtestMacros.h"\
+	"..\include\cpputestext\mockactualcall.h"\
+	"..\include\CppUTestExt\MockCheckedActualCall.h"\
+	"..\include\CppUTestExt\MockCheckedExpectedCall.h"\
+	"..\include\cpputestext\mockexpectedcall.h"\
+	"..\include\CppUTestExt\MockExpectedCallsList.h"\
+	"..\include\CppUTestExt\MockFailure.h"\
+	"..\include\CppUTestExt\MockNamedValue.h"\
+	"..\include\CppUTestExt\MockSupport.h"\
+	"..\include\CppUTestExt\MockSupportPlugin.h"\
+	"..\include\platforms\visualcpp\stdint.h"\
+	".\CppUTestExt\MockFailureTest.h"\
+	
+
+.\CppUTestExt\MockSupport_cTest.cpp : \
+	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	"..\include\CppUTest\SimpleString.h"\
+	"..\include\CppUTest\StandardCLibrary.h"\
+	"..\include\CppUTest\TestFailure.h"\
+	"..\include\CppUTest\TestFilter.h"\
+	"..\include\CppUTest\TestHarness.h"\
+	"..\include\CppUTest\TestHarness_c.h"\
+	"..\include\CppUTest\TestOutput.h"\
+	"..\include\CppUTest\TestPlugin.h"\
+	"..\include\CppUTest\TestRegistry.h"\
+	"..\include\CppUTest\TestResult.h"\
+	"..\include\CppUTest\TestTestingFixture.h"\
+	"..\include\CppUTest\Utest.h"\
+	"..\include\CppUTest\UtestMacros.h"\
+	"..\include\CppUTestExt\MockSupport_c.h"\
+	"..\include\platforms\visualcpp\stdint.h"\
+	".\CppUTestExt\MockSupport_cTestCFile.h"\
+	
+
+.\CppUTestExt\MockSupport_cTestCFile.c : \
+	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\StandardCLibrary.h"\
+	"..\include\CppUTestExt\MockSupport_c.h"\
+	".\CppUTestExt\MockSupport_cTestCFile.h"\
+	
+
+.\CppUTestExt\MockSupportTest.cpp : \
+	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	"..\include\CppUTest\SimpleString.h"\
+	"..\include\CppUTest\StandardCLibrary.h"\
+	"..\include\CppUTest\TestFailure.h"\
+	"..\include\CppUTest\TestHarness.h"\
+	"..\include\CppUTest\TestPlugin.h"\
+	"..\include\CppUTest\TestResult.h"\
+	"..\include\CppUTest\Utest.h"\
+	"..\include\CppUTest\UtestMacros.h"\
+	"..\include\cpputestext\mockactualcall.h"\
+	"..\include\CppUTestExt\MockCheckedActualCall.h"\
+	"..\include\CppUTestExt\MockCheckedExpectedCall.h"\
+	"..\include\cpputestext\mockexpectedcall.h"\
+	"..\include\CppUTestExt\MockExpectedCallsList.h"\
+	"..\include\CppUTestExt\MockFailure.h"\
+	"..\include\CppUTestExt\MockNamedValue.h"\
+	"..\include\CppUTestExt\MockSupport.h"\
+	"..\include\platforms\visualcpp\stdint.h"\
+	".\CppUTestExt\MockFailureTest.h"\
+	
+
+.\CppUTestExt\OrderedTestTest.cpp : \
+	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	"..\include\CppUTest\SimpleString.h"\
+	"..\include\CppUTest\StandardCLibrary.h"\
+	"..\include\CppUTest\TestFailure.h"\
+	"..\include\CppUTest\TestFilter.h"\
+	"..\include\CppUTest\TestHarness.h"\
+	"..\include\CppUTest\TestOutput.h"\
+	"..\include\CppUTest\TestPlugin.h"\
+	"..\include\CppUTest\TestRegistry.h"\
+	"..\include\CppUTest\TestResult.h"\
+	"..\include\CppUTest\TestTestingFixture.h"\
+	"..\include\CppUTest\Utest.h"\
+	"..\include\CppUTest\UtestMacros.h"\
+	"..\include\CppUTestExt\OrderedTest.h"\
+	"..\include\platforms\visualcpp\stdint.h"\
+	
+
+.\PluginTest.cpp : \
+	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	"..\include\CppUTest\SimpleString.h"\
+	"..\include\CppUTest\StandardCLibrary.h"\
+	"..\include\CppUTest\TestFailure.h"\
+	"..\include\CppUTest\TestFilter.h"\
+	"..\include\CppUTest\TestHarness.h"\
+	"..\include\CppUTest\TestOutput.h"\
+	"..\include\CppUTest\TestPlugin.h"\
+	"..\include\CppUTest\TestRegistry.h"\
+	"..\include\CppUTest\TestResult.h"\
+	"..\include\CppUTest\TestTestingFixture.h"\
+	"..\include\CppUTest\Utest.h"\
+	"..\include\CppUTest\UtestMacros.h"\
+	"..\include\platforms\visualcpp\stdint.h"\
+	
+
+.\PreprocessorTest.cpp : \
+	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	"..\include\CppUTest\SimpleString.h"\
+	"..\include\CppUTest\StandardCLibrary.h"\
+	"..\include\CppUTest\TestFailure.h"\
+	"..\include\CppUTest\TestHarness.h"\
+	"..\include\CppUTest\TestPlugin.h"\
+	"..\include\CppUTest\TestResult.h"\
+	"..\include\CppUTest\Utest.h"\
+	"..\include\CppUTest\UtestMacros.h"\
+	"..\include\platforms\visualcpp\stdint.h"\
+	
+
+.\SetPluginTest.cpp : \
+	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	"..\include\CppUTest\SimpleString.h"\
+	"..\include\CppUTest\StandardCLibrary.h"\
+	"..\include\CppUTest\TestFailure.h"\
+	"..\include\CppUTest\TestFilter.h"\
+	"..\include\CppUTest\TestHarness.h"\
+	"..\include\CppUTest\TestOutput.h"\
+	"..\include\CppUTest\TestPlugin.h"\
+	"..\include\CppUTest\TestRegistry.h"\
+	"..\include\CppUTest\TestResult.h"\
+	"..\include\CppUTest\Utest.h"\
+	"..\include\CppUTest\UtestMacros.h"\
+	"..\include\platforms\visualcpp\stdint.h"\
+	
+
+.\SimpleStringTest.cpp : \
+	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	"..\include\CppUTest\PlatformSpecificFunctions.h"\
+	"..\include\CppUTest\PlatformSpecificFunctions_c.h"\
+	"..\include\CppUTest\SimpleString.h"\
+	"..\include\CppUTest\StandardCLibrary.h"\
+	"..\include\CppUTest\TestFailure.h"\
+	"..\include\CppUTest\TestHarness.h"\
+	"..\include\CppUTest\TestMemoryAllocator.h"\
+	"..\include\CppUTest\TestOutput.h"\
+	"..\include\CppUTest\TestPlugin.h"\
+	"..\include\CppUTest\TestResult.h"\
+	"..\include\CppUTest\Utest.h"\
+	"..\include\CppUTest\UtestMacros.h"\
+	"..\include\platforms\visualcpp\stdint.h"\
+	
+
+.\TestFailureTest.cpp : \
+	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	"..\include\CppUTest\SimpleString.h"\
+	"..\include\CppUTest\StandardCLibrary.h"\
+	"..\include\CppUTest\TestFailure.h"\
+	"..\include\CppUTest\TestHarness.h"\
+	"..\include\CppUTest\TestOutput.h"\
+	"..\include\CppUTest\TestPlugin.h"\
+	"..\include\CppUTest\TestResult.h"\
+	"..\include\CppUTest\Utest.h"\
+	"..\include\CppUTest\UtestMacros.h"\
+	"..\include\platforms\visualcpp\stdint.h"\
+	
+
+.\TestFilterTest.cpp : \
+	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	"..\include\CppUTest\SimpleString.h"\
+	"..\include\CppUTest\StandardCLibrary.h"\
+	"..\include\CppUTest\TestFailure.h"\
+	"..\include\CppUTest\TestFilter.h"\
+	"..\include\CppUTest\TestHarness.h"\
+	"..\include\CppUTest\TestPlugin.h"\
+	"..\include\CppUTest\TestResult.h"\
+	"..\include\CppUTest\Utest.h"\
+	"..\include\CppUTest\UtestMacros.h"\
+	"..\include\platforms\visualcpp\stdint.h"\
+	
+
+.\TestHarness_cTest.cpp : \
+	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetector.h"\
+	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	"..\include\CppUTest\PlatformSpecificFunctions.h"\
+	"..\include\CppUTest\PlatformSpecificFunctions_c.h"\
+	"..\include\CppUTest\SimpleString.h"\
+	"..\include\CppUTest\StandardCLibrary.h"\
+	"..\include\CppUTest\TestFailure.h"\
+	"..\include\CppUTest\TestFilter.h"\
+	"..\include\CppUTest\TestHarness.h"\
+	"..\include\CppUTest\TestHarness_c.h"\
+	"..\include\CppUTest\TestOutput.h"\
+	"..\include\CppUTest\TestPlugin.h"\
+	"..\include\CppUTest\TestRegistry.h"\
+	"..\include\CppUTest\TestResult.h"\
+	"..\include\CppUTest\TestTestingFixture.h"\
+	"..\include\CppUTest\Utest.h"\
+	"..\include\CppUTest\UtestMacros.h"\
+	"..\include\platforms\visualcpp\stdint.h"\
+	
+
+.\TestHarness_cTestCFile.c : \
+	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\PlatformSpecificFunctions_c.h"\
+	"..\include\CppUTest\StandardCLibrary.h"\
+	"..\include\CppUTest\TestHarness_c.h"\
+	
+
+.\TestInstallerTest.cpp : \
+	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	"..\include\CppUTest\SimpleString.h"\
+	"..\include\CppUTest\StandardCLibrary.h"\
+	"..\include\CppUTest\TestFailure.h"\
+	"..\include\CppUTest\TestFilter.h"\
+	"..\include\CppUTest\TestHarness.h"\
+	"..\include\CppUTest\TestPlugin.h"\
+	"..\include\CppUTest\TestRegistry.h"\
+	"..\include\CppUTest\TestResult.h"\
+	"..\include\CppUTest\Utest.h"\
+	"..\include\CppUTest\UtestMacros.h"\
+	"..\include\platforms\visualcpp\stdint.h"\
+	
+
+.\TestMemoryAllocatorTest.cpp : \
+	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	"..\include\CppUTest\PlatformSpecificFunctions.h"\
+	"..\include\CppUTest\PlatformSpecificFunctions_c.h"\
+	"..\include\CppUTest\SimpleString.h"\
+	"..\include\CppUTest\StandardCLibrary.h"\
+	"..\include\CppUTest\TestFailure.h"\
+	"..\include\CppUTest\TestHarness.h"\
+	"..\include\CppUTest\TestMemoryAllocator.h"\
+	"..\include\CppUTest\TestOutput.h"\
+	"..\include\CppUTest\TestPlugin.h"\
+	"..\include\CppUTest\TestResult.h"\
+	"..\include\CppUTest\Utest.h"\
+	"..\include\CppUTest\UtestMacros.h"\
+	"..\include\platforms\visualcpp\stdint.h"\
+	
+
+.\TestOutputTest.cpp : \
+	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	"..\include\CppUTest\PlatformSpecificFunctions.h"\
+	"..\include\CppUTest\PlatformSpecificFunctions_c.h"\
+	"..\include\CppUTest\SimpleString.h"\
+	"..\include\CppUTest\StandardCLibrary.h"\
+	"..\include\CppUTest\TestFailure.h"\
+	"..\include\CppUTest\TestHarness.h"\
+	"..\include\CppUTest\TestOutput.h"\
+	"..\include\CppUTest\TestPlugin.h"\
+	"..\include\CppUTest\TestResult.h"\
+	"..\include\CppUTest\Utest.h"\
+	"..\include\CppUTest\UtestMacros.h"\
+	"..\include\platforms\visualcpp\stdint.h"\
+	
+
+.\TestRegistryTest.cpp : \
+	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	"..\include\CppUTest\SimpleString.h"\
+	"..\include\CppUTest\StandardCLibrary.h"\
+	"..\include\CppUTest\TestFailure.h"\
+	"..\include\CppUTest\TestFilter.h"\
+	"..\include\CppUTest\TestHarness.h"\
+	"..\include\CppUTest\TestOutput.h"\
+	"..\include\CppUTest\TestPlugin.h"\
+	"..\include\CppUTest\TestRegistry.h"\
+	"..\include\CppUTest\TestResult.h"\
+	"..\include\CppUTest\Utest.h"\
+	"..\include\CppUTest\UtestMacros.h"\
+	"..\include\platforms\visualcpp\stdint.h"\
+	
+
+.\TestResultTest.cpp : \
+	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	"..\include\CppUTest\PlatformSpecificFunctions.h"\
+	"..\include\CppUTest\PlatformSpecificFunctions_c.h"\
+	"..\include\CppUTest\SimpleString.h"\
+	"..\include\CppUTest\StandardCLibrary.h"\
+	"..\include\CppUTest\TestFailure.h"\
+	"..\include\CppUTest\TestHarness.h"\
+	"..\include\CppUTest\TestOutput.h"\
+	"..\include\CppUTest\TestPlugin.h"\
+	"..\include\CppUTest\TestResult.h"\
+	"..\include\CppUTest\Utest.h"\
+	"..\include\CppUTest\UtestMacros.h"\
+	"..\include\platforms\visualcpp\stdint.h"\
+	
+
+.\UtestTest.cpp : \
+	"..\include\CppUTest\CppUTestConfig.h"\
+	"..\include\CppUTest\MemoryLeakDetectorNewMacros.h"\
+	"..\include\CppUTest\MemoryLeakWarningPlugin.h"\
+	"..\include\CppUTest\PlatformSpecificFunctions.h"\
+	"..\include\CppUTest\PlatformSpecificFunctions_c.h"\
+	"..\include\CppUTest\SimpleString.h"\
+	"..\include\CppUTest\StandardCLibrary.h"\
+	"..\include\CppUTest\TestFailure.h"\
+	"..\include\CppUTest\TestFilter.h"\
+	"..\include\CppUTest\TestHarness.h"\
+	"..\include\CppUTest\TestOutput.h"\
+	"..\include\CppUTest\TestPlugin.h"\
+	"..\include\CppUTest\TestRegistry.h"\
+	"..\include\CppUTest\TestResult.h"\
+	"..\include\CppUTest\TestTestingFixture.h"\
+	"..\include\CppUTest\Utest.h"\
+	"..\include\CppUTest\UtestMacros.h"\
+	"..\include\platforms\visualcpp\stdint.h"\
+	

--- a/tests/AllTests.dsp
+++ b/tests/AllTests.dsp
@@ -71,8 +71,7 @@ PostBuild_Cmds=$(TargetPath)
 # PROP Ignore_Export_Lib 0
 # PROP Target_Dir ""
 # ADD BASE CPP /nologo /W3 /Gm /GX /ZI /Od /D "WIN32" /D "_DEBUG" /D "_CONSOLE" /D "_MBCS" /YX /FD /GZ /c
-# ADD CPP /nologo /MDd /W3 /GX /ZI /Od /I "..\include" /I "..\include\Platforms\VisualCpp" /D "_CONSOLE" /D "WIN32" /D "_DEBUG" /D "_MBCS" /FR /FD /GZ /c
-# SUBTRACT CPP /YX
+# ADD CPP /nologo /MDd /W3 /GX /ZI /Od /I "..\include" /I "..\include\Platforms\VisualCpp" /FI"CppUTest/MemoryLeakDetectorMallocMacros.h" /FI"CppUTest/MemoryLeakDetectorNewMacros.h" /D "_CONSOLE" /D "WIN32" /D "_DEBUG" /D "_MBCS" /FR /FD /GZ /c
 # ADD BASE RSC /l 0x409 /d "_DEBUG"
 # ADD RSC /l 0x409 /d "_DEBUG"
 BSC32=bscmake.exe
@@ -148,12 +147,19 @@ SOURCE=.\MemoryLeakDetectorTest.cpp
 # Begin Source File
 
 SOURCE=.\MemoryLeakOperatorOverloadsTest.cpp
-# PROP Exclude_From_Build 1
 # End Source File
 # Begin Source File
 
 SOURCE=.\MemoryLeakWarningTest.cpp
+
+!IF  "$(CFG)" == "AllTests - Win32 Release"
+
 # PROP Exclude_From_Build 1
+
+!ELSEIF  "$(CFG)" == "AllTests - Win32 Debug"
+
+!ENDIF 
+
 # End Source File
 # Begin Source File
 

--- a/tests/AllTests.dsp
+++ b/tests/AllTests.dsp
@@ -51,17 +51,11 @@ BSC32=bscmake.exe
 LINK32=link.exe
 # ADD BASE LINK32 kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:console /machine:I386
 # ADD LINK32 kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:console /machine:I386
-# Begin Custom Build
-TargetDir=.\Release
+# Begin Special Build Tool
 TargetPath=.\Release\AllTests.exe
-TargetName=AllTests
-InputPath=.\Release\AllTests.exe
 SOURCE="$(InputPath)"
-
-"$(TargetDir)" : $(SOURCE) "$(INTDIR)" "$(OUTDIR)"
-	$(TargetPath)$(TargetName)
-
-# End Custom Build
+PostBuild_Cmds=$(TargetPath)
+# End Special Build Tool
 
 !ELSEIF  "$(CFG)" == "AllTests - Win32 Debug"
 
@@ -88,16 +82,11 @@ LINK32=link.exe
 # ADD BASE LINK32 kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:console /debug /machine:I386 /pdbtype:sept
 # ADD LINK32 ..\lib\CppUTest.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib winmm.lib /nologo /subsystem:console /debug /machine:I386 /pdbtype:sept
 # SUBTRACT LINK32 /incremental:no
-# Begin Custom Build
-TargetDir=.\Debug
+# Begin Special Build Tool
 TargetPath=.\Debug\AllTests.exe
-InputPath=.\Debug\AllTests.exe
 SOURCE="$(InputPath)"
-
-"$(TargetDir)" : $(SOURCE) "$(INTDIR)" "$(OUTDIR)"
-	$(TargetPath)
-
-# End Custom Build
+PostBuild_Cmds=$(TargetPath)
+# End Special Build Tool
 
 !ENDIF 
 

--- a/tests/AllTests.dsp
+++ b/tests/AllTests.dsp
@@ -147,13 +147,6 @@ SOURCE=.\MemoryLeakDetectorTest.cpp
 # Begin Source File
 
 SOURCE=.\MemoryLeakOperatorOverloadsTest.cpp
-
-!IF  "$(CFG)" == "AllTests - Win32 Release"
-
-!ELSEIF  "$(CFG)" == "AllTests - Win32 Debug"
-
-!ENDIF 
-
 # End Source File
 # Begin Source File
 

--- a/tests/AllTests.dsp
+++ b/tests/AllTests.dsp
@@ -71,7 +71,7 @@ PostBuild_Cmds=$(TargetPath)
 # PROP Ignore_Export_Lib 0
 # PROP Target_Dir ""
 # ADD BASE CPP /nologo /W3 /Gm /GX /ZI /Od /D "WIN32" /D "_DEBUG" /D "_CONSOLE" /D "_MBCS" /YX /FD /GZ /c
-# ADD CPP /nologo /MDd /W3 /GX /ZI /Od /I "..\include" /I "..\include\Platforms\VisualCpp" /FI"CppUTest/MemoryLeakDetectorMallocMacros.h" /FI"CppUTest/MemoryLeakDetectorNewMacros.h" /D "_CONSOLE" /D "WIN32" /D "_DEBUG" /D "_MBCS" /FR /FD /GZ /c
+# ADD CPP /nologo /MDd /W3 /GX /ZI /Od /I "..\include" /I "..\include\Platforms\VisualCpp" /FI"CppUTest/MemoryLeakDetectorMallocMacros.h" /FI"CppUTest/MemoryLeakDetectorNewMacros.h" /D "_CONSOLE" /D "WIN32" /D "_DEBUG" /D "_MBCS" /D "CPPUTEST_MEM_LEAK_DETECTION_DISABLED" /FR /FD /GZ /c
 # ADD BASE RSC /l 0x409 /d "_DEBUG"
 # ADD RSC /l 0x409 /d "_DEBUG"
 BSC32=bscmake.exe
@@ -84,7 +84,7 @@ LINK32=link.exe
 # Begin Special Build Tool
 TargetPath=.\Debug\AllTests.exe
 SOURCE="$(InputPath)"
-PostBuild_Cmds=$(TargetPath)
+PostBuild_Cmds=$(TargetPath) -v
 # End Special Build Tool
 
 !ENDIF 
@@ -147,6 +147,13 @@ SOURCE=.\MemoryLeakDetectorTest.cpp
 # Begin Source File
 
 SOURCE=.\MemoryLeakOperatorOverloadsTest.cpp
+
+!IF  "$(CFG)" == "AllTests - Win32 Release"
+
+!ELSEIF  "$(CFG)" == "AllTests - Win32 Debug"
+
+!ENDIF 
+
 # End Source File
 # Begin Source File
 

--- a/tests/AllTests.mak
+++ b/tests/AllTests.mak
@@ -25,6 +25,9 @@ NULL=
 NULL=nul
 !ENDIF 
 
+CPP=cl.exe
+RSC=rc.exe
+
 !IF  "$(CFG)" == "AllTests - Win32 Release"
 
 OUTDIR=.\Release
@@ -35,11 +38,11 @@ OutDir=.\Release
 
 !IF "$(RECURSE)" == "0" 
 
-ALL : "$(OUTDIR)\AllTests.exe" ".\Release"
+ALL : "$(OUTDIR)\AllTests.exe"
 
 !ELSE 
 
-ALL : "CppUTest - Win32 Release" "$(OUTDIR)\AllTests.exe" ".\Release"
+ALL : "CppUTest - Win32 Release" "$(OUTDIR)\AllTests.exe"
 
 !ENDIF 
 
@@ -60,6 +63,7 @@ CLEAN :
 	-@erase "$(INTDIR)\GTest2ConvertorTest.obj"
 	-@erase "$(INTDIR)\JUnitOutputTest.obj"
 	-@erase "$(INTDIR)\MemoryLeakDetectorTest.obj"
+	-@erase "$(INTDIR)\MemoryLeakOperatorOverloadsTest.obj"
 	-@erase "$(INTDIR)\MemoryReportAllocatorTest.obj"
 	-@erase "$(INTDIR)\MemoryReporterPluginTest.obj"
 	-@erase "$(INTDIR)\MemoryReportFormatterTest.obj"
@@ -89,45 +93,11 @@ CLEAN :
 	-@erase "$(INTDIR)\UtestTest.obj"
 	-@erase "$(INTDIR)\vc60.idb"
 	-@erase "$(OUTDIR)\AllTests.exe"
-	-@erase ".\Release"
 
 "$(OUTDIR)" :
     if not exist "$(OUTDIR)/$(NULL)" mkdir "$(OUTDIR)"
 
-CPP=cl.exe
 CPP_PROJ=/nologo /ML /W3 /GX /O2 /I "..\include" /I "..\include\Platforms\VisualCpp" /D "WIN32" /D "NDEBUG" /D "_CONSOLE" /D "_MBCS" /Fp"$(INTDIR)\AllTests.pch" /YX /Fo"$(INTDIR)\\" /Fd"$(INTDIR)\\" /FD /c 
-
-.c{$(INTDIR)}.obj::
-   $(CPP) @<<
-   $(CPP_PROJ) $< 
-<<
-
-.cpp{$(INTDIR)}.obj::
-   $(CPP) @<<
-   $(CPP_PROJ) $< 
-<<
-
-.cxx{$(INTDIR)}.obj::
-   $(CPP) @<<
-   $(CPP_PROJ) $< 
-<<
-
-.c{$(INTDIR)}.sbr::
-   $(CPP) @<<
-   $(CPP_PROJ) $< 
-<<
-
-.cpp{$(INTDIR)}.sbr::
-   $(CPP) @<<
-   $(CPP_PROJ) $< 
-<<
-
-.cxx{$(INTDIR)}.sbr::
-   $(CPP) @<<
-   $(CPP_PROJ) $< 
-<<
-
-RSC=rc.exe
 BSC32=bscmake.exe
 BSC32_FLAGS=/nologo /o"$(OUTDIR)\AllTests.bsc" 
 BSC32_SBRS= \
@@ -147,6 +117,7 @@ LINK32_OBJS= \
 	"$(INTDIR)\GTest2ConvertorTest.obj" \
 	"$(INTDIR)\JUnitOutputTest.obj" \
 	"$(INTDIR)\MemoryLeakDetectorTest.obj" \
+	"$(INTDIR)\MemoryLeakOperatorOverloadsTest.obj" \
 	"$(INTDIR)\MemoryReportAllocatorTest.obj" \
 	"$(INTDIR)\MemoryReporterPluginTest.obj" \
 	"$(INTDIR)\MemoryReportFormatterTest.obj" \
@@ -181,18 +152,19 @@ LINK32_OBJS= \
   $(LINK32_FLAGS) $(LINK32_OBJS)
 <<
 
-TargetDir=.\Release
 TargetPath=.\Release\AllTests.exe
-TargetName=AllTests
-InputPath=.\Release\AllTests.exe
 SOURCE="$(InputPath)"
+DS_POSTBUILD_DEP=$(INTDIR)\postbld.dep
 
-".\Release" : $(SOURCE) "$(INTDIR)" "$(OUTDIR)"
-	<<tempfile.bat 
-	@echo off 
-	$(TargetPath)$(TargetName)
-<< 
-	
+ALL : $(DS_POSTBUILD_DEP)
+
+# Begin Custom Macros
+OutDir=.\Release
+# End Custom Macros
+
+$(DS_POSTBUILD_DEP) : "CppUTest - Win32 Release" "$(OUTDIR)\AllTests.exe"
+   .\Release\AllTests.exe
+	echo Helper for Post-build step > "$(DS_POSTBUILD_DEP)"
 
 !ELSEIF  "$(CFG)" == "AllTests - Win32 Debug"
 
@@ -204,11 +176,11 @@ OutDir=.\Debug
 
 !IF "$(RECURSE)" == "0" 
 
-ALL : "$(OUTDIR)\AllTests.exe" "$(OUTDIR)\AllTests.bsc" ".\Debug"
+ALL : "$(OUTDIR)\AllTests.exe" "$(OUTDIR)\AllTests.bsc"
 
 !ELSE 
 
-ALL : "CppUTest - Win32 Debug" "$(OUTDIR)\AllTests.exe" "$(OUTDIR)\AllTests.bsc" ".\Debug"
+ALL : "CppUTest - Win32 Debug" "$(OUTDIR)\AllTests.exe" "$(OUTDIR)\AllTests.bsc"
 
 !ENDIF 
 
@@ -241,6 +213,10 @@ CLEAN :
 	-@erase "$(INTDIR)\JUnitOutputTest.sbr"
 	-@erase "$(INTDIR)\MemoryLeakDetectorTest.obj"
 	-@erase "$(INTDIR)\MemoryLeakDetectorTest.sbr"
+	-@erase "$(INTDIR)\MemoryLeakOperatorOverloadsTest.obj"
+	-@erase "$(INTDIR)\MemoryLeakOperatorOverloadsTest.sbr"
+	-@erase "$(INTDIR)\MemoryLeakWarningTest.obj"
+	-@erase "$(INTDIR)\MemoryLeakWarningTest.sbr"
 	-@erase "$(INTDIR)\MemoryReportAllocatorTest.obj"
 	-@erase "$(INTDIR)\MemoryReportAllocatorTest.sbr"
 	-@erase "$(INTDIR)\MemoryReporterPluginTest.obj"
@@ -301,45 +277,11 @@ CLEAN :
 	-@erase "$(OUTDIR)\AllTests.exe"
 	-@erase "$(OUTDIR)\AllTests.ilk"
 	-@erase "$(OUTDIR)\AllTests.pdb"
-	-@erase ".\Debug"
 
 "$(OUTDIR)" :
     if not exist "$(OUTDIR)/$(NULL)" mkdir "$(OUTDIR)"
 
-CPP=cl.exe
-CPP_PROJ=/nologo /MDd /W3 /GX /ZI /Od /I "..\include" /I "..\include\Platforms\VisualCpp" /D "_CONSOLE" /D "WIN32" /D "_DEBUG" /D "_MBCS" /FR"$(INTDIR)\\" /Fo"$(INTDIR)\\" /Fd"$(INTDIR)\\" /FD /GZ /c 
-
-.c{$(INTDIR)}.obj::
-   $(CPP) @<<
-   $(CPP_PROJ) $< 
-<<
-
-.cpp{$(INTDIR)}.obj::
-   $(CPP) @<<
-   $(CPP_PROJ) $< 
-<<
-
-.cxx{$(INTDIR)}.obj::
-   $(CPP) @<<
-   $(CPP_PROJ) $< 
-<<
-
-.c{$(INTDIR)}.sbr::
-   $(CPP) @<<
-   $(CPP_PROJ) $< 
-<<
-
-.cpp{$(INTDIR)}.sbr::
-   $(CPP) @<<
-   $(CPP_PROJ) $< 
-<<
-
-.cxx{$(INTDIR)}.sbr::
-   $(CPP) @<<
-   $(CPP_PROJ) $< 
-<<
-
-RSC=rc.exe
+CPP_PROJ=/nologo /MDd /W3 /GX /ZI /Od /I "..\include" /I "..\include\Platforms\VisualCpp" /FI"CppUTest/MemoryLeakDetectorMallocMacros.h" /FI"CppUTest/MemoryLeakDetectorNewMacros.h" /D "_CONSOLE" /D "WIN32" /D "_DEBUG" /D "_MBCS" /D "CPPUTEST_MEM_LEAK_DETECTION_DISABLED" /FR"$(INTDIR)\\" /Fo"$(INTDIR)\\" /Fd"$(INTDIR)\\" /FD /GZ /c 
 BSC32=bscmake.exe
 BSC32_FLAGS=/nologo /o"$(OUTDIR)\AllTests.bsc" 
 BSC32_SBRS= \
@@ -355,6 +297,8 @@ BSC32_SBRS= \
 	"$(INTDIR)\GTest2ConvertorTest.sbr" \
 	"$(INTDIR)\JUnitOutputTest.sbr" \
 	"$(INTDIR)\MemoryLeakDetectorTest.sbr" \
+	"$(INTDIR)\MemoryLeakOperatorOverloadsTest.sbr" \
+	"$(INTDIR)\MemoryLeakWarningTest.sbr" \
 	"$(INTDIR)\MemoryReportAllocatorTest.sbr" \
 	"$(INTDIR)\MemoryReporterPluginTest.sbr" \
 	"$(INTDIR)\MemoryReportFormatterTest.sbr" \
@@ -403,6 +347,8 @@ LINK32_OBJS= \
 	"$(INTDIR)\GTest2ConvertorTest.obj" \
 	"$(INTDIR)\JUnitOutputTest.obj" \
 	"$(INTDIR)\MemoryLeakDetectorTest.obj" \
+	"$(INTDIR)\MemoryLeakOperatorOverloadsTest.obj" \
+	"$(INTDIR)\MemoryLeakWarningTest.obj" \
 	"$(INTDIR)\MemoryReportAllocatorTest.obj" \
 	"$(INTDIR)\MemoryReporterPluginTest.obj" \
 	"$(INTDIR)\MemoryReportFormatterTest.obj" \
@@ -437,19 +383,51 @@ LINK32_OBJS= \
   $(LINK32_FLAGS) $(LINK32_OBJS)
 <<
 
-TargetDir=.\Debug
 TargetPath=.\Debug\AllTests.exe
-InputPath=.\Debug\AllTests.exe
 SOURCE="$(InputPath)"
+DS_POSTBUILD_DEP=$(INTDIR)\postbld.dep
 
-".\Debug" : $(SOURCE) "$(INTDIR)" "$(OUTDIR)"
-	<<tempfile.bat 
-	@echo off 
-	$(TargetPath)
-<< 
-	
+ALL : $(DS_POSTBUILD_DEP)
+
+# Begin Custom Macros
+OutDir=.\Debug
+# End Custom Macros
+
+$(DS_POSTBUILD_DEP) : "CppUTest - Win32 Debug" "$(OUTDIR)\AllTests.exe" "$(OUTDIR)\AllTests.bsc"
+   .\Debug\AllTests.exe -v
+	echo Helper for Post-build step > "$(DS_POSTBUILD_DEP)"
 
 !ENDIF 
+
+.c{$(INTDIR)}.obj::
+   $(CPP) @<<
+   $(CPP_PROJ) $< 
+<<
+
+.cpp{$(INTDIR)}.obj::
+   $(CPP) @<<
+   $(CPP_PROJ) $< 
+<<
+
+.cxx{$(INTDIR)}.obj::
+   $(CPP) @<<
+   $(CPP_PROJ) $< 
+<<
+
+.c{$(INTDIR)}.sbr::
+   $(CPP) @<<
+   $(CPP_PROJ) $< 
+<<
+
+.cpp{$(INTDIR)}.sbr::
+   $(CPP) @<<
+   $(CPP_PROJ) $< 
+<<
+
+.cxx{$(INTDIR)}.sbr::
+   $(CPP) @<<
+   $(CPP_PROJ) $< 
+<<
 
 
 !IF "$(NO_EXTERNAL_DEPS)" != "1"
@@ -663,7 +641,33 @@ SOURCE=.\MemoryLeakDetectorTest.cpp
 !ENDIF 
 
 SOURCE=.\MemoryLeakOperatorOverloadsTest.cpp
+
+!IF  "$(CFG)" == "AllTests - Win32 Release"
+
+
+"$(INTDIR)\MemoryLeakOperatorOverloadsTest.obj" : $(SOURCE) "$(INTDIR)"
+
+
+!ELSEIF  "$(CFG)" == "AllTests - Win32 Debug"
+
+
+"$(INTDIR)\MemoryLeakOperatorOverloadsTest.obj"	"$(INTDIR)\MemoryLeakOperatorOverloadsTest.sbr" : $(SOURCE) "$(INTDIR)"
+
+
+!ENDIF 
+
 SOURCE=.\MemoryLeakWarningTest.cpp
+
+!IF  "$(CFG)" == "AllTests - Win32 Release"
+
+!ELSEIF  "$(CFG)" == "AllTests - Win32 Debug"
+
+
+"$(INTDIR)\MemoryLeakWarningTest.obj"	"$(INTDIR)\MemoryLeakWarningTest.sbr" : $(SOURCE) "$(INTDIR)"
+
+
+!ENDIF 
+
 SOURCE=.\CppUTestExt\MemoryReportAllocatorTest.cpp
 
 !IF  "$(CFG)" == "AllTests - Win32 Release"

--- a/tests/AllTests.mak
+++ b/tests/AllTests.mak
@@ -25,9 +25,6 @@ NULL=
 NULL=nul
 !ENDIF 
 
-CPP=cl.exe
-RSC=rc.exe
-
 !IF  "$(CFG)" == "AllTests - Win32 Release"
 
 OUTDIR=.\Release
@@ -38,11 +35,11 @@ OutDir=.\Release
 
 !IF "$(RECURSE)" == "0" 
 
-ALL : "$(OUTDIR)\AllTests.exe"
+ALL : "$(OUTDIR)\AllTests.exe" ".\Release"
 
 !ELSE 
 
-ALL : "CppUTest - Win32 Release" "$(OUTDIR)\AllTests.exe"
+ALL : "CppUTest - Win32 Release" "$(OUTDIR)\AllTests.exe" ".\Release"
 
 !ENDIF 
 
@@ -54,210 +51,51 @@ CLEAN :
 	-@erase "$(INTDIR)\AllocationInCFile.obj"
 	-@erase "$(INTDIR)\AllocationInCppFile.obj"
 	-@erase "$(INTDIR)\AllTests.obj"
+	-@erase "$(INTDIR)\CheatSheetTest.obj"
+	-@erase "$(INTDIR)\CodeMemoryReportFormatterTest.obj"
 	-@erase "$(INTDIR)\CommandLineArgumentsTest.obj"
 	-@erase "$(INTDIR)\CommandLineTestRunnerTest.obj"
-	-@erase "$(INTDIR)\FailureTest.obj"
+	-@erase "$(INTDIR)\GMockTest.obj"
+	-@erase "$(INTDIR)\GTest1Test.obj"
+	-@erase "$(INTDIR)\GTest2ConvertorTest.obj"
 	-@erase "$(INTDIR)\JUnitOutputTest.obj"
-	-@erase "$(INTDIR)\MemoryLeakAllocator.obj"
-	-@erase "$(INTDIR)\MemoryLeakAllocatorTest.obj"
 	-@erase "$(INTDIR)\MemoryLeakDetectorTest.obj"
-	-@erase "$(INTDIR)\MemoryLeakOperatorOverloadsTest.obj"
-	-@erase "$(INTDIR)\MemoryLeakWarningTest.obj"
-	-@erase "$(INTDIR)\NullTestTest.obj"
+	-@erase "$(INTDIR)\MemoryReportAllocatorTest.obj"
+	-@erase "$(INTDIR)\MemoryReporterPluginTest.obj"
+	-@erase "$(INTDIR)\MemoryReportFormatterTest.obj"
+	-@erase "$(INTDIR)\MockActualCallTest.obj"
+	-@erase "$(INTDIR)\MockCheatSheetTest.obj"
+	-@erase "$(INTDIR)\MockExpectedCallTest.obj"
+	-@erase "$(INTDIR)\MockExpectedFunctionsListTest.obj"
+	-@erase "$(INTDIR)\MockFailureTest.obj"
+	-@erase "$(INTDIR)\MockPluginTest.obj"
+	-@erase "$(INTDIR)\MockSupport_cTest.obj"
+	-@erase "$(INTDIR)\MockSupport_cTestCFile.obj"
+	-@erase "$(INTDIR)\MockSupportTest.obj"
+	-@erase "$(INTDIR)\OrderedTestTest.obj"
 	-@erase "$(INTDIR)\PluginTest.obj"
+	-@erase "$(INTDIR)\PreprocessorTest.obj"
 	-@erase "$(INTDIR)\SetPluginTest.obj"
 	-@erase "$(INTDIR)\SimpleStringTest.obj"
+	-@erase "$(INTDIR)\TestFailureTest.obj"
+	-@erase "$(INTDIR)\TestFilterTest.obj"
 	-@erase "$(INTDIR)\TestHarness_cTest.obj"
+	-@erase "$(INTDIR)\TestHarness_cTestCFile.obj"
 	-@erase "$(INTDIR)\TestInstallerTest.obj"
+	-@erase "$(INTDIR)\TestMemoryAllocatorTest.obj"
 	-@erase "$(INTDIR)\TestOutputTest.obj"
 	-@erase "$(INTDIR)\TestRegistryTest.obj"
 	-@erase "$(INTDIR)\TestResultTest.obj"
 	-@erase "$(INTDIR)\UtestTest.obj"
 	-@erase "$(INTDIR)\vc60.idb"
 	-@erase "$(OUTDIR)\AllTests.exe"
+	-@erase ".\Release"
 
 "$(OUTDIR)" :
     if not exist "$(OUTDIR)/$(NULL)" mkdir "$(OUTDIR)"
 
-CPP_PROJ=/nologo /ML /W3 /GX /O2 /D "WIN32" /D "NDEBUG" /D "_CONSOLE" /D "_MBCS" /Fp"$(INTDIR)\AllTests.pch" /YX /Fo"$(INTDIR)\\" /Fd"$(INTDIR)\\" /FD /c 
-BSC32=bscmake.exe
-BSC32_FLAGS=/nologo /o"$(OUTDIR)\AllTests.bsc" 
-BSC32_SBRS= \
-	
-LINK32=link.exe
-LINK32_FLAGS=kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:console /incremental:no /pdb:"$(OUTDIR)\AllTests.pdb" /machine:I386 /out:"$(OUTDIR)\AllTests.exe" 
-LINK32_OBJS= \
-	"$(INTDIR)\AllTests.obj" \
-	"$(INTDIR)\CommandLineArgumentsTest.obj" \
-	"$(INTDIR)\CommandLineTestRunnerTest.obj" \
-	"$(INTDIR)\FailureTest.obj" \
-	"$(INTDIR)\JUnitOutputTest.obj" \
-	"$(INTDIR)\MemoryLeakAllocator.obj" \
-	"$(INTDIR)\MemoryLeakAllocatorTest.obj" \
-	"$(INTDIR)\MemoryLeakDetectorTest.obj" \
-	"$(INTDIR)\MemoryLeakWarningTest.obj" \
-	"$(INTDIR)\NullTestTest.obj" \
-	"$(INTDIR)\PluginTest.obj" \
-	"$(INTDIR)\SetPluginTest.obj" \
-	"$(INTDIR)\SimpleStringTest.obj" \
-	"$(INTDIR)\TestHarness_cTest.obj" \
-	"$(INTDIR)\TestInstallerTest.obj" \
-	"$(INTDIR)\TestOutputTest.obj" \
-	"$(INTDIR)\TestRegistryTest.obj" \
-	"$(INTDIR)\TestResultTest.obj" \
-	"$(INTDIR)\UtestTest.obj" \
-	"$(INTDIR)\AllocationInCppFile.obj" \
-	"$(INTDIR)\MemoryLeakOperatorOverloadsTest.obj" \
-	"$(INTDIR)\AllocationInCFile.obj" \
-	"..\Release\CppUTest.lib"
-
-"$(OUTDIR)\AllTests.exe" : "$(OUTDIR)" $(DEF_FILE) $(LINK32_OBJS)
-    $(LINK32) @<<
-  $(LINK32_FLAGS) $(LINK32_OBJS)
-<<
-
-!ELSEIF  "$(CFG)" == "AllTests - Win32 Debug"
-
-OUTDIR=.\Debug
-INTDIR=.\Debug
-# Begin Custom Macros
-OutDir=.\Debug
-# End Custom Macros
-
-!IF "$(RECURSE)" == "0" 
-
-ALL : "$(OUTDIR)\AllTests.exe" "$(OUTDIR)\AllTests.bsc"
-
-!ELSE 
-
-ALL : "CppUTest - Win32 Debug" "$(OUTDIR)\AllTests.exe" "$(OUTDIR)\AllTests.bsc"
-
-!ENDIF 
-
-!IF "$(RECURSE)" == "1" 
-CLEAN :"CppUTest - Win32 DebugCLEAN" 
-!ELSE 
-CLEAN :
-!ENDIF 
-	-@erase "$(INTDIR)\AllocationInCFile.obj"
-	-@erase "$(INTDIR)\AllocationInCFile.sbr"
-	-@erase "$(INTDIR)\AllocationInCppFile.obj"
-	-@erase "$(INTDIR)\AllocationInCppFile.sbr"
-	-@erase "$(INTDIR)\AllTests.obj"
-	-@erase "$(INTDIR)\AllTests.sbr"
-	-@erase "$(INTDIR)\CommandLineArgumentsTest.obj"
-	-@erase "$(INTDIR)\CommandLineArgumentsTest.sbr"
-	-@erase "$(INTDIR)\CommandLineTestRunnerTest.obj"
-	-@erase "$(INTDIR)\CommandLineTestRunnerTest.sbr"
-	-@erase "$(INTDIR)\FailureTest.obj"
-	-@erase "$(INTDIR)\FailureTest.sbr"
-	-@erase "$(INTDIR)\JUnitOutputTest.obj"
-	-@erase "$(INTDIR)\JUnitOutputTest.sbr"
-	-@erase "$(INTDIR)\MemoryLeakAllocator.obj"
-	-@erase "$(INTDIR)\MemoryLeakAllocator.sbr"
-	-@erase "$(INTDIR)\MemoryLeakAllocatorTest.obj"
-	-@erase "$(INTDIR)\MemoryLeakAllocatorTest.sbr"
-	-@erase "$(INTDIR)\MemoryLeakDetectorTest.obj"
-	-@erase "$(INTDIR)\MemoryLeakDetectorTest.sbr"
-	-@erase "$(INTDIR)\MemoryLeakOperatorOverloadsTest.obj"
-	-@erase "$(INTDIR)\MemoryLeakOperatorOverloadsTest.sbr"
-	-@erase "$(INTDIR)\MemoryLeakWarningTest.obj"
-	-@erase "$(INTDIR)\MemoryLeakWarningTest.sbr"
-	-@erase "$(INTDIR)\NullTestTest.obj"
-	-@erase "$(INTDIR)\NullTestTest.sbr"
-	-@erase "$(INTDIR)\PluginTest.obj"
-	-@erase "$(INTDIR)\PluginTest.sbr"
-	-@erase "$(INTDIR)\SetPluginTest.obj"
-	-@erase "$(INTDIR)\SetPluginTest.sbr"
-	-@erase "$(INTDIR)\SimpleStringTest.obj"
-	-@erase "$(INTDIR)\SimpleStringTest.sbr"
-	-@erase "$(INTDIR)\TestHarness_cTest.obj"
-	-@erase "$(INTDIR)\TestHarness_cTest.sbr"
-	-@erase "$(INTDIR)\TestInstallerTest.obj"
-	-@erase "$(INTDIR)\TestInstallerTest.sbr"
-	-@erase "$(INTDIR)\TestOutputTest.obj"
-	-@erase "$(INTDIR)\TestOutputTest.sbr"
-	-@erase "$(INTDIR)\TestRegistryTest.obj"
-	-@erase "$(INTDIR)\TestRegistryTest.sbr"
-	-@erase "$(INTDIR)\TestResultTest.obj"
-	-@erase "$(INTDIR)\TestResultTest.sbr"
-	-@erase "$(INTDIR)\UtestTest.obj"
-	-@erase "$(INTDIR)\UtestTest.sbr"
-	-@erase "$(INTDIR)\vc60.idb"
-	-@erase "$(INTDIR)\vc60.pdb"
-	-@erase "$(OUTDIR)\AllTests.bsc"
-	-@erase "$(OUTDIR)\AllTests.exe"
-	-@erase "$(OUTDIR)\AllTests.ilk"
-	-@erase "$(OUTDIR)\AllTests.pdb"
-
-"$(OUTDIR)" :
-    if not exist "$(OUTDIR)/$(NULL)" mkdir "$(OUTDIR)"
-
-CPP_PROJ=/nologo /MDd /W3 /GX /ZI /Od /I "..\include" /I "..\include\Platforms\VisualCpp" /D "_CONSOLE" /D "WIN32" /D "_DEBUG" /D "_MBCS" /FR"$(INTDIR)\\" /Fo"$(INTDIR)\\" /Fd"$(INTDIR)\\" /FD /GZ /c 
-BSC32=bscmake.exe
-BSC32_FLAGS=/nologo /o"$(OUTDIR)\AllTests.bsc" 
-BSC32_SBRS= \
-	"$(INTDIR)\AllTests.sbr" \
-	"$(INTDIR)\CommandLineArgumentsTest.sbr" \
-	"$(INTDIR)\CommandLineTestRunnerTest.sbr" \
-	"$(INTDIR)\FailureTest.sbr" \
-	"$(INTDIR)\JUnitOutputTest.sbr" \
-	"$(INTDIR)\MemoryLeakAllocator.sbr" \
-	"$(INTDIR)\MemoryLeakAllocatorTest.sbr" \
-	"$(INTDIR)\MemoryLeakDetectorTest.sbr" \
-	"$(INTDIR)\MemoryLeakWarningTest.sbr" \
-	"$(INTDIR)\NullTestTest.sbr" \
-	"$(INTDIR)\PluginTest.sbr" \
-	"$(INTDIR)\SetPluginTest.sbr" \
-	"$(INTDIR)\SimpleStringTest.sbr" \
-	"$(INTDIR)\TestHarness_cTest.sbr" \
-	"$(INTDIR)\TestInstallerTest.sbr" \
-	"$(INTDIR)\TestOutputTest.sbr" \
-	"$(INTDIR)\TestRegistryTest.sbr" \
-	"$(INTDIR)\TestResultTest.sbr" \
-	"$(INTDIR)\UtestTest.sbr" \
-	"$(INTDIR)\AllocationInCppFile.sbr" \
-	"$(INTDIR)\MemoryLeakOperatorOverloadsTest.sbr" \
-	"$(INTDIR)\AllocationInCFile.sbr"
-
-"$(OUTDIR)\AllTests.bsc" : "$(OUTDIR)" $(BSC32_SBRS)
-    $(BSC32) @<<
-  $(BSC32_FLAGS) $(BSC32_SBRS)
-<<
-
-LINK32=link.exe
-LINK32_FLAGS=..\lib\CppUTest.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib winmm.lib /nologo /subsystem:console /incremental:yes /pdb:"$(OUTDIR)\AllTests.pdb" /debug /machine:I386 /out:"$(OUTDIR)\AllTests.exe" /pdbtype:sept 
-LINK32_OBJS= \
-	"$(INTDIR)\AllTests.obj" \
-	"$(INTDIR)\CommandLineArgumentsTest.obj" \
-	"$(INTDIR)\CommandLineTestRunnerTest.obj" \
-	"$(INTDIR)\FailureTest.obj" \
-	"$(INTDIR)\JUnitOutputTest.obj" \
-	"$(INTDIR)\MemoryLeakAllocator.obj" \
-	"$(INTDIR)\MemoryLeakAllocatorTest.obj" \
-	"$(INTDIR)\MemoryLeakDetectorTest.obj" \
-	"$(INTDIR)\MemoryLeakWarningTest.obj" \
-	"$(INTDIR)\NullTestTest.obj" \
-	"$(INTDIR)\PluginTest.obj" \
-	"$(INTDIR)\SetPluginTest.obj" \
-	"$(INTDIR)\SimpleStringTest.obj" \
-	"$(INTDIR)\TestHarness_cTest.obj" \
-	"$(INTDIR)\TestInstallerTest.obj" \
-	"$(INTDIR)\TestOutputTest.obj" \
-	"$(INTDIR)\TestRegistryTest.obj" \
-	"$(INTDIR)\TestResultTest.obj" \
-	"$(INTDIR)\UtestTest.obj" \
-	"$(INTDIR)\AllocationInCppFile.obj" \
-	"$(INTDIR)\MemoryLeakOperatorOverloadsTest.obj" \
-	"$(INTDIR)\AllocationInCFile.obj" \
-	"..\lib\CppUTest.lib"
-
-"$(OUTDIR)\AllTests.exe" : "$(OUTDIR)" $(DEF_FILE) $(LINK32_OBJS)
-    $(LINK32) @<<
-  $(LINK32_FLAGS) $(LINK32_OBJS)
-<<
-
-!ENDIF 
+CPP=cl.exe
+CPP_PROJ=/nologo /ML /W3 /GX /O2 /I "..\include" /I "..\include\Platforms\VisualCpp" /D "WIN32" /D "NDEBUG" /D "_CONSOLE" /D "_MBCS" /Fp"$(INTDIR)\AllTests.pch" /YX /Fo"$(INTDIR)\\" /Fd"$(INTDIR)\\" /FD /c 
 
 .c{$(INTDIR)}.obj::
    $(CPP) @<<
@@ -288,6 +126,330 @@ LINK32_OBJS= \
    $(CPP) @<<
    $(CPP_PROJ) $< 
 <<
+
+RSC=rc.exe
+BSC32=bscmake.exe
+BSC32_FLAGS=/nologo /o"$(OUTDIR)\AllTests.bsc" 
+BSC32_SBRS= \
+	
+LINK32=link.exe
+LINK32_FLAGS=kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:console /incremental:no /pdb:"$(OUTDIR)\AllTests.pdb" /machine:I386 /out:"$(OUTDIR)\AllTests.exe" 
+LINK32_OBJS= \
+	"$(INTDIR)\AllocationInCFile.obj" \
+	"$(INTDIR)\AllocationInCppFile.obj" \
+	"$(INTDIR)\AllTests.obj" \
+	"$(INTDIR)\CheatSheetTest.obj" \
+	"$(INTDIR)\CodeMemoryReportFormatterTest.obj" \
+	"$(INTDIR)\CommandLineArgumentsTest.obj" \
+	"$(INTDIR)\CommandLineTestRunnerTest.obj" \
+	"$(INTDIR)\GMockTest.obj" \
+	"$(INTDIR)\GTest1Test.obj" \
+	"$(INTDIR)\GTest2ConvertorTest.obj" \
+	"$(INTDIR)\JUnitOutputTest.obj" \
+	"$(INTDIR)\MemoryLeakDetectorTest.obj" \
+	"$(INTDIR)\MemoryReportAllocatorTest.obj" \
+	"$(INTDIR)\MemoryReporterPluginTest.obj" \
+	"$(INTDIR)\MemoryReportFormatterTest.obj" \
+	"$(INTDIR)\MockActualCallTest.obj" \
+	"$(INTDIR)\MockCheatSheetTest.obj" \
+	"$(INTDIR)\MockExpectedCallTest.obj" \
+	"$(INTDIR)\MockExpectedFunctionsListTest.obj" \
+	"$(INTDIR)\MockFailureTest.obj" \
+	"$(INTDIR)\MockPluginTest.obj" \
+	"$(INTDIR)\MockSupport_cTest.obj" \
+	"$(INTDIR)\MockSupport_cTestCFile.obj" \
+	"$(INTDIR)\MockSupportTest.obj" \
+	"$(INTDIR)\OrderedTestTest.obj" \
+	"$(INTDIR)\PluginTest.obj" \
+	"$(INTDIR)\PreprocessorTest.obj" \
+	"$(INTDIR)\SetPluginTest.obj" \
+	"$(INTDIR)\SimpleStringTest.obj" \
+	"$(INTDIR)\TestFailureTest.obj" \
+	"$(INTDIR)\TestFilterTest.obj" \
+	"$(INTDIR)\TestHarness_cTest.obj" \
+	"$(INTDIR)\TestHarness_cTestCFile.obj" \
+	"$(INTDIR)\TestInstallerTest.obj" \
+	"$(INTDIR)\TestMemoryAllocatorTest.obj" \
+	"$(INTDIR)\TestOutputTest.obj" \
+	"$(INTDIR)\TestRegistryTest.obj" \
+	"$(INTDIR)\TestResultTest.obj" \
+	"$(INTDIR)\UtestTest.obj" \
+	"..\Release\CppUTest.lib"
+
+"$(OUTDIR)\AllTests.exe" : "$(OUTDIR)" $(DEF_FILE) $(LINK32_OBJS)
+    $(LINK32) @<<
+  $(LINK32_FLAGS) $(LINK32_OBJS)
+<<
+
+TargetDir=.\Release
+TargetPath=.\Release\AllTests.exe
+TargetName=AllTests
+InputPath=.\Release\AllTests.exe
+SOURCE="$(InputPath)"
+
+".\Release" : $(SOURCE) "$(INTDIR)" "$(OUTDIR)"
+	<<tempfile.bat 
+	@echo off 
+	$(TargetPath)$(TargetName)
+<< 
+	
+
+!ELSEIF  "$(CFG)" == "AllTests - Win32 Debug"
+
+OUTDIR=.\Debug
+INTDIR=.\Debug
+# Begin Custom Macros
+OutDir=.\Debug
+# End Custom Macros
+
+!IF "$(RECURSE)" == "0" 
+
+ALL : "$(OUTDIR)\AllTests.exe" "$(OUTDIR)\AllTests.bsc" ".\Debug"
+
+!ELSE 
+
+ALL : "CppUTest - Win32 Debug" "$(OUTDIR)\AllTests.exe" "$(OUTDIR)\AllTests.bsc" ".\Debug"
+
+!ENDIF 
+
+!IF "$(RECURSE)" == "1" 
+CLEAN :"CppUTest - Win32 DebugCLEAN" 
+!ELSE 
+CLEAN :
+!ENDIF 
+	-@erase "$(INTDIR)\AllocationInCFile.obj"
+	-@erase "$(INTDIR)\AllocationInCFile.sbr"
+	-@erase "$(INTDIR)\AllocationInCppFile.obj"
+	-@erase "$(INTDIR)\AllocationInCppFile.sbr"
+	-@erase "$(INTDIR)\AllTests.obj"
+	-@erase "$(INTDIR)\AllTests.sbr"
+	-@erase "$(INTDIR)\CheatSheetTest.obj"
+	-@erase "$(INTDIR)\CheatSheetTest.sbr"
+	-@erase "$(INTDIR)\CodeMemoryReportFormatterTest.obj"
+	-@erase "$(INTDIR)\CodeMemoryReportFormatterTest.sbr"
+	-@erase "$(INTDIR)\CommandLineArgumentsTest.obj"
+	-@erase "$(INTDIR)\CommandLineArgumentsTest.sbr"
+	-@erase "$(INTDIR)\CommandLineTestRunnerTest.obj"
+	-@erase "$(INTDIR)\CommandLineTestRunnerTest.sbr"
+	-@erase "$(INTDIR)\GMockTest.obj"
+	-@erase "$(INTDIR)\GMockTest.sbr"
+	-@erase "$(INTDIR)\GTest1Test.obj"
+	-@erase "$(INTDIR)\GTest1Test.sbr"
+	-@erase "$(INTDIR)\GTest2ConvertorTest.obj"
+	-@erase "$(INTDIR)\GTest2ConvertorTest.sbr"
+	-@erase "$(INTDIR)\JUnitOutputTest.obj"
+	-@erase "$(INTDIR)\JUnitOutputTest.sbr"
+	-@erase "$(INTDIR)\MemoryLeakDetectorTest.obj"
+	-@erase "$(INTDIR)\MemoryLeakDetectorTest.sbr"
+	-@erase "$(INTDIR)\MemoryReportAllocatorTest.obj"
+	-@erase "$(INTDIR)\MemoryReportAllocatorTest.sbr"
+	-@erase "$(INTDIR)\MemoryReporterPluginTest.obj"
+	-@erase "$(INTDIR)\MemoryReporterPluginTest.sbr"
+	-@erase "$(INTDIR)\MemoryReportFormatterTest.obj"
+	-@erase "$(INTDIR)\MemoryReportFormatterTest.sbr"
+	-@erase "$(INTDIR)\MockActualCallTest.obj"
+	-@erase "$(INTDIR)\MockActualCallTest.sbr"
+	-@erase "$(INTDIR)\MockCheatSheetTest.obj"
+	-@erase "$(INTDIR)\MockCheatSheetTest.sbr"
+	-@erase "$(INTDIR)\MockExpectedCallTest.obj"
+	-@erase "$(INTDIR)\MockExpectedCallTest.sbr"
+	-@erase "$(INTDIR)\MockExpectedFunctionsListTest.obj"
+	-@erase "$(INTDIR)\MockExpectedFunctionsListTest.sbr"
+	-@erase "$(INTDIR)\MockFailureTest.obj"
+	-@erase "$(INTDIR)\MockFailureTest.sbr"
+	-@erase "$(INTDIR)\MockPluginTest.obj"
+	-@erase "$(INTDIR)\MockPluginTest.sbr"
+	-@erase "$(INTDIR)\MockSupport_cTest.obj"
+	-@erase "$(INTDIR)\MockSupport_cTest.sbr"
+	-@erase "$(INTDIR)\MockSupport_cTestCFile.obj"
+	-@erase "$(INTDIR)\MockSupport_cTestCFile.sbr"
+	-@erase "$(INTDIR)\MockSupportTest.obj"
+	-@erase "$(INTDIR)\MockSupportTest.sbr"
+	-@erase "$(INTDIR)\OrderedTestTest.obj"
+	-@erase "$(INTDIR)\OrderedTestTest.sbr"
+	-@erase "$(INTDIR)\PluginTest.obj"
+	-@erase "$(INTDIR)\PluginTest.sbr"
+	-@erase "$(INTDIR)\PreprocessorTest.obj"
+	-@erase "$(INTDIR)\PreprocessorTest.sbr"
+	-@erase "$(INTDIR)\SetPluginTest.obj"
+	-@erase "$(INTDIR)\SetPluginTest.sbr"
+	-@erase "$(INTDIR)\SimpleStringTest.obj"
+	-@erase "$(INTDIR)\SimpleStringTest.sbr"
+	-@erase "$(INTDIR)\TestFailureTest.obj"
+	-@erase "$(INTDIR)\TestFailureTest.sbr"
+	-@erase "$(INTDIR)\TestFilterTest.obj"
+	-@erase "$(INTDIR)\TestFilterTest.sbr"
+	-@erase "$(INTDIR)\TestHarness_cTest.obj"
+	-@erase "$(INTDIR)\TestHarness_cTest.sbr"
+	-@erase "$(INTDIR)\TestHarness_cTestCFile.obj"
+	-@erase "$(INTDIR)\TestHarness_cTestCFile.sbr"
+	-@erase "$(INTDIR)\TestInstallerTest.obj"
+	-@erase "$(INTDIR)\TestInstallerTest.sbr"
+	-@erase "$(INTDIR)\TestMemoryAllocatorTest.obj"
+	-@erase "$(INTDIR)\TestMemoryAllocatorTest.sbr"
+	-@erase "$(INTDIR)\TestOutputTest.obj"
+	-@erase "$(INTDIR)\TestOutputTest.sbr"
+	-@erase "$(INTDIR)\TestRegistryTest.obj"
+	-@erase "$(INTDIR)\TestRegistryTest.sbr"
+	-@erase "$(INTDIR)\TestResultTest.obj"
+	-@erase "$(INTDIR)\TestResultTest.sbr"
+	-@erase "$(INTDIR)\UtestTest.obj"
+	-@erase "$(INTDIR)\UtestTest.sbr"
+	-@erase "$(INTDIR)\vc60.idb"
+	-@erase "$(INTDIR)\vc60.pdb"
+	-@erase "$(OUTDIR)\AllTests.bsc"
+	-@erase "$(OUTDIR)\AllTests.exe"
+	-@erase "$(OUTDIR)\AllTests.ilk"
+	-@erase "$(OUTDIR)\AllTests.pdb"
+	-@erase ".\Debug"
+
+"$(OUTDIR)" :
+    if not exist "$(OUTDIR)/$(NULL)" mkdir "$(OUTDIR)"
+
+CPP=cl.exe
+CPP_PROJ=/nologo /MDd /W3 /GX /ZI /Od /I "..\include" /I "..\include\Platforms\VisualCpp" /D "_CONSOLE" /D "WIN32" /D "_DEBUG" /D "_MBCS" /FR"$(INTDIR)\\" /Fo"$(INTDIR)\\" /Fd"$(INTDIR)\\" /FD /GZ /c 
+
+.c{$(INTDIR)}.obj::
+   $(CPP) @<<
+   $(CPP_PROJ) $< 
+<<
+
+.cpp{$(INTDIR)}.obj::
+   $(CPP) @<<
+   $(CPP_PROJ) $< 
+<<
+
+.cxx{$(INTDIR)}.obj::
+   $(CPP) @<<
+   $(CPP_PROJ) $< 
+<<
+
+.c{$(INTDIR)}.sbr::
+   $(CPP) @<<
+   $(CPP_PROJ) $< 
+<<
+
+.cpp{$(INTDIR)}.sbr::
+   $(CPP) @<<
+   $(CPP_PROJ) $< 
+<<
+
+.cxx{$(INTDIR)}.sbr::
+   $(CPP) @<<
+   $(CPP_PROJ) $< 
+<<
+
+RSC=rc.exe
+BSC32=bscmake.exe
+BSC32_FLAGS=/nologo /o"$(OUTDIR)\AllTests.bsc" 
+BSC32_SBRS= \
+	"$(INTDIR)\AllocationInCFile.sbr" \
+	"$(INTDIR)\AllocationInCppFile.sbr" \
+	"$(INTDIR)\AllTests.sbr" \
+	"$(INTDIR)\CheatSheetTest.sbr" \
+	"$(INTDIR)\CodeMemoryReportFormatterTest.sbr" \
+	"$(INTDIR)\CommandLineArgumentsTest.sbr" \
+	"$(INTDIR)\CommandLineTestRunnerTest.sbr" \
+	"$(INTDIR)\GMockTest.sbr" \
+	"$(INTDIR)\GTest1Test.sbr" \
+	"$(INTDIR)\GTest2ConvertorTest.sbr" \
+	"$(INTDIR)\JUnitOutputTest.sbr" \
+	"$(INTDIR)\MemoryLeakDetectorTest.sbr" \
+	"$(INTDIR)\MemoryReportAllocatorTest.sbr" \
+	"$(INTDIR)\MemoryReporterPluginTest.sbr" \
+	"$(INTDIR)\MemoryReportFormatterTest.sbr" \
+	"$(INTDIR)\MockActualCallTest.sbr" \
+	"$(INTDIR)\MockCheatSheetTest.sbr" \
+	"$(INTDIR)\MockExpectedCallTest.sbr" \
+	"$(INTDIR)\MockExpectedFunctionsListTest.sbr" \
+	"$(INTDIR)\MockFailureTest.sbr" \
+	"$(INTDIR)\MockPluginTest.sbr" \
+	"$(INTDIR)\MockSupport_cTest.sbr" \
+	"$(INTDIR)\MockSupport_cTestCFile.sbr" \
+	"$(INTDIR)\MockSupportTest.sbr" \
+	"$(INTDIR)\OrderedTestTest.sbr" \
+	"$(INTDIR)\PluginTest.sbr" \
+	"$(INTDIR)\PreprocessorTest.sbr" \
+	"$(INTDIR)\SetPluginTest.sbr" \
+	"$(INTDIR)\SimpleStringTest.sbr" \
+	"$(INTDIR)\TestFailureTest.sbr" \
+	"$(INTDIR)\TestFilterTest.sbr" \
+	"$(INTDIR)\TestHarness_cTest.sbr" \
+	"$(INTDIR)\TestHarness_cTestCFile.sbr" \
+	"$(INTDIR)\TestInstallerTest.sbr" \
+	"$(INTDIR)\TestMemoryAllocatorTest.sbr" \
+	"$(INTDIR)\TestOutputTest.sbr" \
+	"$(INTDIR)\TestRegistryTest.sbr" \
+	"$(INTDIR)\TestResultTest.sbr" \
+	"$(INTDIR)\UtestTest.sbr"
+
+"$(OUTDIR)\AllTests.bsc" : "$(OUTDIR)" $(BSC32_SBRS)
+    $(BSC32) @<<
+  $(BSC32_FLAGS) $(BSC32_SBRS)
+<<
+
+LINK32=link.exe
+LINK32_FLAGS=..\lib\CppUTest.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib winmm.lib /nologo /subsystem:console /incremental:yes /pdb:"$(OUTDIR)\AllTests.pdb" /debug /machine:I386 /out:"$(OUTDIR)\AllTests.exe" /pdbtype:sept 
+LINK32_OBJS= \
+	"$(INTDIR)\AllocationInCFile.obj" \
+	"$(INTDIR)\AllocationInCppFile.obj" \
+	"$(INTDIR)\AllTests.obj" \
+	"$(INTDIR)\CheatSheetTest.obj" \
+	"$(INTDIR)\CodeMemoryReportFormatterTest.obj" \
+	"$(INTDIR)\CommandLineArgumentsTest.obj" \
+	"$(INTDIR)\CommandLineTestRunnerTest.obj" \
+	"$(INTDIR)\GMockTest.obj" \
+	"$(INTDIR)\GTest1Test.obj" \
+	"$(INTDIR)\GTest2ConvertorTest.obj" \
+	"$(INTDIR)\JUnitOutputTest.obj" \
+	"$(INTDIR)\MemoryLeakDetectorTest.obj" \
+	"$(INTDIR)\MemoryReportAllocatorTest.obj" \
+	"$(INTDIR)\MemoryReporterPluginTest.obj" \
+	"$(INTDIR)\MemoryReportFormatterTest.obj" \
+	"$(INTDIR)\MockActualCallTest.obj" \
+	"$(INTDIR)\MockCheatSheetTest.obj" \
+	"$(INTDIR)\MockExpectedCallTest.obj" \
+	"$(INTDIR)\MockExpectedFunctionsListTest.obj" \
+	"$(INTDIR)\MockFailureTest.obj" \
+	"$(INTDIR)\MockPluginTest.obj" \
+	"$(INTDIR)\MockSupport_cTest.obj" \
+	"$(INTDIR)\MockSupport_cTestCFile.obj" \
+	"$(INTDIR)\MockSupportTest.obj" \
+	"$(INTDIR)\OrderedTestTest.obj" \
+	"$(INTDIR)\PluginTest.obj" \
+	"$(INTDIR)\PreprocessorTest.obj" \
+	"$(INTDIR)\SetPluginTest.obj" \
+	"$(INTDIR)\SimpleStringTest.obj" \
+	"$(INTDIR)\TestFailureTest.obj" \
+	"$(INTDIR)\TestFilterTest.obj" \
+	"$(INTDIR)\TestHarness_cTest.obj" \
+	"$(INTDIR)\TestHarness_cTestCFile.obj" \
+	"$(INTDIR)\TestInstallerTest.obj" \
+	"$(INTDIR)\TestMemoryAllocatorTest.obj" \
+	"$(INTDIR)\TestOutputTest.obj" \
+	"$(INTDIR)\TestRegistryTest.obj" \
+	"$(INTDIR)\TestResultTest.obj" \
+	"$(INTDIR)\UtestTest.obj" \
+	"..\lib\CppUTest.lib"
+
+"$(OUTDIR)\AllTests.exe" : "$(OUTDIR)" $(DEF_FILE) $(LINK32_OBJS)
+    $(LINK32) @<<
+  $(LINK32_FLAGS) $(LINK32_OBJS)
+<<
+
+TargetDir=.\Debug
+TargetPath=.\Debug\AllTests.exe
+InputPath=.\Debug\AllTests.exe
+SOURCE="$(InputPath)"
+
+".\Debug" : $(SOURCE) "$(INTDIR)" "$(OUTDIR)"
+	<<tempfile.bat 
+	@echo off 
+	$(TargetPath)
+<< 
+	
+
+!ENDIF 
 
 
 !IF "$(NO_EXTERNAL_DEPS)" != "1"
@@ -348,6 +510,40 @@ SOURCE=.\AllTests.cpp
 
 !ENDIF 
 
+SOURCE=.\CheatSheetTest.cpp
+
+!IF  "$(CFG)" == "AllTests - Win32 Release"
+
+
+"$(INTDIR)\CheatSheetTest.obj" : $(SOURCE) "$(INTDIR)"
+
+
+!ELSEIF  "$(CFG)" == "AllTests - Win32 Debug"
+
+
+"$(INTDIR)\CheatSheetTest.obj"	"$(INTDIR)\CheatSheetTest.sbr" : $(SOURCE) "$(INTDIR)"
+
+
+!ENDIF 
+
+SOURCE=.\CppUTestExt\CodeMemoryReportFormatterTest.cpp
+
+!IF  "$(CFG)" == "AllTests - Win32 Release"
+
+
+"$(INTDIR)\CodeMemoryReportFormatterTest.obj" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ELSEIF  "$(CFG)" == "AllTests - Win32 Debug"
+
+
+"$(INTDIR)\CodeMemoryReportFormatterTest.obj"	"$(INTDIR)\CodeMemoryReportFormatterTest.sbr" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ENDIF 
+
 SOURCE=.\CommandLineArgumentsTest.cpp
 
 !IF  "$(CFG)" == "AllTests - Win32 Release"
@@ -380,18 +576,56 @@ SOURCE=.\CommandLineTestRunnerTest.cpp
 
 !ENDIF 
 
-SOURCE=.\FailureTest.cpp
+SOURCE=.\CppUTestExt\GMockTest.cpp
 
 !IF  "$(CFG)" == "AllTests - Win32 Release"
 
 
-"$(INTDIR)\FailureTest.obj" : $(SOURCE) "$(INTDIR)"
+"$(INTDIR)\GMockTest.obj" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
 
 
 !ELSEIF  "$(CFG)" == "AllTests - Win32 Debug"
 
 
-"$(INTDIR)\FailureTest.obj"	"$(INTDIR)\FailureTest.sbr" : $(SOURCE) "$(INTDIR)"
+"$(INTDIR)\GMockTest.obj"	"$(INTDIR)\GMockTest.sbr" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ENDIF 
+
+SOURCE=.\CppUTestExt\GTest1Test.cpp
+
+!IF  "$(CFG)" == "AllTests - Win32 Release"
+
+
+"$(INTDIR)\GTest1Test.obj" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ELSEIF  "$(CFG)" == "AllTests - Win32 Debug"
+
+
+"$(INTDIR)\GTest1Test.obj"	"$(INTDIR)\GTest1Test.sbr" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ENDIF 
+
+SOURCE=.\CppUTestExt\GTest2ConvertorTest.cpp
+
+!IF  "$(CFG)" == "AllTests - Win32 Release"
+
+
+"$(INTDIR)\GTest2ConvertorTest.obj" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ELSEIF  "$(CFG)" == "AllTests - Win32 Debug"
+
+
+"$(INTDIR)\GTest2ConvertorTest.obj"	"$(INTDIR)\GTest2ConvertorTest.sbr" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
 
 
 !ENDIF 
@@ -408,40 +642,6 @@ SOURCE=.\JUnitOutputTest.cpp
 
 
 "$(INTDIR)\JUnitOutputTest.obj"	"$(INTDIR)\JUnitOutputTest.sbr" : $(SOURCE) "$(INTDIR)"
-
-
-!ENDIF 
-
-SOURCE=..\src\CppUTest\MemoryLeakAllocator.cpp
-
-!IF  "$(CFG)" == "AllTests - Win32 Release"
-
-
-"$(INTDIR)\MemoryLeakAllocator.obj" : $(SOURCE) "$(INTDIR)"
-	$(CPP) $(CPP_PROJ) $(SOURCE)
-
-
-!ELSEIF  "$(CFG)" == "AllTests - Win32 Debug"
-
-
-"$(INTDIR)\MemoryLeakAllocator.obj"	"$(INTDIR)\MemoryLeakAllocator.sbr" : $(SOURCE) "$(INTDIR)"
-	$(CPP) $(CPP_PROJ) $(SOURCE)
-
-
-!ENDIF 
-
-SOURCE=.\MemoryLeakAllocatorTest.cpp
-
-!IF  "$(CFG)" == "AllTests - Win32 Release"
-
-
-"$(INTDIR)\MemoryLeakAllocatorTest.obj" : $(SOURCE) "$(INTDIR)"
-
-
-!ELSEIF  "$(CFG)" == "AllTests - Win32 Debug"
-
-
-"$(INTDIR)\MemoryLeakAllocatorTest.obj"	"$(INTDIR)\MemoryLeakAllocatorTest.sbr" : $(SOURCE) "$(INTDIR)"
 
 
 !ENDIF 
@@ -463,49 +663,237 @@ SOURCE=.\MemoryLeakDetectorTest.cpp
 !ENDIF 
 
 SOURCE=.\MemoryLeakOperatorOverloadsTest.cpp
-
-!IF  "$(CFG)" == "AllTests - Win32 Release"
-
-
-"$(INTDIR)\MemoryLeakOperatorOverloadsTest.obj" : $(SOURCE) "$(INTDIR)"
-
-
-!ELSEIF  "$(CFG)" == "AllTests - Win32 Debug"
-
-
-"$(INTDIR)\MemoryLeakOperatorOverloadsTest.obj"	"$(INTDIR)\MemoryLeakOperatorOverloadsTest.sbr" : $(SOURCE) "$(INTDIR)"
-
-
-!ENDIF 
-
 SOURCE=.\MemoryLeakWarningTest.cpp
+SOURCE=.\CppUTestExt\MemoryReportAllocatorTest.cpp
 
 !IF  "$(CFG)" == "AllTests - Win32 Release"
 
 
-"$(INTDIR)\MemoryLeakWarningTest.obj" : $(SOURCE) "$(INTDIR)"
+"$(INTDIR)\MemoryReportAllocatorTest.obj" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
 
 
 !ELSEIF  "$(CFG)" == "AllTests - Win32 Debug"
 
 
-"$(INTDIR)\MemoryLeakWarningTest.obj"	"$(INTDIR)\MemoryLeakWarningTest.sbr" : $(SOURCE) "$(INTDIR)"
+"$(INTDIR)\MemoryReportAllocatorTest.obj"	"$(INTDIR)\MemoryReportAllocatorTest.sbr" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
 
 
 !ENDIF 
 
-SOURCE=.\NullTestTest.cpp
+SOURCE=.\CppUTestExt\MemoryReporterPluginTest.cpp
 
 !IF  "$(CFG)" == "AllTests - Win32 Release"
 
 
-"$(INTDIR)\NullTestTest.obj" : $(SOURCE) "$(INTDIR)"
+"$(INTDIR)\MemoryReporterPluginTest.obj" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
 
 
 !ELSEIF  "$(CFG)" == "AllTests - Win32 Debug"
 
 
-"$(INTDIR)\NullTestTest.obj"	"$(INTDIR)\NullTestTest.sbr" : $(SOURCE) "$(INTDIR)"
+"$(INTDIR)\MemoryReporterPluginTest.obj"	"$(INTDIR)\MemoryReporterPluginTest.sbr" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ENDIF 
+
+SOURCE=.\CppUTestExt\MemoryReportFormatterTest.cpp
+
+!IF  "$(CFG)" == "AllTests - Win32 Release"
+
+
+"$(INTDIR)\MemoryReportFormatterTest.obj" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ELSEIF  "$(CFG)" == "AllTests - Win32 Debug"
+
+
+"$(INTDIR)\MemoryReportFormatterTest.obj"	"$(INTDIR)\MemoryReportFormatterTest.sbr" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ENDIF 
+
+SOURCE=.\CppUTestExt\MockActualCallTest.cpp
+
+!IF  "$(CFG)" == "AllTests - Win32 Release"
+
+
+"$(INTDIR)\MockActualCallTest.obj" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ELSEIF  "$(CFG)" == "AllTests - Win32 Debug"
+
+
+"$(INTDIR)\MockActualCallTest.obj"	"$(INTDIR)\MockActualCallTest.sbr" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ENDIF 
+
+SOURCE=.\CppUTestExt\MockCheatSheetTest.cpp
+
+!IF  "$(CFG)" == "AllTests - Win32 Release"
+
+
+"$(INTDIR)\MockCheatSheetTest.obj" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ELSEIF  "$(CFG)" == "AllTests - Win32 Debug"
+
+
+"$(INTDIR)\MockCheatSheetTest.obj"	"$(INTDIR)\MockCheatSheetTest.sbr" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ENDIF 
+
+SOURCE=.\CppUTestExt\MockExpectedCallTest.cpp
+
+!IF  "$(CFG)" == "AllTests - Win32 Release"
+
+
+"$(INTDIR)\MockExpectedCallTest.obj" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ELSEIF  "$(CFG)" == "AllTests - Win32 Debug"
+
+
+"$(INTDIR)\MockExpectedCallTest.obj"	"$(INTDIR)\MockExpectedCallTest.sbr" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ENDIF 
+
+SOURCE=.\CppUTestExt\MockExpectedFunctionsListTest.cpp
+
+!IF  "$(CFG)" == "AllTests - Win32 Release"
+
+
+"$(INTDIR)\MockExpectedFunctionsListTest.obj" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ELSEIF  "$(CFG)" == "AllTests - Win32 Debug"
+
+
+"$(INTDIR)\MockExpectedFunctionsListTest.obj"	"$(INTDIR)\MockExpectedFunctionsListTest.sbr" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ENDIF 
+
+SOURCE=.\CppUTestExt\MockFailureTest.cpp
+
+!IF  "$(CFG)" == "AllTests - Win32 Release"
+
+
+"$(INTDIR)\MockFailureTest.obj" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ELSEIF  "$(CFG)" == "AllTests - Win32 Debug"
+
+
+"$(INTDIR)\MockFailureTest.obj"	"$(INTDIR)\MockFailureTest.sbr" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ENDIF 
+
+SOURCE=.\CppUTestExt\MockPluginTest.cpp
+
+!IF  "$(CFG)" == "AllTests - Win32 Release"
+
+
+"$(INTDIR)\MockPluginTest.obj" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ELSEIF  "$(CFG)" == "AllTests - Win32 Debug"
+
+
+"$(INTDIR)\MockPluginTest.obj"	"$(INTDIR)\MockPluginTest.sbr" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ENDIF 
+
+SOURCE=.\CppUTestExt\MockSupport_cTest.cpp
+
+!IF  "$(CFG)" == "AllTests - Win32 Release"
+
+
+"$(INTDIR)\MockSupport_cTest.obj" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ELSEIF  "$(CFG)" == "AllTests - Win32 Debug"
+
+
+"$(INTDIR)\MockSupport_cTest.obj"	"$(INTDIR)\MockSupport_cTest.sbr" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ENDIF 
+
+SOURCE=.\CppUTestExt\MockSupport_cTestCFile.c
+
+!IF  "$(CFG)" == "AllTests - Win32 Release"
+
+
+"$(INTDIR)\MockSupport_cTestCFile.obj" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ELSEIF  "$(CFG)" == "AllTests - Win32 Debug"
+
+
+"$(INTDIR)\MockSupport_cTestCFile.obj"	"$(INTDIR)\MockSupport_cTestCFile.sbr" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ENDIF 
+
+SOURCE=.\CppUTestExt\MockSupportTest.cpp
+
+!IF  "$(CFG)" == "AllTests - Win32 Release"
+
+
+"$(INTDIR)\MockSupportTest.obj" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ELSEIF  "$(CFG)" == "AllTests - Win32 Debug"
+
+
+"$(INTDIR)\MockSupportTest.obj"	"$(INTDIR)\MockSupportTest.sbr" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ENDIF 
+
+SOURCE=.\CppUTestExt\OrderedTestTest.cpp
+
+!IF  "$(CFG)" == "AllTests - Win32 Release"
+
+
+"$(INTDIR)\OrderedTestTest.obj" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
+
+
+!ELSEIF  "$(CFG)" == "AllTests - Win32 Debug"
+
+
+"$(INTDIR)\OrderedTestTest.obj"	"$(INTDIR)\OrderedTestTest.sbr" : $(SOURCE) "$(INTDIR)"
+	$(CPP) $(CPP_PROJ) $(SOURCE)
 
 
 !ENDIF 
@@ -522,6 +910,22 @@ SOURCE=.\PluginTest.cpp
 
 
 "$(INTDIR)\PluginTest.obj"	"$(INTDIR)\PluginTest.sbr" : $(SOURCE) "$(INTDIR)"
+
+
+!ENDIF 
+
+SOURCE=.\PreprocessorTest.cpp
+
+!IF  "$(CFG)" == "AllTests - Win32 Release"
+
+
+"$(INTDIR)\PreprocessorTest.obj" : $(SOURCE) "$(INTDIR)"
+
+
+!ELSEIF  "$(CFG)" == "AllTests - Win32 Debug"
+
+
+"$(INTDIR)\PreprocessorTest.obj"	"$(INTDIR)\PreprocessorTest.sbr" : $(SOURCE) "$(INTDIR)"
 
 
 !ENDIF 
@@ -558,6 +962,38 @@ SOURCE=.\SimpleStringTest.cpp
 
 !ENDIF 
 
+SOURCE=.\TestFailureTest.cpp
+
+!IF  "$(CFG)" == "AllTests - Win32 Release"
+
+
+"$(INTDIR)\TestFailureTest.obj" : $(SOURCE) "$(INTDIR)"
+
+
+!ELSEIF  "$(CFG)" == "AllTests - Win32 Debug"
+
+
+"$(INTDIR)\TestFailureTest.obj"	"$(INTDIR)\TestFailureTest.sbr" : $(SOURCE) "$(INTDIR)"
+
+
+!ENDIF 
+
+SOURCE=.\TestFilterTest.cpp
+
+!IF  "$(CFG)" == "AllTests - Win32 Release"
+
+
+"$(INTDIR)\TestFilterTest.obj" : $(SOURCE) "$(INTDIR)"
+
+
+!ELSEIF  "$(CFG)" == "AllTests - Win32 Debug"
+
+
+"$(INTDIR)\TestFilterTest.obj"	"$(INTDIR)\TestFilterTest.sbr" : $(SOURCE) "$(INTDIR)"
+
+
+!ENDIF 
+
 SOURCE=.\TestHarness_cTest.cpp
 
 !IF  "$(CFG)" == "AllTests - Win32 Release"
@@ -574,6 +1010,22 @@ SOURCE=.\TestHarness_cTest.cpp
 
 !ENDIF 
 
+SOURCE=.\TestHarness_cTestCFile.c
+
+!IF  "$(CFG)" == "AllTests - Win32 Release"
+
+
+"$(INTDIR)\TestHarness_cTestCFile.obj" : $(SOURCE) "$(INTDIR)"
+
+
+!ELSEIF  "$(CFG)" == "AllTests - Win32 Debug"
+
+
+"$(INTDIR)\TestHarness_cTestCFile.obj"	"$(INTDIR)\TestHarness_cTestCFile.sbr" : $(SOURCE) "$(INTDIR)"
+
+
+!ENDIF 
+
 SOURCE=.\TestInstallerTest.cpp
 
 !IF  "$(CFG)" == "AllTests - Win32 Release"
@@ -586,6 +1038,22 @@ SOURCE=.\TestInstallerTest.cpp
 
 
 "$(INTDIR)\TestInstallerTest.obj"	"$(INTDIR)\TestInstallerTest.sbr" : $(SOURCE) "$(INTDIR)"
+
+
+!ENDIF 
+
+SOURCE=.\TestMemoryAllocatorTest.cpp
+
+!IF  "$(CFG)" == "AllTests - Win32 Release"
+
+
+"$(INTDIR)\TestMemoryAllocatorTest.obj" : $(SOURCE) "$(INTDIR)"
+
+
+!ELSEIF  "$(CFG)" == "AllTests - Win32 Debug"
+
+
+"$(INTDIR)\TestMemoryAllocatorTest.obj"	"$(INTDIR)\TestMemoryAllocatorTest.sbr" : $(SOURCE) "$(INTDIR)"
 
 
 !ENDIF 
@@ -657,24 +1125,24 @@ SOURCE=.\UtestTest.cpp
 !IF  "$(CFG)" == "AllTests - Win32 Release"
 
 "CppUTest - Win32 Release" : 
-   cd "\workspace\CppUTest"
+   cd "\DEV\05_CPPUTEST\CPPUTEST"
    $(MAKE) /$(MAKEFLAGS) /F .\CppUTest.mak CFG="CppUTest - Win32 Release" 
    cd ".\tests"
 
 "CppUTest - Win32 ReleaseCLEAN" : 
-   cd "\workspace\CppUTest"
+   cd "\DEV\05_CPPUTEST\CPPUTEST"
    $(MAKE) /$(MAKEFLAGS) /F .\CppUTest.mak CFG="CppUTest - Win32 Release" RECURSE=1 CLEAN 
    cd ".\tests"
 
 !ELSEIF  "$(CFG)" == "AllTests - Win32 Debug"
 
 "CppUTest - Win32 Debug" : 
-   cd "\workspace\CppUTest"
+   cd "\DEV\05_CPPUTEST\CPPUTEST"
    $(MAKE) /$(MAKEFLAGS) /F .\CppUTest.mak CFG="CppUTest - Win32 Debug" 
    cd ".\tests"
 
 "CppUTest - Win32 DebugCLEAN" : 
-   cd "\workspace\CppUTest"
+   cd "\DEV\05_CPPUTEST\CPPUTEST"
    $(MAKE) /$(MAKEFLAGS) /F .\CppUTest.mak CFG="CppUTest - Win32 Debug" RECURSE=1 CLEAN 
    cd ".\tests"
 

--- a/tests/CppUTestExt/MemoryReporterPluginTest.cpp
+++ b/tests/CppUTestExt/MemoryReporterPluginTest.cpp
@@ -145,6 +145,7 @@ TEST_GROUP(MemoryReporterPlugin)
         delete reporter;
         delete test;
         delete result;
+        mock().clear();
     }
 };
 

--- a/tests/CppUTestExt/MockExpectedCallTest.cpp
+++ b/tests/CppUTestExt/MockExpectedCallTest.cpp
@@ -212,6 +212,8 @@ TEST(MockExpectedCall, callWithObjectParameterEqualComparisonButFailsWithoutComp
     parameter.setObjectPointer("type", &equalType);
     call->withParameterOfType("type", "name", &type);
     CHECK(!call->hasInputParameter(parameter));
+
+    MockNamedValue::setDefaultComparatorRepository(NULL);
 }
 
 TEST(MockExpectedCall, callWithObjectParameterEqualComparison)
@@ -256,6 +258,7 @@ TEST(MockExpectedCall, getParameterValueOfObjectTypeWithoutComparator)
     MockNamedValue::setDefaultComparatorRepository(&repository);
     call->withParameterOfType("type", "name", &type);
     STRCMP_EQUAL("No comparator found for type: \"type\"", call->getInputParameterValueString("name").asCharString());
+    MockNamedValue::setDefaultComparatorRepository(NULL);
 }
 
 TEST(MockExpectedCall, callWithTwoUnsignedIntegerParameter)

--- a/tests/CppUTestExt/MockPluginTest.cpp
+++ b/tests/CppUTestExt/MockPluginTest.cpp
@@ -79,7 +79,6 @@ TEST(MockPlugin, checkExpectationsAndClearAtEnd)
 
     STRCMP_CONTAINS(expectedFailure.getMessage().asCharString(), output->getOutput().asCharString())
     LONGS_EQUAL(0, mock().expectedCallsLeft());
-//	clear makes sure there are no memory leaks.
 }
 
 TEST(MockPlugin, checkExpectationsWorksAlsoWithHierachicalObjects)

--- a/tests/CppUTestExt/MockPluginTest.cpp
+++ b/tests/CppUTestExt/MockPluginTest.cpp
@@ -64,6 +64,7 @@ TEST_GROUP(MockPlugin)
 
         CHECK_NO_MOCK_FAILURE();
         mock().setMockFailureStandardReporter(NULL);
+        mock().clear();
     }
 };
 
@@ -135,4 +136,5 @@ TEST(MockPlugin, preTestActionWillEnableMultipleComparatorsToTheGlobalMockSuppor
     mock().checkExpectations();
     CHECK_NO_MOCK_FAILURE();
     LONGS_EQUAL(0, result->getFailureCount());
+    plugin->postTestAction(*test, *result);
 }

--- a/tests/CppUTestExt/MockSupportTest.cpp
+++ b/tests/CppUTestExt/MockSupportTest.cpp
@@ -95,18 +95,18 @@ TEST(MockSupportTest, checkExpectationsClearsTheExpectations)
     CHECK_EXPECTED_MOCK_FAILURE(expectedFailure);
 }
 
-TEST(MockSupportTest, exceptACallThatHappens)
+TEST(MockSupportTest, expectACallThatHappens)
 {
     mock().expectOneCall("func");
     mock().actualCall("func");
     CHECK(! mock().expectedCallsLeft());
 }
 
-TEST(MockSupportTest, exceptACallInceasesExpectedCallsLeft)
+TEST(MockSupportTest, expectACallIncreasesExpectedCallsLeft)
 {
     mock().expectOneCall("func");
     CHECK(mock().expectedCallsLeft());
-    mock().clear();
+    mock().actualCall("func");
 }
 
 TEST(MockSupportTest, unexpectedCallHappened)
@@ -122,11 +122,11 @@ TEST(MockSupportTest, ignoreOtherCallsExceptForTheExpectedOne)
 {
     mock().expectOneCall("foo");
     mock().ignoreOtherCalls();
-    mock().actualCall("bar").withParameter("foo", 1);;
+    mock().actualCall("bar").withParameter("foo", 1);
 
     CHECK_NO_MOCK_FAILURE();
 
-    mock().clear();
+    mock().actualCall("foo");
 }
 
 TEST(MockSupportTest, ignoreOtherCallsDoesntIgnoreMultipleCallsOfTheSameFunction)
@@ -840,7 +840,7 @@ TEST(MockSupportTest, outputParameterTraced)
     mock().checkExpectations();
     STRCMP_CONTAINS("Function name: someFunc someParameter:", mock().getTraceOutput());
 
-    mock().clear();
+    mock().tracing(false);
 }
 
 TEST(MockSupportTest, outputParameterWithIgnoredParameters)
@@ -980,7 +980,8 @@ TEST(MockSupportTest, usingTwoMockSupportsByName)
     mock("first").expectOneCall("boo");
     LONGS_EQUAL(0, mock("other").expectedCallsLeft());
     LONGS_EQUAL(1, mock("first").expectedCallsLeft());
-    mock("first").clear();
+
+    mock("first").actualCall("boo");
 }
 
 TEST(MockSupportTest, EnableDisableWorkHierarchically)
@@ -995,7 +996,7 @@ TEST(MockSupportTest, EnableDisableWorkHierarchically)
     mock("first").expectOneCall("boo");
     LONGS_EQUAL(1, mock("first").expectedCallsLeft());
 
-    mock("first").clear();
+    mock("first").actualCall("boo");
 }
 
 TEST(MockSupportTest, EnableDisableWorkHierarchicallyWhenSupportIsDynamicallyCreated)
@@ -1008,7 +1009,7 @@ TEST(MockSupportTest, EnableDisableWorkHierarchicallyWhenSupportIsDynamicallyCre
     mock("second").expectOneCall("boo");
     LONGS_EQUAL(1, mock("second").expectedCallsLeft());
 
-    mock().clear();
+    mock("second").actualCall("boo");
 }
 
 TEST(MockSupportTest, ExpectedCallsLeftWorksHierarchically)
@@ -1016,7 +1017,7 @@ TEST(MockSupportTest, ExpectedCallsLeftWorksHierarchically)
     mock("first").expectOneCall("foobar");
     LONGS_EQUAL(1, mock().expectedCallsLeft());
 
-    mock().clear();
+    mock("first").actualCall("foobar");
 }
 
 TEST(MockSupportTest, checkExpectationsWorksHierarchically)
@@ -1030,8 +1031,6 @@ TEST(MockSupportTest, checkExpectationsWorksHierarchically)
 
     mock().checkExpectations();
     CHECK_EXPECTED_MOCK_FAILURE(expectedFailure);
-
-    mock().clear();
 }
 
 TEST(MockSupportTest, ignoreOtherCallsWorksHierarchically)
@@ -1040,8 +1039,6 @@ TEST(MockSupportTest, ignoreOtherCallsWorksHierarchically)
     mock().ignoreOtherCalls();
     mock("first").actualCall("boo");
     CHECK_NO_MOCK_FAILURE();
-
-    mock().clear();
 }
 
 TEST(MockSupportTest, ignoreOtherCallsWorksHierarchicallyWhenDynamicallyCreated)

--- a/tests/CppUTestExt/MockSupportTest.cpp
+++ b/tests/CppUTestExt/MockSupportTest.cpp
@@ -1680,7 +1680,7 @@ TEST(MockSupportTest, shouldSupportConstParameters)
     functionWithConstParam(param);
 
     mock().checkExpectations();
-	mock().removeAllComparators();
+    mock().removeAllComparators();
 }
 
 IGNORE_TEST(MockSupportTest, testForPerformanceProfiling)

--- a/tests/CppUTestExt/MockSupportTest.cpp
+++ b/tests/CppUTestExt/MockSupportTest.cpp
@@ -48,6 +48,8 @@ TEST_GROUP(MockSupportTest)
         expectationsList->deleteAllExpectationsAndClearList();
         delete expectationsList;
         mock().setMockFailureStandardReporter(NULL);
+
+        mock().clear();
     }
 
     MockCheckedExpectedCall* addFunctionToExpectationsList(const SimpleString& name)
@@ -837,6 +839,8 @@ TEST(MockSupportTest, outputParameterTraced)
     mock().actualCall("someFunc").withOutputParameter("someParameter", &param);
     mock().checkExpectations();
     STRCMP_CONTAINS("Function name: someFunc someParameter:", mock().getTraceOutput());
+
+    mock().clear();
 }
 
 TEST(MockSupportTest, outputParameterWithIgnoredParameters)
@@ -1011,6 +1015,7 @@ TEST(MockSupportTest, ExpectedCallsLeftWorksHierarchically)
 {
     mock("first").expectOneCall("foobar");
     LONGS_EQUAL(1, mock().expectedCallsLeft());
+
     mock().clear();
 }
 
@@ -1025,6 +1030,8 @@ TEST(MockSupportTest, checkExpectationsWorksHierarchically)
 
     mock().checkExpectations();
     CHECK_EXPECTED_MOCK_FAILURE(expectedFailure);
+
+    mock().clear();
 }
 
 TEST(MockSupportTest, ignoreOtherCallsWorksHierarchically)
@@ -1033,6 +1040,8 @@ TEST(MockSupportTest, ignoreOtherCallsWorksHierarchically)
     mock().ignoreOtherCalls();
     mock("first").actualCall("boo");
     CHECK_NO_MOCK_FAILURE();
+
+    mock().clear();
 }
 
 TEST(MockSupportTest, ignoreOtherCallsWorksHierarchicallyWhenDynamicallyCreated)
@@ -1672,6 +1681,7 @@ TEST(MockSupportTest, shouldSupportConstParameters)
     functionWithConstParam(param);
 
     mock().checkExpectations();
+	mock().removeAllComparators();
 }
 
 IGNORE_TEST(MockSupportTest, testForPerformanceProfiling)


### PR DESCRIPTION
With this, VC6 will compile and run successfully all tests for CppUTest and CppUTestExt -- without memory leak detection.

If someone other than me knows how to resolve this operator new[] stuff, maybe we could get memory leak detection to work, too.