### PR TITLE
gcov not run in the right when SRC_DIRS has only C or CPP files

### DIFF
--- a/build/MakefileWorker.mk
+++ b/build/MakefileWorker.mk
@@ -516,7 +516,8 @@ ifeq ($(CPPUTEST_USE_VPATH), Y)
 	$(SILENCE)gcov --object-directory $(CPPUTEST_OBJS_DIR) $(SRC) >> $(GCOV_OUTPUT) 2>> $(GCOV_ERROR)
 else
 	$(SILENCE)for d in $(SRC_DIRS) ; do \
-		gcov --object-directory $(CPPUTEST_OBJS_DIR)/$$d $$d/*.c $$d/*.cpp >> $(GCOV_OUTPUT) 2>>$(GCOV_ERROR) ; \
+		FILES=`ls $$d/*.c $$d/*.cpp 2> /dev/null` ; \
+		gcov --object-directory $(CPPUTEST_OBJS_DIR)/$$d $$FILES >> $(GCOV_OUTPUT) 2>>$(GCOV_ERROR) ; \
 	done
 	$(SILENCE)for f in $(SRC_FILES) ; do \
 		gcov --object-directory $(CPPUTEST_OBJS_DIR)/$$f $$f >> $(GCOV_OUTPUT) 2>>$(GCOV_ERROR) ; \

--- a/build/MakefileWorker.mk
+++ b/build/MakefileWorker.mk
@@ -516,7 +516,7 @@ ifeq ($(CPPUTEST_USE_VPATH), Y)
 	$(SILENCE)gcov --object-directory $(CPPUTEST_OBJS_DIR) $(SRC) >> $(GCOV_OUTPUT) 2>> $(GCOV_ERROR)
 else
 	$(SILENCE)for d in $(SRC_DIRS) ; do \
-		FILES=`ls $$d/*.c $$d/*.cpp 2> /dev/null` ; \
+		FILES=`ls $$d/*.c $$d/*.cc $$d/*.cpp 2> /dev/null` ; \
 		gcov --object-directory $(CPPUTEST_OBJS_DIR)/$$d $$FILES >> $(GCOV_OUTPUT) 2>>$(GCOV_ERROR) ; \
 	done
 	$(SILENCE)for f in $(SRC_FILES) ; do \


### PR DESCRIPTION
I had a same problem (#488).
If SRC_DIRS is `src` and has only C or CPP files, gcov_error.txt has
> objs/src/*.gcno:cannot open notes file