### PR TITLE
BITS_EQUAL assertion

### DIFF
--- a/include/CppUTest/SimpleString.h
+++ b/include/CppUTest/SimpleString.h
@@ -149,6 +149,7 @@ SimpleString StringFromFormat(const char* format, ...) __check_format__(printf, 
 SimpleString VStringFromFormat(const char* format, va_list args);
 SimpleString StringFromBinary(const unsigned char* value, size_t size);
 SimpleString StringFromBinaryOrNull(const unsigned char* value, size_t size);
+SimpleString StringFromMaskedBits(unsigned long value, unsigned long mask, size_t byteCount);
 
 #if CPPUTEST_USE_STD_CPP_LIB
 

--- a/include/CppUTest/TestFailure.h
+++ b/include/CppUTest/TestFailure.h
@@ -150,4 +150,10 @@ public:
 	BinaryEqualFailure(UtestShell* test, const char* fileName, int lineNumber, const unsigned char* expected, const unsigned char* actual, size_t size);
 };
 
+class BitsEqualFailure : public TestFailure
+{
+public:
+	BitsEqualFailure(UtestShell* test, const char* fileName, int lineNumber, unsigned long expected, unsigned long actual, unsigned long mask, size_t byteCount);
+};
+
 #endif

--- a/include/CppUTest/Utest.h
+++ b/include/CppUTest/Utest.h
@@ -118,6 +118,7 @@ public:
     virtual void assertDoublesEqual(double expected, double actual, double threshold, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
     virtual void assertEquals(bool failed, const char* expected, const char* actual, const char* file, int line, const TestTerminator& testTerminator = NormalTestTerminator());
     virtual void assertBinaryEqual(const void *expected, const void *actual, size_t length, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
+    virtual void assertBitsEqual(unsigned long expected, unsigned long actual, unsigned long mask, size_t byteCount, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
     virtual void fail(const char *text, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
 
     virtual void print(const char *text, const char *fileName, int lineNumber);

--- a/include/CppUTest/UtestMacros.h
+++ b/include/CppUTest/UtestMacros.h
@@ -195,6 +195,12 @@
 #define MEMCMP_EQUAL_LOCATION(expected,actual,size,file,line)\
   { UtestShell::getCurrent()->assertBinaryEqual(expected, actual, size, file, line); }
 
+#define BITS_EQUAL(expected,actual,mask)\
+  BITS_LOCATION(expected,actual,mask,__FILE__,__LINE__)
+
+#define BITS_LOCATION(expected,actual,mask,file,line)\
+  { UtestShell::getCurrent()->assertBitsEqual(expected, actual, mask, sizeof(actual), file, line); }
+
 //Fail if you get to this macro
 //The macro FAIL may already be taken, so allow FAIL_TEST too
 #ifndef FAIL

--- a/src/CppUTest/SimpleString.cpp
+++ b/src/CppUTest/SimpleString.cpp
@@ -586,6 +586,31 @@ SimpleString StringFromBinaryOrNull(const unsigned char* value, size_t size)
     return (value) ? StringFromBinary(value, size) : "(null)";
 }
 
+SimpleString StringFromMaskedBits(unsigned long value, unsigned long mask, size_t byteCount)
+{
+    SimpleString result;
+    size_t bitCount = (byteCount > sizeof(unsigned long)) ? (sizeof(unsigned long) * 8) : (byteCount * 8);
+    const unsigned long msbMask = (((unsigned long) 1) << (bitCount - 1));
+
+    for (size_t i = 0; i < bitCount; i++) {
+        if (mask & msbMask) {
+            result += (value & msbMask) ? "1" : "0";
+        }
+        else {
+            result += "x";
+        }
+
+        if (((i % 8) == 7) && (i != (bitCount - 1))) {
+            result += " ";
+        }
+
+        value <<= 1;
+        mask <<= 1;
+    }
+
+    return result;
+}
+
 SimpleStringCollection::SimpleStringCollection()
 {
     collection_ = 0;

--- a/src/CppUTest/TestFailure.cpp
+++ b/src/CppUTest/TestFailure.cpp
@@ -283,3 +283,9 @@ BinaryEqualFailure::BinaryEqualFailure(UtestShell* test, const char* fileName, i
 		message_ += createDifferenceAtPosString(StringFromBinary(actual, size), failStart, DIFFERENCE_BINARY);
 	}
 }
+
+BitsEqualFailure::BitsEqualFailure(UtestShell* test, const char* fileName, int lineNumber, unsigned long expected, unsigned long actual, unsigned long mask, size_t byteCount) :
+        TestFailure(test, fileName, lineNumber)
+{
+    message_ = createButWasString(StringFromMaskedBits(expected, mask, byteCount), StringFromMaskedBits(actual, mask, byteCount));
+}

--- a/src/CppUTest/Utest.cpp
+++ b/src/CppUTest/Utest.cpp
@@ -445,7 +445,7 @@ void UtestShell::assertBitsEqual(unsigned long expected, unsigned long actual, u
 {
     getTestResult()->countCheck();
     if ((expected & mask) != (actual & mask))
-        failWith(BitsEqualFailure(this, fileName, lineNumber, expected, actual, mask, byteCount));
+        failWith(BitsEqualFailure(this, fileName, lineNumber, expected, actual, mask, byteCount), testTerminator);
 }
 
 void UtestShell::assertEquals(bool failed, const char* expected, const char* actual, const char* file, int line, const TestTerminator& testTerminator)

--- a/src/CppUTest/Utest.cpp
+++ b/src/CppUTest/Utest.cpp
@@ -441,6 +441,13 @@ void UtestShell::assertBinaryEqual(const void *expected, const void *actual, siz
         failWith(BinaryEqualFailure(this, fileName, lineNumber, (const unsigned char *) expected, (const unsigned char *) actual, length), testTerminator);
 }
 
+void UtestShell::assertBitsEqual(unsigned long expected, unsigned long actual, unsigned long mask, size_t byteCount, const char *fileName, int lineNumber, const TestTerminator& testTerminator)
+{
+    getTestResult()->countCheck();
+    if ((expected & mask) != (actual & mask))
+        failWith(BitsEqualFailure(this, fileName, lineNumber, expected, actual, mask, byteCount));
+}
+
 void UtestShell::assertEquals(bool failed, const char* expected, const char* actual, const char* file, int line, const TestTerminator& testTerminator)
 {
     getTestResult()->countCheck();

--- a/tests/SimpleStringTest.cpp
+++ b/tests/SimpleStringTest.cpp
@@ -836,7 +836,7 @@ TEST(SimpleString, MaskedBits1byte)
     STRCMP_EQUAL("11xx11xx", StringFromMaskedBits(0xFF, 0xCC, 1).asCharString());
 }
 
-TEST(SimpleString, MaskedBits2byte)
+TEST(SimpleString, MaskedBits2bytes)
 {
     STRCMP_EQUAL("xxxxxxxx xxxxxxxx", StringFromMaskedBits(0x0000, 0x0000, 2).asCharString());
     STRCMP_EQUAL("00000000 00000000", StringFromMaskedBits(0x0000, 0xFFFF, 2).asCharString());
@@ -846,7 +846,7 @@ TEST(SimpleString, MaskedBits2byte)
     STRCMP_EQUAL("11xx11xx 11xx11xx", StringFromMaskedBits(0xFFFF, 0xCCCC, 2).asCharString());
 }
 
-TEST(SimpleString, MaskedBits4byte)
+TEST(SimpleString, MaskedBits4bytes)
 {
     STRCMP_EQUAL("xxxxxxxx xxxxxxxx xxxxxxxx xxxxxxxx", StringFromMaskedBits(0x00000000, 0x00000000, 4).asCharString());
     STRCMP_EQUAL("00000000 00000000 00000000 00000000", StringFromMaskedBits(0x00000000, 0xFFFFFFFF, 4).asCharString());

--- a/tests/SimpleStringTest.cpp
+++ b/tests/SimpleStringTest.cpp
@@ -824,3 +824,34 @@ TEST(SimpleString, MemCmpFirstLastNotMatching)
     CHECK(0 != SimpleString::MemCmp(base, firstNotMatching, sizeof(base)));
     CHECK(0 != SimpleString::MemCmp(base, lastNotMatching, sizeof(base)));
 }
+
+
+TEST(SimpleString, MaskedBits1byte)
+{
+    STRCMP_EQUAL("xxxxxxxx", StringFromMaskedBits(0x00, 0x00, 1).asCharString());
+    STRCMP_EQUAL("00000000", StringFromMaskedBits(0x00, 0xFF, 1).asCharString());
+    STRCMP_EQUAL("11111111", StringFromMaskedBits(0xFF, 0xFF, 1).asCharString());
+    STRCMP_EQUAL("1xxxxxxx", StringFromMaskedBits(0x80, 0x80, 1).asCharString());
+    STRCMP_EQUAL("xxxxxxx1", StringFromMaskedBits(0x01, 0x01, 1).asCharString());
+    STRCMP_EQUAL("11xx11xx", StringFromMaskedBits(0xFF, 0xCC, 1).asCharString());
+}
+
+TEST(SimpleString, MaskedBits2byte)
+{
+    STRCMP_EQUAL("xxxxxxxx xxxxxxxx", StringFromMaskedBits(0x0000, 0x0000, 2).asCharString());
+    STRCMP_EQUAL("00000000 00000000", StringFromMaskedBits(0x0000, 0xFFFF, 2).asCharString());
+    STRCMP_EQUAL("11111111 11111111", StringFromMaskedBits(0xFFFF, 0xFFFF, 2).asCharString());
+    STRCMP_EQUAL("1xxxxxxx xxxxxxxx", StringFromMaskedBits(0x8000, 0x8000, 2).asCharString());
+    STRCMP_EQUAL("xxxxxxxx xxxxxxx1", StringFromMaskedBits(0x0001, 0x0001, 2).asCharString());
+    STRCMP_EQUAL("11xx11xx 11xx11xx", StringFromMaskedBits(0xFFFF, 0xCCCC, 2).asCharString());
+}
+
+TEST(SimpleString, MaskedBits4byte)
+{
+    STRCMP_EQUAL("xxxxxxxx xxxxxxxx xxxxxxxx xxxxxxxx", StringFromMaskedBits(0x00000000, 0x00000000, 4).asCharString());
+    STRCMP_EQUAL("00000000 00000000 00000000 00000000", StringFromMaskedBits(0x00000000, 0xFFFFFFFF, 4).asCharString());
+    STRCMP_EQUAL("11111111 11111111 11111111 11111111", StringFromMaskedBits(0xFFFFFFFF, 0xFFFFFFFF, 4).asCharString());
+    STRCMP_EQUAL("1xxxxxxx xxxxxxxx xxxxxxxx xxxxxxxx", StringFromMaskedBits(0x80000000, 0x80000000, 4).asCharString());
+    STRCMP_EQUAL("xxxxxxxx xxxxxxxx xxxxxxxx xxxxxxx1", StringFromMaskedBits(0x00000001, 0x00000001, 4).asCharString());
+    STRCMP_EQUAL("11xx11xx 11xx11xx 11xx11xx 11xx11xx", StringFromMaskedBits(0xFFFFFFFF, 0xCCCCCCCC, 4).asCharString());
+}

--- a/tests/TestFailureTest.cpp
+++ b/tests/TestFailureTest.cpp
@@ -293,3 +293,21 @@ TEST(TestFailure, BinaryEqualExpectedNull)
     BinaryEqualFailure f(test, failFileName, failLineNumber, NULL, actualData, sizeof(actualData));
     FAILURE_EQUAL("expected <(null)>\n\tbut was  <00 00 00 00 00 00 01>", f);
 }
+
+TEST(TestFailure, BitsEqual1byte)
+{
+    BitsEqualFailure f(test, failFileName, failLineNumber, 0x01, 0x03, 0xFF, 1);
+    FAILURE_EQUAL("expected <00000001>\n\tbut was  <00000011>", f);
+}
+
+TEST(TestFailure, BitsEqual2bytes)
+{
+    BitsEqualFailure f(test, failFileName, failLineNumber, 0x0001, 0x0003, 0xFFFF, 2);
+    FAILURE_EQUAL("expected <00000000 00000001>\n\tbut was  <00000000 00000011>", f);
+}
+
+TEST(TestFailure, BitsEqual4bytes)
+{
+    BitsEqualFailure f(test, failFileName, failLineNumber, 0x00000001, 0x00000003, 0xFFFFFFFF, 4);
+    FAILURE_EQUAL("expected <00000000 00000000 00000000 00000001>\n\tbut was  <00000000 00000000 00000000 00000011>", f);
+}

--- a/tests/TestUTestMacro.cpp
+++ b/tests/TestUTestMacro.cpp
@@ -568,6 +568,9 @@ static int functionThatReturnsAValue()
     DOUBLES_EQUAL(1.0, 1.0, .01);
     POINTERS_EQUAL(0, 0);
     MEMCMP_EQUAL("THIS", "THIS", 5);
+    BITS_EQUAL(0x01, (unsigned char )0x01, 0xFF);
+    BITS_EQUAL(0x0001, (unsigned short )0x0001, 0xFFFF);
+    BITS_EQUAL(0x00000001, (unsigned long )0x00000001, 0xFFFFFFFF);
     return 0;
 }
 
@@ -702,6 +705,35 @@ TEST(UnitTestMacros, MEMCMP_EQUALNullExpectedNullActual)
 {
     MEMCMP_EQUAL(NULL, NULL, 0);
     MEMCMP_EQUAL(NULL, NULL, 1024);
+}
+
+TEST(UnitTestMacros, BITS_EQUALBehavesAsAProperMacro)
+{
+    if (false) BITS_EQUAL(0x00, 0xFF, 0xFF)
+    else BITS_EQUAL(0x00, 0x00, 0xFF)
+}
+
+IGNORE_TEST(UnitTestMacros, BITS_EQUALWorksInAnIgnoredTest)
+{
+    BITS_EQUAL(0x00, 0xFF, 0xFF); // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
+static void _BITS_EQUALFailingTestMethodWithUnequalInput()
+{
+    BITS_EQUAL(0x00, 0xFF, 0xFF);
+    lineOfCodeExecutedAfterCheck = true; // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
+TEST(UnitTestMacros, BITS_EQUALFailureWithUnequalInput)
+{
+    runTestWithMethod(_BITS_EQUALFailingTestMethodWithUnequalInput);
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("00000000>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("11111111>");
+}
+
+TEST(UnitTestMacros, BITS_EQUALZeroMaskEqual)
+{
+    BITS_EQUAL(0x00, 0xFF, 0x00);
 }
 
 #if CPPUTEST_USE_STD_CPP_LIB


### PR DESCRIPTION
I've created an assertion for checking the equality of the specified bits in a value. Here's an example of it's usage:
```
TEST(BitsDemo, Demo) {
    uint16_t expected = 0x1234;
    uint16_t actual = 0xFF74;
    uint16_t mask = 0x00F8;

    BITS_EQUAL(expected, actual, mask)
}
```
The output:
```
TestBits.cpp:10: error: Failure in TEST(BitsDemo, Demo)
	expected <xxxxxxxx 00110xxx>
	but was  <xxxxxxxx 01110xxx>
```

I used the sizeof operator on the actual value for determine the number of bits that the error message should display. I don't know if it's good or it's not. I think it's not so nice when I'm checking a variable with the length of 8 bits then I get an error message containing 64 bits. There can be another solution for this problem, if there are separate test macros for the integers with different length.