### PR TITLE
CMake build-time test discovery

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CppUTestRootDirectory}/cmake/Module
 
 include("${CppUTestRootDirectory}/cmake/Modules/CppUTestConfigurationOptions.cmake")
 include(CTest)
+include("${CppUTestRootDirectory}/cmake/Modules/CppUTestBuildTimeDiscoverTests.cmake")
 
 configure_file (
     "${PROJECT_SOURCE_DIR}/config.h.cmake"
@@ -87,6 +88,9 @@ Features configure in CppUTest:
 
     Generating map file:                ${MAP_FILE}
     Compiling with coverage:            ${COVERAGE}
+
+    Compile and run self-tests          ${TESTS}
+    Run self-tests separately           ${TESTS_DETAILED}
 
 -------------------------------------------------------
 ")

--- a/cmake/Modules/CppUTestBuildTimeDiscoverTests.cmake
+++ b/cmake/Modules/CppUTestBuildTimeDiscoverTests.cmake
@@ -1,0 +1,9 @@
+# Create target to discover tests
+function (cpputest_buildtime_discover_tests EXECUTABLE)
+    add_custom_command (TARGET ${EXECUTABLE}
+			POST_BUILD
+			COMMAND ${CMAKE_COMMAND} -DTESTS_DETAILED:BOOL=${TESTS_DETAILED} -DEXECUTABLE=${EXECUTABLE} -P ${PROJECT_SOURCE_DIR}/cmake/Scripts/CppUTestBuildTimeDiscoverTests.cmake
+			WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+			COMMENT "Discovering Tests in ${EXECUTABLE}"
+			VERBATIM)
+endfunction ()

--- a/cmake/Scripts/CppUTestBuildTimeDiscoverTests.cmake
+++ b/cmake/Scripts/CppUTestBuildTimeDiscoverTests.cmake
@@ -1,0 +1,87 @@
+# Create CTest entries for EXECUTABLE in CTestTestfile.cmake
+# Overwrite CTestTestfile.cmake with update version.
+
+# Usage:
+#
+# This script is to be called from ../Modules/CppUTestBuildTimeDiscoverTests.cmake
+#
+# Steps to generate ADD_TEST() commands build time
+# - Read CTestTestfile.cmake
+# - Create update entries
+# - Remove duplicate entries
+# - Write new CTestTestfile.cmake
+
+######################################################################
+# helpers
+######################################################################
+function (buildtime_add_test)
+  # Create ADD_TEST() command string
+  # - Extract and remove testname from ARGV
+  # - Add inner quotes to test arguments
+  # - Add "ADD_TEST()", and first and last quote
+  # Append result to CTESTTESTS
+  list(GET ARGV 0 testname)
+  list(REMOVE_AT ARGV 0)
+  string (REPLACE ";" "\" \"" TEST_ARGS "${ARGV}")
+  set(test_to_add "ADD_TEST(${testname} \"${TEST_ARGS}\")")
+  list(APPEND CTESTTESTS ${test_to_add})
+  SET(CTESTTESTS ${CTESTTESTS} PARENT_SCOPE)
+endfunction()
+
+function (JOIN VALUES GLUE OUTPUT)
+  string (REPLACE ";" "${GLUE}" _TMP_STR "${VALUES}")
+  set (${OUTPUT} "${_TMP_STR}" PARENT_SCOPE)
+endfunction()
+
+function (buildtime_discover_tests EXECUTABLE_CMD DISCOVER_ARG OUTPUT)
+  execute_process(COMMAND ${EXECUTABLE_CMD} ${DISCOVER_ARG}
+    OUTPUT_VARIABLE _TMP_OUTPUT
+    ERROR_VARIABLE DISCOVER_ERR
+    RESULT_VARIABLE DISCOVER_ERR)
+  if(NOT ${DISCOVER_ERR} EQUAL 0)
+    message(SEND_ERROR "Executable \"${EXECUTABLE_CMD} ${DISCOVER_ARG}\" failed with output:\n"
+      "${DISCOVER_ERR}\n"
+      "Please check that the excutable was added.")
+  endif(NOT ${DISCOVER_ERR} EQUAL 0)
+  separate_arguments(_TMP_OUTPUT)
+  set(${OUTPUT} "${_TMP_OUTPUT}" PARENT_SCOPE)
+endfunction()
+
+
+######################################################################
+# Implementation
+######################################################################
+
+set(CTESTFNAME "${CMAKE_CURRENT_BINARY_DIR}/CTestTestfile.cmake")
+file(STRINGS ${CTESTFNAME} CTESTTESTS)
+set(EXECUTABLE_CMD "${CMAKE_CURRENT_BINARY_DIR}/${EXECUTABLE}")
+
+if (TESTS_DETAILED)
+  set(DISCOVER_ARG "-ln")
+  buildtime_discover_tests("${EXECUTABLE_CMD}" "${DISCOVER_ARG}" TestList_GroupsAndNames)
+  set(lastgroup "")
+  foreach(testfullname ${TestList_GroupsAndNames})
+    string(REGEX MATCH "^([^/.]+)" groupname ${testfullname})
+    string(REGEX MATCH "([^/.]+)$" testname ${testfullname})
+    if (NOT ("${groupname}" STREQUAL "${lastgroup}"))
+      message("TestGroup: ${groupname}:")
+      set(lastgroup "${groupname}")
+    endif (NOT ("${groupname}" STREQUAL "${lastgroup}"))
+    message("... ${testname}")
+    buildtime_add_test(${EXECUTABLE}.${testfullname} ${EXECUTABLE_CMD} -sg ${groupname} -sn ${testname} -c)
+  endforeach()
+else (TESTS_DETAILED)
+  set(DISCOVER_ARG "-lg")
+  buildtime_discover_tests("${EXECUTABLE_CMD}" "${DISCOVER_ARG}" TestList_Groups)
+  foreach(group ${TestList_Groups})
+    message("TestGroup: ${group}")
+    buildtime_add_test(${EXECUTABLE}.${group} "${EXECUTABLE_CMD}" -sg ${group} -c)
+  endforeach()
+endif (TESTS_DETAILED)
+
+
+# create separate CTest test for each CppUTestTests test
+
+list(REMOVE_DUPLICATES CTESTTESTS)
+JOIN("${CTESTTESTS}" "\n" CTESTTESTS)
+file(WRITE ${CTESTFNAME} "${CTESTTESTS}\n")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,6 +46,5 @@ endif (MINGW)
 add_executable(CppUTestTests ${CppUTestTests_src})
 target_link_libraries(CppUTestTests CppUTest ${THREAD_LIB})
 
-
+add_subdirectory(CppUTestExt)
 cpputest_buildtime_discover_tests (CppUTestTests)
-

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,35 +46,6 @@ endif (MINGW)
 add_executable(CppUTestTests ${CppUTestTests_src})
 target_link_libraries(CppUTestTests CppUTest ${THREAD_LIB})
 
-if (TESTS)
-    if (TESTS_DETAILED)
-        # get all test groups and names
-        execute_process(COMMAND tests/CppUTestTests -ln OUTPUT_VARIABLE CppUTestTests_GroupsAndNames)
-        # convert space-separated string into a list
-        separate_arguments(CppUTestTests_GroupsAndNames)
-        # create separate CTest test for each CppUTestTests test
-        set(lastgroup "")
-        foreach(testfullname ${CppUTestTests_GroupsAndNames})
-            string(REGEX MATCH "^([^/.]+)" groupname ${testfullname})
-            string(REGEX MATCH "([^/.]+)$" testname ${testfullname})
-            if (NOT ("${groupname}" STREQUAL "${lastgroup}"))
-                message("TestGroup1: ${groupname}:")
-                set(lastgroup "${groupname}")
-            endif (NOT ("${groupname}" STREQUAL "${lastgroup}"))
-            message("... ${testname}")
-            add_test(NAME CppUTest.${testfullname} COMMAND ${EXECUTABLE_OUTPUT_PATH}/CppUTestTests -sg ${groupname} -sn ${testname} -c)
-        endforeach()
-    else (TESTS_DETAILED)
-        # get all test groups
-        execute_process(COMMAND tests/CppUTestTests -lg OUTPUT_VARIABLE CppUTestTests_Groups)
-        # create separate test for each group
-        separate_arguments(CppUTestTests_Groups)
-        foreach(group ${CppUTestTests_Groups})
-            message("TestGroup1: ${group}")
-            add_test(NAME CppUTest.${group} COMMAND ${EXECUTABLE_OUTPUT_PATH}/CppUTestTests -sg ${group} -c)
-        endforeach()
-    endif (TESTS_DETAILED)
 
-    add_subdirectory(CppUTestExt)
-endif (TESTS)
+cpputest_buildtime_discover_tests (CppUTestTests)
 

--- a/tests/CppUTestExt/CMakeLists.txt
+++ b/tests/CppUTestExt/CMakeLists.txt
@@ -25,14 +25,4 @@ endif (MINGW)
 
 add_executable(CppUTestExtTests ${CppUTestExtTests_src})
 target_link_libraries(CppUTestExtTests CppUTest CppUTestExt ${THREAD_LIB} ${CPPUNIT_EXTERNAL_LIBRARIES})
-
-if (TESTS)
-    # get all test groups
-    execute_process(COMMAND tests/CppUTestExt/CppUTestExtTests -lg OUTPUT_VARIABLE CppUTestTestsExt_Groups)
-    # create separate test for each group
-    separate_arguments(CppUTestTestsExt_Groups)
-    foreach(group ${CppUTestTestsExt_Groups})
-        message("TestGroup2: ${group}:")
-        add_test(NAME CppUTestExt.${group} COMMAND ${EXECUTABLE_OUTPUT_PATH}/CppUTestExtTests -sg ${group} -c)
-    endforeach()
-endif (TESTS)
+cpputest_buildtime_discover_tests (CppUTestExtTests)


### PR DESCRIPTION
Improve the CMake infrastructure by doing (post)-build-time test discovery. 

Currently `tests/CMakeLists.txt` executes  the `tests/CppUTestTests` binary at configure-time to obtain a list of tests to be added using the ADD_TEST() command. This is a problem because:

* The `tests/CppUTestTests` binary does not exist when staring with a clean build-tree
* New tests are not detected until a reconfigure is issued.

The proposed patch generates ADD_TEST() commands from a test list obtained by invoking the binary containing the tests *after* the binary has been build.

Now test discovery is done my invoking `cpputest_buildtime_discover_tests ()` e.g. in `tests/CMakeLists.txt`:

    cpputest_buildtime_discover_tests (CppUTestTests)

 