### PR TITLE
Cmake improve

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,12 +80,14 @@ write_basic_package_version_file(
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/install/CppUTestConfig.cmake
               ${CMAKE_CURRENT_BINARY_DIR}/install/CppUTestConfigVersion.cmake
         DESTINATION ${LIB_INSTALL_DIR}/CppUTest/cmake )
-
+install(EXPORT CppUTestTargets
+  DESTINATION ${LIB_INSTALL_DIR}/CppUTest/cmake)
 configure_package_config_file(CppUTestConfig.cmake.build.in
   ${CMAKE_CURRENT_BINARY_DIR}/CppUTestConfig.cmake
   INSTALL_DESTINATION ${CMAKE_CURRENT_BINARY_DIR}
   PATH_VARS INCLUDE_DIR CMAKE_CURRENT_BINARY_DIR
   INSTALL_PREFIX ${CMAKE_CURRENT_BINARY_DIR})
+export(EXPORT CppUTestTargets)
 write_basic_package_version_file(
   ${CMAKE_CURRENT_BINARY_DIR}/CppUTestConfigVersion.cmake
   VERSION ${CppUTest_version_major}.${CppUTest_version_minor}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ set(CppUTest_version_major 3)
 set(CppUTest_version_minor 7dev)
 
 # 2.6.3 is needed for ctest support
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 2.8.7)
 
 option(STD_C "Use the standard C library" ON)
 option(STD_CPP "Use the standard C++ library" ON)
@@ -68,31 +68,40 @@ install(FILES  ${CMAKE_CURRENT_SOURCE_DIR}/${CppUTest_PKGCONFIG_FILE}
     DESTINATION ${LIB_INSTALL_DIR}/pkgconfig
     )
 
-include(CMakePackageConfigHelpers)
-configure_package_config_file(CppUTestConfig.cmake.install.in
-  ${CMAKE_CURRENT_BINARY_DIR}/install/CppUTestConfig.cmake
-  INSTALL_DESTINATION ${LIB_INSTALL_DIR}/CppUTest/cmake
-  PATH_VARS INCLUDE_INSTALL_DIR LIB_INSTALL_DIR)
-write_basic_package_version_file(
-  ${CMAKE_CURRENT_BINARY_DIR}/install/CppUTestConfigVersion.cmake
-  VERSION ${CppUTest_version_major}.${CppUTest_version_minor}
-  COMPATIBILITY SameMajorVersion )
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/install/CppUTestConfig.cmake
-              ${CMAKE_CURRENT_BINARY_DIR}/install/CppUTestConfigVersion.cmake
-        DESTINATION ${LIB_INSTALL_DIR}/CppUTest/cmake )
-install(EXPORT CppUTestTargets
-  DESTINATION ${LIB_INSTALL_DIR}/CppUTest/cmake)
-configure_package_config_file(CppUTestConfig.cmake.build.in
-  ${CMAKE_CURRENT_BINARY_DIR}/CppUTestConfig.cmake
-  INSTALL_DESTINATION ${CMAKE_CURRENT_BINARY_DIR}
-  PATH_VARS INCLUDE_DIR CMAKE_CURRENT_BINARY_DIR)
-export(TARGETS CppUTest CppUTestExt
-  FILE "${CMAKE_CURRENT_BINARY_DIR}/CppUTestTargets.cmake")
-write_basic_package_version_file(
-  ${CMAKE_CURRENT_BINARY_DIR}/CppUTestConfigVersion.cmake
-  VERSION ${CppUTest_version_major}.${CppUTest_version_minor}
-  COMPATIBILITY SameMajorVersion )
-set(CppUTest_DIR "${CMAKE_CURRENT_BINARY_DIR}" CACHE PATH "The directory containing a CMake configuration file for CppUTest.")
+# Try to include helper module
+include(CMakePackageConfigHelpers OPTIONAL
+  RESULT_VARIABLE PkgHelpers_AVAILABLE)
+# guard against older versions of cmake which do not provide it
+if(PkgHelpers_AVAILABLE)
+  configure_package_config_file(CppUTestConfig.cmake.install.in
+    ${CMAKE_CURRENT_BINARY_DIR}/install/CppUTestConfig.cmake
+    INSTALL_DESTINATION ${LIB_INSTALL_DIR}/CppUTest/cmake
+    PATH_VARS INCLUDE_INSTALL_DIR LIB_INSTALL_DIR)
+  write_basic_package_version_file(
+    ${CMAKE_CURRENT_BINARY_DIR}/install/CppUTestConfigVersion.cmake
+    VERSION ${CppUTest_version_major}.${CppUTest_version_minor}
+    COMPATIBILITY SameMajorVersion )
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/install/CppUTestConfig.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/install/CppUTestConfigVersion.cmake
+    DESTINATION ${LIB_INSTALL_DIR}/CppUTest/cmake )
+  install(EXPORT CppUTestTargets
+    DESTINATION ${LIB_INSTALL_DIR}/CppUTest/cmake)
+  configure_package_config_file(CppUTestConfig.cmake.build.in
+    ${CMAKE_CURRENT_BINARY_DIR}/CppUTestConfig.cmake
+    INSTALL_DESTINATION ${CMAKE_CURRENT_BINARY_DIR}
+    PATH_VARS INCLUDE_DIR CMAKE_CURRENT_BINARY_DIR)
+  export(TARGETS CppUTest CppUTestExt
+    FILE "${CMAKE_CURRENT_BINARY_DIR}/CppUTestTargets.cmake")
+  write_basic_package_version_file(
+    ${CMAKE_CURRENT_BINARY_DIR}/CppUTestConfigVersion.cmake
+    VERSION ${CppUTest_version_major}.${CppUTest_version_minor}
+    COMPATIBILITY SameMajorVersion )
+  set(CppUTest_DIR "${CMAKE_CURRENT_BINARY_DIR}" CACHE PATH "The directory containing a CMake configuration file for CppUTest.")
+else()
+  message("If you wish to use find_package(CppUTest) in your own project to find CppUTest library"
+    " please update cmake to version which provides CMakePackageConfighelpers module"
+    " or write generators for CppUTestConfig.cmake by yourself.")
+endif()
 
 message("
 -------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ if (TESTS)
     add_subdirectory(tests)
 endif (TESTS)
 
-set (INCLUDE_INSTALL_DIR "include/CppUTest")
+set (INCLUDE_INSTALL_DIR "include")
 set (LIB_INSTALL_DIR "lib")
 set (INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/include")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,7 @@ write_basic_package_version_file(
   ${CMAKE_CURRENT_BINARY_DIR}/CppUTestConfigVersion.cmake
   VERSION ${CppUTest_version_major}.${CppUTest_version_minor}
   COMPATIBILITY SameMajorVersion )
-set(CppUTest_DIR "${CMAKE_CURRENT_BINARY_DIR}" CACHE PATH "Path to CppUTest" FORCE)
+set(CppUTest_DIR "${CMAKE_CURRENT_BINARY_DIR}" CACHE PATH "The directory containing a CMake configuration file for CppUTest.")
 
 message("
 -------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ set(CppUTest_version_major 3)
 set(CppUTest_version_minor 7dev)
 
 # 2.6.3 is needed for ctest support
-cmake_minimum_required(VERSION 2.6.3)
+cmake_minimum_required(VERSION 2.8.12)
 
 option(STD_C "Use the standard C library" ON)
 option(STD_CPP "Use the standard C++ library" ON)
@@ -85,9 +85,8 @@ install(EXPORT CppUTestTargets
 configure_package_config_file(CppUTestConfig.cmake.build.in
   ${CMAKE_CURRENT_BINARY_DIR}/CppUTestConfig.cmake
   INSTALL_DESTINATION ${CMAKE_CURRENT_BINARY_DIR}
-  PATH_VARS INCLUDE_DIR CMAKE_CURRENT_BINARY_DIR
-  INSTALL_PREFIX ${CMAKE_CURRENT_BINARY_DIR})
-export(EXPORT CppUTestTargets
+  PATH_VARS INCLUDE_DIR CMAKE_CURRENT_BINARY_DIR)
+export(TARGETS CppUTest CppUTestExt
   FILE "${CMAKE_CURRENT_BINARY_DIR}/CppUTestTargets.cmake")
 write_basic_package_version_file(
   ${CMAKE_CURRENT_BINARY_DIR}/CppUTestConfigVersion.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,11 +87,13 @@ configure_package_config_file(CppUTestConfig.cmake.build.in
   INSTALL_DESTINATION ${CMAKE_CURRENT_BINARY_DIR}
   PATH_VARS INCLUDE_DIR CMAKE_CURRENT_BINARY_DIR
   INSTALL_PREFIX ${CMAKE_CURRENT_BINARY_DIR})
-export(EXPORT CppUTestTargets)
+export(EXPORT CppUTestTargets
+  FILE "${CMAKE_CURRENT_BINARY_DIR}/CppUTestTargets.cmake")
 write_basic_package_version_file(
   ${CMAKE_CURRENT_BINARY_DIR}/CppUTestConfigVersion.cmake
   VERSION ${CppUTest_version_major}.${CppUTest_version_minor}
   COMPATIBILITY SameMajorVersion )
+set(CppUTest_DIR "${CMAKE_CURRENT_BINARY_DIR}" CACHE PATH "Path to CppUTest" FORCE)
 
 message("
 -------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,10 @@ if (TESTS)
     add_subdirectory(tests)
 endif (TESTS)
 
+set (INCLUDE_INSTALL_DIR "include/CppUTest")
+set (LIB_INSTALL_DIR "lib")
+set (INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
 # Pkg-config file.
 set (prefix "${CMAKE_INSTALL_PREFIX}")
 set (exec_prefix "${CMAKE_INSTALL_PREFIX}")
@@ -63,6 +67,29 @@ configure_file (cpputest.pc.in
 install(FILES  ${CMAKE_CURRENT_SOURCE_DIR}/${CppUTest_PKGCONFIG_FILE}
     DESTINATION ${LIB_INSTALL_DIR}/pkgconfig
     )
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file(CppUTestConfig.cmake.install.in
+  ${CMAKE_CURRENT_BINARY_DIR}/install/CppUTestConfig.cmake
+  INSTALL_DESTINATION ${LIB_INSTALL_DIR}/CppUTest/cmake
+  PATH_VARS INCLUDE_INSTALL_DIR LIB_INSTALL_DIR)
+write_basic_package_version_file(
+  ${CMAKE_CURRENT_BINARY_DIR}/install/CppUTestConfigVersion.cmake
+  VERSION ${CppUTest_version_major}.${CppUTest_version_minor}
+  COMPATIBILITY SameMajorVersion )
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/install/CppUTestConfig.cmake
+              ${CMAKE_CURRENT_BINARY_DIR}/install/CppUTestConfigVersion.cmake
+        DESTINATION ${LIB_INSTALL_DIR}/CppUTest/cmake )
+
+configure_package_config_file(CppUTestConfig.cmake.build.in
+  ${CMAKE_CURRENT_BINARY_DIR}/CppUTestConfig.cmake
+  INSTALL_DESTINATION ${CMAKE_CURRENT_BINARY_DIR}
+  PATH_VARS INCLUDE_DIR CMAKE_CURRENT_BINARY_DIR
+  INSTALL_PREFIX ${CMAKE_CURRENT_BINARY_DIR})
+write_basic_package_version_file(
+  ${CMAKE_CURRENT_BINARY_DIR}/CppUTestConfigVersion.cmake
+  VERSION ${CppUTest_version_major}.${CppUTest_version_minor}
+  COMPATIBILITY SameMajorVersion )
 
 message("
 -------------------------------------------------------

--- a/CppUTestConfig.cmake.build.in
+++ b/CppUTestConfig.cmake.build.in
@@ -1,8 +1,7 @@
 @PACKAGE_INIT@
 
 set_and_check(CppUTest_INCLUDE_DIRS "@PACKAGE_INCLUDE_DIR@")
-set_and_check(CppUTest_LIBRARY "@PACKAGE_CMAKE_CURRENT_BINARY_DIR@/src/CppUTest")
-set_and_check(CppUTest_Ext_LIBRARY "@PACKAGE_CMAKE_CURRENT_BINARY_DIR@/src/CppUTestExt")
-set(CppUTest_LIBRARIES ${CppUTest_LIBRARY} ${CppUTest_Ext_LIBRARY})
+include("${CMAKE_CURRENT_LIST_DIR}/CppUTestTargets.cmake")
+set(CppUTest_LIBRARIES CppUTest CppUTestExt)
 
 check_required_components(CppUTest)

--- a/CppUTestConfig.cmake.build.in
+++ b/CppUTestConfig.cmake.build.in
@@ -1,0 +1,8 @@
+@PACKAGE_INIT@
+
+set_and_check(CppUTest_INCLUDE_DIRS "@PACKAGE_INCLUDE_DIR@")
+set_and_check(CppUTest_LIBRARY "@PACKAGE_CMAKE_CURRENT_BINARY_DIR@/src/CppUTest")
+set_and_check(CppUTest_Ext_LIBRARY "@PACKAGE_CMAKE_CURRENT_BINARY_DIR@/src/CppUTestExt")
+set(CppUTest_LIBRARIES ${CppUTest_LIBRARY} ${CppUTest_Ext_LIBRARY})
+
+check_required_components(CppUTest)

--- a/CppUTestConfig.cmake.build.in
+++ b/CppUTestConfig.cmake.build.in
@@ -1,7 +1,7 @@
 @PACKAGE_INIT@
 
 set_and_check(CppUTest_INCLUDE_DIRS "@PACKAGE_INCLUDE_DIR@")
-include("${CMAKE_CURRENT_LIST_DIR}/CppUTestTargets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/CppUTestTargets.cmake" OPTIONAL)
 set(CppUTest_LIBRARIES CppUTest CppUTestExt)
 
 check_required_components(CppUTest)

--- a/CppUTestConfig.cmake.install.in
+++ b/CppUTestConfig.cmake.install.in
@@ -1,0 +1,8 @@
+@PACKAGE_INIT@
+
+set_and_check(CppUTest_INCLUDE_DIRS "@PACKAGE_INCLUDE_INSTALL_DIR@")
+set_and_check(CppUTest_LIBRARY "@PACKAGE_LIB_INSTALL_DIR@/CppUTest")
+set_and_check(CppUTest_Ext_LIBRARY "@PACKAGE_LIB_INSTALL_DIR@/CppUTestExt")
+set(CppUTest_LIBRARIES ${CppUTest_LIBRARY} ${CppUTest_Ext_LIBRARY})
+
+check_required_components(CppUTest)

--- a/CppUTestConfig.cmake.install.in
+++ b/CppUTestConfig.cmake.install.in
@@ -1,8 +1,7 @@
 @PACKAGE_INIT@
 
 set_and_check(CppUTest_INCLUDE_DIRS "@PACKAGE_INCLUDE_INSTALL_DIR@")
-set_and_check(CppUTest_LIBRARY "@PACKAGE_LIB_INSTALL_DIR@/CppUTest")
-set_and_check(CppUTest_Ext_LIBRARY "@PACKAGE_LIB_INSTALL_DIR@/CppUTestExt")
-set(CppUTest_LIBRARIES ${CppUTest_LIBRARY} ${CppUTest_Ext_LIBRARY})
+include("${CMAKE_CURRENT_LIST_DIR}/CppUTestTargets.cmake")
+set(CppUTest_LIBRARIES CppUTest CppUTestExt)
 
 check_required_components(CppUTest)

--- a/src/CppUTest/CMakeLists.txt
+++ b/src/CppUTest/CMakeLists.txt
@@ -51,6 +51,7 @@ if (WIN32)
 endif (WIN32)
 install(FILES ${CppUTest_headers} DESTINATION include/CppUTest)
 install(TARGETS CppUTest
+    EXPORT CppUTestTargets 
     RUNTIME DESTINATION bin
     LIBRARY DESTINATION lib
     ARCHIVE DESTINATION lib)

--- a/src/CppUTest/CMakeLists.txt
+++ b/src/CppUTest/CMakeLists.txt
@@ -51,6 +51,7 @@ if (WIN32)
 endif (WIN32)
 install(FILES ${CppUTest_headers} DESTINATION include/CppUTest)
 install(TARGETS CppUTest
+    EXPORT CppUTestTargets
     RUNTIME DESTINATION bin
     LIBRARY DESTINATION lib
     ARCHIVE DESTINATION lib)

--- a/src/CppUTest/CMakeLists.txt
+++ b/src/CppUTest/CMakeLists.txt
@@ -51,7 +51,6 @@ if (WIN32)
 endif (WIN32)
 install(FILES ${CppUTest_headers} DESTINATION include/CppUTest)
 install(TARGETS CppUTest
-    EXPORT CppUTestTargets 
     RUNTIME DESTINATION bin
     LIBRARY DESTINATION lib
     ARCHIVE DESTINATION lib)

--- a/src/CppUTestExt/CMakeLists.txt
+++ b/src/CppUTestExt/CMakeLists.txt
@@ -40,6 +40,7 @@ add_library(CppUTestExt STATIC ${CppUTestExt_src})
 target_link_libraries(CppUTestExt ${CPPUNIT_EXTERNAL_LIBRARIES})
 install(FILES ${CppUTestExt_headers} DESTINATION include/CppUTestExt)
 install(TARGETS CppUTestExt
+    EXPORT CppUTestTargets
     RUNTIME DESTINATION bin
     LIBRARY DESTINATION lib
     ARCHIVE DESTINATION lib)

--- a/src/CppUTestExt/CMakeLists.txt
+++ b/src/CppUTestExt/CMakeLists.txt
@@ -40,7 +40,6 @@ add_library(CppUTestExt STATIC ${CppUTestExt_src})
 target_link_libraries(CppUTestExt ${CPPUNIT_EXTERNAL_LIBRARIES})
 install(FILES ${CppUTestExt_headers} DESTINATION include/CppUTestExt)
 install(TARGETS CppUTestExt
-    EXPORT CppUTestTargets 
     RUNTIME DESTINATION bin
     LIBRARY DESTINATION lib
     ARCHIVE DESTINATION lib)

--- a/src/CppUTestExt/CMakeLists.txt
+++ b/src/CppUTestExt/CMakeLists.txt
@@ -40,6 +40,7 @@ add_library(CppUTestExt STATIC ${CppUTestExt_src})
 target_link_libraries(CppUTestExt ${CPPUNIT_EXTERNAL_LIBRARIES})
 install(FILES ${CppUTestExt_headers} DESTINATION include/CppUTestExt)
 install(TARGETS CppUTestExt
+    EXPORT CppUTestTargets 
     RUNTIME DESTINATION bin
     LIBRARY DESTINATION lib
     ARCHIVE DESTINATION lib)


### PR DESCRIPTION
Generate appropriate CppUTestConfig.cmake files so `find_package` works properly.

After installing CppUTest (using cmake) under one of the predefined default locations other projects may find it by calling `find_package(CppUTest)`. After successful call variable `CppUTest_INCLUDE_DIRS` should be initialized with path to CppUTest headers and `CppUTest_LIBRARIES` variable should be initialized with appropriate targets to link with, e.g.
```
find_package(CppUTest  REQUIRED NO_CMAKE_PATH)
include_directories(${CppUTest_INCLUDE_DIRS})
# ...
target_link_libraries(my_tests ${CppUTest_LIBRARIES})
```
If you wish to use CppUTest installed under non-standard location use `CppUTest_DIR` variable to point out directory with appropriate CppUTestConfig.cmake file. It is usually installed under `<install_prefix>/lib/CppUTest/cmake` path, e.g.
```
set(CppUTest_DIR "/opt/weird_path/lib/CppUTest/cmake")
find_package(CppUTest  REQUIRED NO_CMAKE_PATH)
include_directories(${CppUTest_INCLUDE_DIRS})
# ...
target_link_libraries(my_tests ${CppUTest_LIBRARIES})
```
You may also use CppUTest without installation. Just point out `CppUTest_DIR` variable to the directory where CppUTest was built (it's CMAKE_BINARY_DIR) before calling `find_package`.

Last option is to build CppUTest together with your project. Put CppUTest source code under subdirectory of your own project (e.g. using `git submodule`) and add that directory to build using `add_subdirectory` command. You may set CppUTest configuration variables before that, e.g.

```
set(MEMORY_LEAK_DETECTION OFF)
add_subdirectory(ext/CppUTest)
find_package(CppUTest  REQUIRED NO_CMAKE_PATH)
include_directories(${CppUTest_INCLUDE_DIRS})
# ...
target_link_libraries(my_tests ${CppUTest_LIBRARIES})
```
  

