### PR TITLE
Wide space input support

### DIFF
--- a/include/CppUTest/CommandLineTestRunner.h
+++ b/include/CppUTest/CommandLineTestRunner.h
@@ -49,6 +49,7 @@ public:
 
     static int RunAllTests(int ac, const char** av);
     static int RunAllTests(int ac, char** av);
+    static int RunAllTests(int ac, wchar_t** av);
     CommandLineTestRunner(int ac, const char** av, TestOutput*, TestRegistry* registry);
 
     virtual ~CommandLineTestRunner();

--- a/include/CppUTest/CommandLineTestRunner.h
+++ b/include/CppUTest/CommandLineTestRunner.h
@@ -49,8 +49,11 @@ public:
 
     static int RunAllTests(int ac, const char** av);
     static int RunAllTests(int ac, char** av);
-    static int RunAllTests(int ac, wchar_t** av);
+    static int RunAllTests(int ac, const wchar_t** av);
+    static int RunAllTests( int ac, wchar_t** av );
     CommandLineTestRunner(int ac, const char** av, TestOutput*, TestRegistry* registry);
+
+    static char** ConvertWideArgumentsToNormal( int ac, const wchar_t** av );
 
     virtual ~CommandLineTestRunner();
     int runAllTestsMain();

--- a/src/CppUTest/CommandLineTestRunner.cpp
+++ b/src/CppUTest/CommandLineTestRunner.cpp
@@ -69,27 +69,32 @@ int CommandLineTestRunner::RunAllTests(int ac, const char** av)
     return result;
 }
 
-int CommandLineTestRunner::RunAllTests( int ac, wchar_t** av )
-{
-    char** avc = new char*[ac];
-    for ( int i = 0; i < ac; i++ ) {
-        size_t len = wcslen( av[i] ) + 1;
-        avc[i] = new char[len];
-        wcstombs_s( 0 , avc[i], sizeof(char)*len, av[i], len );
-    }
-    int result = 0;
+int CommandLineTestRunner::RunAllTests( int ac, wchar_t** av ) {
+    return RunAllTests( ac, const_cast<const wchar_t**> ( av ) );
+}
 
-    try {
-        RunAllTests( ac, avc );
-    }
-    catch ( ... ) {
-    }
+int CommandLineTestRunner::RunAllTests( int ac, const wchar_t** av )
+{
+    char** avc = ConvertWideArgumentsToNormal( ac, av );
+
+    int result = RunAllTests( ac, avc );
 
     for ( int i = 0; i < ac; i++ ) {
         delete[] avc[i];
     }
     delete[] avc;
+
     return result;
+}
+
+char** CommandLineTestRunner::ConvertWideArgumentsToNormal( int ac, const wchar_t** av ) {
+    char** avc = new char*[ac];
+    for( int i = 0; i < ac; i++ ) {
+        size_t len = wcslen( av[i] ) + 1;
+        avc[i] = new char[len];
+        wcstombs( avc[i], av[i], len );
+    }
+    return avc;
 }
 
 int CommandLineTestRunner::runAllTestsMain()

--- a/src/CppUTest/CommandLineTestRunner.cpp
+++ b/src/CppUTest/CommandLineTestRunner.cpp
@@ -69,6 +69,29 @@ int CommandLineTestRunner::RunAllTests(int ac, const char** av)
     return result;
 }
 
+int CommandLineTestRunner::RunAllTests( int ac, wchar_t** av )
+{
+    char** avc = new char*[ac];
+    for ( int i = 0; i < ac; i++ ) {
+        size_t len = wcslen( av[i] ) + 1;
+        avc[i] = new char[len];
+        wcstombs_s( 0 , avc[i], sizeof(char)*len, av[i], len );
+    }
+    int result = 0;
+
+    try {
+        RunAllTests( ac, avc );
+    }
+    catch ( ... ) {
+    }
+
+    for ( int i = 0; i < ac; i++ ) {
+        delete[] avc[i];
+    }
+    delete[] avc;
+    return result;
+}
+
 int CommandLineTestRunner::runAllTestsMain()
 {
     int testResult = 0;

--- a/tests/CommandLineTestRunnerTest.cpp
+++ b/tests/CommandLineTestRunnerTest.cpp
@@ -96,6 +96,22 @@ TEST(CommandLineTestRunner, NoPluginsAreInstalledAtTheEndOfARunWhenTheArgumentsA
     LONGS_EQUAL(0, registry.countPlugins());
 }
 
+TEST( CommandLineTestRunner, VerifyWideToNormalConversions ) {
+    const wchar_t* argv[] = { L"dummy.exe", L"-fdskjnfkds" };
+    int ac = 2;
+
+    char** avc = CommandLineTestRunner::ConvertWideArgumentsToNormal( ac, argv );
+
+    STRCMP_EQUAL( "dummy.exe", avc[0] );
+    STRCMP_EQUAL( "-fdskjnfkds", avc[1] );
+
+    for( int i = 0; i < ac; i++ ) {
+        delete[] avc[i];
+    }
+    delete[] avc;
+}
+
+
 struct TestOutputCheckingCommandLineTestRunner : public CommandLineTestRunner
 {
     TestOutputCheckingCommandLineTestRunner(int ac, const char** av, TestOutput* output, TestRegistry* registry) :


### PR DESCRIPTION
Due to internationalisation, everything here has to go in wide characters. I discovered an uncommited change floating around here to run tests with wide character parameter input support that might be useful here as well.