### PR TITLE
Fixes a problem with warning when compiling with MinGW

### DIFF
--- a/include/CppUTest/CppUTestConfig.h
+++ b/include/CppUTest/CppUTestConfig.h
@@ -177,6 +177,7 @@
 #endif
 
 /* MinGW-w64 prefers to act like Visual C++, but we want the ANSI behaviors instead */
+#undef __USE_MINGW_ANSI_STDIO
 #define __USE_MINGW_ANSI_STDIO 1
 
 /* Should be the only #include here. Standard C library wrappers */


### PR DESCRIPTION
Fixes a problem that caused compiler warnings when compiling using MinGW, if standard C library headers (e.g. stdint.h) are included before cpputest headers (e.g. MockSupport.h).

The problem was that standard headers include "%MINGW_DIR%/include/_mingw.h", which defines the macro __USE_MINGW_ANSI_STDIO, but CppUTestConfig.h also defines that macro unconditionally, and therefore the compiler complains about macro redefinition.