### PR TITLE
Print test group names

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ option(COVERAGE "Enable running with coverage" OFF)
 option(C++11 "Compile with C++11 support" OFF)
 
 option(TESTS "Compile and make tests for the code?" ON)
+option(TESTS_DETAILED "Run each test separately instead of grouped?" OFF)
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "What kind of build this is" FORCE)

--- a/include/CppUTest/CommandLineArguments.h
+++ b/include/CppUTest/CommandLineArguments.h
@@ -43,6 +43,8 @@ public:
     bool parse(TestPlugin* plugin);
     bool isVerbose() const;
     bool isColor() const;
+    bool isListingTestGroupNames() const;
+    bool isListingTestGroupAndCaseNames() const;
     int getRepeatCount() const;
     const TestFilter* getGroupFilters() const;
     const TestFilter* getNameFilters() const;
@@ -64,6 +66,8 @@ private:
     bool verbose_;
     bool color_;
     bool runTestsAsSeperateProcess_;
+    bool listTestGroupNames_;
+    bool listTestGroupAndCaseNames_;
     int repeat_;
     TestFilter* groupFilters_;
     TestFilter* nameFilters_;

--- a/include/CppUTest/TestRegistry.h
+++ b/include/CppUTest/TestRegistry.h
@@ -50,6 +50,8 @@ public:
     virtual void unDoLastAddTest();
     virtual int countTests();
     virtual void runAllTests(TestResult& result);
+    virtual void listTestGroupNames(TestResult& result);
+    virtual void listTestGroupAndCaseNames(TestResult& result);
     virtual void setNameFilters(const TestFilter* filters);
     virtual void setGroupFilters(const TestFilter* filters);
 

--- a/src/CppUTest/CommandLineArguments.cpp
+++ b/src/CppUTest/CommandLineArguments.cpp
@@ -30,7 +30,7 @@
 #include "CppUTest/PlatformSpecificFunctions.h"
 
 CommandLineArguments::CommandLineArguments(int ac, const char** av) :
-    ac_(ac), av_(av), verbose_(false), color_(false), runTestsAsSeperateProcess_(false), repeat_(1), groupFilters_(NULL), nameFilters_(NULL), outputType_(OUTPUT_ECLIPSE)
+    ac_(ac), av_(av), verbose_(false), color_(false), runTestsAsSeperateProcess_(false), listTestGroupNames_(false), listTestGroupAndCaseNames_(false), repeat_(1), groupFilters_(NULL), nameFilters_(NULL), outputType_(OUTPUT_ECLIPSE)
 {
 }
 
@@ -53,9 +53,12 @@ bool CommandLineArguments::parse(TestPlugin* plugin)
     bool correctParameters = true;
     for (int i = 1; i < ac_; i++) {
         SimpleString argument = av_[i];
-        if (argument == "-v") verbose_ = true;
+        
+        if      (argument == "-v") verbose_ = true;
         else if (argument == "-c") color_ = true;
         else if (argument == "-p") runTestsAsSeperateProcess_ = true;
+        else if (argument == "-lg") listTestGroupNames_ = true;
+        else if (argument == "-ln") listTestGroupAndCaseNames_ = true;
         else if (argument.startsWith("-r")) SetRepeatCount(ac_, av_, i);
         else if (argument.startsWith("-g")) AddGroupFilter(ac_, av_, i);
         else if (argument.startsWith("-sg")) AddStrictGroupFilter(ac_, av_, i);
@@ -77,7 +80,7 @@ bool CommandLineArguments::parse(TestPlugin* plugin)
 
 const char* CommandLineArguments::usage() const
 {
-    return "usage [-v] [-c] [-r#] [-g|sg groupName]... [-n|sn testName]... [\"TEST(groupName, testName)\"]... [-o{normal, junit}] [-k packageName]\n";
+    return "usage [-v] [-c] [-p] [-lg] [-ln] [-r#] [-g|sg groupName]... [-n|sn testName]... [\"TEST(groupName, testName)\"]... [-o{normal, junit}] [-k packageName]\n";
 }
 
 bool CommandLineArguments::isVerbose() const
@@ -88,6 +91,16 @@ bool CommandLineArguments::isVerbose() const
 bool CommandLineArguments::isColor() const
 {
     return color_;
+}
+
+bool CommandLineArguments::isListingTestGroupNames() const
+{
+    return listTestGroupNames_;
+}
+
+bool CommandLineArguments::isListingTestGroupAndCaseNames() const
+{
+    return listTestGroupAndCaseNames_;
 }
 
 bool CommandLineArguments::runTestsInSeperateProcess() const

--- a/src/CppUTest/CommandLineTestRunner.cpp
+++ b/src/CppUTest/CommandLineTestRunner.cpp
@@ -99,6 +99,20 @@ int CommandLineTestRunner::runAllTests()
     int failureCount = 0;
     int repeat_ = arguments_->getRepeatCount();
 
+    if (arguments_->isListingTestGroupNames())
+    {
+        TestResult tr(*output_);
+        registry_->listTestGroupNames(tr);
+        return 0;
+    }
+
+    if (arguments_->isListingTestGroupAndCaseNames())
+    {
+        TestResult tr(*output_);
+        registry_->listTestGroupAndCaseNames(tr);
+        return 0;
+    }
+
     while (loopCount++ < repeat_) {
         output_->printTestRun(loopCount, repeat_);
         TestResult tr(*output_);

--- a/src/CppUTest/TestRegistry.cpp
+++ b/src/CppUTest/TestRegistry.cpp
@@ -74,28 +74,34 @@ void TestRegistry::runAllTests(TestResult& result)
 
 void TestRegistry::listTestGroupNames(TestResult& result)
 {
-    SimpleString lastgroup = "";
+    SimpleString groupList;
 
     for (UtestShell *test = tests_; test != NULL; test = test->getNext()) {
         SimpleString gname = test->getGroup();
-        if (gname != lastgroup) {
-            lastgroup = gname;
-            result.print(gname.asCharString());
-            result.print(" ");
+        if (!groupList.contains(gname)) {
+            groupList += gname;
+            groupList += " ";
         }
     }
+    result.print(groupList.asCharString());
 }
 
 void TestRegistry::listTestGroupAndCaseNames(TestResult& result)
 {
+    SimpleString groupAndNameList;
+
     for (UtestShell *test = tests_; test != NULL; test = test->getNext()) {
         if (testShouldRun(test, result)) {
-            result.print(test->getGroup().asCharString());
-            result.print(".");
-            result.print(test->getName().asCharString());
-            result.print(" ");
+            SimpleString groupAndName = test->getGroup();
+            groupAndName += ".";
+            groupAndName += test->getName();
+            groupAndName += " ";
+            if (!groupAndNameList.contains(groupAndName)) {
+                groupAndNameList += groupAndName;
+            }
         }
     }
+    result.print(groupAndNameList.asCharString());
 }
 
 bool TestRegistry::endOfGroup(UtestShell* test)

--- a/src/CppUTest/TestRegistry.cpp
+++ b/src/CppUTest/TestRegistry.cpp
@@ -72,6 +72,32 @@ void TestRegistry::runAllTests(TestResult& result)
     currentRepetition_++;
 }
 
+void TestRegistry::listTestGroupNames(TestResult& result)
+{
+    SimpleString lastgroup = "";
+
+    for (UtestShell *test = tests_; test != NULL; test = test->getNext()) {
+        SimpleString gname = test->getGroup();
+        if (gname != lastgroup) {
+            lastgroup = gname;
+            result.print(gname.asCharString());
+            result.print(" ");
+        }
+    }
+}
+
+void TestRegistry::listTestGroupAndCaseNames(TestResult& result)
+{
+    for (UtestShell *test = tests_; test != NULL; test = test->getNext()) {
+        if (testShouldRun(test, result)) {
+            result.print(test->getGroup().asCharString());
+            result.print(".");
+            result.print(test->getName().asCharString());
+            result.print(" ");
+        }
+    }
+}
+
 bool TestRegistry::endOfGroup(UtestShell* test)
 {
     return (!test || !test->getNext() || test->getGroup() != test->getNext()->getGroup());

--- a/src/CppUTest/TestRegistry.cpp
+++ b/src/CppUTest/TestRegistry.cpp
@@ -83,6 +83,8 @@ void TestRegistry::listTestGroupNames(TestResult& result)
             groupList += " ";
         }
     }
+    if (groupList.endsWith(" "))
+        groupList = groupList.subString(0, groupList.size() - 1);
     result.print(groupList.asCharString());
 }
 
@@ -101,6 +103,8 @@ void TestRegistry::listTestGroupAndCaseNames(TestResult& result)
             }
         }
     }
+    if (groupAndNameList.endsWith(" "))
+        groupAndNameList = groupAndNameList.subString(0, groupAndNameList.size() - 1);
     result.print(groupAndNameList.asCharString());
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,36 +1,36 @@
 enable_testing()
 
 set(CppUTestTests_src
-        AllTests.cpp
-        SetPluginTest.cpp
-        CheatSheetTest.cpp
-        SimpleStringTest.cpp
-        CommandLineArgumentsTest.cpp
-        TestFailureTest.cpp
-        TestFailureNaNTest.cpp
-        CommandLineTestRunnerTest.cpp
-        TestFilterTest.cpp
-        TestHarness_cTest.cpp
-        JUnitOutputTest.cpp
-        TestHarness_cTestCFile.c
-        MemoryLeakDetectorTest.cpp
-        TestInstallerTest.cpp
-        AllocLetTestFree.c
-        MemoryLeakOperatorOverloadsTest.cpp
-        TestMemoryAllocatorTest.cpp
-        MemoryLeakWarningTest.cpp
-        TestOutputTest.cpp
-        AllocLetTestFreeTest.cpp
-        TestRegistryTest.cpp
-        AllocationInCFile.c
-        PluginTest.cpp
-        TestResultTest.cpp
-        PreprocessorTest.cpp
-        TestUTestMacro.cpp
-        AllocationInCppFile.cpp
-        UtestTest.cpp
-        SimpleMutexTest.cpp
-        UtestPlatformTest.cpp
+    AllTests.cpp
+    SetPluginTest.cpp
+    CheatSheetTest.cpp
+    SimpleStringTest.cpp
+    CommandLineArgumentsTest.cpp
+    TestFailureTest.cpp
+    TestFailureNaNTest.cpp
+    CommandLineTestRunnerTest.cpp
+    TestFilterTest.cpp
+    TestHarness_cTest.cpp
+    JUnitOutputTest.cpp
+    TestHarness_cTestCFile.c
+    MemoryLeakDetectorTest.cpp
+    TestInstallerTest.cpp
+    AllocLetTestFree.c
+    MemoryLeakOperatorOverloadsTest.cpp
+    TestMemoryAllocatorTest.cpp
+    MemoryLeakWarningTest.cpp
+    TestOutputTest.cpp
+    AllocLetTestFreeTest.cpp
+    TestRegistryTest.cpp
+    AllocationInCFile.c
+    PluginTest.cpp
+    TestResultTest.cpp
+    PreprocessorTest.cpp
+    TestUTestMacro.cpp
+    AllocationInCppFile.cpp
+    UtestTest.cpp
+    SimpleMutexTest.cpp
+    UtestPlatformTest.cpp
 )
 
 if (MSVC)
@@ -41,16 +41,35 @@ endif (MSVC)
 add_executable(CppUTestTests ${CppUTestTests_src})
 target_link_libraries(CppUTestTests CppUTest)
 
-# get all test groups
-execute_process(COMMAND tests/CppUTestTests -lg OUTPUT_VARIABLE CppUTestTests_Groups)
-
-# create separate test for each group
-separate_arguments(CppUTestTests_Groups)
-foreach(group ${CppUTestTests_Groups})
-	message("Add test: ${group}")
-	add_test(NAME CppUTest.${group} COMMAND ${EXECUTABLE_OUTPUT_PATH}/CppUTestTests -g ${group})
-endforeach()
-
 if (TESTS)
+    if (TESTS_DETAILED)
+        # get all test groups and names
+        execute_process(COMMAND tests/CppUTestTests -ln OUTPUT_VARIABLE CppUTestTests_GroupsAndNames)
+        # convert space-separated string into a list
+        separate_arguments(CppUTestTests_GroupsAndNames)
+        # create separate CTest test for each CppUTestTests test
+        set(lastgroup "")
+        foreach(testfullname ${CppUTestTests_GroupsAndNames})
+            string(REGEX MATCH "^([^/.]+)" groupname ${testfullname})
+            string(REGEX MATCH "([^/.]+)$" testname ${testfullname})
+            if (NOT ("${groupname}" STREQUAL "${lastgroup}"))
+                message("TestGroup1: ${groupname}:")
+                set(lastgroup "${groupname}")
+            endif (NOT ("${groupname}" STREQUAL "${lastgroup}"))
+            message("... ${testname}")
+            add_test(NAME CppUTest.${testfullname} COMMAND ${EXECUTABLE_OUTPUT_PATH}/CppUTestTests -sg ${groupname} -sn ${testname} -c)
+        endforeach()
+    else (TESTS_DETAILED)
+        # get all test groups
+        execute_process(COMMAND tests/CppUTestTests -lg OUTPUT_VARIABLE CppUTestTests_Groups)
+        # create separate test for each group
+        separate_arguments(CppUTestTests_Groups)
+        foreach(group ${CppUTestTests_Groups})
+            message("TestGroup1: ${group}")
+            add_test(NAME CppUTest.${group} COMMAND ${EXECUTABLE_OUTPUT_PATH}/CppUTestTests -sg ${group} -c)
+        endforeach()
+    endif (TESTS_DETAILED)
+
     add_subdirectory(CppUTestExt)
 endif (TESTS)
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -40,7 +40,16 @@ endif (MSVC)
 
 add_executable(CppUTestTests ${CppUTestTests_src})
 target_link_libraries(CppUTestTests CppUTest)
-add_test(CppUTestTests ${EXECUTABLE_OUTPUT_PATH}/CppUTestTests)
+
+# get all test groups
+execute_process(COMMAND tests/CppUTestTests -lg OUTPUT_VARIABLE CppUTestTests_Groups)
+
+# create separate test for each group
+separate_arguments(CppUTestTests_Groups)
+foreach(group ${CppUTestTests_Groups})
+	message("Add test: ${group}")
+	add_test(NAME CppUTest.${group} COMMAND ${EXECUTABLE_OUTPUT_PATH}/CppUTestTests -g ${group})
+endforeach()
 
 if (TESTS)
     add_subdirectory(CppUTestExt)

--- a/tests/CommandLineArgumentsTest.cpp
+++ b/tests/CommandLineArgumentsTest.cpp
@@ -248,12 +248,28 @@ TEST(CommandLineArguments, setOutputToGarbage)
     CHECK(!newArgumentParser(argc, argv));
 }
 
+TEST(CommandLineArguments, setPrintGroups)
+{
+    int argc = 2;
+    const char* argv[] = { "tests.exe", "-lg" };
+    CHECK(newArgumentParser(argc, argv));
+    CHECK(args->isListingTestGroupNames());
+}
+
+TEST(CommandLineArguments, setPrintGroupsAndNames)
+{
+    int argc = 2;
+    const char* argv[] = { "tests.exe", "-ln" };
+    CHECK(newArgumentParser(argc, argv));
+    CHECK(args->isListingTestGroupAndCaseNames());
+}
+
 TEST(CommandLineArguments, weirdParamatersPrintsUsageAndReturnsFalse)
 {
     int argc = 2;
     const char* argv[] = { "tests.exe", "-SomethingWeird" };
     CHECK(!newArgumentParser(argc, argv));
-    STRCMP_EQUAL("usage [-v] [-c] [-r#] [-g|sg groupName]... [-n|sn testName]... [\"TEST(groupName, testName)\"]... [-o{normal, junit}] [-k packageName]\n",
+    STRCMP_EQUAL("usage [-v] [-c] [-p] [-lg] [-ln] [-r#] [-g|sg groupName]... [-n|sn testName]... [\"TEST(groupName, testName)\"]... [-o{normal, junit}] [-k packageName]\n",
             args->usage());
 }
 

--- a/tests/CppUTestExt/CMakeLists.txt
+++ b/tests/CppUTestExt/CMakeLists.txt
@@ -20,4 +20,13 @@ set(CppUTestExtTests_src
 
 add_executable(CppUTestExtTests ${CppUTestExtTests_src})
 target_link_libraries(CppUTestExtTests CppUTest CppUTestExt ${CPPUNIT_EXTERNAL_LIBRARIES})
-add_test(CppUTestExtTests ${EXECUTABLE_OUTPUT_PATH}/CppUTestExtTests)
+
+# get all test groups
+execute_process(COMMAND tests/CppUTestExt/CppUTestExtTests -lg OUTPUT_VARIABLE CppUTestTestsExt_Groups)
+
+# create separate test for each group
+separate_arguments(CppUTestTestsExt_Groups)
+foreach(group ${CppUTestTestsExt_Groups})
+	message("Add test: ${group}")
+	add_test(NAME CppUTestExt.${group} COMMAND ${EXECUTABLE_OUTPUT_PATH}/CppUTestExtTests -g ${group})
+endforeach()

--- a/tests/CppUTestExt/CMakeLists.txt
+++ b/tests/CppUTestExt/CMakeLists.txt
@@ -1,32 +1,33 @@
 set(CppUTestExtTests_src
-        AllTests.cpp
-        CodeMemoryReportFormatterTest.cpp
-        GMockTest.cpp
-        GTest1Test.cpp
-        MemoryReportAllocatorTest.cpp
-        MemoryReporterPluginTest.cpp
-        MemoryReportFormatterTest.cpp
-        MockActualCallTest.cpp
-        MockCheatSheetTest.cpp
-        MockExpectedCallTest.cpp
-        MockExpectedFunctionsListTest.cpp
-        MockFailureTest.cpp
-        MockPluginTest.cpp
-        MockSupportTest.cpp
-        MockSupport_cTestCFile.c
-        MockSupport_cTest.cpp
-        OrderedTestTest.cpp
+    AllTests.cpp
+    CodeMemoryReportFormatterTest.cpp
+    GMockTest.cpp
+    GTest1Test.cpp
+    MemoryReportAllocatorTest.cpp
+    MemoryReporterPluginTest.cpp
+    MemoryReportFormatterTest.cpp
+    MockActualCallTest.cpp
+    MockCheatSheetTest.cpp
+    MockExpectedCallTest.cpp
+    MockExpectedFunctionsListTest.cpp
+    MockFailureTest.cpp
+    MockPluginTest.cpp
+    MockSupportTest.cpp
+    MockSupport_cTestCFile.c
+    MockSupport_cTest.cpp
+    OrderedTestTest.cpp
 )
 
 add_executable(CppUTestExtTests ${CppUTestExtTests_src})
 target_link_libraries(CppUTestExtTests CppUTest CppUTestExt ${CPPUNIT_EXTERNAL_LIBRARIES})
 
-# get all test groups
-execute_process(COMMAND tests/CppUTestExt/CppUTestExtTests -lg OUTPUT_VARIABLE CppUTestTestsExt_Groups)
-
-# create separate test for each group
-separate_arguments(CppUTestTestsExt_Groups)
-foreach(group ${CppUTestTestsExt_Groups})
-	message("Add test: ${group}")
-	add_test(NAME CppUTestExt.${group} COMMAND ${EXECUTABLE_OUTPUT_PATH}/CppUTestExtTests -g ${group})
-endforeach()
+if (TESTS)
+    # get all test groups
+    execute_process(COMMAND tests/CppUTestExt/CppUTestExtTests -lg OUTPUT_VARIABLE CppUTestTestsExt_Groups)
+    # create separate test for each group
+    separate_arguments(CppUTestTestsExt_Groups)
+    foreach(group ${CppUTestTestsExt_Groups})
+        message("TestGroup2: ${group}:")
+        add_test(NAME CppUTestExt.${group} COMMAND ${EXECUTABLE_OUTPUT_PATH}/CppUTestExtTests -sg ${group} -c)
+    endforeach()
+endif (TESTS)

--- a/tests/TestRegistryTest.cpp
+++ b/tests/TestRegistryTest.cpp
@@ -330,15 +330,14 @@ TEST(TestRegistry, listGroupNames)
     myRegistry->addTest(test1);
     test2->setGroupName("GROUP_2");
     myRegistry->addTest(test2);
-    test3->setGroupName("GROUP_3");
+    test3->setGroupName("GROUP_1");
     myRegistry->addTest(test3);
 
-    output->flush();
     myRegistry->listTestGroupNames(*result);
     SimpleString s = output->getOutput();
     STRCMP_CONTAINS("GROUP_1 ", s.asCharString());
     STRCMP_CONTAINS("GROUP_2 ", s.asCharString());
-    STRCMP_CONTAINS("GROUP_3 ", s.asCharString());
+    LONGS_EQUAL(1, s.count("GROUP_1 "));
 }
 
 TEST(TestRegistry, listTestNames)
@@ -353,7 +352,6 @@ TEST(TestRegistry, listTestNames)
     test3->setTestName("test_c");
     myRegistry->addTest(test3);
 
-    output->flush();
     myRegistry->listTestGroupAndCaseNames(*result);
     SimpleString s = output->getOutput();
     STRCMP_CONTAINS("GROUP_A.test_a ", s.asCharString());

--- a/tests/TestRegistryTest.cpp
+++ b/tests/TestRegistryTest.cpp
@@ -335,7 +335,7 @@ TEST(TestRegistry, listGroupNames)
 
     myRegistry->listTestGroupNames(*result);
     SimpleString s = output->getOutput();
-    STRCMP_EQUAL("GROUP_1 GROUP_2 ", s.asCharString());
+    STRCMP_EQUAL("GROUP_1 GROUP_2", s.asCharString());
 }
 
 TEST(TestRegistry, listTestNames)
@@ -352,7 +352,5 @@ TEST(TestRegistry, listTestNames)
 
     myRegistry->listTestGroupAndCaseNames(*result);
     SimpleString s = output->getOutput();
-    STRCMP_CONTAINS("GROUP_A.test_a ", s.asCharString());
-    STRCMP_CONTAINS("GROUP_B.test_b ", s.asCharString());
-    STRCMP_CONTAINS("GROUP_C.test_c ", s.asCharString());
+    STRCMP_EQUAL("GROUP_C.test_c GROUP_B.test_b GROUP_A.test_a", s.asCharString());
 }

--- a/tests/TestRegistryTest.cpp
+++ b/tests/TestRegistryTest.cpp
@@ -335,9 +335,7 @@ TEST(TestRegistry, listGroupNames)
 
     myRegistry->listTestGroupNames(*result);
     SimpleString s = output->getOutput();
-    STRCMP_CONTAINS("GROUP_1 ", s.asCharString());
-    STRCMP_CONTAINS("GROUP_2 ", s.asCharString());
-    LONGS_EQUAL(1, s.count("GROUP_1 "));
+    STRCMP_EQUAL("GROUP_1 GROUP_2 ", s.asCharString());
 }
 
 TEST(TestRegistry, listTestNames)

--- a/tests/TestRegistryTest.cpp
+++ b/tests/TestRegistryTest.cpp
@@ -323,3 +323,40 @@ TEST(TestRegistry, ResetPluginsWorks)
     myRegistry->resetPlugins();
     LONGS_EQUAL(0, myRegistry->countPlugins());
 }
+
+TEST(TestRegistry, listGroupNames)
+{
+    test1->setGroupName("GROUP_1");
+    myRegistry->addTest(test1);
+    test2->setGroupName("GROUP_2");
+    myRegistry->addTest(test2);
+    test3->setGroupName("GROUP_3");
+    myRegistry->addTest(test3);
+
+    output->flush();
+    myRegistry->listTestGroupNames(*result);
+    SimpleString s = output->getOutput();
+    STRCMP_CONTAINS("GROUP_1 ", s.asCharString());
+    STRCMP_CONTAINS("GROUP_2 ", s.asCharString());
+    STRCMP_CONTAINS("GROUP_3 ", s.asCharString());
+}
+
+TEST(TestRegistry, listTestNames)
+{
+    test1->setGroupName("GROUP_A");
+    test1->setTestName("test_a");
+    myRegistry->addTest(test1);
+    test2->setGroupName("GROUP_B");
+    test2->setTestName("test_b");
+    myRegistry->addTest(test2);
+    test3->setGroupName("GROUP_C");
+    test3->setTestName("test_c");
+    myRegistry->addTest(test3);
+
+    output->flush();
+    myRegistry->listTestGroupAndCaseNames(*result);
+    SimpleString s = output->getOutput();
+    STRCMP_CONTAINS("GROUP_A.test_a ", s.asCharString());
+    STRCMP_CONTAINS("GROUP_B.test_b ", s.asCharString());
+    STRCMP_CONTAINS("GROUP_C.test_c ", s.asCharString());
+}


### PR DESCRIPTION
* added commandline switch -lg for printing all test group names instead of running them
* added switch -ln printing list of all group.test pairs
* switch -ln use groups filter
* tests added for new command line arguments
