### PR TITLE
Change the test group to match the new name

### DIFF
--- a/tests/CppUTestExt/MockSupportTest.cpp
+++ b/tests/CppUTestExt/MockSupportTest.cpp
@@ -1738,6 +1738,6 @@ TEST(MockSupportTestWithFixture, shouldCrashOnFailure)
 
 #else
 
-IGNORE_TEST(MockSupportCrashTest, shouldCrashOnFailure) {}
+IGNORE_TEST(MockSupportTestWithFixture, shouldCrashOnFailure) {}
 
 #endif


### PR DESCRIPTION
Error introduced by PR 575 (I think), the test group inside the preprocessor #if block was changed, but the test group inside the #else block was not changed.