### PR TITLE
MEMCMP_EQUAL assertion

### DIFF
--- a/include/CppUTest/SimpleString.h
+++ b/include/CppUTest/SimpleString.h
@@ -146,6 +146,8 @@ SimpleString StringFrom(double value, int precision = 6);
 SimpleString StringFrom(const SimpleString& other);
 SimpleString StringFromFormat(const char* format, ...) __check_format__(printf, 1, 2);
 SimpleString VStringFromFormat(const char* format, va_list args);
+SimpleString StringFromBinary(const unsigned char *value, size_t size);
+SimpleString StringFromBinaryOrNull(const unsigned char *value, size_t size);
 
 #if CPPUTEST_USE_STD_CPP_LIB
 

--- a/include/CppUTest/SimpleString.h
+++ b/include/CppUTest/SimpleString.h
@@ -97,6 +97,7 @@ public:
     static char* StrNCpy(char* s1, const char* s2, size_t n);
     static char* StrStr(const char* s1, const char* s2);
     static char ToLower(char ch);
+    static int MemCmp(const void* s1, const void *s2, size_t n);
     static void deallocStringBuffer(char* str);
 private:
     char *buffer_;

--- a/include/CppUTest/SimpleString.h
+++ b/include/CppUTest/SimpleString.h
@@ -147,8 +147,8 @@ SimpleString StringFrom(double value, int precision = 6);
 SimpleString StringFrom(const SimpleString& other);
 SimpleString StringFromFormat(const char* format, ...) __check_format__(printf, 1, 2);
 SimpleString VStringFromFormat(const char* format, va_list args);
-SimpleString StringFromBinary(const unsigned char *value, size_t size);
-SimpleString StringFromBinaryOrNull(const unsigned char *value, size_t size);
+SimpleString StringFromBinary(const unsigned char* value, size_t size);
+SimpleString StringFromBinaryOrNull(const unsigned char* value, size_t size);
 
 #if CPPUTEST_USE_STD_CPP_LIB
 

--- a/include/CppUTest/TestFailure.h
+++ b/include/CppUTest/TestFailure.h
@@ -63,9 +63,13 @@ public:
 
 
 protected:
+    enum DifferenceFormat
+    {
+        DIFFERENCE_STRING, DIFFERENCE_BINARY
+    };
 
     SimpleString createButWasString(const SimpleString& expected, const SimpleString& actual);
-    SimpleString createDifferenceAtPosString(const SimpleString& actual, size_t position);
+    SimpleString createDifferenceAtPosString(const SimpleString& actual, size_t position, DifferenceFormat format = DIFFERENCE_STRING);
 
     SimpleString testName_;
     SimpleString fileName_;
@@ -138,6 +142,12 @@ class StringEqualNoCaseFailure : public TestFailure
 {
 public:
     StringEqualNoCaseFailure(UtestShell* test, const char* fileName, int lineNumber, const char* expected, const char* actual);
+};
+
+class BinaryEqualFailure : public TestFailure
+{
+public:
+	BinaryEqualFailure(UtestShell* test, const char* fileName, int lineNumber, const unsigned char* expected, const unsigned char* actual, size_t size);
 };
 
 #endif

--- a/include/CppUTest/Utest.h
+++ b/include/CppUTest/Utest.h
@@ -117,6 +117,7 @@ public:
     virtual void assertPointersEqual(const void *expected, const void *actual, const char *fileName, int lineNumber);
     virtual void assertDoublesEqual(double expected, double actual, double threshold, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
     virtual void assertEquals(bool failed, const char* expected, const char* actual, const char* file, int line, const TestTerminator& testTerminator = NormalTestTerminator());
+    virtual void assertBinaryEqual(const void *expected, const void *actual, size_t length, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
     virtual void fail(const char *text, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
 
     virtual void print(const char *text, const char *fileName, int lineNumber);

--- a/include/CppUTest/UtestMacros.h
+++ b/include/CppUTest/UtestMacros.h
@@ -189,6 +189,13 @@
 #define DOUBLES_EQUAL_LOCATION(expected,actual,threshold,file,line)\
   { UtestShell::getCurrent()->assertDoublesEqual(expected, actual, threshold,  file, line); }
 
+//Check two memory areas for equality
+#define MEMCMP_EQUAL(expected,actual,size)\
+  MEMCMP_EQUAL_LOCATION(expected,actual,size,__FILE__,__LINE__)
+
+#define MEMCMP_EQUAL_LOCATION(expected,actual,size,file,line)\
+  { UtestShell::getCurrent()->assertBinaryEqual(expected, actual, size, file, line); }
+
 //Fail if you get to this macro
 //The macro FAIL may already be taken, so allow FAIL_TEST too
 #ifndef FAIL

--- a/include/CppUTest/UtestMacros.h
+++ b/include/CppUTest/UtestMacros.h
@@ -189,7 +189,6 @@
 #define DOUBLES_EQUAL_LOCATION(expected,actual,threshold,file,line)\
   { UtestShell::getCurrent()->assertDoublesEqual(expected, actual, threshold,  file, line); }
 
-//Check two memory areas for equality
 #define MEMCMP_EQUAL(expected,actual,size)\
   MEMCMP_EQUAL_LOCATION(expected,actual,size,__FILE__,__LINE__)
 

--- a/src/CppUTest/SimpleString.cpp
+++ b/src/CppUTest/SimpleString.cpp
@@ -125,6 +125,19 @@ char SimpleString::ToLower(char ch)
     return isUpper(ch) ? (char)((int)ch + ('a' - 'A')) : ch;
 }
 
+int SimpleString::MemCmp(const void* s1, const void *s2, size_t n)
+{
+	const unsigned char* p1 = (const unsigned char*) s1;
+	const unsigned char* p2 = (const unsigned char*) s2;
+
+	while (n--)
+		if (*p1 != *p2)
+		return *p1 - *p2;
+		else
+		p1++, p2++;
+	return 0;
+}
+
 SimpleString::SimpleString(const char *otherBuffer)
 {
     if (otherBuffer == 0) {

--- a/src/CppUTest/SimpleString.cpp
+++ b/src/CppUTest/SimpleString.cpp
@@ -132,9 +132,9 @@ int SimpleString::MemCmp(const void* s1, const void *s2, size_t n)
 
 	while (n--)
 		if (*p1 != *p2)
-		return *p1 - *p2;
+			return *p1 - *p2;
 		else
-		p1++, p2++;
+			p1++, p2++;
 	return 0;
 }
 
@@ -569,7 +569,7 @@ SimpleString VStringFromFormat(const char* format, va_list args)
     return resultString;
 }
 
-SimpleString StringFromBinary(const unsigned char *value, size_t size)
+SimpleString StringFromBinary(const unsigned char* value, size_t size)
 {
 	SimpleString result;
 
@@ -581,7 +581,7 @@ SimpleString StringFromBinary(const unsigned char *value, size_t size)
 	return result;
 }
 
-SimpleString StringFromBinaryOrNull(const unsigned char *value, size_t size)
+SimpleString StringFromBinaryOrNull(const unsigned char* value, size_t size)
 {
 	return (value) ? StringFromBinary(value, size) : "(null)";
 }

--- a/src/CppUTest/SimpleString.cpp
+++ b/src/CppUTest/SimpleString.cpp
@@ -556,6 +556,23 @@ SimpleString VStringFromFormat(const char* format, va_list args)
     return resultString;
 }
 
+SimpleString StringFromBinary(const unsigned char *value, size_t size)
+{
+	SimpleString result;
+
+	for (size_t i = 0; i < size; i++) {
+		result += StringFromFormat("%02X ", value[i]);
+	}
+	result = result.subString(0, result.size() - 1);
+
+	return result;
+}
+
+SimpleString StringFromBinaryOrNull(const unsigned char *value, size_t size)
+{
+	return (value) ? StringFromBinary(value, size) : "(null)";
+}
+
 SimpleStringCollection::SimpleStringCollection()
 {
     collection_ = 0;

--- a/src/CppUTest/SimpleString.cpp
+++ b/src/CppUTest/SimpleString.cpp
@@ -127,15 +127,15 @@ char SimpleString::ToLower(char ch)
 
 int SimpleString::MemCmp(const void* s1, const void *s2, size_t n)
 {
-	const unsigned char* p1 = (const unsigned char*) s1;
-	const unsigned char* p2 = (const unsigned char*) s2;
+    const unsigned char* p1 = (const unsigned char*) s1;
+    const unsigned char* p2 = (const unsigned char*) s2;
 
-	while (n--)
-		if (*p1 != *p2)
-			return *p1 - *p2;
-		else
-			p1++, p2++;
-	return 0;
+    while (n--)
+        if (*p1 != *p2)
+            return *p1 - *p2;
+        else
+            p1++, p2++;
+    return 0;
 }
 
 SimpleString::SimpleString(const char *otherBuffer)
@@ -571,19 +571,19 @@ SimpleString VStringFromFormat(const char* format, va_list args)
 
 SimpleString StringFromBinary(const unsigned char* value, size_t size)
 {
-	SimpleString result;
+    SimpleString result;
 
-	for (size_t i = 0; i < size; i++) {
-		result += StringFromFormat("%02X ", value[i]);
-	}
-	result = result.subString(0, result.size() - 1);
+    for (size_t i = 0; i < size; i++) {
+        result += StringFromFormat("%02X ", value[i]);
+    }
+    result = result.subString(0, result.size() - 1);
 
-	return result;
+    return result;
 }
 
 SimpleString StringFromBinaryOrNull(const unsigned char* value, size_t size)
 {
-	return (value) ? StringFromBinary(value, size) : "(null)";
+    return (value) ? StringFromBinary(value, size) : "(null)";
 }
 
 SimpleStringCollection::SimpleStringCollection()

--- a/src/CppUTest/Utest.cpp
+++ b/src/CppUTest/Utest.cpp
@@ -431,6 +431,16 @@ void UtestShell::assertDoublesEqual(double expected, double actual, double thres
         failWith(DoublesEqualFailure(this, fileName, lineNumber, expected, actual, threshold), testTerminator);
 }
 
+void UtestShell::assertBinaryEqual(const void *expected, const void *actual, size_t length, const char *fileName, int lineNumber, const TestTerminator& testTerminator)
+{
+    getTestResult()->countCheck();
+    if (actual == 0 && expected == 0) return;
+    if (actual == 0 || expected == 0)
+        failWith(BinaryEqualFailure(this, fileName, lineNumber, (const unsigned char *) expected, (const unsigned char *) actual, length), testTerminator);
+    if (SimpleString::MemCmp(expected, actual, length) != 0)
+        failWith(BinaryEqualFailure(this, fileName, lineNumber, (const unsigned char *) expected, (const unsigned char *) actual, length), testTerminator);
+}
+
 void UtestShell::assertEquals(bool failed, const char* expected, const char* actual, const char* file, int line, const TestTerminator& testTerminator)
 {
     getTestResult()->countCheck();

--- a/tests/SimpleStringTest.cpp
+++ b/tests/SimpleStringTest.cpp
@@ -797,53 +797,30 @@ TEST(SimpleString, AtoI)
 TEST(SimpleString, Binary)
 {
 	const unsigned char value[] = { 0x00, 0x01, 0x2A, 0xFF };
-	STRCMP_EQUAL("00 01 2A FF", StringFromBinary(value, sizeof(value)).asCharString());
-}
+	const char expectedString[] = "00 01 2A FF";
 
-TEST(SimpleString, BinaryZeroLength)
-{
-	const unsigned char value[] = { 0x00, 0x01, 0x2A, 0xFF };
+	STRCMP_EQUAL(expectedString, StringFromBinary(value, sizeof(value)).asCharString());
+	STRCMP_EQUAL(expectedString, StringFromBinaryOrNull(value, sizeof(value)).asCharString());
 	STRCMP_EQUAL("", StringFromBinary(value, 0).asCharString());
-}
-
-TEST(SimpleString, BinaryNotNull)
-{
-	const unsigned char value[] = { 0x00, 0x01, 0x2A, 0xFF };
-	STRCMP_EQUAL("00 01 2A FF", StringFromBinaryOrNull(value, sizeof(value)).asCharString());
-}
-
-TEST(SimpleString, BinaryNull)
-{
 	STRCMP_EQUAL("(null)", StringFromBinaryOrNull(NULL, 0).asCharString());
 }
 
-TEST(SimpleString, MemCmpMatching) {
-	unsigned char s1[] = { 0x00, 0x01, 0x2A, 0xFF };
-	LONGS_EQUAL(0, SimpleString::MemCmp(s1, s1, sizeof(s1)));
-}
-
-TEST(SimpleString, MemCmpZeroLength) {
-	LONGS_EQUAL(0, SimpleString::MemCmp(NULL, NULL, 0));
-}
-
-TEST(SimpleString, MemCmpFirstNotMatching)
-{
-	unsigned char s1[] = { 0x00, 0x01, 0x2A, 0xFF };
-	unsigned char s2[] = { 0x01, 0x01, 0x2A, 0xFF };
-	CHECK(0 != SimpleString::MemCmp(s1, s2, sizeof(s1)));
-}
-
-TEST(SimpleString, MemCmpLastNotMatching)
-{
-	unsigned char s1[] = { 0x00, 0x01, 0x2A, 0xFF };
-	unsigned char s2[] = { 0x00, 0x01, 0x2A, 0x00 };
-	CHECK(0 != SimpleString::MemCmp(s1, s2, sizeof(s1)));
-}
-
-TEST(SimpleString, MemCmpGreater)
+TEST(SimpleString, MemCmp)
 {
 	unsigned char smaller[] = { 0x00, 0x01, 0x2A, 0xFF };
 	unsigned char greater[] = { 0x00, 0x01, 0xFF, 0xFF };
+
+	LONGS_EQUAL(0, SimpleString::MemCmp(smaller, smaller, sizeof(smaller)));
 	CHECK(SimpleString::MemCmp(smaller, greater, sizeof(smaller)) < 0);
 	CHECK(SimpleString::MemCmp(greater, smaller, sizeof(smaller)) > 0);
+	LONGS_EQUAL(0, SimpleString::MemCmp(NULL, NULL, 0));
+}
+
+TEST(SimpleString, MemCmpFirstLastNotMatching)
+{
+	unsigned char base[] = { 0x00, 0x01, 0x2A, 0xFF };
+	unsigned char firstNotMatching[] = { 0x01, 0x01, 0x2A, 0xFF };
+	unsigned char lastNotMatching[] = { 0x00, 0x01, 0x2A, 0x00 };
+	CHECK(0 != SimpleString::MemCmp(base, firstNotMatching, sizeof(base)));
+	CHECK(0 != SimpleString::MemCmp(base, lastNotMatching, sizeof(base)));
 }

--- a/tests/SimpleStringTest.cpp
+++ b/tests/SimpleStringTest.cpp
@@ -793,3 +793,26 @@ TEST(SimpleString, AtoI)
     CHECK(-32768 == SimpleString::AtoI(min_short_str));
     CHECK(32767  == SimpleString::AtoI(max_short_str));
 }
+
+TEST(SimpleString, Binary)
+{
+	const unsigned char value[] = { 0x00, 0x01, 0x2A, 0xFF };
+	STRCMP_EQUAL("00 01 2A FF", StringFromBinary(value, sizeof(value)).asCharString());
+}
+
+TEST(SimpleString, BinaryZeroLength)
+{
+	const unsigned char value[] = { 0x00, 0x01, 0x2A, 0xFF };
+	STRCMP_EQUAL("", StringFromBinary(value, 0).asCharString());
+}
+
+TEST(SimpleString, BinaryNotNull)
+{
+	const unsigned char value[] = { 0x00, 0x01, 0x2A, 0xFF };
+	STRCMP_EQUAL("00 01 2A FF", StringFromBinaryOrNull(value, sizeof(value)).asCharString());
+}
+
+TEST(SimpleString, BinaryNull)
+{
+	STRCMP_EQUAL("(null)", StringFromBinaryOrNull(NULL, 0).asCharString());
+}

--- a/tests/SimpleStringTest.cpp
+++ b/tests/SimpleStringTest.cpp
@@ -796,31 +796,31 @@ TEST(SimpleString, AtoI)
 
 TEST(SimpleString, Binary)
 {
-	const unsigned char value[] = { 0x00, 0x01, 0x2A, 0xFF };
-	const char expectedString[] = "00 01 2A FF";
+    const unsigned char value[] = { 0x00, 0x01, 0x2A, 0xFF };
+    const char expectedString[] = "00 01 2A FF";
 
-	STRCMP_EQUAL(expectedString, StringFromBinary(value, sizeof(value)).asCharString());
-	STRCMP_EQUAL(expectedString, StringFromBinaryOrNull(value, sizeof(value)).asCharString());
-	STRCMP_EQUAL("", StringFromBinary(value, 0).asCharString());
-	STRCMP_EQUAL("(null)", StringFromBinaryOrNull(NULL, 0).asCharString());
+    STRCMP_EQUAL(expectedString, StringFromBinary(value, sizeof(value)).asCharString());
+    STRCMP_EQUAL(expectedString, StringFromBinaryOrNull(value, sizeof(value)).asCharString());
+    STRCMP_EQUAL("", StringFromBinary(value, 0).asCharString());
+    STRCMP_EQUAL("(null)", StringFromBinaryOrNull(NULL, 0).asCharString());
 }
 
 TEST(SimpleString, MemCmp)
 {
-	unsigned char smaller[] = { 0x00, 0x01, 0x2A, 0xFF };
-	unsigned char greater[] = { 0x00, 0x01, 0xFF, 0xFF };
+    unsigned char smaller[] = { 0x00, 0x01, 0x2A, 0xFF };
+    unsigned char greater[] = { 0x00, 0x01, 0xFF, 0xFF };
 
-	LONGS_EQUAL(0, SimpleString::MemCmp(smaller, smaller, sizeof(smaller)));
-	CHECK(SimpleString::MemCmp(smaller, greater, sizeof(smaller)) < 0);
-	CHECK(SimpleString::MemCmp(greater, smaller, sizeof(smaller)) > 0);
-	LONGS_EQUAL(0, SimpleString::MemCmp(NULL, NULL, 0));
+    LONGS_EQUAL(0, SimpleString::MemCmp(smaller, smaller, sizeof(smaller)));
+    CHECK(SimpleString::MemCmp(smaller, greater, sizeof(smaller)) < 0);
+    CHECK(SimpleString::MemCmp(greater, smaller, sizeof(smaller)) > 0);
+    LONGS_EQUAL(0, SimpleString::MemCmp(NULL, NULL, 0));
 }
 
 TEST(SimpleString, MemCmpFirstLastNotMatching)
 {
-	unsigned char base[] = { 0x00, 0x01, 0x2A, 0xFF };
-	unsigned char firstNotMatching[] = { 0x01, 0x01, 0x2A, 0xFF };
-	unsigned char lastNotMatching[] = { 0x00, 0x01, 0x2A, 0x00 };
-	CHECK(0 != SimpleString::MemCmp(base, firstNotMatching, sizeof(base)));
-	CHECK(0 != SimpleString::MemCmp(base, lastNotMatching, sizeof(base)));
+    unsigned char base[] = { 0x00, 0x01, 0x2A, 0xFF };
+    unsigned char firstNotMatching[] = { 0x01, 0x01, 0x2A, 0xFF };
+    unsigned char lastNotMatching[] = { 0x00, 0x01, 0x2A, 0x00 };
+    CHECK(0 != SimpleString::MemCmp(base, firstNotMatching, sizeof(base)));
+    CHECK(0 != SimpleString::MemCmp(base, lastNotMatching, sizeof(base)));
 }

--- a/tests/SimpleStringTest.cpp
+++ b/tests/SimpleStringTest.cpp
@@ -816,3 +816,34 @@ TEST(SimpleString, BinaryNull)
 {
 	STRCMP_EQUAL("(null)", StringFromBinaryOrNull(NULL, 0).asCharString());
 }
+
+TEST(SimpleString, MemCmpMatching) {
+	unsigned char s1[] = { 0x00, 0x01, 0x2A, 0xFF };
+	LONGS_EQUAL(0, SimpleString::MemCmp(s1, s1, sizeof(s1)));
+}
+
+TEST(SimpleString, MemCmpZeroLength) {
+	LONGS_EQUAL(0, SimpleString::MemCmp(NULL, NULL, 0));
+}
+
+TEST(SimpleString, MemCmpFirstNotMatching)
+{
+	unsigned char s1[] = { 0x00, 0x01, 0x2A, 0xFF };
+	unsigned char s2[] = { 0x01, 0x01, 0x2A, 0xFF };
+	CHECK(0 != SimpleString::MemCmp(s1, s2, sizeof(s1)));
+}
+
+TEST(SimpleString, MemCmpLastNotMatching)
+{
+	unsigned char s1[] = { 0x00, 0x01, 0x2A, 0xFF };
+	unsigned char s2[] = { 0x00, 0x01, 0x2A, 0x00 };
+	CHECK(0 != SimpleString::MemCmp(s1, s2, sizeof(s1)));
+}
+
+TEST(SimpleString, MemCmpGreater)
+{
+	unsigned char smaller[] = { 0x00, 0x01, 0x2A, 0xFF };
+	unsigned char greater[] = { 0x00, 0x01, 0xFF, 0xFF };
+	CHECK(SimpleString::MemCmp(smaller, greater, sizeof(smaller)) < 0);
+	CHECK(SimpleString::MemCmp(greater, smaller, sizeof(smaller)) > 0);
+}

--- a/tests/TestFailureTest.cpp
+++ b/tests/TestFailureTest.cpp
@@ -224,3 +224,72 @@ TEST(TestFailure, DoublesEqualNormal)
     FAILURE_EQUAL("expected <1>\n"
                 "\tbut was  <2> threshold used was <3>", f);
 }
+
+TEST(TestFailure, BinaryEqualOneByte)
+{
+    const unsigned char expectedData[] = { 0x00 };
+    const unsigned char actualData[] = { 0x01 };
+    BinaryEqualFailure f(test, failFileName, failLineNumber, expectedData, actualData, sizeof(expectedData));
+    FAILURE_EQUAL("expected <00>\n"
+                "\tbut was  <01>\n"
+    			"\tdifference starts at position 0 at: <         01         >\n"
+    			"\t                                               ^", f);
+}
+
+TEST(TestFailure, BinaryEqualTwoBytes)
+{
+    const unsigned char expectedData[] = {0x00, 0x01};
+    const unsigned char actualData[] = {0x00, 0x02};
+    BinaryEqualFailure f(test, failFileName, failLineNumber, expectedData, actualData, sizeof(expectedData));
+    FAILURE_EQUAL("expected <00 01>\n"
+                "\tbut was  <00 02>\n"
+    			"\tdifference starts at position 1 at: <      00 02         >\n"
+    			"\t                                               ^", f);
+}
+
+TEST(TestFailure, BinaryEqualThreeBytes)
+{
+    const unsigned char expectedData[] = {0x00, 0x01, 0x00};
+    const unsigned char actualData[] = {0x00, 0x02, 0x00};
+    BinaryEqualFailure f(test, failFileName, failLineNumber, expectedData, actualData, sizeof(expectedData));
+    FAILURE_EQUAL("expected <00 01 00>\n"
+                "\tbut was  <00 02 00>\n"
+    			"\tdifference starts at position 1 at: <      00 02 00      >\n"
+    			"\t                                               ^", f);
+}
+
+TEST(TestFailure, BinaryEqualFullWidth)
+{
+    const unsigned char expectedData[] = {0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00};
+    const unsigned char actualData[] = {0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00};
+    BinaryEqualFailure f(test, failFileName, failLineNumber, expectedData, actualData, sizeof(expectedData));
+    FAILURE_EQUAL("expected <00 00 00 01 00 00 00>\n"
+                "\tbut was  <00 00 00 02 00 00 00>\n"
+    			"\tdifference starts at position 3 at: <00 00 00 02 00 00 00>\n"
+    			"\t                                               ^", f);
+}
+
+TEST(TestFailure, BinaryEqualLast)
+{
+    const unsigned char expectedData[] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+	const unsigned char actualData[] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01};
+    BinaryEqualFailure f(test, failFileName, failLineNumber, expectedData, actualData, sizeof(expectedData));
+    FAILURE_EQUAL("expected <00 00 00 00 00 00 00>\n"
+                "\tbut was  <00 00 00 00 00 00 01>\n"
+    			"\tdifference starts at position 6 at: <00 00 00 01         >\n"
+    			"\t                                               ^", f);
+}
+
+TEST(TestFailure, BinaryEqualActualNull)
+{
+    const unsigned char expectedData[] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+    BinaryEqualFailure f(test, failFileName, failLineNumber, expectedData, NULL, sizeof(expectedData));
+    FAILURE_EQUAL("expected <00 00 00 00 00 00 00>\n\tbut was  <(null)>", f);
+}
+
+TEST(TestFailure, BinaryEqualExpectedNull)
+{
+    const unsigned char actualData[] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01};
+    BinaryEqualFailure f(test, failFileName, failLineNumber, NULL, actualData, sizeof(actualData));
+    FAILURE_EQUAL("expected <(null)>\n\tbut was  <00 00 00 00 00 00 01>", f);
+}

--- a/tests/TestUTestMacro.cpp
+++ b/tests/TestUTestMacro.cpp
@@ -567,6 +567,7 @@ static int functionThatReturnsAValue()
     STRCMP_EQUAL("THIS", "THIS");
     DOUBLES_EQUAL(1.0, 1.0, .01);
     POINTERS_EQUAL(0, 0);
+    MEMCMP_EQUAL("THIS", "THIS", 5);
     return 0;
 }
 
@@ -637,6 +638,64 @@ TEST(UnitTestMacros, CompareNFirstCharsWithLastCharDifferent)
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <Not empty string?>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <Not empty string!>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("difference starts at position 16");
+}
+
+TEST(UnitTestMacros, MEMCMP_EQUALBehavesAsAProperMacro)
+{
+    if (false) MEMCMP_EQUAL("TEST", "test", 5)
+    else MEMCMP_EQUAL("TEST", "TEST", 5)
+}
+
+IGNORE_TEST(UnitTestMacros, MEMCMP_EQUALWorksInAnIgnoredTest)
+{
+    MEMCMP_EQUAL("TEST", "test", 5); // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
+static void _MEMCMP_EQUALFailingTestMethodWithUnequalInput()
+{
+    unsigned char expectedData[] = { 0x00, 0x01, 0x02, 0x03 };
+    unsigned char actualData[] = { 0x00, 0x01, 0x03, 0x03 };
+
+    MEMCMP_EQUAL(expectedData, actualData, sizeof(expectedData));
+    lineOfCodeExecutedAfterCheck = true; // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
+TEST(UnitTestMacros, MEMCMP_EQUALFailureWithUnequalInput)
+{
+    runTestWithMethod(_MEMCMP_EQUALFailingTestMethodWithUnequalInput);
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <00 01 02 03>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <00 01 03 03>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("difference starts at position 2");
+}
+
+static void _MEMCMP_EQUALFailingTestMethodWithNullExpected()
+{
+    unsigned char actualData[] = { 0x00, 0x01, 0x02, 0x03 };
+
+    MEMCMP_EQUAL(NULL, actualData, sizeof(actualData));
+    lineOfCodeExecutedAfterCheck = true; // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
+TEST(UnitTestMacros, MEMCMP_EQUALFailureWithNullExpected)
+{
+    runTestWithMethod(_MEMCMP_EQUALFailingTestMethodWithNullExpected);
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <(null)>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <00 01 02 03>");
+}
+
+static void _MEMCMP_EQUALFailingTestMethodWithNullActual()
+{
+    unsigned char expectedData[] = { 0x00, 0x01, 0x02, 0x03 };
+
+    MEMCMP_EQUAL(expectedData, NULL, sizeof(expectedData));
+    lineOfCodeExecutedAfterCheck = true; // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
+TEST(UnitTestMacros, MEMCMP_EQUALFailureWithNullActual)
+{
+    runTestWithMethod(_MEMCMP_EQUALFailingTestMethodWithNullActual);
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <00 01 02 03>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <(null)>");
 }
 
 #if CPPUTEST_USE_STD_CPP_LIB

--- a/tests/TestUTestMacro.cpp
+++ b/tests/TestUTestMacro.cpp
@@ -698,6 +698,12 @@ TEST(UnitTestMacros, MEMCMP_EQUALFailureWithNullActual)
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <(null)>");
 }
 
+TEST(UnitTestMacros, MEMCMP_EQUALNullExpectedNullActual)
+{
+    MEMCMP_EQUAL(NULL, NULL, 0);
+    MEMCMP_EQUAL(NULL, NULL, 1024);
+}
+
 #if CPPUTEST_USE_STD_CPP_LIB
 static void _failingTestMethod_NoThrowWithCHECK_THROWS()
 {


### PR DESCRIPTION
I've implemented the MEMCMP_EQUAL feature in my fork. Feel free to use any part of my code if you find it useful. It's output look like this:
```
../mainTest.cpp:16: error: Failure in TEST(MemCmpDemo, Demo)
	expected <01 23 45 67>
	but was  <01 23 00 67>
	difference starts at position 2 at: <   01 23 00 67      >
	                                               ^
```