### PR TITLE
Fixed the problem of optimizing away division by zero

### DIFF
--- a/include/CppUTest/Utest.h
+++ b/include/CppUTest/Utest.h
@@ -40,6 +40,7 @@ class TestFilter;
 class TestTerminator;
 
 extern bool doubles_equal(double d1, double d2, double threshold);
+extern int division(int one, int two);
 
 //////////////////// Utest
 

--- a/src/CppUTest/Utest.cpp
+++ b/src/CppUTest/Utest.cpp
@@ -37,6 +37,11 @@ bool doubles_equal(double d1, double d2, double threshold)
     return PlatformSpecificFabs(d1 - d2) <= threshold;
 }
 
+int division(int one, int two)
+{
+  return one / two;
+}
+
 /* Sometimes stubs use the CppUTest assertions.
  * Its not correct to do so, but this small helper class will prevent a segmentation fault and instead
  * will give an error message and also the file/line of the check that was executed outside the tests.

--- a/tests/UtestPlatformTest.cpp
+++ b/tests/UtestPlatformTest.cpp
@@ -65,27 +65,27 @@ static void _failFunction()
 #include <errno.h>
 
 extern "C" {
-    
+
     static int (*original_waitpid)(int, int*, int) = NULL;
 
     static int fork_failed_stub(void) { return -1; }
-    
+
     static int waitpid_while_debugging_stub(int pid, int* status, int options)
-    { 
+    {
         static int number_called = 0;
         static int saved_status;
-        
+
         if (number_called++ < 10) {
             saved_status = *status;
             errno=EINTR;
             return -1;
         }
         else {
-            *status = saved_status; 
+            *status = saved_status;
             return original_waitpid(pid, status, options);
         }
     }
-    
+
     static int waitpid_failed_stub(int, int*, int) { return -1; }
 }
 
@@ -96,8 +96,9 @@ static int _accessViolationTestFunction()
 
 static int _divisionByZeroTestFunction()
 {
-    volatile int a = 1;
-    return 1 / (a - a);
+    int divisionByZero =  division(1, 0);
+    FAIL(StringFromFormat("Should have divided by zero. Outcome: %d", divisionByZero).asCharString());
+    return divisionByZero;
 }
 
 #include <unistd.h>


### PR DESCRIPTION
Moved the division in a separate compilation unit so that the compiler can't optimize it away anymore. HAH :)