### PR TITLE
Fixed eclipse project generation using cmake

### DIFF
--- a/src/CppUTest/CMakeLists.txt
+++ b/src/CppUTest/CMakeLists.txt
@@ -45,7 +45,7 @@ set(CppUTest_headers
         ${CppUTestRootDirectory}/include/CppUTest/UtestMacros.h
 )
 
-add_library(CppUTest STATIC ${CppUTest_src})
+add_library(CppUTest STATIC ${CppUTest_src} ${CppUTest_headers})
 if (WIN32)
     target_link_libraries(CppUTest winmm.lib)
 endif (WIN32)

--- a/src/CppUTestExt/CMakeLists.txt
+++ b/src/CppUTestExt/CMakeLists.txt
@@ -36,7 +36,7 @@ set(CppUTestExt_headers
         ${CppUTestRootDirectory}/include/CppUTestExt/MockSupport.h
 )
 
-add_library(CppUTestExt STATIC ${CppUTestExt_src})
+add_library(CppUTestExt STATIC ${CppUTestExt_src} ${CppUTestExt_headers})
 target_link_libraries(CppUTestExt ${CPPUNIT_EXTERNAL_LIBRARIES})
 install(FILES ${CppUTestExt_headers} DESTINATION include/CppUTestExt)
 install(TARGETS CppUTestExt


### PR DESCRIPTION
Added headers to cmake's library files to obtain proper projects with proper headers when creating an eclipse project.

Without this patch, when creating an eclipse project using cmake (e.g. cmake -G "Eclipse CDT4 - MinGW Makefiles"), the header files don't appear in the target's headers, which makes indexing not working properly, and finding them a bit harder.