### PR TITLE
New test for crash on failure with mock_c()

### DIFF
--- a/include/CppUTestExt/MockSupport_c.h
+++ b/include/CppUTestExt/MockSupport_c.h
@@ -128,6 +128,7 @@ struct SMockSupport_c
     int (*expectedCallsLeft)(void);
 
     void (*clear)(void);
+    void (*crashOnFailure)(void);
 
     void (*installComparator) (const char* typeName, MockTypeEqualFunction_c isEqual, MockTypeValueToStringFunction_c valueToString);
     void (*removeAllComparators)(void);

--- a/src/CppUTestExt/MockSupport_c.cpp
+++ b/src/CppUTestExt/MockSupport_c.cpp
@@ -63,7 +63,10 @@ public:
         if (!getTestToFail()->hasFailed())
             getTestToFail()->failWith(failure, MockFailureReporterTestTerminatorForInCOnlyCode(crashOnFailure_));
     }
-
+    void clear()
+    {
+        crashOnFailure_ = false;
+    }
 };
 
 static MockSupport* currentMockSupport = NULL;
@@ -502,6 +505,7 @@ int expectedCallsLeft_c()
 
 void clear_c()
 {
+    failureReporterForC.clear();
     currentMockSupport->clear();
 }
 

--- a/src/CppUTestExt/MockSupport_c.cpp
+++ b/src/CppUTestExt/MockSupport_c.cpp
@@ -111,6 +111,7 @@ MockValue_c getData_c(const char* name);
 void checkExpectations_c();
 int expectedCallsLeft_c();
 void clear_c();
+void crashOnFailure_c();
 
 MockExpectedCall_c* withIntParameters_c(const char* name, int value);
 MockExpectedCall_c* withUnsignedIntParameters_c(const char* name, unsigned int value);
@@ -212,6 +213,7 @@ static MockSupport_c gMockSupport = {
         checkExpectations_c,
         expectedCallsLeft_c,
         clear_c,
+        crashOnFailure_c,
         installComparator_c,
         removeAllComparators_c
 };
@@ -501,6 +503,11 @@ int expectedCallsLeft_c()
 void clear_c()
 {
     currentMockSupport->clear();
+}
+
+void crashOnFailure_c()
+{
+    currentMockSupport->crashOnFailure();
 }
 
 MockSupport_c* mock_c()

--- a/tests/CppUTestExt/MockSupport_cTest.cpp
+++ b/tests/CppUTestExt/MockSupport_cTest.cpp
@@ -252,13 +252,11 @@ MSC_SWITCHED_TEST(MockSupport_c, NoExceptionsAreThrownWhenAMock_cCallFailed)
 
 #if !defined(__MINGW32__) && !defined(_MSC_VER)
 
-#include "CppUTestExt/MockSupport.h"
-
 TEST(MockSupport_c, shouldCrashOnFailure)
 {
     TestTestingFixture fixture;
 
-    mock().crashOnFailure();
+    mock_c()->crashOnFailure();
     fixture.registry_->setRunTestsInSeperateProcess();
     fixture.setTestFunction(failedCallToMockC);
     fixture.runAllTests();

--- a/tests/CppUTestExt/MockSupport_cTest.cpp
+++ b/tests/CppUTestExt/MockSupport_cTest.cpp
@@ -262,6 +262,7 @@ TEST(MockSupport_c, shouldCrashOnFailure)
     fixture.runAllTests();
 
     fixture.assertPrintContains("Failed in separate process - killed by signal 11");
+    mock_c()->clear();
 }
 
 #else

--- a/tests/CppUTestExt/MockSupport_cTest.cpp
+++ b/tests/CppUTestExt/MockSupport_cTest.cpp
@@ -250,3 +250,24 @@ MSC_SWITCHED_TEST(MockSupport_c, NoExceptionsAreThrownWhenAMock_cCallFailed)
     CHECK(!destructorWasCalled);
 }
 
+#if !defined(__MINGW32__) && !defined(_MSC_VER)
+
+#include "CppUTestExt/MockSupport.h"
+
+TEST(MockSupport_c, shouldCrashOnFailure)
+{
+    TestTestingFixture fixture;
+
+    mock().crashOnFailure();
+    fixture.registry_->setRunTestsInSeperateProcess();
+    fixture.setTestFunction(failedCallToMockC);
+    fixture.runAllTests();
+
+    fixture.assertPrintContains("Failed in separate process - killed by signal 11");
+}
+
+#else
+
+IGNORE_TEST(MockSupport_c, shouldCrashOnFailure) {}
+
+#endif


### PR DESCRIPTION
This test fails because crashOnFailure_ is never passed to MockFailureReporterTestTerminatorForInCOnlyCode. It is only passed to the default test terminator, which isn't called here.

The Travis CI build is expected to fail at this point ;-)