### PR TITLE
Issue571, step 2: Refactor TestOutput preparing for inserting decorator.

### DIFF
--- a/CppUTest.vcxproj
+++ b/CppUTest.vcxproj
@@ -146,6 +146,7 @@ copy $(OutDir)CppUTest.lib lib\CppUTest.lib
     <ClCompile Include="src\CppUTestExt\OrderedTest.cpp" />
     <ClCompile Include="src\CppUTest\CommandLineArguments.cpp" />
     <ClCompile Include="src\CppUTest\CommandLineTestRunner.cpp" />
+    <ClCompile Include="src\CppUTest\ConsoleTestOutput.cpp" />
     <ClCompile Include="src\CppUTest\JUnitTestOutput.cpp" />
     <ClCompile Include="src\CppUTest\MemoryLeakDetector.cpp" />
     <ClCompile Include="src\CppUTest\MemoryLeakWarningPlugin.cpp" />
@@ -184,6 +185,7 @@ copy $(OutDir)CppUTest.lib lib\CppUTest.lib
     <ClInclude Include="include\CppUTestExt\OrderedTest.h" />
     <ClInclude Include="include\CppUTest\CommandLineArguments.h" />
     <ClInclude Include="include\CppUTest\CommandLineTestRunner.h" />
+    <ClInclude Include="include\CppUTest\ConsoleTestOutput.h" />
     <ClInclude Include="include\CppUTest\JUnitTestOutput.h" />
     <ClInclude Include="include\CppUTest\MemoryLeakDetector.h" />
     <ClInclude Include="include\CppUTest\MemoryLeakDetectorMallocMacros.h" />
@@ -193,12 +195,14 @@ copy $(OutDir)CppUTest.lib lib\CppUTest.lib
     <ClInclude Include="include\CppUTest\SimpleMutex.h" />
     <ClInclude Include="include\CppUTest\SimpleString.h" />
     <ClInclude Include="include\CppUTest\StandardCLibrary.h" />
+    <ClInclude Include="include\CppUTest\StringBufferTestOutput.h" />
     <ClInclude Include="include\CppUTest\TestFailure.h" />
     <ClInclude Include="include\CppUTest\TestFilter.h" />
     <ClInclude Include="include\CppUTest\TestHarness.h" />
     <ClInclude Include="include\CppUTest\TestHarness_c.h" />
     <ClInclude Include="include\CppUTest\TestMemoryAllocator.h" />
     <ClInclude Include="include\CppUTest\TestOutput.h" />
+    <ClInclude Include="include\CppUTest\TestOutputDecorator.h" />
     <ClInclude Include="include\CppUTest\TestPlugin.h" />
     <ClInclude Include="include\CppUTest\TestRegistry.h" />
     <ClInclude Include="include\CppUTest\TestResult.h" />

--- a/Makefile.am
+++ b/Makefile.am
@@ -45,6 +45,7 @@ lib_libCppUTest_a_SOURCES = \
 	src/CppUTest/TestHarness_c.cpp \
 	src/CppUTest/TestMemoryAllocator.cpp \
 	src/CppUTest/TestOutput.cpp \
+	src/CppUTest/ConsoleTestOutput.cpp \
 	src/CppUTest/TestPlugin.cpp \
 	src/CppUTest/TestRegistry.cpp \
 	src/CppUTest/TestResult.cpp \
@@ -73,6 +74,8 @@ include_cpputest_HEADERS = \
 	include/CppUTest/TestHarness_c.h \
 	include/CppUTest/TestMemoryAllocator.h \
 	include/CppUTest/TestOutput.h \
+	include/CppUTest/ConsoleTestOutput.h \
+	include/CppUTest/StringBufferTestOutput.h \
 	include/CppUTest/TestPlugin.h \
 	include/CppUTest/TestRegistry.h \
 	include/CppUTest/TestResult.h \

--- a/include/CppUTest/CommandLineArguments.h
+++ b/include/CppUTest/CommandLineArguments.h
@@ -47,6 +47,7 @@ public:
     const TestFilter* getGroupFilters() const;
     const TestFilter* getNameFilters() const;
     bool isJUnitOutput() const;
+    bool isSuccesfullyParsed() const;
     bool isEclipseOutput() const;
     bool runTestsInSeperateProcess() const;
     const SimpleString& getPackageName() const;
@@ -69,6 +70,7 @@ private:
     TestFilter* nameFilters_;
     OutputType outputType_;
     SimpleString packageName_;
+    bool succesfullyParsed_;
 
     SimpleString getParameterField(int ac, const char** av, int& i, const SimpleString& parameterName);
     void SetRepeatCount(int ac, const char** av, int& index);

--- a/include/CppUTest/CommandLineTestRunner.h
+++ b/include/CppUTest/CommandLineTestRunner.h
@@ -49,20 +49,18 @@ public:
 
     static int RunAllTests(int ac, const char** av);
     static int RunAllTests(int ac, char** av);
-    CommandLineTestRunner(int ac, const char** av, TestOutput*, TestRegistry* registry);
+    CommandLineTestRunner(TestOutput*, TestRegistry* registry, CommandLineArguments* arguments );
 
     virtual ~CommandLineTestRunner();
     int runAllTestsMain();
 
 protected:
     TestOutput* output_;
-    JUnitTestOutput* jUnitOutput_;
 
 private:
     CommandLineArguments* arguments_;
     TestRegistry* registry_;
 
-    bool parseArguments(TestPlugin*);
     int runAllTests();
     void initializeTestRun();
 };

--- a/include/CppUTest/ConsoleTestOutput.h
+++ b/include/CppUTest/ConsoleTestOutput.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2007, Michael Feathers, James Grenning and Bas Vodde
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the <organization> nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE EARLIER MENTIONED AUTHORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL <copyright holder> BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef D_ConsoleTestOutput_h
+#define D_ConsoleTestOutput_h
+
+#include "CppUTest/TestOutput.h"
+
+
+///////////////////////////////////////////////////////////////////////////////
+//
+//  ConsoleTestOutput.h
+//
+//  Printf Based Solution
+//
+///////////////////////////////////////////////////////////////////////////////
+
+class ConsoleTestOutput: public TestOutput
+{
+public:
+    explicit ConsoleTestOutput( bool verbose = false, bool color = false );
+    virtual ~ConsoleTestOutput()
+    {
+    }
+
+    virtual void printTestsStarted() _override;
+    virtual void printTestsEnded( const TestResult& result ) _override;
+    virtual void printCurrentTestStarted( const UtestShell& test ) _override;
+    virtual void printCurrentTestEnded( const TestResult& res ) _override;
+    virtual void printCurrentGroupStarted( const UtestShell& test ) _override;
+    virtual void printCurrentGroupEnded( const TestResult& res ) _override;
+
+    virtual void printBuffer( const char* ) _override;
+    virtual void print( const char* ) _override;
+    virtual void print( long ) _override;
+    virtual void printDouble( double ) _override;
+    virtual void print( const TestFailure& failure ) _override;
+    virtual void printTestRun( int number, int total ) _override;
+    virtual void setProgressIndicator( const char* );
+
+    virtual void flush() _override;
+
+protected:
+  virtual void printEclipseErrorInFileOnLine( SimpleString file, int lineNumber );
+  virtual void printVistualStudioErrorInFileOnLine( SimpleString file, int lineNumber );
+
+  virtual void printProgressIndicator();
+  void printFileAndLineForTestAndFailure( const TestFailure& failure );
+  void printFileAndLineForFailure( const TestFailure& failure );
+  void printFailureInTest( SimpleString testName );
+  void printFailureMessage( SimpleString reason );
+  void printErrorInFileOnLineFormattedForWorkingEnvironment( SimpleString testFile, int lineNumber );
+
+  int dotCount_;
+  bool verbose_;
+  bool color_;
+  const char* progressIndication_;
+
+private:
+    ConsoleTestOutput(const ConsoleTestOutput&);
+    ConsoleTestOutput& operator=(const ConsoleTestOutput&);
+};
+
+#endif

--- a/include/CppUTest/JUnitTestOutput.h
+++ b/include/CppUTest/JUnitTestOutput.h
@@ -50,6 +50,8 @@ public:
     virtual void printBuffer(const char*) _override;
     virtual void print(const char*) _override;
     virtual void print(long) _override;
+    virtual void printDouble( double ) _override;
+    virtual void printTestRun( int number, int total ) _override;
     virtual void print(const TestFailure& failure) _override;
 
     virtual void flush() _override;

--- a/include/CppUTest/StringBufferTestOutput.h
+++ b/include/CppUTest/StringBufferTestOutput.h
@@ -25,32 +25,51 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "CppUTest/TestHarness.h"
-#include "CppUTest/TestOutput.h"
-#include "CppUTest/PlatformSpecificFunctions.h"
+#ifndef D_StringBufferTestOutput_h
+#define D_StringBufferTestOutput_h
 
-TestOutput::WorkingEnvironment TestOutput::workingEnvironment_ = TestOutput::detectEnvironment;
+#include "CppUTest/ConsoleTestOutput.h"
 
-void TestOutput::setWorkingEnvironment(TestOutput::WorkingEnvironment workEnvironment)
+///////////////////////////////////////////////////////////////////////////////
+//
+//  StringBufferTestOutput.h
+//
+//  TestOutput for test purposes
+//
+///////////////////////////////////////////////////////////////////////////////
+
+
+class StringBufferTestOutput: public ConsoleTestOutput
 {
-    workingEnvironment_ = workEnvironment;
-}
+public:
+    explicit StringBufferTestOutput( bool verbose = false, bool color = false ):
+      ConsoleTestOutput(verbose, color)
+    {
+    }
 
-TestOutput::WorkingEnvironment TestOutput::getWorkingEnvironment()
-{
-    if (workingEnvironment_ == TestOutput::detectEnvironment)
-        return PlatformSpecificGetWorkingEnvironment();
-    return workingEnvironment_;
-}
+    virtual ~StringBufferTestOutput() {}
 
-TestOutput& operator<<( TestOutput& p, const char* s )
-{
-    p.print( s );
-    return p;
-}
+    void printBuffer(const char* s) _override
+    {
+        output += s;
+    }
 
-TestOutput& operator<<( TestOutput& p, long int i )
-{
-    p.print( i );
-    return p;
-}
+    void flush() _override
+    {
+        output = "";
+    }
+
+    const SimpleString& getOutput()
+    {
+        return output;
+    }
+
+private:
+    SimpleString output;
+
+    StringBufferTestOutput(const StringBufferTestOutput&);
+    StringBufferTestOutput& operator=(const StringBufferTestOutput&);
+
+};
+
+#endif

--- a/include/CppUTest/TestOutput.h
+++ b/include/CppUTest/TestOutput.h
@@ -30,12 +30,14 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 //
-//  This is a minimal printer inteface.
+//  This is a minimal printer interface.
 //  We kept streams out too keep footprint small, and so the test
 //  harness could be used with less capable compilers so more
 //  platforms could use this test harness
 //
 ///////////////////////////////////////////////////////////////////////////////
+
+#include "SimpleString.h"
 
 class UtestShell;
 class TestFailure;
@@ -44,25 +46,22 @@ class TestResult;
 class TestOutput
 {
 public:
-    explicit TestOutput();
-    virtual ~TestOutput();
+    explicit TestOutput() {}
+    virtual ~TestOutput() {}
 
-    virtual void printTestsStarted();
-    virtual void printTestsEnded(const TestResult& result);
-    virtual void printCurrentTestStarted(const UtestShell& test);
-    virtual void printCurrentTestEnded(const TestResult& res);
-    virtual void printCurrentGroupStarted(const UtestShell& test);
-    virtual void printCurrentGroupEnded(const TestResult& res);
+    virtual void printTestsStarted() = 0;
+    virtual void printTestsEnded( const TestResult& result ) = 0;
+    virtual void printCurrentTestStarted( const UtestShell& test ) = 0;
+    virtual void printCurrentTestEnded( const TestResult& res ) = 0;
+    virtual void printCurrentGroupStarted( const UtestShell& test ) = 0;
+    virtual void printCurrentGroupEnded( const TestResult& res ) = 0;
 
-    virtual void verbose();
-    virtual void color();
     virtual void printBuffer(const char*)=0;
-    virtual void print(const char*);
-    virtual void print(long);
-    virtual void printDouble(double);
-    virtual void print(const TestFailure& failure);
-    virtual void printTestRun(int number, int total);
-    virtual void setProgressIndicator(const char*);
+    virtual void print( const char* ) = 0;
+    virtual void print( long ) = 0;
+    virtual void printDouble( double ) = 0;
+    virtual void print( const TestFailure& failure ) = 0;
+    virtual void printTestRun( int number, int total ) = 0;
 
     virtual void flush()=0;
 
@@ -72,96 +71,13 @@ public:
     static WorkingEnvironment getWorkingEnvironment();
 
 protected:
-
-    virtual void printEclipseErrorInFileOnLine(SimpleString file, int lineNumber);
-    virtual void printVistualStudioErrorInFileOnLine(SimpleString file, int lineNumber);
-
-    virtual void printProgressIndicator();
-    void printFileAndLineForTestAndFailure(const TestFailure& failure);
-    void printFileAndLineForFailure(const TestFailure& failure);
-    void printFailureInTest(SimpleString testName);
-    void printFailureMessage(SimpleString reason);
-    void printErrorInFileOnLineFormattedForWorkingEnvironment(SimpleString testFile, int lineNumber);
-
     TestOutput(const TestOutput&);
     TestOutput& operator=(const TestOutput&);
-
-    int dotCount_;
-    bool verbose_;
-    bool color_;
-    const char* progressIndication_;
 
     static WorkingEnvironment workingEnvironment_;
 };
 
 TestOutput& operator<<(TestOutput&, const char*);
 TestOutput& operator<<(TestOutput&, long);
-
-///////////////////////////////////////////////////////////////////////////////
-//
-//  ConsoleTestOutput.h
-//
-//  Printf Based Solution
-//
-///////////////////////////////////////////////////////////////////////////////
-
-class ConsoleTestOutput: public TestOutput
-{
-public:
-    explicit ConsoleTestOutput()
-    {
-    }
-    virtual ~ConsoleTestOutput()
-    {
-    }
-
-    virtual void printBuffer(const char* s) _override;
-    virtual void flush() _override;
-
-private:
-    ConsoleTestOutput(const ConsoleTestOutput&);
-    ConsoleTestOutput& operator=(const ConsoleTestOutput&);
-};
-
-///////////////////////////////////////////////////////////////////////////////
-//
-//  StringBufferTestOutput.h
-//
-//  TestOutput for test purposes
-//
-///////////////////////////////////////////////////////////////////////////////
-
-
-class StringBufferTestOutput: public TestOutput
-{
-public:
-    explicit StringBufferTestOutput()
-    {
-    }
-
-    virtual ~StringBufferTestOutput();
-
-    void printBuffer(const char* s) _override
-    {
-        output += s;
-    }
-
-    void flush() _override
-    {
-        output = "";
-    }
-
-    const SimpleString& getOutput()
-    {
-        return output;
-    }
-
-private:
-    SimpleString output;
-
-    StringBufferTestOutput(const StringBufferTestOutput&);
-    StringBufferTestOutput& operator=(const StringBufferTestOutput&);
-
-};
 
 #endif

--- a/include/CppUTest/TestTestingFixture.h
+++ b/include/CppUTest/TestTestingFixture.h
@@ -29,7 +29,7 @@
 #define D_TestTestingFixture_H
 
 #include "TestRegistry.h"
-#include "TestOutput.h"
+#include "StringBufferTestOutput.h"
 
 class TestTestingFixture
 {

--- a/platforms/Eclipse-Cygwin/.project
+++ b/platforms/Eclipse-Cygwin/.project
@@ -1059,6 +1059,16 @@
 			<type>1</type>
 			<locationURI>PARENT-2-ECLIPSE_HOME/00_Dev/05_CppUTest/cpputest/include/CppUTest/TestOutput.h</locationURI>
 		</link>
+    <link>
+			<name>include/CppUTest/ConsoleTestOutput.h</name>
+			<type>1</type>
+			<locationURI>PARENT-2-ECLIPSE_HOME/00_Dev/05_CppUTest/cpputest/include/CppUTest/ConsoleTestOutput.h</locationURI>
+		</link>
+    <link>
+			<name>include/CppUTest/StringBufferTestOutput.h</name>
+			<type>1</type>
+			<locationURI>PARENT-2-ECLIPSE_HOME/00_Dev/05_CppUTest/cpputest/include/CppUTest/StringBufferTestOutput.h</locationURI>
+		</link>
 		<link>
 			<name>include/CppUTest/TestPlugin.h</name>
 			<type>1</type>
@@ -1538,6 +1548,11 @@
 			<name>src/CppUTest/TestOutput.cpp</name>
 			<type>1</type>
 			<locationURI>PARENT-2-ECLIPSE_HOME/00_Dev/05_CppUTest/cpputest/src/CppUTest/TestOutput.cpp</locationURI>
+		</link>
+    <link>
+			<name>include/CppUTest/ConsoleTestOutput.cpp</name>
+			<type>1</type>
+			<locationURI>PARENT-2-ECLIPSE_HOME/00_Dev/05_CppUTest/cpputest/src/CppUTest/ConsoleTestOutput.cpp</locationURI>
 		</link>
 		<link>
 			<name>src/CppUTest/TestPlugin.cpp</name>

--- a/src/CppUTest/CMakeLists.txt
+++ b/src/CppUTest/CMakeLists.txt
@@ -10,6 +10,7 @@ set(CppUTest_src
         JUnitTestOutput.cpp
         TestFailure.cpp
         TestOutput.cpp
+        ConsoleTestOutput.cpp
         MemoryLeakDetector.cpp
         TestFilter.cpp
         TestPlugin.cpp
@@ -25,6 +26,8 @@ set(CppUTest_headers
         ${CppUTestRootDirectory}/include/CppUTest/CommandLineTestRunner.h
         ${CppUTestRootDirectory}/include/CppUTest/PlatformSpecificFunctions_c.h
         ${CppUTestRootDirectory}/include/CppUTest/TestOutput.h
+        ${CppUTestRootDirectory}/include/CppUTest/ConsoleTestOutput.h
+        ${CppUTestRootDirectory}/include/CppUTest/StringBufferTestOutput.h
         ${CppUTestRootDirectory}/include/CppUTest/CppUTestConfig.h
         ${CppUTestRootDirectory}/include/CppUTest/SimpleString.h
         ${CppUTestRootDirectory}/include/CppUTest/TestPlugin.h

--- a/src/CppUTest/CommandLineArguments.cpp
+++ b/src/CppUTest/CommandLineArguments.cpp
@@ -30,7 +30,7 @@
 #include "CppUTest/PlatformSpecificFunctions.h"
 
 CommandLineArguments::CommandLineArguments(int ac, const char** av) :
-    ac_(ac), av_(av), verbose_(false), color_(false), runTestsAsSeperateProcess_(false), repeat_(1), groupFilters_(NULL), nameFilters_(NULL), outputType_(OUTPUT_ECLIPSE)
+    ac_(ac), av_(av), verbose_(false), color_(false), runTestsAsSeperateProcess_(false), repeat_(1), groupFilters_(NULL), nameFilters_(NULL), outputType_(OUTPUT_ECLIPSE), succesfullyParsed_(false)
 {
 }
 
@@ -69,15 +69,21 @@ bool CommandLineArguments::parse(TestPlugin* plugin)
         else correctParameters = false;
 
         if (correctParameters == false) {
+            succesfullyParsed_ = false;
             return false;
         }
     }
+    succesfullyParsed_ = true;
     return true;
 }
 
 const char* CommandLineArguments::usage() const
 {
     return "usage [-v] [-c] [-r#] [-g|sg groupName]... [-n|sn testName]... [\"TEST(groupName, testName)\"]... [-o{normal, junit}] [-k packageName]\n";
+}
+
+bool CommandLineArguments::isSuccesfullyParsed() const {
+    return succesfullyParsed_;
 }
 
 bool CommandLineArguments::isVerbose() const

--- a/src/CppUTest/CommandLineTestRunner.cpp
+++ b/src/CppUTest/CommandLineTestRunner.cpp
@@ -27,7 +27,7 @@
 
 #include "CppUTest/TestHarness.h"
 #include "CppUTest/CommandLineTestRunner.h"
-#include "CppUTest/TestOutput.h"
+#include "CppUTest/ConsoleTestOutput.h"
 #include "CppUTest/JUnitTestOutput.h"
 #include "CppUTest/TestRegistry.h"
 
@@ -59,7 +59,7 @@ int CommandLineTestRunner::RunAllTests(int ac, const char** av)
         output = jUnitOutput;
     }
     else {
-        output = new ConsoleTestOutput;
+        output = new ConsoleTestOutput( arguments.isVerbose(), arguments.isColor() );
     }
 
     MemoryLeakWarningPlugin memLeakWarn(DEF_PLUGIN_MEM_LEAK);
@@ -105,8 +105,6 @@ void CommandLineTestRunner::initializeTestRun()
 {
     registry_->setGroupFilters(arguments_->getGroupFilters());
     registry_->setNameFilters(arguments_->getNameFilters());
-    if (arguments_->isVerbose()) output_->verbose();
-    if (arguments_->isColor()) output_->color();
     if (arguments_->runTestsInSeperateProcess()) registry_->setRunTestsInSeperateProcess();
 }
 

--- a/src/CppUTest/ConsoleTestOutput.cpp
+++ b/src/CppUTest/ConsoleTestOutput.cpp
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) 2007, Michael Feathers, James Grenning and Bas Vodde
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the <organization> nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE EARLIER MENTIONED AUTHORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL <copyright holder> BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "CppUTest/TestHarness.h"
+#include "CppUTest/ConsoleTestOutput.h"
+#include "CppUTest/PlatformSpecificFunctions.h"
+
+
+ConsoleTestOutput::ConsoleTestOutput(bool verbose, bool color) :
+    dotCount_(0), verbose_(verbose), color_(color), progressIndication_(".")
+{
+}
+
+void ConsoleTestOutput::print(const char* str)
+{
+    printBuffer(str);
+}
+
+void ConsoleTestOutput::print(long n)
+{
+    print(StringFrom(n).asCharString());
+}
+
+void ConsoleTestOutput::printDouble(double d)
+{
+    print(StringFrom(d).asCharString());
+}
+
+void ConsoleTestOutput::printCurrentTestStarted(const UtestShell& test)
+{
+    if (verbose_) print(test.getFormattedName().asCharString());
+
+    if (test.willRun()) {
+       setProgressIndicator(".");
+    }
+    else {
+       setProgressIndicator("!");
+    }
+}
+
+void ConsoleTestOutput::printCurrentTestEnded(const TestResult& res)
+{
+    if (verbose_) {
+        print(" - ");
+        print(res.getCurrentTestTotalExecutionTime());
+        print(" ms\n");
+    }
+    else {
+        printProgressIndicator();
+    }
+}
+
+void ConsoleTestOutput::printProgressIndicator()
+{
+    print(progressIndication_);
+    if (++dotCount_ % 50 == 0) print("\n");
+}
+
+void ConsoleTestOutput::setProgressIndicator(const char* indicator)
+{
+    progressIndication_ = indicator;
+}
+
+void ConsoleTestOutput::printTestsStarted()
+{
+}
+
+void ConsoleTestOutput::printCurrentGroupStarted(const UtestShell& /*test*/)
+{
+}
+
+void ConsoleTestOutput::printCurrentGroupEnded(const TestResult& /*res*/)
+{
+}
+
+void ConsoleTestOutput::printTestsEnded(const TestResult& result)
+{
+    print("\n");
+    if (result.getFailureCount() > 0) {
+        if (color_) {
+            print("\033[31;1m");
+        }
+        print("Errors (");
+        print(result.getFailureCount());
+        print(" failures, ");
+    }
+    else {
+        if (color_) {
+            print("\033[32;1m");
+        }
+        print("OK (");
+    }
+    print(result.getTestCount());
+    print(" tests, ");
+    print(result.getRunCount());
+    print(" ran, ");
+    print(result.getCheckCount());
+    print(" checks, ");
+    print(result.getIgnoredCount());
+    print(" ignored, ");
+    print(result.getFilteredOutCount());
+    print(" filtered out, ");
+    print(result.getTotalExecutionTime());
+    print(" ms)");
+    if (color_) {
+        print("\033[m");
+    }
+    print("\n\n");
+}
+
+void ConsoleTestOutput::printTestRun(int number, int total)
+{
+    if (total > 1) {
+        print("Test run ");
+        print(number);
+        print(" of ");
+        print(total);
+        print("\n");
+    }
+}
+
+void ConsoleTestOutput::print(const TestFailure& failure)
+{
+    if (failure.isOutsideTestFile() || failure.isInHelperFunction())
+        printFileAndLineForTestAndFailure(failure);
+    else
+        printFileAndLineForFailure(failure);
+
+    printFailureMessage(failure.getMessage());
+}
+
+void ConsoleTestOutput::printFileAndLineForTestAndFailure(const TestFailure& failure)
+{
+    printErrorInFileOnLineFormattedForWorkingEnvironment(failure.getTestFileName(), failure.getTestLineNumber());
+    printFailureInTest(failure.getTestName());
+    printErrorInFileOnLineFormattedForWorkingEnvironment(failure.getFileName(), failure.getFailureLineNumber());
+}
+
+void ConsoleTestOutput::printFileAndLineForFailure(const TestFailure& failure)
+{
+    printErrorInFileOnLineFormattedForWorkingEnvironment(failure.getFileName(), failure.getFailureLineNumber());
+    printFailureInTest(failure.getTestName());
+}
+
+void ConsoleTestOutput::printFailureInTest(SimpleString testName)
+{
+    print(" Failure in ");
+    print(testName.asCharString());
+}
+
+void ConsoleTestOutput::printFailureMessage(SimpleString reason)
+{
+    print("\n");
+    print("\t");
+    print(reason.asCharString());
+    print("\n\n");
+}
+
+void ConsoleTestOutput::printErrorInFileOnLineFormattedForWorkingEnvironment(SimpleString file, int lineNumber)
+{
+    if (ConsoleTestOutput::getWorkingEnvironment() == ConsoleTestOutput::vistualStudio)
+        printVistualStudioErrorInFileOnLine(file, lineNumber);
+    else
+        printEclipseErrorInFileOnLine(file, lineNumber);
+}
+
+void ConsoleTestOutput::printEclipseErrorInFileOnLine(SimpleString file, int lineNumber)
+{
+    print("\n");
+    print(file.asCharString());
+    print(":");
+    print(lineNumber);
+    print(":");
+    print(" error:");
+}
+
+void ConsoleTestOutput::printVistualStudioErrorInFileOnLine(SimpleString file, int lineNumber)
+{
+    print("\n");
+    print(file.asCharString());
+    print("(");
+    print(lineNumber);
+    print("):");
+    print(" error:");
+}
+
+void ConsoleTestOutput::printBuffer(const char* s)
+{
+    while (*s) {
+        PlatformSpecificPutchar(*s);
+        s++;
+    }
+    flush();
+}
+
+void ConsoleTestOutput::flush()
+{
+    PlatformSpecificFlush();
+}

--- a/src/CppUTest/JUnitTestOutput.cpp
+++ b/src/CppUTest/JUnitTestOutput.cpp
@@ -253,6 +253,14 @@ void JUnitTestOutput::print(long)
 {
 }
 
+void JUnitTestOutput::printDouble( double )
+{
+}
+
+void JUnitTestOutput::printTestRun( int /*number*/, int /*total*/ )
+{
+}
+
 void JUnitTestOutput::flush()
 {
 }

--- a/src/CppUTest/Utest.cpp
+++ b/src/CppUTest/Utest.cpp
@@ -28,7 +28,7 @@
 #include "CppUTest/TestHarness.h"
 #include "CppUTest/TestRegistry.h"
 #include "CppUTest/PlatformSpecificFunctions.h"
-#include "CppUTest/TestOutput.h"
+#include "CppUTest/ConsoleTestOutput.h"
 
 bool doubles_equal(double d1, double d2, double threshold)
 {

--- a/tests/CommandLineTestRunnerTest.cpp
+++ b/tests/CommandLineTestRunnerTest.cpp
@@ -72,25 +72,12 @@ TEST_GROUP(CommandLineTestRunner)
     }
 };
 
-TEST(CommandLineTestRunner, OnePluginGetsInstalledDuringTheRunningTheTests)
-{
-    const char* argv[] = { "tests.exe", "-psomething"};
-
-    registry.installPlugin(pluginCountingPlugin);
-
-    CommandLineTestRunner commandLineTestRunner(2, argv, &output, &registry);
-    commandLineTestRunner.runAllTestsMain();
-    registry.removePluginByName("PluginCountingPlugin");
-
-    LONGS_EQUAL(0, registry.countPlugins());
-    LONGS_EQUAL(1, pluginCountingPlugin->amountOfPlugins);
-}
-
 TEST(CommandLineTestRunner, NoPluginsAreInstalledAtTheEndOfARunWhenTheArgumentsAreInvalid)
 {
-    const char* argv[] = { "tests.exe", "-fdskjnfkds"};
+    const char* argv[] = { "tests.exe", "-fdskjnfkds" };
+    CommandLineArguments arguments( 2, argv );
 
-    CommandLineTestRunner commandLineTestRunner(2, argv, &output, &registry);
+    CommandLineTestRunner commandLineTestRunner(&output, &registry, &arguments);
     commandLineTestRunner.runAllTestsMain();
 
     LONGS_EQUAL(0, registry.countPlugins());
@@ -98,22 +85,24 @@ TEST(CommandLineTestRunner, NoPluginsAreInstalledAtTheEndOfARunWhenTheArgumentsA
 
 struct TestOutputCheckingCommandLineTestRunner : public CommandLineTestRunner
 {
-    TestOutputCheckingCommandLineTestRunner(int ac, const char** av, TestOutput* output, TestRegistry* registry) :
-        CommandLineTestRunner(ac, av, output, registry)
+    TestOutputCheckingCommandLineTestRunner( TestOutput* output, TestRegistry* registry, CommandLineArguments* arguments ):
+        CommandLineTestRunner( output, registry, arguments)
     {
     }
 
     bool hasJUnitTestOutput(void)
     {
-        return (output_ == jUnitOutput_);
+        return ( dynamic_cast<JUnitTestOutput*>( output_ ) );
     }
 };
 
 TEST(CommandLineTestRunner, JunitOutputEnabled)
 {
-    const char* argv[] = { "tests.exe", "-ojunit"};
+    const char* argv[] = { "tests.exe", "-ojunit" };
+    CommandLineArguments arguments( 2, argv );
+    JUnitTestOutput output;
 
-    TestOutputCheckingCommandLineTestRunner testRunner(2, argv, &output, &registry);
+    TestOutputCheckingCommandLineTestRunner testRunner(&output, &registry, &arguments);
     testRunner.runAllTestsMain();
     CHECK(testRunner.hasJUnitTestOutput());
 }

--- a/tests/CommandLineTestRunnerTest.cpp
+++ b/tests/CommandLineTestRunnerTest.cpp
@@ -60,6 +60,7 @@ TEST_GROUP(CommandLineTestRunner)
 {
     TestRegistry registry;
     StringBufferTestOutput output;
+    JUnitTestOutput jUnitOutput;
     DummyPluginWhichCountsThePlugins* pluginCountingPlugin;
 
     void setup()
@@ -100,9 +101,8 @@ TEST(CommandLineTestRunner, JunitOutputEnabled)
 {
     const char* argv[] = { "tests.exe", "-ojunit" };
     CommandLineArguments arguments( 2, argv );
-    JUnitTestOutput output;
 
-    TestOutputCheckingCommandLineTestRunner testRunner(&output, &registry, &arguments);
+    TestOutputCheckingCommandLineTestRunner testRunner( &jUnitOutput, &registry, &arguments );
     testRunner.runAllTestsMain();
     CHECK(testRunner.hasJUnitTestOutput());
 }

--- a/tests/CppUTestExt/CodeMemoryReportFormatterTest.cpp
+++ b/tests/CppUTestExt/CodeMemoryReportFormatterTest.cpp
@@ -26,7 +26,7 @@
  */
 
 #include "CppUTest/TestHarness.h"
-#include "CppUTest/TestOutput.h"
+#include "CppUTest/StringBufferTestOutput.h"
 #include "CppUTestExt/MemoryReportAllocator.h"
 #include "CppUTestExt/CodeMemoryReportFormatter.h"
 

--- a/tests/CppUTestExt/GTest1Test.cpp
+++ b/tests/CppUTestExt/GTest1Test.cpp
@@ -79,7 +79,7 @@ TEST(GTestSimpleTest, GTestDeathTest)
 #undef TEST
 
 #include "CppUTest/TestHarness.h"
-#include "CppUTest/TestOutput.h"
+#include "CppUTest/StringBufferTestOutput.h"
 #include "CppUTest/TestTestingFixture.h"
 
 TEST_GROUP(gtest)

--- a/tests/CppUTestExt/MemoryReportFormatterTest.cpp
+++ b/tests/CppUTestExt/MemoryReportFormatterTest.cpp
@@ -26,7 +26,7 @@
  */
 
 #include "CppUTest/TestHarness.h"
-#include "CppUTest/TestOutput.h"
+#include "CppUTest/StringBufferTestOutput.h"
 #include "CppUTestExt/MemoryReportAllocator.h"
 #include "CppUTestExt/MemoryReportFormatter.h"
 

--- a/tests/CppUTestExt/MemoryReporterPluginTest.cpp
+++ b/tests/CppUTestExt/MemoryReporterPluginTest.cpp
@@ -26,7 +26,7 @@
  */
 
 #include "CppUTest/TestHarness.h"
-#include "CppUTest/TestOutput.h"
+#include "CppUTest/StringBufferTestOutput.h"
 #include "CppUTestExt/MemoryReporterPlugin.h"
 #include "CppUTestExt/MemoryReportFormatter.h"
 #include "CppUTestExt/MockSupport.h"

--- a/tests/CppUTestExt/MockPluginTest.cpp
+++ b/tests/CppUTestExt/MockPluginTest.cpp
@@ -25,7 +25,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "CppUTest/TestHarness.h"
-#include "CppUTest/TestOutput.h"
+#include "CppUTest/StringBufferTestOutput.h"
 #include "CppUTestExt/MockSupport.h"
 #include "CppUTestExt/MockSupportPlugin.h"
 #include "MockFailureTest.h"

--- a/tests/SetPluginTest.cpp
+++ b/tests/SetPluginTest.cpp
@@ -1,6 +1,6 @@
 #include "CppUTest/TestHarness.h"
 #include "CppUTest/TestRegistry.h"
-#include "CppUTest/TestOutput.h"
+#include "CppUTest/StringBufferTestOutput.h"
 #include "CppUTest/TestPlugin.h"
 
 static void orig_func1()

--- a/tests/TestRegistryTest.cpp
+++ b/tests/TestRegistryTest.cpp
@@ -27,7 +27,7 @@
 
 #include "CppUTest/TestHarness.h"
 #include "CppUTest/TestRegistry.h"
-#include "CppUTest/TestOutput.h"
+#include "CppUTest/StringBufferTestOutput.h"
 
 namespace
 {

--- a/tests/TestResultTest.cpp
+++ b/tests/TestResultTest.cpp
@@ -27,7 +27,7 @@
 
 #include "CppUTest/TestHarness.h"
 #include "CppUTest/PlatformSpecificFunctions.h"
-#include "CppUTest/TestOutput.h"
+#include "CppUTest/StringBufferTestOutput.h"
 
 extern "C" {
 

--- a/tests/TestUTestMacro.cpp
+++ b/tests/TestUTestMacro.cpp
@@ -706,7 +706,8 @@ TEST(IgnoreTest, doesIgnoreCount)
 
 TEST(IgnoreTest, printsIGNORE_TESTwhenVerbose)
 {
-    fixture.output_->verbose();
+    delete fixture.output_;
+    fixture.output_ = new StringBufferTestOutput(true);
     fixture.runAllTests();
     fixture.assertPrintContains("IGNORE_TEST");
 }


### PR DESCRIPTION
Moved everything to specialised classes leaving TestOutput only as the interface so lateron a TestOutputDecorator can be placed right below TestOutput in the inheritance chain(s)