### PR TITLE
do not include config if target is already defined

### DIFF
--- a/CppUTestConfig.cmake.build.in
+++ b/CppUTestConfig.cmake.build.in
@@ -1,7 +1,9 @@
 @PACKAGE_INIT@
 
 set_and_check(CppUTest_INCLUDE_DIRS "@PACKAGE_INCLUDE_DIR@")
-include("${CMAKE_CURRENT_LIST_DIR}/CppUTestTargets.cmake" OPTIONAL)
+if(NOT TARGET CppUTest)
+  include("${CMAKE_CURRENT_LIST_DIR}/CppUTestTargets.cmake")
+endif()
 set(CppUTest_LIBRARIES CppUTest CppUTestExt)
 
 check_required_components(CppUTest)


### PR DESCRIPTION
Without this change recent cmake versions (>3.0) reports warning during configure phase.