### PR TITLE
cso - print verbose output with -junit

### DIFF
--- a/include/CppUTest/JUnitTestOutput.h
+++ b/include/CppUTest/JUnitTestOutput.h
@@ -37,7 +37,7 @@ struct JUnitTestCaseResultNode;
 class JUnitTestOutput: public TestOutput
 {
 public:
-    explicit JUnitTestOutput();
+    explicit JUnitTestOutput(ConsoleTestOutput* output = NULL);
     virtual ~JUnitTestOutput();
 
     virtual void printTestsStarted() _override;
@@ -47,10 +47,10 @@ public:
     virtual void printCurrentGroupStarted(const UtestShell& test) _override;
     virtual void printCurrentGroupEnded(const TestResult& res) _override;
 
-    virtual void verbose() _override {}
-    virtual void color() _override {}
-    virtual bool isVerbose() _override { return false; }
-    virtual void print(const char*) _override {}
+    virtual void verbose() _override { currentConsoleOutput_->verbose(); }
+    virtual void color() _override { currentConsoleOutput_->color(); }
+    virtual bool isVerbose() _override { return currentConsoleOutput_->isVerbose(); }
+    virtual void print(const char* str) _override { currentConsoleOutput_->print(str); }
     virtual void print(const TestFailure& failure) _override;
     virtual void printTestRun(int number, int total) _override;
 
@@ -74,6 +74,9 @@ protected:
     virtual void writeFailure(JUnitTestCaseResultNode* node);
     virtual void writeFileEnding();
 
+private:
+    ConsoleTestOutput* currentConsoleOutput_;
+    ConsoleTestOutput defaultConsoleOutput_;
 };
 
 #endif

--- a/include/CppUTest/JUnitTestOutput.h
+++ b/include/CppUTest/JUnitTestOutput.h
@@ -37,7 +37,7 @@ struct JUnitTestCaseResultNode;
 class JUnitTestOutput: public TestOutput
 {
 public:
-    JUnitTestOutput();
+    explicit JUnitTestOutput();
     virtual ~JUnitTestOutput();
 
     virtual void printTestsStarted() _override;
@@ -47,12 +47,12 @@ public:
     virtual void printCurrentGroupStarted(const UtestShell& test) _override;
     virtual void printCurrentGroupEnded(const TestResult& res) _override;
 
-    virtual void printBuffer(const char*) _override;
-    virtual void print(const char*) _override;
-    virtual void print(long) _override;
+    virtual void verbose() _override {}
+    virtual void color() _override {}
+    virtual bool isVerbose() _override { return false; }
+    virtual void print(const char*) _override {}
     virtual void print(const TestFailure& failure) _override;
-
-    virtual void flush() _override;
+    virtual void printTestRun(int number, int total) _override;
 
     virtual SimpleString createFileName(const SimpleString& group);
     void setPackageName(const SimpleString &package);

--- a/include/CppUTest/TestOutput.h
+++ b/include/CppUTest/TestOutput.h
@@ -44,32 +44,69 @@ class TestResult;
 class TestOutput
 {
 public:
-    explicit TestOutput();
-    virtual ~TestOutput();
+    explicit TestOutput() {}
+    virtual ~TestOutput() {}
 
-    virtual void printTestsStarted();
-    virtual void printTestsEnded(const TestResult& result);
-    virtual void printCurrentTestStarted(const UtestShell& test);
-    virtual void printCurrentTestEnded(const TestResult& res);
-    virtual void printCurrentGroupStarted(const UtestShell& test);
-    virtual void printCurrentGroupEnded(const TestResult& res);
+    virtual void printTestsStarted() = 0;
+    virtual void printTestsEnded(const TestResult& result) = 0;
+    virtual void printCurrentTestStarted(const UtestShell& test) = 0;
+    virtual void printCurrentTestEnded(const TestResult& res) = 0;
+    virtual void printCurrentGroupStarted(const UtestShell& test) = 0;
+    virtual void printCurrentGroupEnded(const TestResult& res) = 0;
 
-    virtual void verbose();
-    virtual void color();
-    virtual void printBuffer(const char*)=0;
-    virtual void print(const char*);
-    virtual void print(long);
-    virtual void printDouble(double);
-    virtual void print(const TestFailure& failure);
-    virtual void printTestRun(int number, int total);
-    virtual void setProgressIndicator(const char*);
-
-    virtual void flush()=0;
+    virtual void verbose() = 0;
+    virtual void color() = 0;
+    virtual bool isVerbose() = 0;
+    virtual void print(const char*) = 0;
+    virtual void print(const TestFailure& failure) = 0;
+    virtual void printTestRun(int number, int total) = 0;
 
     enum WorkingEnvironment {vistualStudio, eclipse, detectEnvironment};
 
     static void setWorkingEnvironment(WorkingEnvironment workEnvironment);
     static WorkingEnvironment getWorkingEnvironment();
+
+protected:
+
+    TestOutput(const TestOutput&);
+    TestOutput& operator=(const TestOutput&);
+
+    static WorkingEnvironment workingEnvironment_;
+};
+
+///////////////////////////////////////////////////////////////////////////////
+//
+//  ConsoleTestOutput.h
+//
+//  Printf Based Solution
+//
+///////////////////////////////////////////////////////////////////////////////
+
+class ConsoleTestOutput: public TestOutput
+{
+public:
+    explicit ConsoleTestOutput();
+    virtual ~ConsoleTestOutput();
+
+    virtual void printTestsStarted() _override;
+    virtual void printTestsEnded(const TestResult& result) _override;
+    virtual void printCurrentTestStarted(const UtestShell& test) _override;
+    virtual void printCurrentTestEnded(const TestResult& res) _override;
+    virtual void printCurrentGroupStarted(const UtestShell& test) _override;
+    virtual void printCurrentGroupEnded(const TestResult& res) _override;
+
+    virtual void verbose() _override;
+    virtual bool isVerbose() _override { return verbose_; }
+    virtual void color() _override;
+    virtual void printBuffer(const char*);
+    virtual void print(const char*) _override;
+    virtual void print(long);
+    virtual void printDouble(double);
+    virtual void print(const TestFailure& failure) _override;
+    virtual void printTestRun(int number, int total) _override;
+    virtual void setProgressIndicator(const char*);
+
+    virtual void flush();
 
 protected:
 
@@ -83,45 +120,18 @@ protected:
     void printFailureMessage(SimpleString reason);
     void printErrorInFileOnLineFormattedForWorkingEnvironment(SimpleString testFile, int lineNumber);
 
-    TestOutput(const TestOutput&);
-    TestOutput& operator=(const TestOutput&);
-
     int dotCount_;
     bool verbose_;
     bool color_;
     const char* progressIndication_;
 
-    static WorkingEnvironment workingEnvironment_;
-};
-
-TestOutput& operator<<(TestOutput&, const char*);
-TestOutput& operator<<(TestOutput&, long);
-
-///////////////////////////////////////////////////////////////////////////////
-//
-//  ConsoleTestOutput.h
-//
-//  Printf Based Solution
-//
-///////////////////////////////////////////////////////////////////////////////
-
-class ConsoleTestOutput: public TestOutput
-{
-public:
-    explicit ConsoleTestOutput()
-    {
-    }
-    virtual ~ConsoleTestOutput()
-    {
-    }
-
-    virtual void printBuffer(const char* s) _override;
-    virtual void flush() _override;
-
 private:
     ConsoleTestOutput(const ConsoleTestOutput&);
     ConsoleTestOutput& operator=(const ConsoleTestOutput&);
 };
+
+ConsoleTestOutput& operator<<(ConsoleTestOutput&, const char*);
+ConsoleTestOutput& operator<<(ConsoleTestOutput&, long);
 
 ///////////////////////////////////////////////////////////////////////////////
 //
@@ -132,13 +142,10 @@ private:
 ///////////////////////////////////////////////////////////////////////////////
 
 
-class StringBufferTestOutput: public TestOutput
+class StringBufferTestOutput: public ConsoleTestOutput
 {
 public:
-    explicit StringBufferTestOutput()
-    {
-    }
-
+    explicit StringBufferTestOutput() {}
     virtual ~StringBufferTestOutput();
 
     void printBuffer(const char* s) _override

--- a/src/CppUTest/JUnitTestOutput.cpp
+++ b/src/CppUTest/JUnitTestOutput.cpp
@@ -141,6 +141,10 @@ void JUnitTestOutput::printCurrentTestStarted(const UtestShell& test)
     }
 }
 
+void JUnitTestOutput::printTestRun(int /*number*/, int /*total*/)
+{
+}
+
 SimpleString JUnitTestOutput::createFileName(const SimpleString& group)
 {
     SimpleString fileName = "cpputest_";
@@ -238,26 +242,6 @@ void JUnitTestOutput::writeTestGroupToFile()
     writeFileEnding();
     closeFile();
 }
-
-// LCOV_EXCL_START
-
-void JUnitTestOutput::printBuffer(const char*)
-{
-}
-
-void JUnitTestOutput::print(const char*)
-{
-}
-
-void JUnitTestOutput::print(long)
-{
-}
-
-void JUnitTestOutput::flush()
-{
-}
-
-// LCOV_EXCL_STOP
 
 void JUnitTestOutput::print(const TestFailure& failure)
 {

--- a/src/CppUTest/JUnitTestOutput.cpp
+++ b/src/CppUTest/JUnitTestOutput.cpp
@@ -68,8 +68,8 @@ struct JUnitTestOutputImpl
     SimpleString package_;
 };
 
-JUnitTestOutput::JUnitTestOutput() :
-    impl_(new JUnitTestOutputImpl)
+JUnitTestOutput::JUnitTestOutput(ConsoleTestOutput* output) :
+    impl_(new JUnitTestOutputImpl), currentConsoleOutput_(output? output : &defaultConsoleOutput_)
 {
 }
 
@@ -98,24 +98,31 @@ void JUnitTestOutput::resetTestGroupResult()
 
 void JUnitTestOutput::printTestsStarted()
 {
+    if (isVerbose()) { currentConsoleOutput_->printTestsStarted(); }
 }
 
-void JUnitTestOutput::printCurrentGroupStarted(const UtestShell& /*test*/)
+void JUnitTestOutput::printCurrentGroupStarted(const UtestShell& test)
 {
+    if(isVerbose()) { currentConsoleOutput_->printCurrentGroupStarted(test);}
 }
 
 void JUnitTestOutput::printCurrentTestEnded(const TestResult& result)
 {
+    if (isVerbose()) { currentConsoleOutput_->printCurrentTestEnded(result); }
+
     impl_->results_.tail_->execTime_
             = result.getCurrentTestTotalExecutionTime();
 }
 
-void JUnitTestOutput::printTestsEnded(const TestResult& /*result*/)
+void JUnitTestOutput::printTestsEnded(const TestResult& result)
 {
+    if (isVerbose()) { currentConsoleOutput_->printTestsEnded(result); }
 }
 
 void JUnitTestOutput::printCurrentGroupEnded(const TestResult& result)
 {
+    if (isVerbose()) { currentConsoleOutput_->printCurrentGroupEnded(result); }
+
     impl_->results_.groupExecTime_ = result.getCurrentGroupTotalExecutionTime();
     writeTestGroupToFile();
     resetTestGroupResult();
@@ -123,6 +130,8 @@ void JUnitTestOutput::printCurrentGroupEnded(const TestResult& result)
 
 void JUnitTestOutput::printCurrentTestStarted(const UtestShell& test)
 {
+    if (isVerbose()) { currentConsoleOutput_->printCurrentTestStarted(test); }
+
     impl_->results_.testCount_++;
     impl_->results_.group_ = test.getGroup();
     impl_->results_.startTime_ = GetPlatformSpecificTimeInMillis();
@@ -141,8 +150,9 @@ void JUnitTestOutput::printCurrentTestStarted(const UtestShell& test)
     }
 }
 
-void JUnitTestOutput::printTestRun(int /*number*/, int /*total*/)
+void JUnitTestOutput::printTestRun(int number, int total)
 {
+    if (isVerbose()) currentConsoleOutput_->printTestRun(number, total);
 }
 
 SimpleString JUnitTestOutput::createFileName(const SimpleString& group)
@@ -245,6 +255,8 @@ void JUnitTestOutput::writeTestGroupToFile()
 
 void JUnitTestOutput::print(const TestFailure& failure)
 {
+    currentConsoleOutput_->print(failure);
+
     if (impl_->results_.tail_->failure_ == 0) {
         impl_->results_.failureCount_++;
         impl_->results_.tail_->failure_ = new TestFailure(failure);

--- a/src/CppUTest/TestOutput.cpp
+++ b/src/CppUTest/TestOutput.cpp
@@ -44,53 +44,53 @@ TestOutput::WorkingEnvironment TestOutput::getWorkingEnvironment()
 }
 
 
-TestOutput::TestOutput() :
+ConsoleTestOutput::ConsoleTestOutput() :
     dotCount_(0), verbose_(false), color_(false), progressIndication_(".")
 {
 }
 
-TestOutput::~TestOutput()
+ConsoleTestOutput::~ConsoleTestOutput()
 {
 }
 
-void TestOutput::verbose()
+void ConsoleTestOutput::verbose()
 {
     verbose_ = true;
 }
 
-void TestOutput::color()
+void ConsoleTestOutput::color()
 {
     color_ = true;
 }
 
-void TestOutput::print(const char* str)
+void ConsoleTestOutput::print(const char* str)
 {
     printBuffer(str);
 }
 
-void TestOutput::print(long n)
+void ConsoleTestOutput::print(long n)
 {
     print(StringFrom(n).asCharString());
 }
 
-void TestOutput::printDouble(double d)
+void ConsoleTestOutput::printDouble(double d)
 {
     print(StringFrom(d).asCharString());
 }
 
-TestOutput& operator<<(TestOutput& p, const char* s)
+ConsoleTestOutput& operator<<(ConsoleTestOutput& p, const char* s)
 {
     p.print(s);
     return p;
 }
 
-TestOutput& operator<<(TestOutput& p, long int i)
+ConsoleTestOutput& operator<<(ConsoleTestOutput& p, long int i)
 {
     p.print(i);
     return p;
 }
 
-void TestOutput::printCurrentTestStarted(const UtestShell& test)
+void ConsoleTestOutput::printCurrentTestStarted(const UtestShell& test)
 {
     if (verbose_) print(test.getFormattedName().asCharString());
 
@@ -102,7 +102,7 @@ void TestOutput::printCurrentTestStarted(const UtestShell& test)
     }
 }
 
-void TestOutput::printCurrentTestEnded(const TestResult& res)
+void ConsoleTestOutput::printCurrentTestEnded(const TestResult& res)
 {
     if (verbose_) {
         print(" - ");
@@ -114,30 +114,30 @@ void TestOutput::printCurrentTestEnded(const TestResult& res)
     }
 }
 
-void TestOutput::printProgressIndicator()
+void ConsoleTestOutput::printProgressIndicator()
 {
     print(progressIndication_);
     if (++dotCount_ % 50 == 0) print("\n");
 }
 
-void TestOutput::setProgressIndicator(const char* indicator)
+void ConsoleTestOutput::setProgressIndicator(const char* indicator)
 {
     progressIndication_ = indicator;
 }
 
-void TestOutput::printTestsStarted()
+void ConsoleTestOutput::printTestsStarted()
 {
 }
 
-void TestOutput::printCurrentGroupStarted(const UtestShell& /*test*/)
+void ConsoleTestOutput::printCurrentGroupStarted(const UtestShell& /*test*/)
 {
 }
 
-void TestOutput::printCurrentGroupEnded(const TestResult& /*res*/)
+void ConsoleTestOutput::printCurrentGroupEnded(const TestResult& /*res*/)
 {
 }
 
-void TestOutput::printTestsEnded(const TestResult& result)
+void ConsoleTestOutput::printTestsEnded(const TestResult& result)
 {
     print("\n");
     if (result.getFailureCount() > 0) {
@@ -172,7 +172,7 @@ void TestOutput::printTestsEnded(const TestResult& result)
     print("\n\n");
 }
 
-void TestOutput::printTestRun(int number, int total)
+void ConsoleTestOutput::printTestRun(int number, int total)
 {
     if (total > 1) {
         print("Test run ");
@@ -183,7 +183,7 @@ void TestOutput::printTestRun(int number, int total)
     }
 }
 
-void TestOutput::print(const TestFailure& failure)
+void ConsoleTestOutput::print(const TestFailure& failure)
 {
     if (failure.isOutsideTestFile() || failure.isInHelperFunction())
         printFileAndLineForTestAndFailure(failure);
@@ -193,26 +193,26 @@ void TestOutput::print(const TestFailure& failure)
     printFailureMessage(failure.getMessage());
 }
 
-void TestOutput::printFileAndLineForTestAndFailure(const TestFailure& failure)
+void ConsoleTestOutput::printFileAndLineForTestAndFailure(const TestFailure& failure)
 {
     printErrorInFileOnLineFormattedForWorkingEnvironment(failure.getTestFileName(), failure.getTestLineNumber());
     printFailureInTest(failure.getTestName());
     printErrorInFileOnLineFormattedForWorkingEnvironment(failure.getFileName(), failure.getFailureLineNumber());
 }
 
-void TestOutput::printFileAndLineForFailure(const TestFailure& failure)
+void ConsoleTestOutput::printFileAndLineForFailure(const TestFailure& failure)
 {
     printErrorInFileOnLineFormattedForWorkingEnvironment(failure.getFileName(), failure.getFailureLineNumber());
     printFailureInTest(failure.getTestName());
 }
 
-void TestOutput::printFailureInTest(SimpleString testName)
+void ConsoleTestOutput::printFailureInTest(SimpleString testName)
 {
     print(" Failure in ");
     print(testName.asCharString());
 }
 
-void TestOutput::printFailureMessage(SimpleString reason)
+void ConsoleTestOutput::printFailureMessage(SimpleString reason)
 {
     print("\n");
     print("\t");
@@ -220,15 +220,15 @@ void TestOutput::printFailureMessage(SimpleString reason)
     print("\n\n");
 }
 
-void TestOutput::printErrorInFileOnLineFormattedForWorkingEnvironment(SimpleString file, int lineNumber)
+void ConsoleTestOutput::printErrorInFileOnLineFormattedForWorkingEnvironment(SimpleString file, int lineNumber)
 {
-    if (TestOutput::getWorkingEnvironment() == TestOutput::vistualStudio)
+    if (ConsoleTestOutput::getWorkingEnvironment() == ConsoleTestOutput::vistualStudio)
         printVistualStudioErrorInFileOnLine(file, lineNumber);
     else
         printEclipseErrorInFileOnLine(file, lineNumber);
 }
 
-void TestOutput::printEclipseErrorInFileOnLine(SimpleString file, int lineNumber)
+void ConsoleTestOutput::printEclipseErrorInFileOnLine(SimpleString file, int lineNumber)
 {
     print("\n");
     print(file.asCharString());
@@ -238,7 +238,7 @@ void TestOutput::printEclipseErrorInFileOnLine(SimpleString file, int lineNumber
     print(" error:");
 }
 
-void TestOutput::printVistualStudioErrorInFileOnLine(SimpleString file, int lineNumber)
+void ConsoleTestOutput::printVistualStudioErrorInFileOnLine(SimpleString file, int lineNumber)
 {
     print("\n");
     print(file.asCharString());

--- a/tests/JUnitOutputTest.cpp
+++ b/tests/JUnitOutputTest.cpp
@@ -289,6 +289,7 @@ extern "C" {
 
 TEST_GROUP(JUnitOutputTest)
 {
+    StringBufferTestOutput printer;
     JUnitTestOutput *junitOutput;
     TestResult *result;
     JUnitTestOutputTestRunner *testCaseRunner;
@@ -299,7 +300,7 @@ TEST_GROUP(JUnitOutputTest)
         UT_PTR_SET(PlatformSpecificFOpen, (PlatformSpecificFile(*)(const char*, const char*))mockFOpen);
         UT_PTR_SET(PlatformSpecificFPuts, mockFPuts);
         UT_PTR_SET(PlatformSpecificFClose, mockFClose);
-        junitOutput = new JUnitTestOutput();
+        junitOutput = new JUnitTestOutput(&printer);
         result = new TestResult(*junitOutput);
         testCaseRunner = new JUnitTestOutputTestRunner(*result);
     }
@@ -598,4 +599,34 @@ TEST(JUnitOutputTest, TestCaseBlockForIgnoredTest)
    STRCMP_EQUAL("<testcase classname=\"packagename.groupname\" name=\"testname\" time=\"0.000\">\n", outputFile->line(5));
    STRCMP_EQUAL("<skipped />\n", outputFile->line(6));
    STRCMP_EQUAL("</testcase>\n", outputFile->line(7));
+}
+
+TEST(JUnitOutputTest, shouldAlsoPrintVerboseOutputWhenVerboseEnabled)
+{
+    junitOutput->verbose();
+    testCaseRunner->start().withGroup("groupname").withTest("testname").end();
+
+    outputFile = fileSystem.file("cpputest_groupname.xml");
+    STRCMP_EQUAL("<testsuite errors=\"0\" failures=\"0\" hostname=\"localhost\" name=\"groupname\" tests=\"1\" time=\"0.000\" timestamp=\"1978-10-03T00:00:00\">\n", outputFile->line(2));
+    STRCMP_EQUAL("</testsuite>", outputFile->lineFromTheBack(1));
+    STRCMP_EQUAL("TEST(groupname, testname) - 0 ms\n\nOK (0 tests, 0 ran, 0 checks, 0 ignored, 0 filtered out, 0 ms)\n\n", printer.getOutput().asCharString());
+}
+
+TEST(JUnitOutputTest, shouldAlsoPrintVerboseOutputWhenVerboseAndColorEnabled)
+{
+    junitOutput->verbose();
+    junitOutput->color();
+    testCaseRunner->start().withGroup("groupname").withTest("testname").end();
+
+    outputFile = fileSystem.file("cpputest_groupname.xml");
+    STRCMP_EQUAL("<testsuite errors=\"0\" failures=\"0\" hostname=\"localhost\" name=\"groupname\" tests=\"1\" time=\"0.000\" timestamp=\"1978-10-03T00:00:00\">\n", outputFile->line(2));
+    STRCMP_EQUAL("</testsuite>", outputFile->lineFromTheBack(1));
+    STRCMP_EQUAL("TEST(groupname, testname) - 0 ms\n\n\033[32;1mOK (0 tests, 0 ran, 0 checks, 0 ignored, 0 filtered out, 0 ms)\033[m\n\n", printer.getOutput().asCharString());
+}
+
+TEST(JUnitOutputTest, canPrintAString)
+{
+    junitOutput->print("hello");
+
+    STRCMP_EQUAL("hello", printer.getOutput().asCharString());
 }

--- a/tests/TestOutputTest.cpp
+++ b/tests/TestOutputTest.cpp
@@ -43,7 +43,7 @@ extern "C" {
 
 TEST_GROUP(TestOutput)
 {
-    TestOutput* printer;
+    ConsoleTestOutput* printer;
     StringBufferTestOutput* mock;
     UtestShell* tst;
     TestFailure *f;


### PR DESCRIPTION
This will print verbose output along with junit output, if -v -ojunit is specified
+ uses composition
+ only minimal refactoring
+ doesn't break any existing tests
+ @basvodde sorry, had no good reason to use your suggestion, but it could be used without breaking anything