### PR TITLE
Suggestion for first step: Extract color into decorator.

### DIFF
--- a/include/CppUTest/CommandLineTestRunner.h
+++ b/include/CppUTest/CommandLineTestRunner.h
@@ -56,6 +56,7 @@ public:
 
 protected:
     TestOutput* output_;
+    ColoredTestOutput* colorOutput_;
     JUnitTestOutput* jUnitOutput_;
 
 private:

--- a/include/CppUTest/TestOutput.h
+++ b/include/CppUTest/TestOutput.h
@@ -127,30 +127,10 @@ public:
     ColoredTestOutput(ConsoleTestOutput* testOutput) : c_(testOutput) {}
     virtual ~ColoredTestOutput() {}
     
-    virtual void printCurrentTestStarted(const UtestShell& test) _override
-    {
-        c_->printCurrentTestStarted(test);
-    }
-
-    virtual void printCurrentTestEnded(const TestResult& res) _override
-    {
-        c_->printCurrentTestEnded(res);
-    }
-
-    virtual void printTestsEnded(const TestResult& result) _override
-    {
-        if (result.getFailureCount() > 0)
-            c_->print("\033[31;1m");
-        else
-            c_->print("\033[32;1m");
-        c_->printTestsEnded(result);
-        c_->print("\033[m");
-    }
-   
-    virtual void flush() _override
-    {
-        c_->flush();
-    }
+    virtual void printCurrentTestStarted(const UtestShell& test) _override;
+    virtual void printCurrentTestEnded(const TestResult& res) _override;
+    virtual void printTestsEnded(const TestResult& result) _override;
+    virtual void flush() _override;
     
 private:
     explicit ColoredTestOutput() {}

--- a/include/CppUTest/TestOutput.h
+++ b/include/CppUTest/TestOutput.h
@@ -126,6 +126,16 @@ class ColoredTestOutput: public ConsoleTestOutput
 public:
     ColoredTestOutput(ConsoleTestOutput* testOutput) : c_(testOutput) {}
     virtual ~ColoredTestOutput() {}
+    
+    virtual void printCurrentTestStarted(const UtestShell& test) _override
+    {
+        c_->printCurrentTestStarted(test);
+    }
+
+    virtual void printCurrentTestEnded(const TestResult& res) _override
+    {
+        c_->printCurrentTestEnded(res);
+    }
 
     virtual void printTestsEnded(const TestResult& result) _override
     {
@@ -136,12 +146,12 @@ public:
         c_->printTestsEnded(result);
         c_->print("\033[m");
     }
-    
+   
     virtual void flush() _override
     {
         c_->flush();
     }
-
+    
 private:
     explicit ColoredTestOutput() {}
     ConsoleTestOutput* c_;

--- a/include/CppUTest/TestOutput.h
+++ b/include/CppUTest/TestOutput.h
@@ -55,7 +55,6 @@ public:
     virtual void printCurrentGroupEnded(const TestResult& res);
 
     virtual void verbose();
-    virtual void color();
     virtual void printBuffer(const char*)=0;
     virtual void print(const char*);
     virtual void print(long);
@@ -88,7 +87,6 @@ protected:
 
     int dotCount_;
     bool verbose_;
-    bool color_;
     const char* progressIndication_;
 
     static WorkingEnvironment workingEnvironment_;
@@ -123,6 +121,34 @@ private:
     ConsoleTestOutput& operator=(const ConsoleTestOutput&);
 };
 
+class ColoredTestOutput: public ConsoleTestOutput
+{
+public:
+    ColoredTestOutput(ConsoleTestOutput* testOutput) : c_(testOutput) {}
+    virtual ~ColoredTestOutput() {}
+
+    virtual void printTestsEnded(const TestResult& result) _override
+    {
+        if (result.getFailureCount() > 0)
+            c_->print("\033[31;1m");
+        else
+            c_->print("\033[32;1m");
+        c_->printTestsEnded(result);
+        c_->print("\033[m");
+    }
+    
+    virtual void flush() _override
+    {
+        c_->flush();
+    }
+
+private:
+    explicit ColoredTestOutput() {}
+    ConsoleTestOutput* c_;
+    ColoredTestOutput(const ColoredTestOutput&);
+    ColoredTestOutput& operator=(const ColoredTestOutput&);
+};
+
 ///////////////////////////////////////////////////////////////////////////////
 //
 //  StringBufferTestOutput.h
@@ -132,7 +158,7 @@ private:
 ///////////////////////////////////////////////////////////////////////////////
 
 
-class StringBufferTestOutput: public TestOutput
+class StringBufferTestOutput: public ConsoleTestOutput
 {
 public:
     explicit StringBufferTestOutput()

--- a/src/CppUTest/CommandLineTestRunner.cpp
+++ b/src/CppUTest/CommandLineTestRunner.cpp
@@ -32,7 +32,7 @@
 #include "CppUTest/TestRegistry.h"
 
 CommandLineTestRunner::CommandLineTestRunner(int ac, const char** av, TestOutput* output, TestRegistry* registry) :
-    output_(output), jUnitOutput_(NULL), arguments_(NULL), registry_(registry)
+    output_(output), colorOutput_(NULL), jUnitOutput_(NULL), arguments_(NULL), registry_(registry)
 {
     arguments_ = new CommandLineArguments(ac, av);
 }
@@ -40,6 +40,7 @@ CommandLineTestRunner::CommandLineTestRunner(int ac, const char** av, TestOutput
 CommandLineTestRunner::~CommandLineTestRunner()
 {
     delete arguments_;
+    delete colorOutput_;
     delete jUnitOutput_;
 }
 
@@ -88,7 +89,10 @@ void CommandLineTestRunner::initializeTestRun()
     registry_->setGroupFilters(arguments_->getGroupFilters());
     registry_->setNameFilters(arguments_->getNameFilters());
     if (arguments_->isVerbose()) output_->verbose();
-    if (arguments_->isColor()) output_->color();
+    if (arguments_->isColor()) {
+        colorOutput_ = new ColoredTestOutput((ConsoleTestOutput*)output_);
+        output_ = colorOutput_;
+    }
     if (arguments_->runTestsInSeperateProcess()) registry_->setRunTestsInSeperateProcess();
 }
 

--- a/src/CppUTest/TestOutput.cpp
+++ b/src/CppUTest/TestOutput.cpp
@@ -248,6 +248,32 @@ void ConsoleTestOutput::flush()
     PlatformSpecificFlush();
 }
 
+void ColoredTestOutput::printCurrentTestStarted(const UtestShell& test)
+{
+    c_->printCurrentTestStarted(test);
+}
+
+void ColoredTestOutput::printCurrentTestEnded(const TestResult& res)
+{
+    c_->printCurrentTestEnded(res);
+}
+
+ void ColoredTestOutput::printTestsEnded(const TestResult& result)
+{
+    if (result.getFailureCount() > 0)
+        c_->print("\033[31;1m");
+    else
+        c_->print("\033[32;1m");
+    c_->printTestsEnded(result);
+    c_->print("\033[m");
+}
+   
+void ColoredTestOutput::flush()
+{
+    c_->flush();
+}
+    
+
 StringBufferTestOutput::~StringBufferTestOutput()
 {
 }

--- a/src/CppUTest/TestOutput.cpp
+++ b/src/CppUTest/TestOutput.cpp
@@ -45,7 +45,7 @@ TestOutput::WorkingEnvironment TestOutput::getWorkingEnvironment()
 
 
 TestOutput::TestOutput() :
-    dotCount_(0), verbose_(false), color_(false), progressIndication_(".")
+    dotCount_(0), verbose_(false), progressIndication_(".")
 {
 }
 
@@ -56,11 +56,6 @@ TestOutput::~TestOutput()
 void TestOutput::verbose()
 {
     verbose_ = true;
-}
-
-void TestOutput::color()
-{
-    color_ = true;
 }
 
 void TestOutput::print(const char* str)
@@ -141,17 +136,11 @@ void TestOutput::printTestsEnded(const TestResult& result)
 {
     print("\n");
     if (result.getFailureCount() > 0) {
-        if (color_) {
-            print("\033[31;1m");
-        }
         print("Errors (");
         print(result.getFailureCount());
         print(" failures, ");
     }
     else {
-        if (color_) {
-            print("\033[32;1m");
-        }
         print("OK (");
     }
     print(result.getTestCount());
@@ -166,9 +155,6 @@ void TestOutput::printTestsEnded(const TestResult& result)
     print(" filtered out, ");
     print(result.getTotalExecutionTime());
     print(" ms)");
-    if (color_) {
-        print("\033[m");
-    }
     print("\n\n");
 }
 

--- a/tests/TestOutputTest.cpp
+++ b/tests/TestOutputTest.cpp
@@ -147,18 +147,18 @@ TEST(TestOutput, PrintTestVerboseEnded)
 
 TEST(TestOutput, printColorWithSuccess)
 {
-    mock->color();
-    printer->printTestsEnded(*result);
-    STRCMP_EQUAL("\n\033[32;1mOK (0 tests, 0 ran, 0 checks, 0 ignored, 0 filtered out, 10 ms)\033[m\n\n", mock->getOutput().asCharString());
+    ColoredTestOutput coloredMock(mock);
+    coloredMock.printTestsEnded(*result);
+    STRCMP_EQUAL("\033[32;1m\nOK (0 tests, 0 ran, 0 checks, 0 ignored, 0 filtered out, 10 ms)\n\n\033[m", mock->getOutput().asCharString());
 }
 
 TEST(TestOutput, printColorWithFailures)
 {
-    mock->color();
+    ColoredTestOutput coloredMock(mock);
     result->addFailure(*f);
-    printer->flush();
-    printer->printTestsEnded(*result);
-    STRCMP_EQUAL("\n\033[31;1mErrors (1 failures, 0 tests, 0 ran, 0 checks, 0 ignored, 0 filtered out, 10 ms)\033[m\n\n", mock->getOutput().asCharString());
+    coloredMock.flush();
+    coloredMock.printTestsEnded(*result);
+    STRCMP_EQUAL("\033[31;1m\nErrors (1 failures, 0 tests, 0 ran, 0 checks, 0 ignored, 0 filtered out, 10 ms)\n\n\033[m", mock->getOutput().asCharString());
 }
 
 TEST(TestOutput, PrintTestRun)

--- a/tests/TestOutputTest.cpp
+++ b/tests/TestOutputTest.cpp
@@ -161,6 +161,16 @@ TEST(TestOutput, printColorWithFailures)
     STRCMP_EQUAL("\033[31;1m\nErrors (1 failures, 0 tests, 0 ran, 0 checks, 0 ignored, 0 filtered out, 10 ms)\n\n\033[m", mock->getOutput().asCharString());
 }
 
+TEST(TestOutput, PrintVerboseAndColorCombined)
+{
+    mock->verbose();
+    ColoredTestOutput coloredMock(mock);
+    coloredMock.printCurrentTestStarted(*tst);
+    result->currentTestEnded(tst);
+    coloredMock.printTestsEnded(*result);
+    STRCMP_CONTAINS("TEST(group, test) - 0 ms\n\033[32;1m\nOK (0 tests, 0 ran, ", mock->getOutput().asCharString());
+}
+
 TEST(TestOutput, PrintTestRun)
 {
     printer->printTestRun(2, 3);


### PR DESCRIPTION
NOTE:
1. This still needs improvement - for example, should probably be initialized in the same placeas junit output
2. For some reason, the combination -v -c doesn't work. This will probably go away once -v is also handled via decorator.
3. Slight changes to the expected output -- the newlines are now in color ;-)
4. Even this small change affects five files :-(