### PR TITLE
100% statement coverage for TestOutput.cpp

### DIFF
--- a/include/CppUTest/TestOutput.h
+++ b/include/CppUTest/TestOutput.h
@@ -64,7 +64,7 @@ public:
     virtual void printTestRun(int number, int total);
     virtual void setProgressIndicator(const char*);
 
-    virtual void flush();
+    virtual void flush()=0;
 
     enum WorkingEnvironment {vistualStudio, eclipse, detectEnvironment};
 

--- a/src/CppUTest/TestOutput.cpp
+++ b/src/CppUTest/TestOutput.cpp
@@ -137,10 +137,6 @@ void TestOutput::printCurrentGroupEnded(const TestResult& /*res*/)
 {
 }
 
-void TestOutput::flush()
-{
-}
-
 void TestOutput::printTestsEnded(const TestResult& result)
 {
     print("\n");


### PR DESCRIPTION
by making pointless TestOutput::flush () pure virtual.