### PR TITLE
stdint2 - Fix

### DIFF
--- a/include/CppUTest/SimpleString.h
+++ b/include/CppUTest/SimpleString.h
@@ -150,7 +150,6 @@ SimpleString VStringFromFormat(const char* format, va_list args);
 #if CPPUTEST_USE_STD_CPP_LIB
 
 #include <string>
-#include <stdint.h>
 
 SimpleString StringFrom(const std::string& other);
 


### PR DESCRIPTION
It turns out I overlooked a redundant #include <stdint.h> in SimpleString.h. This needs to go for VisualCpp to work properly without <stdint.h>.