### PR TITLE
Test JUnitOutput properly again

### DIFF
--- a/tests/CommandLineTestRunnerTest.cpp
+++ b/tests/CommandLineTestRunnerTest.cpp
@@ -139,3 +139,23 @@ TEST(CommandLineTestRunner, JunitOutputAndVerboseEnabled)
     STRCMP_CONTAINS("TEST(group, test)", commandLineTestRunner.fakeJUnitOuputWhichIsReallyABuffer_->getOutput().asCharString());
     STRCMP_CONTAINS("TEST(group, test)", commandLineTestRunner.fakeConsoleOutputWhichIsReallyABuffer->getOutput().asCharString());
 }
+
+TEST(CommandLineTestRunner, listTestGroupNamesShouldWorkProperly)
+{
+    const char* argv[] = { "tests.exe", "-lg" };
+    
+    CommandLineTestRunnerWithStringBufferOutput commandLineTestRunner(2, argv, &registry);
+    commandLineTestRunner.runAllTestsMain();
+
+    STRCMP_CONTAINS("group", commandLineTestRunner.fakeConsoleOutputWhichIsReallyABuffer->getOutput().asCharString());
+}
+
+TEST(CommandLineTestRunner, listTestGroupAndCaseNamesShouldWorkProperly)
+{
+    const char* argv[] = { "tests.exe", "-ln" };
+    
+    CommandLineTestRunnerWithStringBufferOutput commandLineTestRunner(2, argv, &registry);
+    commandLineTestRunner.runAllTestsMain();
+
+    STRCMP_CONTAINS("group.test", commandLineTestRunner.fakeConsoleOutputWhichIsReallyABuffer->getOutput().asCharString());
+}

--- a/tests/CommandLineTestRunnerTest.cpp
+++ b/tests/CommandLineTestRunnerTest.cpp
@@ -31,6 +31,7 @@
 #include "CppUTest/TestTestingFixture.h"
 #include "CppUTest/TestPlugin.h"
 #include "CppUTest/JUnitTestOutput.h"
+#include "CppUTest/PlatformSpecificFunctions.h"
 
 class DummyPluginWhichCountsThePlugins : public TestPlugin
 {
@@ -143,7 +144,7 @@ TEST(CommandLineTestRunner, JunitOutputAndVerboseEnabled)
 TEST(CommandLineTestRunner, listTestGroupNamesShouldWorkProperly)
 {
     const char* argv[] = { "tests.exe", "-lg" };
-    
+
     CommandLineTestRunnerWithStringBufferOutput commandLineTestRunner(2, argv, &registry);
     commandLineTestRunner.runAllTestsMain();
 
@@ -153,9 +154,69 @@ TEST(CommandLineTestRunner, listTestGroupNamesShouldWorkProperly)
 TEST(CommandLineTestRunner, listTestGroupAndCaseNamesShouldWorkProperly)
 {
     const char* argv[] = { "tests.exe", "-ln" };
-    
+
     CommandLineTestRunnerWithStringBufferOutput commandLineTestRunner(2, argv, &registry);
     commandLineTestRunner.runAllTestsMain();
 
     STRCMP_CONTAINS("group.test", commandLineTestRunner.fakeConsoleOutputWhichIsReallyABuffer->getOutput().asCharString());
+}
+
+struct FakeOutput
+{
+    FakeOutput() : SaveFOpen(PlatformSpecificFOpen), SaveFPuts(PlatformSpecificFPuts),
+        SaveFClose(PlatformSpecificFClose), SavePutchar(PlatformSpecificPutchar)
+    {
+        PlatformSpecificFOpen = fopen_fake;
+        PlatformSpecificFPuts = fputs_fake;
+        PlatformSpecificFClose = fclose_fake;
+        PlatformSpecificPutchar = putchar_fake;
+    }
+    ~FakeOutput()
+    {
+        PlatformSpecificPutchar = SavePutchar;
+        PlatformSpecificFOpen = SaveFOpen;
+        PlatformSpecificFPuts = SaveFPuts;
+        PlatformSpecificFClose = SaveFClose;
+    }
+    static PlatformSpecificFile fopen_fake(const char*, const char*)
+    {
+        return (PlatformSpecificFile)0;
+    }
+    static void fputs_fake(const char* str, PlatformSpecificFile)
+    {
+        file += str;
+    }
+    static void fclose_fake(PlatformSpecificFile)
+    {
+    }
+    static int putchar_fake(int c)
+    {
+        console += StringFrom((char)c);
+        return c;
+    }
+    static SimpleString file;
+    static SimpleString console;
+private:
+    PlatformSpecificFile (*SaveFOpen)(const char*, const char*);
+    void (*SaveFPuts)(const char*, PlatformSpecificFile);
+    void (*SaveFClose)(PlatformSpecificFile);
+    int (*SavePutchar)(int);
+};
+
+SimpleString FakeOutput::console = "";
+SimpleString FakeOutput::file = "";
+
+TEST(CommandLineTestRunner, realJunitOutputShouldBeCreatedAndWorkProperly)
+{
+    const char* argv[] = { "tests.exe", "-ojunit", "-v", "-kpackage", };
+
+    FakeOutput* fakeOutput = new FakeOutput; /* UT_PTR_SET() is not reentrant */
+
+    CommandLineTestRunner commandLineTestRunner(4, argv, &registry);
+    commandLineTestRunner.runAllTestsMain();
+
+    delete fakeOutput; /* Original output must be restored before further output occurs */
+
+    STRCMP_CONTAINS("<testcase classname=\"package.group\" name=\"test\"", FakeOutput::file.asCharString());
+    STRCMP_CONTAINS("TEST(group, test)", FakeOutput::console.asCharString());
 }


### PR DESCRIPTION
Due to CommandLineTestRunnerWithStringBufferOutput overriding some methods for testing, the original methods weren't tested anymore.

This test tests the original methods.