### PR TITLE
ignt - Add missing IGNORE_TEST for VS / MinGW

### DIFF
--- a/tests/UtestTest.cpp
+++ b/tests/UtestTest.cpp
@@ -184,6 +184,10 @@ TEST(UtestShell, TestDefaultCrashMethodInSeparateProcessTest)
     fixture.assertPrintContains("Failed in separate process - killed by signal 11");
 }
 
+#else
+
+IGNORE_TEST(UtestShell, TestDefaultCrashMethodInSeparateProcessTest) {}
+
 #endif
 
 #if CPPUTEST_USE_STD_CPP_LIB


### PR DESCRIPTION
I think we agreed on using IGNORE_TEST() when excluding tests from certain platforms, to minimize variances in test count between platforms. I forgot this one.
