### PR TITLE
Removed some redundant methods

### DIFF
--- a/include/CppUTest/TestOutput.h
+++ b/include/CppUTest/TestOutput.h
@@ -60,7 +60,6 @@ public:
     virtual void print(const char*);
     virtual void print(long);
     virtual void printDouble(double);
-    virtual void printHex(long);
     virtual void print(const TestFailure& failure);
     virtual void printTestRun(int number, int total);
     virtual void setProgressIndicator(const char*);

--- a/include/CppUTestExt/MockCheckedActualCall.h
+++ b/include/CppUTestExt/MockCheckedActualCall.h
@@ -101,7 +101,6 @@ protected:
         CALL_FAILED,
         CALL_SUCCEED
     };
-    virtual const char* stringFromState(ActualCallState state);
     virtual void setState(ActualCallState state);
 
 private:

--- a/src/CppUTest/TestOutput.cpp
+++ b/src/CppUTest/TestOutput.cpp
@@ -78,11 +78,6 @@ void TestOutput::printDouble(double d)
     print(StringFrom(d).asCharString());
 }
 
-void TestOutput::printHex(long n)
-{
-    print(HexStringFrom(n).asCharString());
-}
-
 TestOutput& operator<<(TestOutput& p, const char* s)
 {
     p.print(s);

--- a/src/CppUTestExt/MockActualCall.cpp
+++ b/src/CppUTestExt/MockActualCall.cpp
@@ -262,7 +262,7 @@ void MockCheckedActualCall::checkExpectations()
     if (state_ != CALL_IN_PROGESS) return;
 
     if (! unfulfilledExpectations_.hasUnfullfilledExpectations())
-        FAIL("Actual call is in progress. Checking expectations. But no unfulfilled expectations. Cannot happen.")
+        FAIL("Actual call is in progress. Checking expectations. But no unfulfilled expectations. Cannot happen.") // LCOV_EXCL_LINE
 
     fulfilledExpectation_ = unfulfilledExpectations_.removeOneFulfilledExpectationWithIgnoredParameters();
     if (fulfilledExpectation_) {
@@ -278,21 +278,6 @@ void MockCheckedActualCall::checkExpectations()
         MockExpectedObjectDidntHappenFailure failure(getTest(), getName(), allExpectations_);
         failTest(failure);
     }
-}
-
-const char* MockCheckedActualCall::stringFromState(ActualCallState state)
-{
-    switch (state) {
-    case CALL_IN_PROGESS: return "In progress";
-    case CALL_FAILED: return "Failed";
-    case CALL_SUCCEED: return "Succeed";
-#ifndef __clang__
-    default: ;
-#endif
-    }
-#ifndef __clang__
-    return "No valid state info";
-#endif
 }
 
 void MockCheckedActualCall::setState(ActualCallState state)


### PR DESCRIPTION
These are never used anywhere (and also, not tested, of course).

Since it is not likely they would be used by anyone outside of CppUTest, I removed them (rather than adding tests for them).
