### PR TITLE
Added proper pthread library linking when using CMake and MinGW to compile

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,8 +38,13 @@ if (MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4723")
 endif (MSVC)
 
+if (MINGW)
+    find_package (Threads REQUIRED)
+    set(THREAD_LIB "pthread")
+endif (MINGW)
+
 add_executable(CppUTestTests ${CppUTestTests_src})
-target_link_libraries(CppUTestTests CppUTest)
+target_link_libraries(CppUTestTests CppUTest ${THREAD_LIB})
 
 if (TESTS)
     if (TESTS_DETAILED)

--- a/tests/CppUTestExt/CMakeLists.txt
+++ b/tests/CppUTestExt/CMakeLists.txt
@@ -18,8 +18,13 @@ set(CppUTestExtTests_src
     OrderedTestTest.cpp
 )
 
+if (MINGW)
+    find_package (Threads REQUIRED)
+    set(THREAD_LIB "pthread")
+endif (MINGW)
+
 add_executable(CppUTestExtTests ${CppUTestExtTests_src})
-target_link_libraries(CppUTestExtTests CppUTest CppUTestExt ${CPPUNIT_EXTERNAL_LIBRARIES})
+target_link_libraries(CppUTestExtTests CppUTest CppUTestExt ${THREAD_LIB} ${CPPUNIT_EXTERNAL_LIBRARIES})
 
 if (TESTS)
     # get all test groups


### PR DESCRIPTION
It seems that when compiling using MinGW, the pthread library has to be linked explicitly, so I've modified the CMakeLists to do so when using that compiler.

NOTE: cmake's find_package(Threads) is buggy, at least at version 2.8.12, as ${CMAKE_THREAD_LIBS_INIT} is not set properly (it's actually empty), therefore this variable is not used to add the library to the linker.