### PR TITLE
100% Coverage For MockSupport_c - Part 2

### DIFF
--- a/src/CppUTestExt/MockSupport_c.cpp
+++ b/src/CppUTestExt/MockSupport_c.cpp
@@ -46,10 +46,11 @@ public:
 
         TestTerminatorWithoutExceptions::exitCurrentTest();
     } // LCOV_EXCL_LINE
-
+    // LCOV_EXCL_START
     virtual ~MockFailureReporterTestTerminatorForInCOnlyCode()
     {
     }
+    // LCOV_EXCL_STOP
 private:
     bool crashOnFailure_;
 
@@ -62,7 +63,7 @@ public:
     {
         if (!getTestToFail()->hasFailed())
             getTestToFail()->failWith(failure, MockFailureReporterTestTerminatorForInCOnlyCode(crashOnFailure_));
-    }
+    } // LCOV_EXCL_LINE
 
 };
 


### PR DESCRIPTION
Exclude unhittable lines from lcov. 

I can't say I am entirely happy with excluding the destructor (although it does nothing), but for the life of me I can't figure out why it never gets called, and the destructors of all the other terminators do. :-(

Also, I'm not entirely sure that hasFailed() couldn't be true (but then if it was, the test should have been terminated already?), and if it couldn't be true, I'd prefer to get rid of the condition altogether (which would justify the } being __really__ unhittable)...