### PR TITLE
Remove division-by-zero tests again because

### DIFF
--- a/include/CppUTest/Utest.h
+++ b/include/CppUTest/Utest.h
@@ -40,7 +40,6 @@ class TestFilter;
 class TestTerminator;
 
 extern bool doubles_equal(double d1, double d2, double threshold);
-extern int division(int one, int two);
 
 //////////////////// Utest
 

--- a/src/CppUTest/Utest.cpp
+++ b/src/CppUTest/Utest.cpp
@@ -37,11 +37,6 @@ bool doubles_equal(double d1, double d2, double threshold)
     return PlatformSpecificFabs(d1 - d2) <= threshold;
 }
 
-int division(int one, int two)
-{
-  return one / two;
-}
-
 /* Sometimes stubs use the CppUTest assertions.
  * Its not correct to do so, but this small helper class will prevent a segmentation fault and instead
  * will give an error message and also the file/line of the check that was executed outside the tests.

--- a/tests/UtestPlatformTest.cpp
+++ b/tests/UtestPlatformTest.cpp
@@ -94,13 +94,6 @@ static int _accessViolationTestFunction()
     return *(volatile int*) 0;
 }
 
-static int _divisionByZeroTestFunction()
-{
-    int divisionByZero =  division(1, 0);
-    FAIL(StringFromFormat("Should have divided by zero. Outcome: %d", divisionByZero).asCharString());
-    return divisionByZero;
-}
-
 #include <unistd.h>
 #include <signal.h>
 
@@ -123,14 +116,6 @@ TEST(UTestPlatformsTest_PlatformSpecificRunTestInASeperateProcess, AccessViolati
     fixture.setTestFunction((void(*)())_accessViolationTestFunction);
     fixture.runAllTests();
     fixture.assertPrintContains("Failed in separate process - killed by signal 11");
-}
-
-TEST(UTestPlatformsTest_PlatformSpecificRunTestInASeperateProcess, DivisionByZeroInSeparateProcessWorks)
-{
-    fixture.registry_->setRunTestsInSeperateProcess();
-    fixture.setTestFunction((void(*)())_divisionByZeroTestFunction);
-    fixture.runAllTests();
-    fixture.assertPrintContains("Failed in separate process - killed by signal 8");
 }
 
 TEST(UTestPlatformsTest_PlatformSpecificRunTestInASeperateProcess, StoppedInSeparateProcessWorks)

--- a/tests/UtestTest.cpp
+++ b/tests/UtestTest.cpp
@@ -34,11 +34,6 @@ TEST_GROUP(Utest)
 {
 };
 
-TEST(Utest, division)
-{
-    LONGS_EQUAL(3, division(13, 4));
-}
-
 TEST_GROUP(UtestShell)
 {
     TestTestingFixture fixture;


### PR DESCRIPTION
of too many problems with different compilers / architectures.