### PR TITLE
Fixed base class constructor call

### DIFF
--- a/tests/CommandLineTestRunnerTest.cpp
+++ b/tests/CommandLineTestRunnerTest.cpp
@@ -99,7 +99,7 @@ TEST(CommandLineTestRunner, NoPluginsAreInstalledAtTheEndOfARunWhenTheArgumentsA
 struct TestOutputCheckingCommandLineTestRunner : public CommandLineTestRunner
 {
     TestOutputCheckingCommandLineTestRunner(int ac, const char** av, TestOutput* output, TestRegistry* registry) :
-        CommandLineTestRunner::CommandLineTestRunner(ac, av, output, registry)
+        CommandLineTestRunner(ac, av, output, registry)
     {
     }
 


### PR DESCRIPTION
Last pull request caused errors in my VC build.  Looks like it doesn't like treating the constructor as a static function as part of an initializer list.  I'm a bit surprised that other compilers didn't mind this, I don't think I've ever seen it before.