### PR TITLE
Fixed eclipse project generation using cmake

### DIFF
--- a/include/CppUTest/PlatformSpecificFunctions_c.h
+++ b/include/CppUTest/PlatformSpecificFunctions_c.h
@@ -74,6 +74,7 @@ extern void* (*PlatformSpecificRealloc)(void* memory, size_t size);
 extern void (*PlatformSpecificFree)(void* memory);
 extern void* (*PlatformSpecificMemCpy)(void* s1, const void* s2, size_t size);
 extern void* (*PlatformSpecificMemset)(void* mem, int c, size_t size);
+extern int (*PlatformSpecificMemCmp)(const void* s1, const void* s2, size_t size);
 
 typedef void* PlatformSpecificMutex;
 extern PlatformSpecificMutex (*PlatformSpecificMutexCreate)(void);

--- a/include/CppUTest/SimpleString.h
+++ b/include/CppUTest/SimpleString.h
@@ -140,6 +140,7 @@ SimpleString StringFrom(int value);
 SimpleString StringFrom(unsigned int value);
 SimpleString StringFrom(long value);
 SimpleString StringFrom(unsigned long value);
+SimpleString StringFrom(const unsigned char* value, size_t size);
 SimpleString HexStringFrom(long value);
 SimpleString HexStringFrom(unsigned long value);
 SimpleString HexStringFrom(const void* value);

--- a/include/CppUTestExt/MockActualCall.h
+++ b/include/CppUTestExt/MockActualCall.h
@@ -51,6 +51,7 @@ public:
     MockActualCall& withParameter(const SimpleString& name, const char* value) { return withStringParameter(name, value); }
     MockActualCall& withParameter(const SimpleString& name, void* value) { return withPointerParameter(name, value); }
     MockActualCall& withParameter(const SimpleString& name, const void* value) { return withConstPointerParameter(name, value); }
+    MockActualCall& withParameter(const SimpleString& name, const unsigned char* value, size_t size) { return withMemoryBufferParameter(name, value, size); }
     virtual MockActualCall& withParameterOfType(const SimpleString& typeName, const SimpleString& name, const void* value)=0;
     virtual MockActualCall& withOutputParameter(const SimpleString& name, void* output)=0;
 
@@ -62,6 +63,7 @@ public:
     virtual MockActualCall& withStringParameter(const SimpleString& name, const char* value)=0;
     virtual MockActualCall& withPointerParameter(const SimpleString& name, void* value)=0;
     virtual MockActualCall& withConstPointerParameter(const SimpleString& name, const void* value)=0;
+    virtual MockActualCall& withMemoryBufferParameter(const SimpleString& name, const unsigned char* value, size_t size)=0;
 
     virtual bool hasReturnValue()=0;
     virtual MockNamedValue returnValue()=0;

--- a/include/CppUTestExt/MockCheckedActualCall.h
+++ b/include/CppUTestExt/MockCheckedActualCall.h
@@ -47,6 +47,7 @@ public:
     virtual MockActualCall& withStringParameter(const SimpleString& name, const char* value) _override;
     virtual MockActualCall& withPointerParameter(const SimpleString& name, void* value) _override;
     virtual MockActualCall& withConstPointerParameter(const SimpleString& name, const void* value) _override;
+    virtual MockActualCall& withMemoryBufferParameter(const SimpleString& name, const unsigned char* value, size_t size) _override;
     virtual MockActualCall& withParameterOfType(const SimpleString& type, const SimpleString& name, const void* value) _override;
     virtual MockActualCall& withOutputParameter(const SimpleString& name, void* output) _override;
 
@@ -147,6 +148,7 @@ public:
     virtual MockActualCall& withStringParameter(const SimpleString& name, const char* value) _override;
     virtual MockActualCall& withPointerParameter(const SimpleString& name, void* value) _override;
     virtual MockActualCall& withConstPointerParameter(const SimpleString& name, const void* value) _override;
+    virtual MockActualCall& withMemoryBufferParameter(const SimpleString& name, const unsigned char* value, size_t size) _override;
     virtual MockActualCall& withParameterOfType(const SimpleString& typeName, const SimpleString& name, const void* value) _override;
     virtual MockActualCall& withOutputParameter(const SimpleString& name, void* output) _override;
 
@@ -202,6 +204,7 @@ public:
     virtual MockActualCall& withStringParameter(const SimpleString&, const char*) _override { return *this; }
     virtual MockActualCall& withPointerParameter(const SimpleString& , void*) _override { return *this; }
     virtual MockActualCall& withConstPointerParameter(const SimpleString& , const void*) _override { return *this; }
+    virtual MockActualCall& withMemoryBufferParameter(const SimpleString&, const unsigned char*, size_t) _override  { return *this; };
     virtual MockActualCall& withParameterOfType(const SimpleString&, const SimpleString&, const void*) _override { return *this; }
     virtual MockActualCall& withOutputParameter(const SimpleString&, void*) _override { return *this; }
 

--- a/include/CppUTestExt/MockCheckedActualCall.h
+++ b/include/CppUTestExt/MockCheckedActualCall.h
@@ -204,7 +204,7 @@ public:
     virtual MockActualCall& withStringParameter(const SimpleString&, const char*) _override { return *this; }
     virtual MockActualCall& withPointerParameter(const SimpleString& , void*) _override { return *this; }
     virtual MockActualCall& withConstPointerParameter(const SimpleString& , const void*) _override { return *this; }
-    virtual MockActualCall& withMemoryBufferParameter(const SimpleString&, const unsigned char*, size_t) _override  { return *this; };
+    virtual MockActualCall& withMemoryBufferParameter(const SimpleString&, const unsigned char*, size_t) _override  { return *this; }
     virtual MockActualCall& withParameterOfType(const SimpleString&, const SimpleString&, const void*) _override { return *this; }
     virtual MockActualCall& withOutputParameter(const SimpleString&, void*) _override { return *this; }
 

--- a/include/CppUTestExt/MockCheckedExpectedCall.h
+++ b/include/CppUTestExt/MockCheckedExpectedCall.h
@@ -181,7 +181,7 @@ public:
     virtual MockExpectedCall& withStringParameter(const SimpleString&, const char*) _override { return *this; }
     virtual MockExpectedCall& withPointerParameter(const SimpleString& , void*) _override { return *this; }
     virtual MockExpectedCall& withConstPointerParameter(const SimpleString& , const void*) _override { return *this; }
-    virtual MockExpectedCall& withMemoryBufferParameter(const SimpleString&, const unsigned char*, size_t) _override { return *this; };
+    virtual MockExpectedCall& withMemoryBufferParameter(const SimpleString&, const unsigned char*, size_t) _override { return *this; }
     virtual MockExpectedCall& withParameterOfType(const SimpleString&, const SimpleString&, const void*) _override { return *this; }
     virtual MockExpectedCall& withOutputParameterReturning(const SimpleString&, const void*, size_t) { return *this; }
     virtual MockExpectedCall& ignoreOtherParameters() { return *this;}

--- a/include/CppUTestExt/MockCheckedExpectedCall.h
+++ b/include/CppUTestExt/MockCheckedExpectedCall.h
@@ -48,6 +48,7 @@ public:
     virtual MockExpectedCall& withStringParameter(const SimpleString& name, const char* value) _override;
     virtual MockExpectedCall& withPointerParameter(const SimpleString& name, void* value) _override;
     virtual MockExpectedCall& withConstPointerParameter(const SimpleString& name, const void* value) _override;
+    virtual MockExpectedCall& withMemoryBufferParameter(const SimpleString& name, const unsigned char* value, size_t size) _override;
     virtual MockExpectedCall& withParameterOfType(const SimpleString& typeName, const SimpleString& name, const void* value) _override;
     virtual MockExpectedCall& ignoreOtherParameters() _override;
     virtual MockExpectedCall& withOutputParameterReturning(const SimpleString& name, const void* value, size_t size) _override;
@@ -144,6 +145,7 @@ public:
     virtual MockExpectedCall& withStringParameter(const SimpleString& name, const char* value) _override;
     virtual MockExpectedCall& withConstPointerParameter(const SimpleString& name, const void* value) _override;
     virtual MockExpectedCall& withPointerParameter(const SimpleString& name, void* value) _override;
+    virtual MockExpectedCall& withMemoryBufferParameter(const SimpleString& name, const unsigned char* value, size_t size) _override;
     virtual MockExpectedCall& withParameterOfType(const SimpleString& typeName, const SimpleString& name, const void* value) _override;
     virtual MockExpectedCall& withOutputParameterReturning(const SimpleString& name, const void* value, size_t size) _override;
     virtual MockExpectedCall& ignoreOtherParameters() _override;
@@ -179,6 +181,7 @@ public:
     virtual MockExpectedCall& withStringParameter(const SimpleString&, const char*) _override { return *this; }
     virtual MockExpectedCall& withPointerParameter(const SimpleString& , void*) _override { return *this; }
     virtual MockExpectedCall& withConstPointerParameter(const SimpleString& , const void*) _override { return *this; }
+    virtual MockExpectedCall& withMemoryBufferParameter(const SimpleString&, const unsigned char*, size_t) _override { return *this; };
     virtual MockExpectedCall& withParameterOfType(const SimpleString&, const SimpleString&, const void*) _override { return *this; }
     virtual MockExpectedCall& withOutputParameterReturning(const SimpleString&, const void*, size_t) { return *this; }
     virtual MockExpectedCall& ignoreOtherParameters() { return *this;}

--- a/include/CppUTestExt/MockExpectedCall.h
+++ b/include/CppUTestExt/MockExpectedCall.h
@@ -48,6 +48,7 @@ public:
     MockExpectedCall& withParameter(const SimpleString& name, const char* value) { return withStringParameter(name, value); }
     MockExpectedCall& withParameter(const SimpleString& name, void* value) { return withPointerParameter(name, value); }
     MockExpectedCall& withParameter(const SimpleString& name, const void* value) { return withConstPointerParameter(name, value); }
+    MockExpectedCall& withParameter(const SimpleString& name, const unsigned char* value, size_t size) { return withMemoryBufferParameter(name, value, size); }
     virtual MockExpectedCall& withParameterOfType(const SimpleString& typeName, const SimpleString& name, const void* value)=0;
     virtual MockExpectedCall& withOutputParameterReturning(const SimpleString& name, const void* value, size_t size)=0;
     virtual MockExpectedCall& ignoreOtherParameters()=0;
@@ -60,6 +61,7 @@ public:
     virtual MockExpectedCall& withStringParameter(const SimpleString& name, const char* value)=0;
     virtual MockExpectedCall& withPointerParameter(const SimpleString& name, void* value)=0;
     virtual MockExpectedCall& withConstPointerParameter(const SimpleString& name, const void* value)=0;
+    virtual MockExpectedCall& withMemoryBufferParameter(const SimpleString& name, const unsigned char* value, size_t size)=0;
     virtual MockExpectedCall& andReturnValue(int value)=0;
     virtual MockExpectedCall& andReturnValue(unsigned int value)=0;
     virtual MockExpectedCall& andReturnValue(long int value)=0;

--- a/include/CppUTestExt/MockNamedValue.h
+++ b/include/CppUTestExt/MockNamedValue.h
@@ -103,6 +103,7 @@ public:
     virtual const char* getStringValue() const;
     virtual void* getPointerValue() const;
     virtual const void* getConstPointerValue() const;
+    virtual const unsigned char* getMemBufferValue() const;
     virtual const void* getObjectPointer() const;
     virtual size_t getSize() const;
     virtual MockNamedValueComparator* getComparator() const;
@@ -120,6 +121,7 @@ private:
         const char* stringValue_;
         void* pointerValue_;
         const void* constPointerValue_;
+        const unsigned char* memBufferValue_;
         const void* objectPointerValue_;
         const void* outputPointerValue_;
     } value_;

--- a/include/CppUTestExt/MockNamedValue.h
+++ b/include/CppUTestExt/MockNamedValue.h
@@ -82,6 +82,7 @@ public:
     virtual void setValue(void* value);
     virtual void setValue(const void* value);
     virtual void setValue(const char* value);
+    virtual void setValue(const unsigned char* value);
     virtual void setObjectPointer(const SimpleString& type, const void* objectPtr);
     virtual void setSize(size_t size);
 

--- a/src/CppUTest/CMakeLists.txt
+++ b/src/CppUTest/CMakeLists.txt
@@ -45,7 +45,7 @@ set(CppUTest_headers
         ${CppUTestRootDirectory}/include/CppUTest/UtestMacros.h
 )
 
-add_library(CppUTest STATIC ${CppUTest_src})
+add_library(CppUTest STATIC ${CppUTest_src} ${CppUTest_headers})
 if (WIN32)
     target_link_libraries(CppUTest winmm.lib)
 endif (WIN32)

--- a/src/CppUTest/SimpleString.cpp
+++ b/src/CppUTest/SimpleString.cpp
@@ -490,6 +490,21 @@ SimpleString HexStringFrom(const void* value)
     return StringFromFormat("%lx", convertPointerToLongValue(value));
 }
 
+SimpleString StringFrom(const unsigned char* value, size_t size)
+{
+    SimpleString str = StringFromFormat("Len = %1u | HexContents =", size);
+    size_t displayedSize = ((size > 128) ? 128 : size);
+    for (size_t i = 0; i < displayedSize; i++)
+    {
+        str += StringFromFormat(" %02X", value[i]);
+    }
+    if( size > displayedSize )
+    {
+        str += " ...";
+    }
+    return str;
+}
+
 SimpleString StringFrom(double value, int precision)
 {
     return StringFromFormat("%.*g", precision, value);

--- a/src/CppUTest/SimpleString.cpp
+++ b/src/CppUTest/SimpleString.cpp
@@ -492,7 +492,7 @@ SimpleString HexStringFrom(const void* value)
 
 SimpleString StringFrom(const unsigned char* value, size_t size)
 {
-    SimpleString str = StringFromFormat("Len = %1u | HexContents =", size);
+    SimpleString str = StringFromFormat("Len = %lu | HexContents =", size);
     size_t displayedSize = ((size > 128) ? 128 : size);
     for (size_t i = 0; i < displayedSize; i++)
     {

--- a/src/CppUTestExt/CMakeLists.txt
+++ b/src/CppUTestExt/CMakeLists.txt
@@ -36,7 +36,7 @@ set(CppUTestExt_headers
         ${CppUTestRootDirectory}/include/CppUTestExt/MockSupport.h
 )
 
-add_library(CppUTestExt STATIC ${CppUTestExt_src})
+add_library(CppUTestExt STATIC ${CppUTestExt_src} ${CppUTestExt_headers})
 target_link_libraries(CppUTestExt ${CPPUNIT_EXTERNAL_LIBRARIES})
 install(FILES ${CppUTestExt_headers} DESTINATION include/CppUTestExt)
 install(TARGETS CppUTestExt

--- a/src/CppUTestExt/MockActualCall.cpp
+++ b/src/CppUTestExt/MockActualCall.cpp
@@ -222,6 +222,15 @@ MockActualCall& MockCheckedActualCall::withConstPointerParameter(const SimpleStr
     return *this;
 }
 
+MockActualCall& MockCheckedActualCall::withMemoryBufferParameter(const SimpleString& name, const unsigned char* value, size_t size)
+{
+    MockNamedValue actualParameter(name);
+    actualParameter.setValue(value);
+    actualParameter.setSize(size);
+    checkInputParameter(actualParameter);
+    return *this;
+}
+
 MockActualCall& MockCheckedActualCall::withParameterOfType(const SimpleString& type, const SimpleString& name, const void* value)
 {
     MockNamedValue actualParameter(name);
@@ -528,6 +537,13 @@ MockActualCall& MockActualCallTrace::withConstPointerParameter(const SimpleStrin
 {
     addParameterName(name);
     traceBuffer_ += StringFrom(value);
+    return *this;
+}
+
+MockActualCall& MockActualCallTrace::withMemoryBufferParameter(const SimpleString& name, const unsigned char* value, size_t size)
+{
+    addParameterName(name);
+    traceBuffer_ += StringFrom(value, size);
     return *this;
 }
 

--- a/src/CppUTestExt/MockExpectedCall.cpp
+++ b/src/CppUTestExt/MockExpectedCall.cpp
@@ -137,6 +137,15 @@ MockExpectedCall& MockCheckedExpectedCall::withConstPointerParameter(const Simpl
     return *this;
 }
 
+MockExpectedCall& MockCheckedExpectedCall::withMemoryBufferParameter(const SimpleString& name, const unsigned char* value, size_t size)
+{
+    MockNamedValue* newParameter = new MockExpectedFunctionParameter(name);
+    inputParameters_->add(newParameter);
+    newParameter->setValue(value);
+    newParameter->setSize(size);
+    return *this;
+}
+
 MockExpectedCall& MockCheckedExpectedCall::withParameterOfType(const SimpleString& type, const SimpleString& name, const void* value)
 {
     MockNamedValue* newParameter = new MockExpectedFunctionParameter(name);
@@ -548,6 +557,13 @@ MockExpectedCall& MockExpectedCallComposite::withConstPointerParameter(const Sim
 {
     for (MockExpectedCallCompositeNode* node = head_; node != NULL; node = node->next_)
         node->call_.withParameter(name, value);
+    return *this;
+}
+
+MockExpectedCall& MockExpectedCallComposite::withMemoryBufferParameter(const SimpleString& name, const unsigned char* value, size_t size)
+{
+    for (MockExpectedCallCompositeNode* node = head_; node != NULL; node = node->next_)
+        node->call_.withParameter(name, value, size);
     return *this;
 }
 

--- a/src/CppUTestExt/MockNamedValue.cpp
+++ b/src/CppUTestExt/MockNamedValue.cpp
@@ -97,7 +97,7 @@ void MockNamedValue::setValue(const char* value)
 void MockNamedValue::setValue(const unsigned char* value)
 {
     type_ = "const unsigned char*";
-    value_.stringValue_ = (const char*) value;
+    value_.memBufferValue_ = value;
 }
 
 void MockNamedValue::setObjectPointer(const SimpleString& type, const void* objectPtr)
@@ -197,6 +197,12 @@ const void* MockNamedValue::getConstPointerValue() const
     return value_.pointerValue_;
 }
 
+const unsigned char* MockNamedValue::getMemBufferValue() const
+{
+    STRCMP_EQUAL("const unsigned char*", type_.asCharString());
+    return value_.memBufferValue_;
+}
+
 const void* MockNamedValue::getObjectPointer() const
 {
     return value_.objectPointerValue_;
@@ -262,7 +268,7 @@ bool MockNamedValue::equals(const MockNamedValue& p) const
         if (size_ != p.size_) {
             return false;
         }
-        return PlatformSpecificMemCmp(value_.stringValue_, p.value_.stringValue_, size_) == 0;
+        return PlatformSpecificMemCmp(value_.memBufferValue_, p.value_.memBufferValue_, size_) == 0;
     }
 
     if (comparator_)
@@ -290,7 +296,7 @@ SimpleString MockNamedValue::toString() const
     else if (type_ == "double")
         return StringFrom(value_.doubleValue_);
     else if (type_ == "const unsigned char*")
-        return StringFrom((const unsigned char*) value_.stringValue_, size_);
+        return StringFrom(value_.memBufferValue_, size_);
 
     if (comparator_)
         return comparator_->valueToString(value_.objectPointerValue_);

--- a/src/CppUTestExt/MockNamedValue.cpp
+++ b/src/CppUTestExt/MockNamedValue.cpp
@@ -94,6 +94,12 @@ void MockNamedValue::setValue(const char* value)
     value_.stringValue_ = value;
 }
 
+void MockNamedValue::setValue(const unsigned char* value)
+{
+    type_ = "const unsigned char*";
+    value_.stringValue_ = (const char*) value;
+}
+
 void MockNamedValue::setObjectPointer(const SimpleString& type, const void* objectPtr)
 {
     type_ = type;
@@ -251,6 +257,13 @@ bool MockNamedValue::equals(const MockNamedValue& p) const
         return value_.constPointerValue_ == p.value_.constPointerValue_;
     else if (type_ == "double")
         return (doubles_equal(value_.doubleValue_, p.value_.doubleValue_, 0.005));
+    else if (type_ == "const unsigned char*")
+    {
+        if (size_ != p.size_) {
+            return false;
+        }
+        return PlatformSpecificMemCmp(value_.stringValue_, p.value_.stringValue_, size_) == 0;
+    }
 
     if (comparator_)
         return comparator_->isEqual(value_.objectPointerValue_, p.value_.objectPointerValue_);
@@ -276,6 +289,8 @@ SimpleString MockNamedValue::toString() const
         return StringFrom(value_.constPointerValue_);
     else if (type_ == "double")
         return StringFrom(value_.doubleValue_);
+    else if (type_ == "const unsigned char*")
+        return StringFrom((const unsigned char*) value_.stringValue_, size_);
 
     if (comparator_)
         return comparator_->valueToString(value_.objectPointerValue_);

--- a/src/Platforms/C2000/UtestPlatform.cpp
+++ b/src/Platforms/C2000/UtestPlatform.cpp
@@ -200,11 +200,17 @@ static void* C2000Memset(void* mem, int c, size_t size)
     return mem;
 }
 
+static void* C2000MemCmp(void* s1, const void* s2, size_t size)
+{
+    return far_memcmp((long)s1, (long)s2, size);
+}
+
 void* (*PlatformSpecificMalloc)(size_t size) = C2000Malloc;
 void* (*PlatformSpecificRealloc)(void* memory, size_t size) = C2000Realloc;
 void (*PlatformSpecificFree)(void* memory) = C2000Free;
 void* (*PlatformSpecificMemCpy)(void* s1, const void* s2, size_t size) = C2000MemCpy;
 void* (*PlatformSpecificMemset)(void* mem, int c, size_t size) = C2000Memset;
+int (*PlatformSpecificMemCmp)(const void*, const void*, size_t) = C2000MemCmp;
 
 /*
 double PlatformSpecificFabs(double d)

--- a/src/Platforms/Gcc/UtestPlatform.cpp
+++ b/src/Platforms/Gcc/UtestPlatform.cpp
@@ -231,6 +231,7 @@ void* (*PlatformSpecificRealloc)(void*, size_t) = realloc;
 void (*PlatformSpecificFree)(void* memory) = free;
 void* (*PlatformSpecificMemCpy)(void*, const void*, size_t) = memcpy;
 void* (*PlatformSpecificMemset)(void*, int, size_t) = memset;
+int (*PlatformSpecificMemCmp)(const void*, const void*, size_t) = memcmp;
 
 static int IsNanImplementation(double d)
 {

--- a/src/Platforms/GccNoStdC/UtestPlatform.cpp
+++ b/src/Platforms/GccNoStdC/UtestPlatform.cpp
@@ -51,6 +51,7 @@ void* (*PlatformSpecificRealloc)(void*, size_t) = NULL;
 void (*PlatformSpecificFree)(void*) = NULL;
 void* (*PlatformSpecificMemCpy)(void*, const void*, size_t) = NULL;
 void* (*PlatformSpecificMemset)(void*, int, size_t) = NULL;
+int (*PlatformSpecificMemCmp)(const void*, const void*, size_t) = NULL;
 
 PlatformSpecificMutex (*PlatformSpecificMutexCreate)(void) = NULL;
 void (*PlatformSpecificMutexLock)(PlatformSpecificMutex mtx) = NULL;

--- a/src/Platforms/Iar/UtestPlatform.cpp
+++ b/src/Platforms/Iar/UtestPlatform.cpp
@@ -157,6 +157,11 @@ void* PlatformSpecificMemset(void* mem, int c, size_t size)
     return memset(mem, c, size);
 }
 
+int PlatformSpecificMemCmp(const void* s1, const void* s2, size_t size)
+{
+    return memcmp(s1, s2, size);
+}
+
 double PlatformSpecificFabs(double d)
 {
     return fabs(d);

--- a/src/Platforms/Symbian/UtestPlatform.cpp
+++ b/src/Platforms/Symbian/UtestPlatform.cpp
@@ -125,6 +125,11 @@ void* PlatformSpecificMemset(void* mem, int c, size_t size)
     return memset(mem, c, size);
 }
 
+int PlatformSpecificMemCmp(const void* s1, const void* s2, size_t size)
+{
+    return memcmp(s1, s2, size);
+}
+
 PlatformSpecificFile PlatformSpecificFOpen(const char* filename, const char* flag) {
     return fopen(filename, flag);
 }

--- a/src/Platforms/VisualCpp/UtestPlatform.cpp
+++ b/src/Platforms/VisualCpp/UtestPlatform.cpp
@@ -160,6 +160,7 @@ void* (*PlatformSpecificRealloc)(void* memory, size_t size) = realloc;
 void (*PlatformSpecificFree)(void* memory) = free;
 void* (*PlatformSpecificMemCpy)(void* s1, const void* s2, size_t size) = memcpy;
 void* (*PlatformSpecificMemset)(void* mem, int c, size_t size) = memset;
+int (*PlatformSpecificMemCmp)(const void*, const void*, size_t) = memcmp;
 
 double (*PlatformSpecificFabs)(double d) = fabs;
 extern "C" int (*PlatformSpecificIsNan)(double) = _isnan;

--- a/src/Platforms/armcc/UtestPlatform.cpp
+++ b/src/Platforms/armcc/UtestPlatform.cpp
@@ -150,6 +150,7 @@ extern "C" void* (*PlatformSpecificRealloc) (void*, size_t) = realloc;
 extern "C" void (*PlatformSpecificFree)(void*) = free;
 extern "C" void* (*PlatformSpecificMemCpy)(void* s1, const void* s2, size_t size) = memcpy;
 extern "C" void* (*PlatformSpecificMemset)(void*, int, size_t) = memset;
+extern "C" int (*PlatformSpecificMemCmp)(const void*, const void*, size_t) = memcmp;
 
 static int IsNanImplementation(double d)
 {

--- a/tests/CppUTestExt/MockActualCallTest.cpp
+++ b/tests/CppUTestExt/MockActualCallTest.cpp
@@ -147,6 +147,7 @@ TEST(MockCheckedActualCall, remainderOfMockActualCallTraceWorksAsItShould)
 {
     int value;
     const int const_value = 1;
+    const unsigned char mem_buffer[] = { 0xFE, 0x15 };
     MockActualCallTrace actual;
     actual.withName("func");
     actual.withCallOrder(1);
@@ -157,6 +158,7 @@ TEST(MockCheckedActualCall, remainderOfMockActualCallTraceWorksAsItShould)
     actual.withLongIntParameter("long_int", (long int) 1);
     actual.withPointerParameter("pointer", &value);
     actual.withConstPointerParameter("const_pointer", &const_value);
+    actual.withMemoryBufferParameter("mem_buffer", mem_buffer, sizeof(mem_buffer));
     actual.withParameterOfType("int", "named_type", &const_value);
     
     SimpleString expectedString("\nFunction name:func");
@@ -170,6 +172,7 @@ TEST(MockCheckedActualCall, remainderOfMockActualCallTraceWorksAsItShould)
     expectedString += HexStringFrom(&value);
     expectedString += " const_pointer:0x";
     expectedString += HexStringFrom(&const_value);
+    expectedString += " mem_buffer:Len = 2 | HexContents = FE 15";
     expectedString += " int named_type:0x";
     expectedString += HexStringFrom(&const_value);
     STRCMP_EQUAL(expectedString.asCharString(), actual.getTraceOutput());

--- a/tests/CppUTestExt/MockExpectedCallTest.cpp
+++ b/tests/CppUTestExt/MockExpectedCallTest.cpp
@@ -176,6 +176,15 @@ TEST(MockExpectedCall, callWithConstPointerParameter)
     POINTERS_EQUAL(ptr, call->getInputParameter("constPointer").getConstPointerValue());
 }
 
+TEST(MockExpectedCall, callWithMemoryBuffer)
+{
+    const unsigned char mem_buffer[] = { 0x12, 0xFE, 0xA1 };
+    call->withParameter("memoryBuffer", mem_buffer, sizeof(mem_buffer));
+    STRCMP_EQUAL("const unsigned char*", call->getInputParameterType("memoryBuffer").asCharString());
+    POINTERS_EQUAL( (void*) mem_buffer, (void*) call->getInputParameter("memoryBuffer").getMemBufferValue() );
+    LONGS_EQUAL(sizeof(mem_buffer),  call->getInputParameter("memoryBuffer").getSize());
+}
+
 TEST(MockExpectedCall, callWithObjectParameter)
 {
     void* ptr = (void*) 0x123;
@@ -456,6 +465,13 @@ TEST(MockExpectedCallComposite, hasConstPointerParameter)
     STRCMP_EQUAL("name -> const void* param: <0x0>", call.callToString().asCharString());
 }
 
+TEST(MockExpectedCallComposite, hasMemoryBufferParameter)
+{
+    const unsigned char mem_buffer[] = { 0x89, 0xFE, 0x15 };
+    composite.withParameter("param", mem_buffer, sizeof(mem_buffer));
+    STRCMP_EQUAL("name -> const unsigned char* param: <Len = 3 | HexContents = 89 FE 15>", call.callToString().asCharString());
+}
+
 TEST(MockExpectedCallComposite, hasParameterOfType)
 {
     composite.withParameterOfType("type", "param", (const void*) 0);
@@ -566,6 +582,7 @@ TEST(MockIgnoredExpectedCall, worksAsItShould)
     ignored.withStringParameter("goo", "hello");
     ignored.withPointerParameter("pie", (void*) 0);
     ignored.withConstPointerParameter("woo", (const void*) 0);
+    ignored.withMemoryBufferParameter("waa", (const unsigned char*) 0, 0);
     ignored.withParameterOfType("top", "mytype", (const void*) 0);
     ignored.withOutputParameterReturning("bar", (const void*) 0, 1);
     ignored.ignoreOtherParameters();

--- a/tests/SimpleStringTest.cpp
+++ b/tests/SimpleStringTest.cpp
@@ -459,6 +459,13 @@ TEST(SimpleString, SmallDoubles)
     STRCMP_CONTAINS("1.2e", s.asCharString());
 }
 
+TEST(SimpleString, MemoryBuffers)
+{
+    const unsigned char mem_buffer[] = { 0x12, 0xFE, 0xA1 };
+    SimpleString s( StringFrom( mem_buffer, sizeof(mem_buffer) ) );
+    STRCMP_EQUAL("Len = 3 | HexContents = 12 FE A1", s.asCharString());
+}
+
 TEST(SimpleString, Sizes)
 {
     size_t size = 10;


### PR DESCRIPTION
Added headers to cmake's library files to obtain proper projects with proper headers when creating an eclipse project.

Without this patch, when creating an eclipse project using cmake (e.g. cmake -G "Eclipse CDT4 - MinGW Makefiles"), the header files don't appear in the target's headers, which makes indexing not working properly, and finding them a bit harder.