### PR TITLE
Real fix for Clang problem -- experimental

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ set(CppUTest_version_minor 7dev)
 # 2.6.3 is needed for ctest support
 cmake_minimum_required(VERSION 2.6.3)
 
+set(CPPUTEST_CXX_FLAGS "${CPPUTEST_CXX_FLAGS} -ffreestanding")
+
 option(STD_C "Use the standard C library" ON)
 option(STD_CPP "Use the standard C++ library" ON)
 option(CPPUTEST_FLAGS "Use the CFLAGS/CXXFLAGS/LDFLAGS set by CppUTest" ON)

--- a/Makefile.am
+++ b/Makefile.am
@@ -217,7 +217,7 @@ cpputest_build_gtest17:
 	mkdir -p cpputest_build_gtest17
 	cd cpputest_build_gtest17; \
 	wget https://googlemock.googlecode.com/files/gmock-1.7.0.zip && unzip gmock-1.7.0.zip 
-	cd cpputest_build_gtest17/gmock-1.7.0; ./configure && make check
+	cd cpputest_build_gtest17/gmock-1.7.0; ./configure CXXFLAGS=$(CXXFLAGS) -ffreestanding" && make check
 
 cpputest_build_gtest16:
 	mkdir -p cpputest_build_gtest16
@@ -234,17 +234,17 @@ cpputest_build_gtest15:
 check_gtest15: cpputest_build_gtest15
 	@echo "Build using gmock 1.5";
 	export GMOCK_HOME=`pwd`/cpputest_build_gtest15/gmock-1.5.0; \
-	make distclean; $(srcdir)/configure; make check
+	make distclean; $(srcdir)/configure $(CXXFLAGS) -ffreestanding"; make check
 
 check_gtest16: cpputest_build_gtest16
 	@echo "Build using gmock 1.6";
 	export GMOCK_HOME=`pwd`/cpputest_build_gtest16/gmock-1.6.0; \
-	make distclean; $(srcdir)/configure; make check
+	make distclean; $(srcdir)/configure $(CXXFLAGS) -ffreestanding"; make check
 
 check_gtest17: cpputest_build_gtest17
 	@echo "Build using gmock 1.7"
 	export GMOCK_HOME=`pwd`/cpputest_build_gtest17/gmock-1.7.0; \
-	make distclean; $(srcdir)/configure; make check
+	make distclean; $(srcdir)/configure $(CXXFLAGS) -ffreestanding"; make check
 	
 remove_gtest_directories:
 	rm -rf cpputest_build_gtest15

--- a/Makefile.am
+++ b/Makefile.am
@@ -307,7 +307,7 @@ check_coverage:
 	if test "x$(CPPUTEST_HAS_CLANG)" = xyes && test "x$(CPPUTEST_ON_MACOSX)" = xyes; then \
 	   echo "Compiling with clang"; make distclean; $(srcdir)/configure CC="clang" CXX="clang++" --enable-coverage CXXFLAGS="-O0"; \
 	else \
-		make distclean; $(srcdir)/configure -enable-coverage $CFLAGS="-g -O0" $CXXFLAGS="-O0";  \
+		make distclean; $(srcdir)/configure -enable-coverage $CFLAGS="-g -O0" CXXFLAGS="-O0";  \
 	fi
 	
 	make check

--- a/Makefile.am
+++ b/Makefile.am
@@ -294,13 +294,13 @@ check_special_situations:
 	fi
 
 	@echo Testing JUnit output
-	make distclean; $(srcdir)/configure; make check
+	make distclean; $(srcdir)/configure CXXFLAGS="$(CXXFLAGS) -ffreestanding"; make check
 	./$(CPPUTEST_TESTS) -ojunit > junit_run_output
 	if [ -s junit_run_output ]; then echo "JUnit run has output. Build failed!"; exit 1; fi
 	rm junit_run_output; rm cpputest_*.xml
 
 	@echo "Building with all flags turned off"
-	make distclean; $(srcdir)/configure --disable-cpputest-flags CFLAGS="" CXXFLAGS="" CPPFLAGS="-I $(srcdir)/include -I$(srcdir)/include/CppUTestExt/CppUTestGTest -I$(srcdir)/include/CppUTestExt/CppUTestGMock" --disable-dependency-tracking; make check
+	make distclean; $(srcdir)/configure --disable-cpputest-flags CFLAGS="" CXXFLAGS="-ffreestanding" CPPFLAGS="-I $(srcdir)/include -I$(srcdir)/include/CppUTestExt/CppUTestGTest -I$(srcdir)/include/CppUTestExt/CppUTestGMock" --disable-dependency-tracking; make check
 
 check_coverage:
 	@echo "Compile with coverage (switch to clang for Mac OSX)"

--- a/Makefile.am
+++ b/Makefile.am
@@ -263,13 +263,13 @@ check_basic:
 	fi
 	
 	@echo "Building without extensions"
-	make distclean; $(srcdir)/configure --disable-extensions; make check
+	make distclean; $(srcdir)/configure --disable-extensions CXXFLAGS="$(CXXFLAGS) -ffreestanding"; make check
 
 	@echo "Building with the Std C++ 11 turned on. Compiler acts differently then."
-	make distclean; $(srcdir)/configure --enable-std-cpp11; make
+	make distclean; $(srcdir)/configure --enable-std-cpp11 CXXFLAGS="$(CXXFLAGS) -ffreestanding"; make
 
 	@echo "Building without the Standard C library"
-	make distclean; $(srcdir)/configure --disable-std-c; make
+	make distclean; $(srcdir)/configure --disable-std-c CXXFLAGS="$(CXXFLAGS) -ffreestanding"; make
 
 	@echo "Building without the Standard C++ library"
 	make distclean; $(srcdir)/configure --disable-std-cpp; make check
@@ -281,16 +281,16 @@ check_basic:
 	make distclean; $(srcdir)/configure --disable-memory-leak-detection --disable-std-cpp; make check
 
 	@echo "Generate a map file while building"
-	make distclean; $(srcdir)/configure -enable-generate-map-file; make check
+	make distclean; $(srcdir)/configure -enable-generate-map-file CXXFLAGS="$(CXXFLAGS) -ffreestanding"; make check
 	if [ -s CppUTest.o.map.txt ]; then echo "Generating map file failed. Build failed!"; exit 1; fi
 
 check_special_situations:
 	@echo "Does the system have gcc? $(CPPUTEST_HAS_GCC)"
-	if test "x$(CPPUTEST_HAS_GCC)" = xyes; then echo "Compiling with gcc"; make distclean; $(srcdir)/configure CC="gcc" CXX="g++"; make check; fi
+	if test "x$(CPPUTEST_HAS_GCC)" = xyes; then echo "Compiling with gcc"; make distclean; $(srcdir)/configure CC="gcc" CXX="g++" CXXFLAGS="$(CXXFLAGS) -ffreestanding"; make check; fi
 
 	@echo "Does the system have clang and is a Mac? $(CPPUTEST_HAS_CLANG)"
 	if test "x$(CPPUTEST_HAS_CLANG)" = xyes && test "x$(CPPUTEST_ON_MACOSX)" = xyes; then \
-	   echo "Compiling with clang"; make distclean; $(srcdir)/configure CC="clang" CXX="clang++"; make check; \
+	   echo "Compiling with clang"; make distclean; $(srcdir)/configure CC="clang" CXX="clang++" CXXFLAGS="$(CXXFLAGS) -ffreestanding"; make check; \
 	fi
 
 	@echo Testing JUnit output
@@ -305,9 +305,9 @@ check_special_situations:
 check_coverage:
 	@echo "Compile with coverage (switch to clang for Mac OSX)"
 	if test "x$(CPPUTEST_HAS_CLANG)" = xyes && test "x$(CPPUTEST_ON_MACOSX)" = xyes; then \
-	   echo "Compiling with clang"; make distclean; $(srcdir)/configure CC="clang" CXX="clang++" --enable-coverage; \
+	   echo "Compiling with clang"; make distclean; $(srcdir)/configure CC="clang" CXX="clang++" --enable-coverage CXXFLAGS="-O0"; \
 	else \
-		make distclean; $(srcdir)/configure -enable-coverage $CFLAGS="-g -O0" $CXXFLAGS="-g -O0";  \
+		make distclean; $(srcdir)/configure -enable-coverage $CFLAGS="-g -O0" $CXXFLAGS="-O0";  \
 	fi
 	
 	make check
@@ -329,11 +329,11 @@ check_examples:
 	$(MAKE) -C $(srcdir)/examples all clean
 	
 	@echo "Compiling and running the examples. This will use the old Makefile"
-	make distclean; $(srcdir)/configure; make; $(MAKE) -C $(srcdir)/examples all clean CPPUTEST_LIB_LINK_DIR="`pwd`/lib"
+	make distclean; $(srcdir)/configure CXXFLAGS="$(CXXFLAGS) -ffreestanding"; make; $(MAKE) -C $(srcdir)/examples all clean CPPUTEST_LIB_LINK_DIR="`pwd`/lib"
 
 check_all: check_basic check_special_situations check_coverage check_examples check_gtest
 	@echo "Last... one normal build and test"
-	make distclean; $(srcdir)/configure; make check; 
+	make distclean; $(srcdir)/configure CXXFLAGS="$(CXXFLAGS) -ffreestanding"; make check; 
 	@echo "Check running tests repeatedly"
 	$(RUN_CPPUTEST_TESTS) - r; $(RUN_CPPUTESTEXT_TESTS) -r
 	@echo "Check running tests in separate process (CppUTestExtTests TEST_GROUP(TestOrderedTestMacro) would have to fail)"

--- a/Makefile.am
+++ b/Makefile.am
@@ -217,7 +217,7 @@ cpputest_build_gtest17:
 	mkdir -p cpputest_build_gtest17
 	cd cpputest_build_gtest17; \
 	wget https://googlemock.googlecode.com/files/gmock-1.7.0.zip && unzip gmock-1.7.0.zip 
-	cd cpputest_build_gtest17/gmock-1.7.0; ./configure CXXFLAGS=$(CXXFLAGS) -ffreestanding" && make check
+	cd cpputest_build_gtest17/gmock-1.7.0; ./configure CXXFLAGS="$(CXXFLAGS) -ffreestanding" && make check
 
 cpputest_build_gtest16:
 	mkdir -p cpputest_build_gtest16
@@ -234,17 +234,17 @@ cpputest_build_gtest15:
 check_gtest15: cpputest_build_gtest15
 	@echo "Build using gmock 1.5";
 	export GMOCK_HOME=`pwd`/cpputest_build_gtest15/gmock-1.5.0; \
-	make distclean; $(srcdir)/configure $(CXXFLAGS) -ffreestanding"; make check
+	make distclean; $(srcdir)/configure CXXFLAGS="$(CXXFLAGS) -ffreestanding"; make check
 
 check_gtest16: cpputest_build_gtest16
 	@echo "Build using gmock 1.6";
 	export GMOCK_HOME=`pwd`/cpputest_build_gtest16/gmock-1.6.0; \
-	make distclean; $(srcdir)/configure $(CXXFLAGS) -ffreestanding"; make check
+	make distclean; $(srcdir)/configure CXXFLAGS="$(CXXFLAGS) -ffreestanding"; make check
 
 check_gtest17: cpputest_build_gtest17
 	@echo "Build using gmock 1.7"
 	export GMOCK_HOME=`pwd`/cpputest_build_gtest17/gmock-1.7.0; \
-	make distclean; $(srcdir)/configure $(CXXFLAGS) -ffreestanding"; make check
+	make distclean; $(srcdir)/configure CXXFLAGS="$(CXXFLAGS) -ffreestanding"; make check
 	
 remove_gtest_directories:
 	rm -rf cpputest_build_gtest15

--- a/cmake/Modules/CppUTestWarningFlags.cmake
+++ b/cmake/Modules/CppUTestWarningFlags.cmake
@@ -51,6 +51,7 @@ else (MSVC)
         Wno-exit-time-destructors
         Wno-weak-vtables
         Wno-old-style-cast
+        Wno-missing-prototypes
         )
 
     check_and_append_c_warning_flags(${WARNING_C_FLAGS})

--- a/src/CppUTest/MemoryLeakWarningPlugin.cpp
+++ b/src/CppUTest/MemoryLeakWarningPlugin.cpp
@@ -453,7 +453,7 @@ public:
     {
         UtestShell* currentTest = UtestShell::getCurrent();
         currentTest->failWith(FailFailure(currentTest, currentTest->getName().asCharString(), currentTest->getLineNumber(), fail_string), TestTerminatorWithoutExceptions());
-    }
+    } // LCOV_EXCL_LINE
 };
 
 static MemoryLeakFailure* globalReporter = 0;

--- a/tests/AllTests.cpp
+++ b/tests/AllTests.cpp
@@ -27,7 +27,7 @@
 
 #include "CppUTest/CommandLineTestRunner.h"
 
-int main(int ac, const char** av)
+extern "C" int main(int ac, const char** av)
 {
     /* These checks are here to make sure assertions outside test runs don't crash */
     CHECK(true);

--- a/tests/CppUTestExt/AllTests.cpp
+++ b/tests/CppUTestExt/AllTests.cpp
@@ -34,7 +34,7 @@
 #include "CppUTestExt/GTestConvertor.h"
 #endif
 
-int main(int ac, const char** av)
+extern "C" int main(int ac, const char** av)
 {
 #ifdef INCLUDE_GTEST_TESTS
     GTestConvertor convertor;

--- a/tests/MemoryLeakWarningTest.cpp
+++ b/tests/MemoryLeakWarningTest.cpp
@@ -71,15 +71,12 @@ TEST(MemoryLeakWarningLocalDetectorTest, localDetectorIsTheOneSpecifiedInConstru
     POINTERS_EQUAL(&localDetector, memoryLeakWarningPlugin.getMemoryLeakDetector());
 }
 
-IGNORE_TEST(MemoryLeakWarningLocalDetectorTest, localDetectorIsGlobalDetector)
+TEST(MemoryLeakWarningLocalDetectorTest, localDetectorIsGlobalDetector)
 {
-    MemoryLeakDetector* saveDetector = MemoryLeakWarningPlugin::getGlobalDetector();
-    MemoryLeakFailure* saveReporter = MemoryLeakWarningPlugin::getGlobalFailureReporter();
-    MemoryLeakDetector globalDetector(&dummy);
-    MemoryLeakWarningPlugin::setGlobalDetector(&globalDetector, &dummy);
+    MemoryLeakDetector* globalDetector = MemoryLeakWarningPlugin::getGlobalDetector();
     MemoryLeakWarningPlugin memoryLeakWarningPlugin("TestMemoryLeakWarningPlugin", NULL);
-    POINTERS_EQUAL(&globalDetector, memoryLeakWarningPlugin.getMemoryLeakDetector());
-    MemoryLeakWarningPlugin::setGlobalDetector(saveDetector, saveReporter);
+    MemoryLeakDetector* localDetector =  memoryLeakWarningPlugin.getMemoryLeakDetector();
+    POINTERS_EQUAL(globalDetector, localDetector);
 }
 
 

--- a/tests/MemoryLeakWarningTest.cpp
+++ b/tests/MemoryLeakWarningTest.cpp
@@ -440,17 +440,6 @@ TEST(MemoryLeakWarningThreadSafe, turnOnThreadSafeNewDeleteOverloadsDebug)
     MemoryLeakWarningPlugin::turnOnNewDeleteOverloads();
 }
 
-#ifdef __clang__
-
-IGNORE_TEST(MemoryLeakWarningThreadSafe, turnOnThreadSafeNewDeleteOverloads)
-{
-    /*  Clang misbehaves with -O2 - it will not overload operator new or
-     *  operator new[] no matter what. Therefore, this test is must be ignored.
-     */
-}
-
-#else
-
 TEST(MemoryLeakWarningThreadSafe, turnOnThreadSafeNewDeleteOverloads)
 {
 #undef new
@@ -481,8 +470,6 @@ TEST(MemoryLeakWarningThreadSafe, turnOnThreadSafeNewDeleteOverloads)
     #include "CppUTest/MemoryLeakDetectorNewMacros.h"
 #endif
 }
-
-#endif
 
 #endif
 

--- a/tests/MemoryLeakWarningTest.cpp
+++ b/tests/MemoryLeakWarningTest.cpp
@@ -404,13 +404,13 @@ TEST(MemoryLeakWarningThreadSafe, turnOnThreadSafeMallocFreeReallocOverloadsDebu
     LONGS_EQUAL(storedAmountOfLeaks + 1, MemoryLeakWarningPlugin::getGlobalDetector()->totalMemoryLeaks(mem_leak_period_all));
     CHECK_EQUAL(1, mutexLockCount);
     CHECK_EQUAL(1, mutexUnlockCount);
-   
+
     n = (int*) cpputest_realloc(n, sizeof(int)*3);
 
     LONGS_EQUAL(storedAmountOfLeaks + 1, MemoryLeakWarningPlugin::getGlobalDetector()->totalMemoryLeaks(mem_leak_period_all));
     CHECK_EQUAL(2, mutexLockCount);
     CHECK_EQUAL(2, mutexUnlockCount);
-   
+
     cpputest_free(n);
 
     LONGS_EQUAL(storedAmountOfLeaks, MemoryLeakWarningPlugin::getGlobalDetector()->totalMemoryLeaks(mem_leak_period_all));
@@ -443,11 +443,22 @@ TEST(MemoryLeakWarningThreadSafe, turnOnThreadSafeNewDeleteOverloadsDebug)
     MemoryLeakWarningPlugin::turnOnNewDeleteOverloads();
 }
 
+#ifdef __clang__
+
+IGNORE_TEST(MemoryLeakWarningThreadSafe, turnOnThreadSafeNewDeleteOverloads)
+{
+    /*  Clang misbehaves with -O2 - it will not overload operator new or
+     *  operator new[] no matter what. Therefore, this test is must be ignored.
+     */
+}
+
+#else
+
 TEST(MemoryLeakWarningThreadSafe, turnOnThreadSafeNewDeleteOverloads)
 {
 #undef new
-    int storedAmountOfLeaks = MemoryLeakWarningPlugin::getGlobalDetector()->totalMemoryLeaks(mem_leak_period_all);
 
+    int storedAmountOfLeaks = MemoryLeakWarningPlugin::getGlobalDetector()->totalMemoryLeaks(mem_leak_period_all);
     MemoryLeakWarningPlugin::turnOnThreadSafeNewDeleteOverloads();
 
     int *n = new int;
@@ -473,6 +484,8 @@ TEST(MemoryLeakWarningThreadSafe, turnOnThreadSafeNewDeleteOverloads)
     #include "CppUTest/MemoryLeakDetectorNewMacros.h"
 #endif
 }
+
+#endif
 
 #endif
 

--- a/tests/MemoryLeakWarningTest.cpp
+++ b/tests/MemoryLeakWarningTest.cpp
@@ -377,7 +377,7 @@ static void StubMutexUnlock(PlatformSpecificMutex)
 
 
 
-TEST_GROUP(MemoryLeakWarningWarningThreadSafe)
+TEST_GROUP(MemoryLeakWarningThreadSafe)
 {
     void setup()
     {
@@ -393,7 +393,34 @@ TEST_GROUP(MemoryLeakWarningWarningThreadSafe)
     }
 };
 
-TEST(MemoryLeakWarningWarningThreadSafe, turnOnThreadSafeNewDeleteOverloadsDebug)
+TEST(MemoryLeakWarningThreadSafe, turnOnThreadSafeMallocFreeReallocOverloadsDebug)
+{
+    int storedAmountOfLeaks = MemoryLeakWarningPlugin::getGlobalDetector()->totalMemoryLeaks(mem_leak_period_all);
+
+    MemoryLeakWarningPlugin::turnOnThreadSafeNewDeleteOverloads();
+
+    int *n = (int*) cpputest_malloc(sizeof(int));
+
+    LONGS_EQUAL(storedAmountOfLeaks + 1, MemoryLeakWarningPlugin::getGlobalDetector()->totalMemoryLeaks(mem_leak_period_all));
+    CHECK_EQUAL(1, mutexLockCount);
+    CHECK_EQUAL(1, mutexUnlockCount);
+   
+    n = (int*) cpputest_realloc(n, sizeof(int)*3);
+
+    LONGS_EQUAL(storedAmountOfLeaks + 1, MemoryLeakWarningPlugin::getGlobalDetector()->totalMemoryLeaks(mem_leak_period_all));
+    CHECK_EQUAL(2, mutexLockCount);
+    CHECK_EQUAL(2, mutexUnlockCount);
+   
+    cpputest_free(n);
+
+    LONGS_EQUAL(storedAmountOfLeaks, MemoryLeakWarningPlugin::getGlobalDetector()->totalMemoryLeaks(mem_leak_period_all));
+    CHECK_EQUAL(3, mutexLockCount);
+    CHECK_EQUAL(3, mutexUnlockCount);
+
+    MemoryLeakWarningPlugin::turnOnNewDeleteOverloads();
+}
+
+TEST(MemoryLeakWarningThreadSafe, turnOnThreadSafeNewDeleteOverloadsDebug)
 {
     int storedAmountOfLeaks = MemoryLeakWarningPlugin::getGlobalDetector()->totalMemoryLeaks(mem_leak_period_all);
 
@@ -416,7 +443,7 @@ TEST(MemoryLeakWarningWarningThreadSafe, turnOnThreadSafeNewDeleteOverloadsDebug
     MemoryLeakWarningPlugin::turnOnNewDeleteOverloads();
 }
 
-TEST(MemoryLeakWarningWarningThreadSafe, turnOnThreadSafeNewDeleteOverloads)
+TEST(MemoryLeakWarningThreadSafe, turnOnThreadSafeNewDeleteOverloads)
 {
 #undef new
     int storedAmountOfLeaks = MemoryLeakWarningPlugin::getGlobalDetector()->totalMemoryLeaks(mem_leak_period_all);

--- a/tests/MemoryLeakWarningTest.cpp
+++ b/tests/MemoryLeakWarningTest.cpp
@@ -54,6 +54,35 @@ static MemoryLeakWarningPlugin* memPlugin;
 static DummyReporter dummy;
 static TestMemoryAllocator* allocator;
 
+TEST_GROUP(MemoryLeakWarningLocalDetectorTest)
+{
+};
+
+TEST(MemoryLeakWarningLocalDetectorTest, localDetectorReturnsNewGlobalWhenNoneWasSet)
+{
+    MemoryLeakWarningPlugin memoryLeakWarningPlugin("TestMemoryLeakWarningPlugin", NULL);
+    CHECK(0 != memoryLeakWarningPlugin.getMemoryLeakDetector());
+}
+
+TEST(MemoryLeakWarningLocalDetectorTest, localDetectorIsTheOneSpecifiedInConstructor)
+{
+    MemoryLeakDetector localDetector(&dummy);
+    MemoryLeakWarningPlugin memoryLeakWarningPlugin("TestMemoryLeakWarningPlugin", &localDetector);
+    POINTERS_EQUAL(&localDetector, memoryLeakWarningPlugin.getMemoryLeakDetector());
+}
+
+IGNORE_TEST(MemoryLeakWarningLocalDetectorTest, localDetectorIsGlobalDetector)
+{
+    MemoryLeakDetector* saveDetector = MemoryLeakWarningPlugin::getGlobalDetector();
+    MemoryLeakFailure* saveReporter = MemoryLeakWarningPlugin::getGlobalFailureReporter();
+    MemoryLeakDetector globalDetector(&dummy);
+    MemoryLeakWarningPlugin::setGlobalDetector(&globalDetector, &dummy);
+    MemoryLeakWarningPlugin memoryLeakWarningPlugin("TestMemoryLeakWarningPlugin", NULL);
+    POINTERS_EQUAL(&globalDetector, memoryLeakWarningPlugin.getMemoryLeakDetector());
+    MemoryLeakWarningPlugin::setGlobalDetector(saveDetector, saveReporter);
+}
+
+
 TEST_GROUP(MemoryLeakWarningTest)
 {
     TestTestingFixture* fixture;


### PR DESCRIPTION
NOTES:

+ This is still a bit of a hack; should probably be done in configure.ac rather than in Makefile.am

+ Maybe we should change the build generally so that it is mostly done with -O0 and use -O2 ony in specific runs to check whether it works

+ Doing so would limit the "special treatment" for Clang to those runs only

+ Wondering how we should treat -g? I would like to see it in the 'normal' build, but do we need it when the builds just run on Travis?