### PR TITLE
100% Coverage for MockSupport_c - Part 1

### DIFF
--- a/tests/CppUTestExt/MockSupport_cTest.cpp
+++ b/tests/CppUTestExt/MockSupport_cTest.cpp
@@ -250,3 +250,18 @@ MSC_SWITCHED_TEST(MockSupport_c, NoExceptionsAreThrownWhenAMock_cCallFailed)
     CHECK(!destructorWasCalled);
 }
 
+static void failingCallToMockCWithParameterOfType_()
+{
+    mock_c()->expectOneCall("bar")->withParameterOfType("typeName", "name", (const void*) 1);
+    mock_c()->actualCall("bar")->withParameterOfType("typeName", "name", (const void*) 2);
+}
+
+TEST(MockSupport_c, failureWithParameterOfTypeCoversValueToString)
+{
+    TestTestingFixture fixture;
+    mock_c()->installComparator("typeName", typeNameIsEqual, typeNameValueToString);
+    fixture.setTestFunction(failingCallToMockCWithParameterOfType_);
+    fixture.runAllTests();
+    fixture.assertPrintContains("typeName name: <valueToString>");
+    mock_c()->removeAllComparators();
+}

--- a/tests/CppUTestExt/MockSupport_cTestCFile.c
+++ b/tests/CppUTestExt/MockSupport_cTestCFile.c
@@ -45,9 +45,11 @@ void all_mock_support_c_calls(void)
     mock_c()->checkExpectations();
 
     mock_c()->expectOneCall("boo")->withIntParameters("integer", 1)->withDoubleParameters("double", 1.0)->
-            withStringParameters("string", "string")->withPointerParameters("pointer", (void*) 1);
+            withStringParameters("string", "string")->withPointerParameters("pointer", (void*) 1)->
+            withConstPointerParameters("constpointer", (const void*) 1);
     mock_c()->actualCall("boo")->withIntParameters("integer", 1)->withDoubleParameters("double", 1.0)->
-            withStringParameters("string", "string")->withPointerParameters("pointer", (void*) 1);
+            withStringParameters("string", "string")->withPointerParameters("pointer", (void*) 1)->
+            withConstPointerParameters("constpointer", (const void*) 1);
 
     mock_c()->installComparator("typeName", typeNameIsEqual, typeNameValueToString);
     mock_c()->expectOneCall("boo")->withParameterOfType("typeName", "name", (void*) 1);


### PR DESCRIPTION
because crashOnFailure_ is never passed to
MockFailureReporterTestTerminatorForInCOnlyCode.