### PR TITLE
Vc6 2 - Fixup tests that crash / fail under VC6

### DIFF
--- a/tests/CppUTestExt/MemoryReporterPluginTest.cpp
+++ b/tests/CppUTestExt/MemoryReporterPluginTest.cpp
@@ -145,6 +145,7 @@ TEST_GROUP(MemoryReporterPlugin)
         delete reporter;
         delete test;
         delete result;
+        mock().clear();
     }
 };
 

--- a/tests/CppUTestExt/MockExpectedCallTest.cpp
+++ b/tests/CppUTestExt/MockExpectedCallTest.cpp
@@ -212,6 +212,8 @@ TEST(MockExpectedCall, callWithObjectParameterEqualComparisonButFailsWithoutComp
     parameter.setObjectPointer("type", &equalType);
     call->withParameterOfType("type", "name", &type);
     CHECK(!call->hasInputParameter(parameter));
+
+    MockNamedValue::setDefaultComparatorRepository(NULL);
 }
 
 TEST(MockExpectedCall, callWithObjectParameterEqualComparison)
@@ -256,6 +258,7 @@ TEST(MockExpectedCall, getParameterValueOfObjectTypeWithoutComparator)
     MockNamedValue::setDefaultComparatorRepository(&repository);
     call->withParameterOfType("type", "name", &type);
     STRCMP_EQUAL("No comparator found for type: \"type\"", call->getInputParameterValueString("name").asCharString());
+    MockNamedValue::setDefaultComparatorRepository(NULL);
 }
 
 TEST(MockExpectedCall, callWithTwoUnsignedIntegerParameter)

--- a/tests/CppUTestExt/MockPluginTest.cpp
+++ b/tests/CppUTestExt/MockPluginTest.cpp
@@ -79,7 +79,6 @@ TEST(MockPlugin, checkExpectationsAndClearAtEnd)
 
     STRCMP_CONTAINS(expectedFailure.getMessage().asCharString(), output->getOutput().asCharString())
     LONGS_EQUAL(0, mock().expectedCallsLeft());
-//	clear makes sure there are no memory leaks.
 }
 
 TEST(MockPlugin, checkExpectationsWorksAlsoWithHierachicalObjects)

--- a/tests/CppUTestExt/MockPluginTest.cpp
+++ b/tests/CppUTestExt/MockPluginTest.cpp
@@ -64,6 +64,7 @@ TEST_GROUP(MockPlugin)
 
         CHECK_NO_MOCK_FAILURE();
         mock().setMockFailureStandardReporter(NULL);
+        mock().clear();
     }
 };
 
@@ -135,4 +136,5 @@ TEST(MockPlugin, preTestActionWillEnableMultipleComparatorsToTheGlobalMockSuppor
     mock().checkExpectations();
     CHECK_NO_MOCK_FAILURE();
     LONGS_EQUAL(0, result->getFailureCount());
+    plugin->postTestAction(*test, *result);
 }

--- a/tests/CppUTestExt/MockSupportTest.cpp
+++ b/tests/CppUTestExt/MockSupportTest.cpp
@@ -48,6 +48,8 @@ TEST_GROUP(MockSupportTest)
         expectationsList->deleteAllExpectationsAndClearList();
         delete expectationsList;
         mock().setMockFailureStandardReporter(NULL);
+
+        mock().clear();
     }
 
     MockCheckedExpectedCall* addFunctionToExpectationsList(const SimpleString& name)
@@ -837,6 +839,8 @@ TEST(MockSupportTest, outputParameterTraced)
     mock().actualCall("someFunc").withOutputParameter("someParameter", &param);
     mock().checkExpectations();
     STRCMP_CONTAINS("Function name: someFunc someParameter:", mock().getTraceOutput());
+
+    mock().clear();
 }
 
 TEST(MockSupportTest, outputParameterWithIgnoredParameters)
@@ -1011,6 +1015,7 @@ TEST(MockSupportTest, ExpectedCallsLeftWorksHierarchically)
 {
     mock("first").expectOneCall("foobar");
     LONGS_EQUAL(1, mock().expectedCallsLeft());
+
     mock().clear();
 }
 
@@ -1025,6 +1030,8 @@ TEST(MockSupportTest, checkExpectationsWorksHierarchically)
 
     mock().checkExpectations();
     CHECK_EXPECTED_MOCK_FAILURE(expectedFailure);
+
+    mock().clear();
 }
 
 TEST(MockSupportTest, ignoreOtherCallsWorksHierarchically)
@@ -1033,6 +1040,8 @@ TEST(MockSupportTest, ignoreOtherCallsWorksHierarchically)
     mock().ignoreOtherCalls();
     mock("first").actualCall("boo");
     CHECK_NO_MOCK_FAILURE();
+
+    mock().clear();
 }
 
 TEST(MockSupportTest, ignoreOtherCallsWorksHierarchicallyWhenDynamicallyCreated)
@@ -1671,6 +1680,7 @@ TEST(MockSupportTest, shouldSupportConstParameters)
     functionWithConstParam(param);
 
     mock().checkExpectations();
+	mock().removeAllComparators();
 }
 
 IGNORE_TEST(MockSupportTest, testForPerformanceProfiling)

--- a/tests/CppUTestExt/MockSupportTest.cpp
+++ b/tests/CppUTestExt/MockSupportTest.cpp
@@ -95,18 +95,18 @@ TEST(MockSupportTest, checkExpectationsClearsTheExpectations)
     CHECK_EXPECTED_MOCK_FAILURE(expectedFailure);
 }
 
-TEST(MockSupportTest, exceptACallThatHappens)
+TEST(MockSupportTest, expectACallThatHappens)
 {
     mock().expectOneCall("func");
     mock().actualCall("func");
     CHECK(! mock().expectedCallsLeft());
 }
 
-TEST(MockSupportTest, exceptACallInceasesExpectedCallsLeft)
+TEST(MockSupportTest, expectACallIncreasesExpectedCallsLeft)
 {
     mock().expectOneCall("func");
     CHECK(mock().expectedCallsLeft());
-    mock().clear();
+    mock().actualCall("func");
 }
 
 TEST(MockSupportTest, unexpectedCallHappened)
@@ -122,11 +122,11 @@ TEST(MockSupportTest, ignoreOtherCallsExceptForTheExpectedOne)
 {
     mock().expectOneCall("foo");
     mock().ignoreOtherCalls();
-    mock().actualCall("bar").withParameter("foo", 1);;
+    mock().actualCall("bar").withParameter("foo", 1);
 
     CHECK_NO_MOCK_FAILURE();
 
-    mock().clear();
+    mock().actualCall("foo");
 }
 
 TEST(MockSupportTest, ignoreOtherCallsDoesntIgnoreMultipleCallsOfTheSameFunction)
@@ -840,7 +840,7 @@ TEST(MockSupportTest, outputParameterTraced)
     mock().checkExpectations();
     STRCMP_CONTAINS("Function name: someFunc someParameter:", mock().getTraceOutput());
 
-    mock().clear();
+    mock().tracing(false);
 }
 
 TEST(MockSupportTest, outputParameterWithIgnoredParameters)
@@ -980,7 +980,8 @@ TEST(MockSupportTest, usingTwoMockSupportsByName)
     mock("first").expectOneCall("boo");
     LONGS_EQUAL(0, mock("other").expectedCallsLeft());
     LONGS_EQUAL(1, mock("first").expectedCallsLeft());
-    mock("first").clear();
+
+    mock("first").actualCall("boo");
 }
 
 TEST(MockSupportTest, EnableDisableWorkHierarchically)
@@ -995,7 +996,7 @@ TEST(MockSupportTest, EnableDisableWorkHierarchically)
     mock("first").expectOneCall("boo");
     LONGS_EQUAL(1, mock("first").expectedCallsLeft());
 
-    mock("first").clear();
+    mock("first").actualCall("boo");
 }
 
 TEST(MockSupportTest, EnableDisableWorkHierarchicallyWhenSupportIsDynamicallyCreated)
@@ -1008,7 +1009,7 @@ TEST(MockSupportTest, EnableDisableWorkHierarchicallyWhenSupportIsDynamicallyCre
     mock("second").expectOneCall("boo");
     LONGS_EQUAL(1, mock("second").expectedCallsLeft());
 
-    mock().clear();
+    mock("second").actualCall("boo");
 }
 
 TEST(MockSupportTest, ExpectedCallsLeftWorksHierarchically)
@@ -1016,7 +1017,7 @@ TEST(MockSupportTest, ExpectedCallsLeftWorksHierarchically)
     mock("first").expectOneCall("foobar");
     LONGS_EQUAL(1, mock().expectedCallsLeft());
 
-    mock().clear();
+    mock("first").actualCall("foobar");
 }
 
 TEST(MockSupportTest, checkExpectationsWorksHierarchically)
@@ -1030,8 +1031,6 @@ TEST(MockSupportTest, checkExpectationsWorksHierarchically)
 
     mock().checkExpectations();
     CHECK_EXPECTED_MOCK_FAILURE(expectedFailure);
-
-    mock().clear();
 }
 
 TEST(MockSupportTest, ignoreOtherCallsWorksHierarchically)
@@ -1040,8 +1039,6 @@ TEST(MockSupportTest, ignoreOtherCallsWorksHierarchically)
     mock().ignoreOtherCalls();
     mock("first").actualCall("boo");
     CHECK_NO_MOCK_FAILURE();
-
-    mock().clear();
 }
 
 TEST(MockSupportTest, ignoreOtherCallsWorksHierarchicallyWhenDynamicallyCreated)

--- a/tests/CppUTestExt/MockSupportTest.cpp
+++ b/tests/CppUTestExt/MockSupportTest.cpp
@@ -1680,7 +1680,7 @@ TEST(MockSupportTest, shouldSupportConstParameters)
     functionWithConstParam(param);
 
     mock().checkExpectations();
-	mock().removeAllComparators();
+    mock().removeAllComparators();
 }
 
 IGNORE_TEST(MockSupportTest, testForPerformanceProfiling)


### PR DESCRIPTION
This pull request is the second replacement for #513. It fixes up the tests.

It is interesting that Clang and Gcc produced code that didn't crash / fail. Nevertheless, these fixes make for cleaner code even when we are not compiling them with VC6.

This code will compile, link, run and succeed under VC6, as well as the Travis build.