### PR TITLE
ts - Testing platform-specific code with a wrapper

### DIFF
--- a/CppUTest.dsp
+++ b/CppUTest.dsp
@@ -90,54 +90,6 @@ SOURCE=.\src\CppUTestExt\CodeMemoryReportFormatter.cpp
 # End Source File
 # Begin Source File
 
-SOURCE=.\src\CppUTestExt\MemoryReportAllocator.cpp
-# End Source File
-# Begin Source File
-
-SOURCE=.\src\CppUTestExt\MemoryReporterPlugin.cpp
-# End Source File
-# Begin Source File
-
-SOURCE=.\src\CppUTestExt\MemoryReportFormatter.cpp
-# End Source File
-# Begin Source File
-
-SOURCE=.\src\CppUTestExt\MockActualCall.cpp"
-# End Source File
-# Begin Source File
-
-SOURCE=.\src\CppUTestExt\MockExpectedCall.cpp"
-# End Source File
-# Begin Source File
-
-SOURCE=.\src\CppUTestExt\MockExpectedCallsList.cpp"
-# End Source File
-# Begin Source File
-
-SOURCE=.\src\CppUTestExt\MockFailure.cpp"
-# End Source File
-# Begin Source File
-
-SOURCE=.\src\CppUTestExt\MockNamedValue.cpp"
-# End Source File
-# Begin Source File
-
-SOURCE=.\src\CppUTestExt\MockSupport.cpp"
-# End Source File
-# Begin Source File
-
-SOURCE=.\src\CppUTestExt\MockSupportPlugin.cpp"
-# End Source File
-# Begin Source File
-
-SOURCE=.\src\CppUTestExt\MockSupport_c.cpp"
-# End Source File
-# Begin Source File
-
-SOURCE=.\src\CppUTestExt\OrderedTest.cpp"
-# End Source File
-# Begin Source File
-
 SOURCE=.\SRC\CPPUTEST\CommandLineArguments.cpp
 # End Source File
 # Begin Source File
@@ -155,6 +107,54 @@ SOURCE=.\SRC\CPPUTEST\MemoryLeakDetector.cpp
 # Begin Source File
 
 SOURCE=.\SRC\CPPUTEST\MemoryLeakWarningPlugin.cpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\CppUTestExt\MemoryReportAllocator.cpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\CppUTestExt\MemoryReporterPlugin.cpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\src\CppUTestExt\MemoryReportFormatter.cpp
+# End Source File
+# Begin Source File
+
+SOURCE=".\src\CppUTestExt\MockActualCall.cpp"
+# End Source File
+# Begin Source File
+
+SOURCE=".\src\CppUTestExt\MockExpectedCall.cpp"
+# End Source File
+# Begin Source File
+
+SOURCE=".\src\CppUTestExt\MockExpectedCallsList.cpp"
+# End Source File
+# Begin Source File
+
+SOURCE=".\src\CppUTestExt\MockFailure.cpp"
+# End Source File
+# Begin Source File
+
+SOURCE=".\src\CppUTestExt\MockNamedValue.cpp"
+# End Source File
+# Begin Source File
+
+SOURCE=".\src\CppUTestExt\MockSupport.cpp"
+# End Source File
+# Begin Source File
+
+SOURCE=".\src\CppUTestExt\MockSupport_c.cpp"
+# End Source File
+# Begin Source File
+
+SOURCE=".\src\CppUTestExt\MockSupportPlugin.cpp"
+# End Source File
+# Begin Source File
+
+SOURCE=".\src\CppUTestExt\OrderedTest.cpp"
 # End Source File
 # Begin Source File
 
@@ -203,6 +203,13 @@ SOURCE=.\SRC\CPPUTEST\Utest.cpp
 # Begin Source File
 
 SOURCE=.\src\Platforms\VisualCpp\UtestPlatform.cpp
+
+!IF  "$(CFG)" == "CppUTest - Win32 Release"
+
+!ELSEIF  "$(CFG)" == "CppUTest - Win32 Debug"
+
+!ENDIF 
+
 # End Source File
 # End Group
 # Begin Group "Header Files"
@@ -210,7 +217,19 @@ SOURCE=.\src\Platforms\VisualCpp\UtestPlatform.cpp
 # PROP Default_Filter "h;hpp;hxx;hm;inl"
 # Begin Source File
 
-SOURCE=.\include\CppUTestExt\CodeMemoryReportFormatter.h"
+SOURCE=".\include\CppUTestExt\CodeMemoryReportFormatter.h"
+# End Source File
+# Begin Source File
+
+SOURCE=.\include\CppUTest\CommandLineTestRunner.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\include\CppUTest\EqualsFailure.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\include\CppUTest\Failure.h
 # End Source File
 # Begin Source File
 
@@ -219,6 +238,18 @@ SOURCE=.\include\CppUTestExt\GMock.h
 # Begin Source File
 
 SOURCE=.\include\CppUTestExt\GTestConvertor.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\include\CppUTest\JunitTestOutput.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\include\CppUTest\MemoryLeakWarning.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\include\CppUTest\MemoryLeakWarningPlugin.h
 # End Source File
 # Begin Source File
 
@@ -258,39 +289,11 @@ SOURCE=.\include\CppUTestExt\MockSupport.h
 # End Source File
 # Begin Source File
 
-SOURCE=.\include\CppUTestExt\MockSupportPlugin.h
-# End Source File
-# Begin Source File
-
 SOURCE=.\include\CppUTestExt\MockSupport_c.h
 # End Source File
 # Begin Source File
 
-SOURCE=.\include\CppUTestExt\OrderedTest.h
-# End Source File
-# Begin Source File
-
-SOURCE=.\include\CppUTest\CommandLineTestRunner.h
-# End Source File
-# Begin Source File
-
-SOURCE=.\include\CppUTest\EqualsFailure.h
-# End Source File
-# Begin Source File
-
-SOURCE=.\include\CppUTest\Failure.h
-# End Source File
-# Begin Source File
-
-SOURCE=.\include\CppUTest\JunitTestOutput.h
-# End Source File
-# Begin Source File
-
-SOURCE=.\include\CppUTest\MemoryLeakWarning.h
-# End Source File
-# Begin Source File
-
-SOURCE=.\include\CppUTest\MemoryLeakWarningPlugin.h
+SOURCE=.\include\CppUTestExt\MockSupportPlugin.h
 # End Source File
 # Begin Source File
 
@@ -299,6 +302,10 @@ SOURCE=.\include\CppUTest\MockTestOutput.h
 # Begin Source File
 
 SOURCE=.\include\CppUTest\NullTest.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\include\CppUTestExt\OrderedTest.h
 # End Source File
 # Begin Source File
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -119,8 +119,8 @@ include_cpputestext_HEADERS = \
 	include/CppUTestExt/MockSupport.h \
 	include/CppUTestExt/MockSupportPlugin.h \
 	include/CppUTestExt/MockSupport_c.h \
-	include/CppUTestExt/OrderedTest.h	
-	
+	include/CppUTestExt/OrderedTest.h
+
 endif
 
 CppUTestTests_CPPFLAGS = $(lib_libCppUTest_a_CPPFLAGS)
@@ -159,7 +159,8 @@ CppUTestTests_SOURCES = \
 	tests/TestResultTest.cpp \
 	tests/TestUTestMacro.cpp \
 	tests/UtestTest.cpp \
-	tests/UtestPlatformTest.cpp
+	tests/UtestPlatformTest.cpp \
+	tests/Platforms/$(CPP_PLATFORM)/UtestPlatformWrapper.cpp
 
 CppUTestExtTests_CPPFLAGS = $(lib_libCppUTestExt_a_CPPFLAGS)
 CppUTestExtTests_CFLAGS = $(lib_libCppUTestExt_a_CFLAGS)

--- a/Makefile_using_MakefileWorker
+++ b/Makefile_using_MakefileWorker
@@ -18,7 +18,8 @@ SRC_DIRS = \
 	src/Platforms/$(CPP_PLATFORM)
 	
 TEST_SRC_DIRS = \
-	tests
+	tests \
+    tests/Platforms/$(CPP_PLATFORM)
 
 INCLUDE_DIRS =\
   include

--- a/include/CppUTest/SimpleString.h
+++ b/include/CppUTest/SimpleString.h
@@ -150,7 +150,6 @@ SimpleString VStringFromFormat(const char* format, va_list args);
 #if CPPUTEST_USE_STD_CPP_LIB
 
 #include <string>
-#include <stdint.h>
 
 SimpleString StringFrom(const std::string& other);
 

--- a/include/CppUTest/UtestPlatformWrapper.h
+++ b/include/CppUTest/UtestPlatformWrapper.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2007, Michael Feathers, James Grenning and Bas Vodde
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the <organization> nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE EARLIER MENTIONED AUTHORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL <copyright holder> BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef D_UtestPlatformWrapper_H
+#define D_UtestPlatformWrapper_H
+
+#include <stdio.h>
+#include <time.h>
+
+struct tm* localtime_stub(const time_t* timer);
+
+#endif

--- a/tests/AllTests.dsp
+++ b/tests/AllTests.dsp
@@ -266,6 +266,21 @@ SOURCE=.\TestResultTest.cpp
 # End Source File
 # Begin Source File
 
+SOURCE=.\UtestPlatformTest.cpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\Platforms\VisualCpp\UtestPlatformWrapper.cpp
+
+!IF  "$(CFG)" == "AllTests - Win32 Release"
+
+!ELSEIF  "$(CFG)" == "AllTests - Win32 Debug"
+
+!ENDIF 
+
+# End Source File
+# Begin Source File
+
 SOURCE=.\UtestTest.cpp
 # End Source File
 # End Group

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -31,6 +31,7 @@ set(CppUTestTests_src
     UtestTest.cpp
     SimpleMutexTest.cpp
     UtestPlatformTest.cpp
+        Platforms/${CPP_PLATFORM}/UtestPlatformWrapper.cpp
 )
 
 if (MSVC)
@@ -40,6 +41,7 @@ endif (MSVC)
 
 add_executable(CppUTestTests ${CppUTestTests_src})
 target_link_libraries(CppUTestTests CppUTest)
+add_test(CppUTestTests ${EXECUTABLE_OUTPUT_PATH}/CppUTestTests)
 
 if (TESTS)
     if (TESTS_DETAILED)

--- a/tests/Platforms/Gcc/UtestPlatformWrapper.cpp
+++ b/tests/Platforms/Gcc/UtestPlatformWrapper.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2007, Michael Feathers, James Grenning and Bas Vodde
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the <organization> nor the
+ *       names of icdts contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE EARLIER MENTIONED AUTHORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL <copyright holder> BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <time.h>
+
+#include "CppUTest/UtestPlatformWrapper.h"
+
+static tm   tm_stub;
+
+struct tm* localtime_stub(const time_t*)
+{
+    return &tm_stub;
+}
+
+#define time(tm)                   0
+#define localtime(x)               localtime_stub((x))
+
+#include "../src/Platforms/Gcc/UtestPlatform.cpp"

--- a/tests/Platforms/VisualCpp/UtestPlatformWrapper.cpp
+++ b/tests/Platforms/VisualCpp/UtestPlatformWrapper.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2007, Michael Feathers, James Grenning and Bas Vodde
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the <organization> nor the
+ *       names of icdts contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE EARLIER MENTIONED AUTHORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL <copyright holder> BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <time.h>
+
+#include "CppUTest/UtestPlatformWrapper.h"
+
+static tm   tm_stub;
+
+void localtime_s_stub(struct tm* the_local_time, const time_t*)
+{
+    the_local_time = &tm_stub;
+}
+
+struct tm* localtime_stub(const time_t*)
+{
+    return &tm_stub;
+}
+
+#define time(tm)                   0
+
+
+#ifdef STDC_WANT_SECURE_LIB
+    #define localtime_s(localtime, time) localtime_s_stub((localtime), (time))
+#else
+    #define localtime(time) localtime_stub(time)
+#endif
+
+
+#include "../src/Platforms/VisualCpp/UtestPlatform.cpp"

--- a/tests/UtestPlatformTest.cpp
+++ b/tests/UtestPlatformTest.cpp
@@ -29,6 +29,22 @@
 #include "CppUTest/TestHarness.h"
 #include "CppUTest/TestTestingFixture.h"
 #include "CppUTest/PlatformSpecificFunctions.h"
+#include "CppUTest/UtestPlatformWrapper.h"
+
+TEST_GROUP(UtestPlatformTest) {};
+
+TEST(UtestPlatformTest, PlatformSpecificGetPlatformSpecificTimeStringWorksProperly)
+{
+    struct tm* time = localtime_stub(NULL);
+    time->tm_year = 115;
+    time->tm_mon = 3;
+    time->tm_mday = 29;
+    time->tm_hour = 3;
+    time->tm_min = 22;
+    time->tm_sec = 55;
+
+    STRCMP_EQUAL("2015-04-29T03:22:55", GetPlatformSpecificTimeString());
+}
 
 TEST_GROUP(UTestPlatformsTest_PlatformSpecificRunTestInASeperateProcess)
 {


### PR DESCRIPTION
This one is for discussion.

It exemplifies a method that would allow to test actual platform-specific code, where the tests test the interface and the wrapper is implemented in a platform-specific way.

The wrapper allows stubbing stuff that otherwise cannot be stubbed. For example, PlatformSpecificTimeString() internally call time(), which you would need to stub to make sure the rest of the function does what it should.

The method employed is *slightly* border-line. I have personally used it in some very tricky situations where production code could not be changed.

It is possible to test the file operations in this way, however, I have not included that here, since there are some tests in the Travis CI build that rely on actual file output being produced.