### PR TITLE
Regenerated and test solution (VS2005)

### DIFF
--- a/CppUTest.sln
+++ b/CppUTest.sln
@@ -1,0 +1,29 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 9.00
+# Visual C++ Express 2005
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "AllTests", "tests\AllTests.vcproj", "{E66A12BB-1E17-4CFE-A358-9E0FA85E0F15}"
+	ProjectSection(ProjectDependencies) = postProject
+		{EC28C821-4AB8-458F-A821-C6E65607B781} = {EC28C821-4AB8-458F-A821-C6E65607B781}
+	EndProjectSection
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "CppUTest", "CppUTest.vcproj", "{EC28C821-4AB8-458F-A821-C6E65607B781}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Win32 = Debug|Win32
+		Release|Win32 = Release|Win32
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{E66A12BB-1E17-4CFE-A358-9E0FA85E0F15}.Debug|Win32.ActiveCfg = Debug|Win32
+		{E66A12BB-1E17-4CFE-A358-9E0FA85E0F15}.Debug|Win32.Build.0 = Debug|Win32
+		{E66A12BB-1E17-4CFE-A358-9E0FA85E0F15}.Release|Win32.ActiveCfg = Release|Win32
+		{E66A12BB-1E17-4CFE-A358-9E0FA85E0F15}.Release|Win32.Build.0 = Release|Win32
+		{EC28C821-4AB8-458F-A821-C6E65607B781}.Debug|Win32.ActiveCfg = Debug|Win32
+		{EC28C821-4AB8-458F-A821-C6E65607B781}.Debug|Win32.Build.0 = Debug|Win32
+		{EC28C821-4AB8-458F-A821-C6E65607B781}.Release|Win32.ActiveCfg = Release|Win32
+		{EC28C821-4AB8-458F-A821-C6E65607B781}.Release|Win32.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/CppUTest.vcproj
+++ b/CppUTest.vcproj
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="Windows-1252"?>
 <VisualStudioProject
 	ProjectType="Visual C++"
-	Version="9.00"
+	Version="8,00"
 	Name="CppUTest"
-	ProjectGUID="{F468F539-27BD-468E-BE64-DDE641400B51}"
-	TargetFrameworkVersion="0"
+	ProjectGUID="{EC28C821-4AB8-458F-A821-C6E65607B781}"
 	>
 	<Platforms>
 		<Platform
@@ -26,7 +25,6 @@
 			>
 			<Tool
 				Name="VCPreBuildEventTool"
-				CommandLine=""
 			/>
 			<Tool
 				Name="VCCustomBuildTool"
@@ -43,18 +41,18 @@
 			<Tool
 				Name="VCCLCompilerTool"
 				Optimization="0"
-				AdditionalIncludeDirectories=".\include,.\include\Platforms\VisualCpp"
-				PreprocessorDefinitions="_LIB;WIN32;_DEBUG"
+				AdditionalIncludeDirectories=".\include\Platforms\VisualCpp,.\include"
+				PreprocessorDefinitions="WIN32;_DEBUG;_LIB;STDC_WANT_SECURE_LIB"
 				BasicRuntimeChecks="3"
 				RuntimeLibrary="3"
 				PrecompiledHeaderFile=".\Debug/CppUTest.pch"
 				AssemblerListingLocation=".\Debug/"
 				ObjectFile=".\Debug/"
 				ProgramDataBaseFileName=".\Debug/"
+				BrowseInformation="1"
 				WarningLevel="3"
 				SuppressStartupBanner="true"
 				DebugInformationFormat="4"
-				ForcedIncludeFiles="..\include\Platforms\VisualCpp\Platform.h;..\include\CppUTest\MemoryLeakDetectorMallocMacros.h"
 			/>
 			<Tool
 				Name="VCManagedResourceCompilerTool"
@@ -69,9 +67,7 @@
 			/>
 			<Tool
 				Name="VCLibrarianTool"
-				LinkLibraryDependencies="true"
-				AdditionalDependencies="winmm.lib"
-				OutputFile=".\lib\CppUTest.lib"
+				OutputFile="lib\CppUTest.lib"
 				SuppressStartupBanner="true"
 			/>
 			<Tool
@@ -90,7 +86,6 @@
 			/>
 			<Tool
 				Name="VCPostBuildEventTool"
-				CommandLine="if not exist lib\vs2008\ md lib\vs2008\&#x0D;&#x0A;copy lib\CppUTest.lib lib\vs2008\CppUTest.lib&#x0D;&#x0A;copy Debug\vc90.pdb lib\vs2008\vc90.pdb&#x0D;&#x0A;"
 			/>
 		</Configuration>
 		<Configuration
@@ -120,10 +115,10 @@
 			/>
 			<Tool
 				Name="VCCLCompilerTool"
-				Optimization="2"
+				Optimization="0"
 				InlineFunctionExpansion="1"
-				AdditionalIncludeDirectories=".\include,.\include\Platforms\VisualCpp"
-				PreprocessorDefinitions="WIN32;NDEBUG;_LIB"
+				AdditionalIncludeDirectories=".\include\Platforms\VisualCpp,.\include"
+				PreprocessorDefinitions="WIN32;NDEBUG;_LIB;STDC_WANT_SECURE_LIB"
 				StringPooling="true"
 				RuntimeLibrary="0"
 				EnableFunctionLevelLinking="true"
@@ -147,8 +142,6 @@
 			/>
 			<Tool
 				Name="VCLibrarianTool"
-				LinkLibraryDependencies="true"
-				AdditionalDependencies="winmm.lib"
 				OutputFile=".\Release\CppUTest.lib"
 				SuppressStartupBanner="true"
 			/>
@@ -179,92 +172,664 @@
 			Filter="cpp;c;cxx;rc;def;r;odl;idl;hpj;bat"
 			>
 			<File
-				RelativePath=".\src\CppUTestExt\CodeMemoryReportFormatter.cpp"
+				RelativePath="src\CppUTestExt\CodeMemoryReportFormatter.cpp"
 				>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
 			</File>
 			<File
-				RelativePath=".\src\CppUTest\CommandLineArguments.cpp"
+				RelativePath="SRC\CPPUTEST\CommandLineArguments.cpp"
 				>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
 			</File>
 			<File
-				RelativePath=".\src\CppUTest\CommandLineTestRunner.cpp"
+				RelativePath="SRC\CPPUTEST\CommandLineTestRunner.cpp"
 				>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
 			</File>
 			<File
-				RelativePath=".\src\CppUTest\JUnitTestOutput.cpp"
+				RelativePath="SRC\CPPUTEST\JUnitTestOutput.cpp"
 				>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
 			</File>
 			<File
-				RelativePath=".\src\CppUTest\MemoryLeakDetector.cpp"
+				RelativePath="SRC\CPPUTEST\MemoryLeakDetector.cpp"
 				>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
 			</File>
 			<File
-				RelativePath=".\src\CppUTest\MemoryLeakWarningPlugin.cpp"
+				RelativePath="SRC\CPPUTEST\MemoryLeakWarningPlugin.cpp"
 				>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
 			</File>
 			<File
-				RelativePath=".\src\CppUTestExt\MemoryReportAllocator.cpp"
+				RelativePath="src\CppUTestExt\MemoryReportAllocator.cpp"
 				>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
 			</File>
 			<File
-				RelativePath=".\src\CppUTestExt\MemoryReporterPlugin.cpp"
+				RelativePath="src\CppUTestExt\MemoryReporterPlugin.cpp"
 				>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
 			</File>
 			<File
-				RelativePath=".\src\CppUTestExt\MemoryReportFormatter.cpp"
+				RelativePath="src\CppUTestExt\MemoryReportFormatter.cpp"
 				>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
 			</File>
 			<File
-				RelativePath=".\src\CppUTestExt\OrderedTest.cpp"
+				RelativePath="src\CppUTestExt\MockActualCall.cpp"
 				>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
 			</File>
 			<File
-				RelativePath=".\src\CppUTest\SimpleMutex.cpp"
+				RelativePath="src\CppUTestExt\MockExpectedCall.cpp"
 				>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
 			</File>
 			<File
-				RelativePath=".\src\CppUTest\SimpleString.cpp"
+				RelativePath="src\CppUTestExt\MockExpectedCallsList.cpp"
 				>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
 			</File>
 			<File
-				RelativePath=".\src\CppUTest\TestFailure.cpp"
+				RelativePath="src\CppUTestExt\MockFailure.cpp"
 				>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
 			</File>
 			<File
-				RelativePath=".\src\CppUTest\TestFilter.cpp"
+				RelativePath="src\CppUTestExt\MockNamedValue.cpp"
 				>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
 			</File>
 			<File
-				RelativePath=".\src\CppUTest\TestHarness_c.cpp"
+				RelativePath="src\CppUTestExt\MockSupport.cpp"
 				>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
 			</File>
 			<File
-				RelativePath=".\src\CppUTest\TestMemoryAllocator.cpp"
+				RelativePath="src\CppUTestExt\MockSupport_c.cpp"
 				>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
 			</File>
 			<File
-				RelativePath=".\src\CppUTest\TestOutput.cpp"
+				RelativePath="src\CppUTestExt\MockSupportPlugin.cpp"
 				>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
 			</File>
 			<File
-				RelativePath=".\src\CppUTest\TestPlugin.cpp"
+				RelativePath="src\CppUTestExt\OrderedTest.cpp"
 				>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
 			</File>
 			<File
-				RelativePath=".\src\CppUTest\TestRegistry.cpp"
+				RelativePath="SRC\CPPUTEST\SimpleMutex.cpp"
 				>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
 			</File>
 			<File
-				RelativePath=".\src\CppUTest\TestResult.cpp"
+				RelativePath="SRC\CPPUTEST\SimpleString.cpp"
 				>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
 			</File>
 			<File
-				RelativePath=".\src\CppUTest\Utest.cpp"
+				RelativePath="SRC\CPPUTEST\TestFailure.cpp"
 				>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="SRC\CPPUTEST\TestFilter.cpp"
+				>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="SRC\CPPUTEST\TestHarness_c.cpp"
+				>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="SRC\CPPUTEST\TestMemoryAllocator.cpp"
+				>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="SRC\CPPUTEST\TestOutput.cpp"
+				>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="SRC\CPPUTEST\TestPlugin.cpp"
+				>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="SRC\CPPUTEST\TestRegistry.cpp"
+				>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="SRC\CPPUTEST\TestResult.cpp"
+				>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="SRC\CPPUTEST\Utest.cpp"
+				>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
 			</File>
 			<File
 				RelativePath="src\Platforms\VisualCpp\UtestPlatform.cpp"
 				>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
 			</File>
 		</Filter>
 		<Filter
@@ -272,203 +837,147 @@
 			Filter="h;hpp;hxx;hm;inl"
 			>
 			<File
-				RelativePath=".\include\CppUTestExt\CodeMemoryReportFormatter.h"
+				RelativePath="include\CppUTestExt\CodeMemoryReportFormatter.h"
 				>
 			</File>
 			<File
-				RelativePath=".\include\CppUTest\CommandLineArguments.h"
+				RelativePath="include\CppUTest\CommandLineTestRunner.h"
 				>
 			</File>
 			<File
-				RelativePath=".\include\CppUTest\CommandLineTestRunner.h"
+				RelativePath="include\CppUTest\EqualsFailure.h"
 				>
 			</File>
 			<File
-				RelativePath=".\include\CppUTestExt\GMock.h"
+				RelativePath="include\CppUTest\Failure.h"
 				>
 			</File>
 			<File
-				RelativePath=".\include\CppUTestExt\GTest.h"
+				RelativePath="include\CppUTestExt\GMock.h"
 				>
 			</File>
 			<File
-				RelativePath=".\include\CppUTestExt\GTestConvertor.h"
+				RelativePath="include\CppUTestExt\GTestConvertor.h"
 				>
 			</File>
 			<File
-				RelativePath=".\include\CppUTest\JUnitTestOutput.h"
+				RelativePath="include\CppUTest\JunitTestOutput.h"
 				>
 			</File>
 			<File
-				RelativePath=".\include\CppUTest\MemoryLeakDetector.h"
+				RelativePath="include\CppUTest\MemoryLeakWarning.h"
 				>
 			</File>
 			<File
-				RelativePath=".\include\CppUTest\MemoryLeakDetectorMallocMacros.h"
+				RelativePath="include\CppUTest\MemoryLeakWarningPlugin.h"
 				>
 			</File>
 			<File
-				RelativePath=".\include\CppUTest\MemoryLeakDetectorNewMacros.h"
+				RelativePath="include\CppUTestExt\MemoryReportAllocator.h"
 				>
 			</File>
 			<File
-				RelativePath=".\include\CppUTest\MemoryLeakWarningPlugin.h"
+				RelativePath="include\CppUTestExt\MemoryReporterPlugin.h"
 				>
 			</File>
 			<File
-				RelativePath=".\include\CppUTestExt\MemoryReportAllocator.h"
+				RelativePath="include\CppUTestExt\MemoryReportFormatter.h"
 				>
 			</File>
 			<File
-				RelativePath=".\include\CppUTestExt\MemoryReporterPlugin.h"
+				RelativePath="include\CppUTestExt\MockCheckedActualCall.h"
 				>
 			</File>
 			<File
-				RelativePath=".\include\CppUTestExt\MemoryReportFormatter.h"
+				RelativePath="include\CppUTestExt\MockCheckedExpectedCall.h"
 				>
 			</File>
 			<File
-				RelativePath=".\include\CppUTestExt\MockActualCall.h"
+				RelativePath="include\CppUTestExt\MockExpectedCallsList.h"
 				>
 			</File>
 			<File
-				RelativePath=".\include\CppUTestExt\MockCheckedActualCall.h"
+				RelativePath="include\CppUTestExt\MockFailure.h"
 				>
 			</File>
 			<File
-				RelativePath=".\include\CppUTestExt\MockCheckedExpectedCall.h"
+				RelativePath="include\CppUTestExt\MockNamedValue.h"
 				>
 			</File>
 			<File
-				RelativePath=".\include\CppUTestExt\MockExpectedCall.h"
+				RelativePath="include\CppUTestExt\MockSupport.h"
 				>
 			</File>
 			<File
-				RelativePath=".\include\CppUTestExt\MockExpectedCallsList.h"
+				RelativePath="include\CppUTestExt\MockSupport_c.h"
 				>
 			</File>
 			<File
-				RelativePath=".\include\CppUTestExt\MockFailure.h"
+				RelativePath="include\CppUTestExt\MockSupportPlugin.h"
 				>
 			</File>
 			<File
-				RelativePath=".\include\CppUTestExt\MockNamedValue.h"
+				RelativePath="include\CppUTest\MockTestOutput.h"
 				>
 			</File>
 			<File
-				RelativePath=".\include\CppUTestExt\MockSupport.h"
+				RelativePath="include\CppUTest\NullTest.h"
 				>
 			</File>
 			<File
-				RelativePath=".\include\CppUTestExt\MockSupport_c.h"
+				RelativePath="include\CppUTestExt\OrderedTest.h"
 				>
 			</File>
 			<File
-				RelativePath=".\include\CppUTestExt\MockSupportPlugin.h"
+				RelativePath="src\Platforms\VisualCpp\Platform.h"
 				>
 			</File>
 			<File
-				RelativePath=".\include\CppUTestExt\OrderedTest.h"
+				RelativePath="include\CppUTest\RealTestOutput.h"
 				>
 			</File>
 			<File
-				RelativePath=".\include\CppUTest\PlatformSpecificFunctions.h"
+				RelativePath="include\CppUTest\SimpleString.h"
 				>
 			</File>
 			<File
-				RelativePath=".\include\CppUTest\SimpleMutex.h"
+				RelativePath="include\CppUTest\SimpleStringExtensions.h"
 				>
 			</File>
 			<File
-				RelativePath=".\include\CppUTest\SimpleString.h"
+				RelativePath="include\CppUTest\TestHarness.h"
 				>
 			</File>
 			<File
-				RelativePath=".\include\CppUTest\StandardCLibrary.h"
+				RelativePath="include\CppUTest\TestHarness_c.h"
 				>
 			</File>
 			<File
-				RelativePath=".\include\CppUTest\TestFailure.h"
+				RelativePath="include\CppUTest\TestInstaller.h"
 				>
 			</File>
 			<File
-				RelativePath=".\include\CppUTest\TestFilter.h"
+				RelativePath="include\CppUTest\TestOutput.h"
 				>
 			</File>
 			<File
-				RelativePath=".\include\CppUTest\TestHarness.h"
+				RelativePath="include\CppUTest\TestPlugin.h"
 				>
 			</File>
 			<File
-				RelativePath=".\include\CppUTest\TestHarness_c.h"
+				RelativePath="include\CppUTest\TestRegistry.h"
 				>
 			</File>
 			<File
-				RelativePath=".\include\CppUTest\TestMemoryAllocator.h"
+				RelativePath="include\CppUTest\TestResult.h"
 				>
 			</File>
 			<File
-				RelativePath=".\include\CppUTest\TestOutput.h"
+				RelativePath="include\CppUTest\Utest.h"
 				>
 			</File>
 			<File
-				RelativePath=".\include\CppUTest\TestPlugin.h"
-				>
-			</File>
-			<File
-				RelativePath=".\include\CppUTest\TestRegistry.h"
-				>
-			</File>
-			<File
-				RelativePath=".\include\CppUTest\TestResult.h"
-				>
-			</File>
-			<File
-				RelativePath=".\include\CppUTest\TestTestingFixture.h"
-				>
-			</File>
-			<File
-				RelativePath=".\include\CppUTest\Utest.h"
-				>
-			</File>
-			<File
-				RelativePath=".\include\CppUTest\UtestMacros.h"
-				>
-			</File>
-		</Filter>
-		<Filter
-			Name="ext"
-			>
-			<File
-				RelativePath=".\src\CppUTestExt\MockActualCall.cpp"
-				>
-			</File>
-			<File
-				RelativePath=".\src\CppUTestExt\MockExpectedCall.cpp"
-				>
-			</File>
-			<File
-				RelativePath=".\src\CppUTestExt\MockExpectedCallsList.cpp"
-				>
-			</File>
-			<File
-				RelativePath=".\src\CppUTestExt\MockFailure.cpp"
-				>
-			</File>
-			<File
-				RelativePath=".\src\CppUTestExt\MockNamedValue.cpp"
-				>
-			</File>
-			<File
-				RelativePath=".\src\CppUTestExt\MockSupport.cpp"
-				>
-			</File>
-			<File
-				RelativePath=".\src\CppUTestExt\MockSupport_c.cpp"
-				>
-			</File>
-			<File
-				RelativePath=".\src\CppUTestExt\MockSupportPlugin.cpp"
+				RelativePath="include\CppUTest\VirtualCall.h"
 				>
 			</File>
 		</Filter>

--- a/tests/AllTests.vcproj
+++ b/tests/AllTests.vcproj
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="Windows-1252"?>
 <VisualStudioProject
 	ProjectType="Visual C++"
-	Version="9.00"
+	Version="8,00"
 	Name="AllTests"
-	ProjectGUID="{913088F6-37C0-4195-80E9-548C7C5303CB}"
-	TargetFrameworkVersion="0"
+	ProjectGUID="{E66A12BB-1E17-4CFE-A358-9E0FA85E0F15}"
 	>
 	<Platforms>
 		<Platform
@@ -43,10 +42,10 @@
 			/>
 			<Tool
 				Name="VCCLCompilerTool"
-				Optimization="2"
+				Optimization="0"
 				InlineFunctionExpansion="1"
-				AdditionalIncludeDirectories="..\include;..\include\Platforms\VisualCpp;..\include\CppUTestExt\CppUTestGMock"
-				PreprocessorDefinitions="WIN32;NDEBUG;_CONSOLE"
+				AdditionalIncludeDirectories="..\include,..\include\Platforms\VisualCpp"
+				PreprocessorDefinitions="WIN32;NDEBUG;_CONSOLE;"
 				StringPooling="true"
 				RuntimeLibrary="0"
 				EnableFunctionLevelLinking="true"
@@ -70,14 +69,12 @@
 			/>
 			<Tool
 				Name="VCLinkerTool"
-				AdditionalDependencies="..\Release\CppUTest.lib $(NOINHERIT)"
+				AdditionalDependencies="odbc32.lib odbccp32.lib winmm.lib"
 				OutputFile=".\Release/AllTests.exe"
-				LinkIncremental="1"
+				LinkIncremental="2"
 				SuppressStartupBanner="true"
 				ProgramDatabaseFile=".\Release/AllTests.pdb"
 				SubSystem="1"
-				RandomizedBaseAddress="1"
-				DataExecutionPrevention="0"
 				TargetMachine="1"
 			/>
 			<Tool
@@ -101,8 +98,11 @@
 				Name="VCAppVerifierTool"
 			/>
 			<Tool
+				Name="VCWebDeploymentTool"
+			/>
+			<Tool
 				Name="VCPostBuildEventTool"
-				CommandLine="&quot;$(TargetPath)&quot;"
+				CommandLine="$(TargetPath)"
 			/>
 		</Configuration>
 		<Configuration
@@ -117,7 +117,6 @@
 			>
 			<Tool
 				Name="VCPreBuildEventTool"
-				CommandLine=""
 			/>
 			<Tool
 				Name="VCCustomBuildTool"
@@ -136,7 +135,7 @@
 			<Tool
 				Name="VCCLCompilerTool"
 				Optimization="0"
-				AdditionalIncludeDirectories="..\include;..\include\Platforms\VisualCpp;..\include\CppUTestExt\CppUTestGMock;..\include\CppUTestExt\CppUTestGTest"
+				AdditionalIncludeDirectories="..\include,..\include\Platforms\VisualCpp"
 				PreprocessorDefinitions="_CONSOLE;WIN32;_DEBUG"
 				BasicRuntimeChecks="3"
 				RuntimeLibrary="3"
@@ -148,7 +147,7 @@
 				WarningLevel="3"
 				SuppressStartupBanner="true"
 				DebugInformationFormat="4"
-				ForcedIncludeFiles="..\include\Platforms\VisualCpp\Platform.h;..\include\CppUTest\MemoryLeakDetectorMallocMacros.h"
+				ForcedIncludeFiles="CppUTest/MemoryLeakDetectorMallocMacros.h,CppUTest/MemoryLeakDetectorNewMacros.h"
 			/>
 			<Tool
 				Name="VCManagedResourceCompilerTool"
@@ -163,15 +162,13 @@
 			/>
 			<Tool
 				Name="VCLinkerTool"
-				AdditionalDependencies="..\lib\CppUTest.lib $(NOINHERIT)"
+				AdditionalDependencies="..\lib\CppUTest.lib odbc32.lib odbccp32.lib winmm.lib"
 				OutputFile=".\Debug/AllTests.exe"
 				LinkIncremental="2"
 				SuppressStartupBanner="true"
 				GenerateDebugInformation="true"
 				ProgramDatabaseFile=".\Debug/AllTests.pdb"
 				SubSystem="1"
-				RandomizedBaseAddress="1"
-				DataExecutionPrevention="0"
 				TargetMachine="1"
 			/>
 			<Tool
@@ -195,8 +192,11 @@
 				Name="VCAppVerifierTool"
 			/>
 			<Tool
+				Name="VCWebDeploymentTool"
+			/>
+			<Tool
 				Name="VCPostBuildEventTool"
-				CommandLine="&quot;$(TargetPath)&quot;"
+				CommandLine="$(TargetPath) -v"
 			/>
 		</Configuration>
 	</Configurations>
@@ -208,104 +208,955 @@
 			Filter="cpp;c;cxx;rc;def;r;odl;idl;hpj;bat"
 			>
 			<File
-				RelativePath=".\AllocationInCFile.c"
+				RelativePath="AllocationInCFile.c"
+				>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+						ForcedIncludeFiles=""
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="AllocationInCppFile.cpp"
+				>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+						ForcedIncludeFiles=""
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="CppUTestExt\AllTests.cpp"
+				>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+						ForcedIncludeFiles=""
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="CheatSheetTest.cpp"
+				>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+						ForcedIncludeFiles=""
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="CppUTestExt\CodeMemoryReportFormatterTest.cpp"
+				>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+						ForcedIncludeFiles=""
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="CommandLineArgumentsTest.cpp"
+				>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+						ForcedIncludeFiles=""
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="CommandLineTestRunnerTest.cpp"
+				>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+						ForcedIncludeFiles=""
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="CppUTestExt\GMockTest.cpp"
+				>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+						ForcedIncludeFiles=""
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="CppUTestExt\GTest1Test.cpp"
+				>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+						ForcedIncludeFiles=""
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="CppUTestExt\GTest2ConvertorTest.cpp"
+				>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+						ForcedIncludeFiles=""
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="JUnitOutputTest.cpp"
+				>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+						ForcedIncludeFiles=""
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="MemoryLeakDetectorTest.cpp"
+				>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+						ForcedIncludeFiles=""
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="MemoryLeakOperatorOverloadsTest.cpp"
+				>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+						ForcedIncludeFiles=""
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="MemoryLeakWarningTest.cpp"
+				>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+						ForcedIncludeFiles=""
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="CppUTestExt\MemoryReportAllocatorTest.cpp"
+				>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+						ForcedIncludeFiles=""
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="CppUTestExt\MemoryReporterPluginTest.cpp"
+				>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+						ForcedIncludeFiles=""
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="CppUTestExt\MemoryReportFormatterTest.cpp"
+				>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+						ForcedIncludeFiles=""
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="CppUTestExt\MockActualCallTest.cpp"
+				>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+						ForcedIncludeFiles=""
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="CppUTestExt\MockCheatSheetTest.cpp"
+				>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+						ForcedIncludeFiles=""
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="CppUTestExt\MockExpectedCallTest.cpp"
+				>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+						ForcedIncludeFiles=""
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="CppUTestExt\MockExpectedFunctionsListTest.cpp"
+				>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+						ForcedIncludeFiles=""
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="CppUTestExt\MockFailureTest.cpp"
+				>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+						ForcedIncludeFiles=""
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="CppUTestExt\MockFailureTest.h"
 				>
 			</File>
 			<File
-				RelativePath=".\AllocationInCppFile.cpp"
+				RelativePath="CppUTestExt\MockPluginTest.cpp"
+				>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+						ForcedIncludeFiles=""
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="CppUTestExt\MockSupport_cTest.cpp"
+				>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+						ForcedIncludeFiles=""
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="CppUTestExt\MockSupport_cTestCFile.c"
+				>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+						ForcedIncludeFiles=""
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="CppUTestExt\MockSupport_cTestCFile.h"
 				>
 			</File>
 			<File
-				RelativePath=".\CppUTestExt\AllTests.cpp"
+				RelativePath="CppUTestExt\MockSupportTest.cpp"
 				>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+						ForcedIncludeFiles=""
+					/>
+				</FileConfiguration>
 			</File>
 			<File
-				RelativePath=".\CheatSheetTest.cpp"
+				RelativePath="CppUTestExt\OrderedTestTest.cpp"
 				>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+						ForcedIncludeFiles=""
+					/>
+				</FileConfiguration>
 			</File>
 			<File
-				RelativePath=".\CommandLineArgumentsTest.cpp"
+				RelativePath="PluginTest.cpp"
 				>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+						ForcedIncludeFiles=""
+					/>
+				</FileConfiguration>
 			</File>
 			<File
-				RelativePath=".\CommandLineTestRunnerTest.cpp"
+				RelativePath="PreprocessorTest.cpp"
 				>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+						ForcedIncludeFiles=""
+					/>
+				</FileConfiguration>
 			</File>
 			<File
-				RelativePath=".\JUnitOutputTest.cpp"
+				RelativePath="SetPluginTest.cpp"
 				>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+						ForcedIncludeFiles=""
+					/>
+				</FileConfiguration>
 			</File>
 			<File
-				RelativePath=".\MemoryLeakDetectorTest.cpp"
+				RelativePath="SimpleStringTest.cpp"
 				>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+						ForcedIncludeFiles=""
+					/>
+				</FileConfiguration>
 			</File>
 			<File
-				RelativePath=".\MemoryLeakOperatorOverloadsTest.cpp"
+				RelativePath="TestFailureTest.cpp"
 				>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+						ForcedIncludeFiles=""
+					/>
+				</FileConfiguration>
 			</File>
 			<File
-				RelativePath=".\MemoryLeakWarningTest.cpp"
+				RelativePath="TestFilterTest.cpp"
 				>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+						ForcedIncludeFiles=""
+					/>
+				</FileConfiguration>
 			</File>
 			<File
-				RelativePath=".\PluginTest.cpp"
+				RelativePath="TestHarness_cTest.cpp"
 				>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+						ForcedIncludeFiles=""
+					/>
+				</FileConfiguration>
 			</File>
 			<File
-				RelativePath=".\PreprocessorTest.cpp"
+				RelativePath="TestHarness_cTestCFile.c"
 				>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+						ForcedIncludeFiles=""
+					/>
+				</FileConfiguration>
 			</File>
 			<File
-				RelativePath=".\SetPluginTest.cpp"
+				RelativePath="TestInstallerTest.cpp"
 				>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+						ForcedIncludeFiles=""
+					/>
+				</FileConfiguration>
 			</File>
 			<File
-				RelativePath=".\SimpleMutexTest.cpp"
+				RelativePath="TestMemoryAllocatorTest.cpp"
 				>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+						ForcedIncludeFiles=""
+					/>
+				</FileConfiguration>
 			</File>
 			<File
-				RelativePath=".\SimpleStringTest.cpp"
+				RelativePath="TestOutputTest.cpp"
 				>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+						ForcedIncludeFiles=""
+					/>
+				</FileConfiguration>
 			</File>
 			<File
-				RelativePath=".\TestFailureTest.cpp"
+				RelativePath="TestRegistryTest.cpp"
 				>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+						ForcedIncludeFiles=""
+					/>
+				</FileConfiguration>
 			</File>
 			<File
-				RelativePath=".\TestFilterTest.cpp"
+				RelativePath="TestResultTest.cpp"
 				>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+						ForcedIncludeFiles=""
+					/>
+				</FileConfiguration>
 			</File>
 			<File
-				RelativePath=".\TestHarness_cTest.cpp"
+				RelativePath="UtestTest.cpp"
 				>
-			</File>
-			<File
-				RelativePath=".\TestHarness_cTestCFile.c"
-				>
-			</File>
-			<File
-				RelativePath=".\TestInstallerTest.cpp"
-				>
-			</File>
-			<File
-				RelativePath=".\TestMemoryAllocatorTest.cpp"
-				>
-			</File>
-			<File
-				RelativePath=".\TestOutputTest.cpp"
-				>
-			</File>
-			<File
-				RelativePath=".\TestRegistryTest.cpp"
-				>
-			</File>
-			<File
-				RelativePath=".\TestResultTest.cpp"
-				>
-			</File>
-			<File
-				RelativePath=".\UtestTest.cpp"
-				>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+						ForcedIncludeFiles=""
+					/>
+				</FileConfiguration>
 			</File>
 		</Filter>
 		<Filter
@@ -313,15 +1164,71 @@
 			Filter="h;hpp;hxx;hm;inl"
 			>
 			<File
-				RelativePath=".\AllocationInCFile.h"
+				RelativePath="AllocationInCFile.h"
 				>
 			</File>
 			<File
-				RelativePath=".\AllocationInCppFile.h"
+				RelativePath="AllocationInCppFile.h"
 				>
 			</File>
 			<File
-				RelativePath=".\AllTests.h"
+				RelativePath="AllTests.h"
+				>
+			</File>
+			<File
+				RelativePath="..\include\CppUTest\CommandLineArguments.h"
+				>
+			</File>
+			<File
+				RelativePath="..\include\CppUTest\CppUTestConfig.h"
+				>
+			</File>
+			<File
+				RelativePath="..\include\CppUTest\MemoryLeakDetector.h"
+				>
+			</File>
+			<File
+				RelativePath="..\include\CppUTest\MemoryLeakDetectorMallocMacros.h"
+				>
+			</File>
+			<File
+				RelativePath="..\include\CppUTest\MemoryLeakDetectorNewMacros.h"
+				>
+			</File>
+			<File
+				RelativePath="..\include\CppUTest\PlatformSpecificFunctions.h"
+				>
+			</File>
+			<File
+				RelativePath="..\include\CppUTest\PlatformSpecificFunctions_c.h"
+				>
+			</File>
+			<File
+				RelativePath="..\include\CppUTest\SimpleMutex.h"
+				>
+			</File>
+			<File
+				RelativePath="..\include\CppUTest\StandardCLibrary.h"
+				>
+			</File>
+			<File
+				RelativePath="..\include\CppUTest\TestFailure.h"
+				>
+			</File>
+			<File
+				RelativePath="..\include\CppUTest\TestFilter.h"
+				>
+			</File>
+			<File
+				RelativePath="..\include\CppUTest\TestMemoryAllocator.h"
+				>
+			</File>
+			<File
+				RelativePath="..\include\CppUTest\TestTestingFixture.h"
+				>
+			</File>
+			<File
+				RelativePath="..\include\CppUTest\UtestMacros.h"
 				>
 			</File>
 		</Filter>
@@ -329,82 +1236,6 @@
 			Name="Resource Files"
 			Filter="ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe"
 			>
-		</Filter>
-		<Filter
-			Name="ext"
-			>
-			<File
-				RelativePath=".\CppUTestExt\CodeMemoryReportFormatterTest.cpp"
-				>
-			</File>
-			<File
-				RelativePath=".\CppUTestExt\GMockTest.cpp"
-				>
-			</File>
-			<File
-				RelativePath=".\CppUTestExt\GTest1Test.cpp"
-				>
-			</File>
-			<File
-				RelativePath=".\CppUTestExt\MemoryReportAllocatorTest.cpp"
-				>
-			</File>
-			<File
-				RelativePath=".\CppUTestExt\MemoryReporterPluginTest.cpp"
-				>
-			</File>
-			<File
-				RelativePath=".\CppUTestExt\MemoryReportFormatterTest.cpp"
-				>
-			</File>
-			<File
-				RelativePath=".\CppUTestExt\MockActualCallTest.cpp"
-				>
-			</File>
-			<File
-				RelativePath=".\CppUTestExt\MockCheatSheetTest.cpp"
-				>
-			</File>
-			<File
-				RelativePath=".\CppUTestExt\MockExpectedCallTest.cpp"
-				>
-			</File>
-			<File
-				RelativePath=".\CppUTestExt\MockExpectedFunctionsListTest.cpp"
-				>
-			</File>
-			<File
-				RelativePath=".\CppUTestExt\MockFailureTest.cpp"
-				>
-			</File>
-			<File
-				RelativePath=".\CppUTestExt\MockFailureTest.h"
-				>
-			</File>
-			<File
-				RelativePath=".\CppUTestExt\MockPluginTest.cpp"
-				>
-			</File>
-			<File
-				RelativePath=".\CppUTestExt\MockSupportTest.cpp"
-				>
-			</File>
-			<File
-				RelativePath=".\CppUTestExt\MockSupport_cTest.cpp"
-				>
-			</File>
-			<File
-				RelativePath=".\CppUTestExt\MockSupport_cTestCFile.c"
-				>
-			</File>
-			<File
-				RelativePath=".\CppUTestExt\MockSupport_cTestCFile.h"
-				>
-			</File>
-			<File
-				RelativePath=".\CppUTestExt\OrderedTestTest.cpp"
-				>
-			</File>
 		</Filter>
 	</Files>
 	<Globals>


### PR DESCRIPTION
Project files and solution for VS2005.

I imported the new VC98 workspace into VS2005.

I also imported this solution into VS2008, which compiled and ran successfully.The same is true of VS2010. 

In the interest of less maintenance, I was wondering whether we should maybe drop the xx_VS2008 (and possibly _VS201x) files and provide xx_VS2005 only instead. 

What does everybody think about that? The only snag is that we would need a relatively ancient copy of VS around for maintenance. I am willing to do that (and relatively unwilling to set up a VM running VS2008/10 on my Mac). 

Looking at the diff for the converted vcxproj's, it seems that it contains quite a bit of redundant stuff, but it works.