### PR TITLE
Issue571, step 1: Refactor CommandlineTestRunner 

### DIFF
--- a/include/CppUTest/CommandLineArguments.h
+++ b/include/CppUTest/CommandLineArguments.h
@@ -47,6 +47,7 @@ public:
     const TestFilter* getGroupFilters() const;
     const TestFilter* getNameFilters() const;
     bool isJUnitOutput() const;
+    bool isSuccesfullyParsed() const;
     bool isEclipseOutput() const;
     bool runTestsInSeperateProcess() const;
     const SimpleString& getPackageName() const;
@@ -69,6 +70,7 @@ private:
     TestFilter* nameFilters_;
     OutputType outputType_;
     SimpleString packageName_;
+    bool succesfullyParsed_;
 
     SimpleString getParameterField(int ac, const char** av, int& i, const SimpleString& parameterName);
     void SetRepeatCount(int ac, const char** av, int& index);

--- a/include/CppUTest/CommandLineTestRunner.h
+++ b/include/CppUTest/CommandLineTestRunner.h
@@ -49,20 +49,18 @@ public:
 
     static int RunAllTests(int ac, const char** av);
     static int RunAllTests(int ac, char** av);
-    CommandLineTestRunner(int ac, const char** av, TestOutput*, TestRegistry* registry);
+    CommandLineTestRunner(TestOutput*, TestRegistry* registry, CommandLineArguments* arguments );
 
     virtual ~CommandLineTestRunner();
     int runAllTestsMain();
 
 protected:
     TestOutput* output_;
-    JUnitTestOutput* jUnitOutput_;
 
 private:
     CommandLineArguments* arguments_;
     TestRegistry* registry_;
 
-    bool parseArguments(TestPlugin*);
     int runAllTests();
     void initializeTestRun();
 };

--- a/src/CppUTest/CommandLineArguments.cpp
+++ b/src/CppUTest/CommandLineArguments.cpp
@@ -30,7 +30,7 @@
 #include "CppUTest/PlatformSpecificFunctions.h"
 
 CommandLineArguments::CommandLineArguments(int ac, const char** av) :
-    ac_(ac), av_(av), verbose_(false), color_(false), runTestsAsSeperateProcess_(false), repeat_(1), groupFilters_(NULL), nameFilters_(NULL), outputType_(OUTPUT_ECLIPSE)
+    ac_(ac), av_(av), verbose_(false), color_(false), runTestsAsSeperateProcess_(false), repeat_(1), groupFilters_(NULL), nameFilters_(NULL), outputType_(OUTPUT_ECLIPSE), succesfullyParsed_(false)
 {
 }
 
@@ -69,15 +69,21 @@ bool CommandLineArguments::parse(TestPlugin* plugin)
         else correctParameters = false;
 
         if (correctParameters == false) {
+            succesfullyParsed_ = false;
             return false;
         }
     }
+    succesfullyParsed_ = true;
     return true;
 }
 
 const char* CommandLineArguments::usage() const
 {
     return "usage [-v] [-c] [-r#] [-g|sg groupName]... [-n|sn testName]... [\"TEST(groupName, testName)\"]... [-o{normal, junit}] [-k packageName]\n";
+}
+
+bool CommandLineArguments::isSuccesfullyParsed() const {
+    return succesfullyParsed_;
 }
 
 bool CommandLineArguments::isVerbose() const

--- a/src/CppUTest/CommandLineTestRunner.cpp
+++ b/src/CppUTest/CommandLineTestRunner.cpp
@@ -52,14 +52,16 @@ int CommandLineTestRunner::RunAllTests(int ac, const char** av)
     TestRegistry* registry = TestRegistry::getCurrentRegistry();
     CommandLineArguments arguments( ac, av );
     arguments.parse( registry->getFirstPlugin() );
+
+    ConsoleTestOutput defaultOutput;
+    JUnitTestOutput jUnitOutput;
+    jUnitOutput.setPackageName( arguments.getPackageName() );
     TestOutput* output;
     if( arguments.isJUnitOutput() ) {
-        JUnitTestOutput* jUnitOutput = new JUnitTestOutput;
-        jUnitOutput->setPackageName( arguments.getPackageName() );
-        output = jUnitOutput;
+        output = &jUnitOutput;
     }
     else {
-        output = new ConsoleTestOutput;
+        output = &defaultOutput;
     }
 
     MemoryLeakWarningPlugin memLeakWarn(DEF_PLUGIN_MEM_LEAK);
@@ -84,8 +86,6 @@ int CommandLineTestRunner::RunAllTests(int ac, const char** av)
         *output << memLeakWarn.FinalReport(0);
     }
     registry->removePluginByName( DEF_PLUGIN_MEM_LEAK );
-
-    delete output;
 
     return result;
 }

--- a/tests/CommandLineTestRunnerTest.cpp
+++ b/tests/CommandLineTestRunnerTest.cpp
@@ -72,25 +72,12 @@ TEST_GROUP(CommandLineTestRunner)
     }
 };
 
-TEST(CommandLineTestRunner, OnePluginGetsInstalledDuringTheRunningTheTests)
-{
-    const char* argv[] = { "tests.exe", "-psomething"};
-
-    registry.installPlugin(pluginCountingPlugin);
-
-    CommandLineTestRunner commandLineTestRunner(2, argv, &output, &registry);
-    commandLineTestRunner.runAllTestsMain();
-    registry.removePluginByName("PluginCountingPlugin");
-
-    LONGS_EQUAL(0, registry.countPlugins());
-    LONGS_EQUAL(1, pluginCountingPlugin->amountOfPlugins);
-}
-
 TEST(CommandLineTestRunner, NoPluginsAreInstalledAtTheEndOfARunWhenTheArgumentsAreInvalid)
 {
-    const char* argv[] = { "tests.exe", "-fdskjnfkds"};
+    const char* argv[] = { "tests.exe", "-fdskjnfkds" };
+    CommandLineArguments arguments( 2, argv );
 
-    CommandLineTestRunner commandLineTestRunner(2, argv, &output, &registry);
+    CommandLineTestRunner commandLineTestRunner(&output, &registry, &arguments);
     commandLineTestRunner.runAllTestsMain();
 
     LONGS_EQUAL(0, registry.countPlugins());
@@ -98,22 +85,24 @@ TEST(CommandLineTestRunner, NoPluginsAreInstalledAtTheEndOfARunWhenTheArgumentsA
 
 struct TestOutputCheckingCommandLineTestRunner : public CommandLineTestRunner
 {
-    TestOutputCheckingCommandLineTestRunner(int ac, const char** av, TestOutput* output, TestRegistry* registry) :
-        CommandLineTestRunner(ac, av, output, registry)
+    TestOutputCheckingCommandLineTestRunner( TestOutput* output, TestRegistry* registry, CommandLineArguments* arguments ):
+        CommandLineTestRunner( output, registry, arguments)
     {
     }
 
     bool hasJUnitTestOutput(void)
     {
-        return (output_ == jUnitOutput_);
+        return ( dynamic_cast<JUnitTestOutput*>( output_ ) );
     }
 };
 
 TEST(CommandLineTestRunner, JunitOutputEnabled)
 {
-    const char* argv[] = { "tests.exe", "-ojunit"};
+    const char* argv[] = { "tests.exe", "-ojunit" };
+    CommandLineArguments arguments( 2, argv );
+    JUnitTestOutput output;
 
-    TestOutputCheckingCommandLineTestRunner testRunner(2, argv, &output, &registry);
+    TestOutputCheckingCommandLineTestRunner testRunner(&output, &registry, &arguments);
     testRunner.runAllTestsMain();
     CHECK(testRunner.hasJUnitTestOutput());
 }

--- a/tests/CommandLineTestRunnerTest.cpp
+++ b/tests/CommandLineTestRunnerTest.cpp
@@ -60,6 +60,7 @@ TEST_GROUP(CommandLineTestRunner)
 {
     TestRegistry registry;
     StringBufferTestOutput output;
+    JUnitTestOutput jUnitOutput;
     DummyPluginWhichCountsThePlugins* pluginCountingPlugin;
 
     void setup()
@@ -100,9 +101,8 @@ TEST(CommandLineTestRunner, JunitOutputEnabled)
 {
     const char* argv[] = { "tests.exe", "-ojunit" };
     CommandLineArguments arguments( 2, argv );
-    JUnitTestOutput output;
 
-    TestOutputCheckingCommandLineTestRunner testRunner(&output, &registry, &arguments);
+    TestOutputCheckingCommandLineTestRunner testRunner( &jUnitOutput, &registry, &arguments );
     testRunner.runAllTestsMain();
     CHECK(testRunner.hasJUnitTestOutput());
 }


### PR DESCRIPTION
Refactor CommandlineTestRunner such that the parsing of arguments and creation of Testoutput based on this result is extracted.

"int CommandLineTestRunner::RunAllTests(int ac, const char** av)"
Is getting a bit long, in a later step where the decorator pattern is applied the initialising of the "output" variable should be put in a separate function.