### PR TITLE
Clang 3.6 warnings

### DIFF
--- a/include/CppUTest/CppUTestConfig.h
+++ b/include/CppUTest/CppUTestConfig.h
@@ -90,6 +90,10 @@
  *
  * This is needed for compiling with clang, without breaking other compilers.
  */
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreserved-id-macro"
+
 #ifndef __has_attribute
   #define __has_attribute(x) 0
 #endif
@@ -105,6 +109,8 @@
 #else
   #define __check_format__(type, format_parameter, other_parameters) /* type, format_parameter, other_parameters */
 #endif
+
+#pragma clang diagnostic pop
 
 /*
  * When we don't link Standard C++, then we won't throw exceptions as we assume the compiler might not support that!
@@ -176,9 +182,14 @@
 #define _override
 #endif
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreserved-id-macro"
+
 /* MinGW-w64 prefers to act like Visual C++, but we want the ANSI behaviors instead */
 #undef __USE_MINGW_ANSI_STDIO
 #define __USE_MINGW_ANSI_STDIO 1
+
+#pragma clang diagnostic pop
 
 /* Should be the only #include here. Standard C library wrappers */
 #include "StandardCLibrary.h"

--- a/include/CppUTest/CppUTestConfig.h
+++ b/include/CppUTest/CppUTestConfig.h
@@ -41,6 +41,13 @@
  *
  */
 
+#ifdef __clang__
+ #pragma clang diagnostic push
+ #if __clang_major__ >= 3 && __clang_minor__ >= 6
+  #pragma clang diagnostic ignored "-Wreserved-id-macro"
+ #endif
+#endif
+
 /*
  * Lib C dependencies that are currently still left:
  *
@@ -90,12 +97,6 @@
  *
  * This is needed for compiling with clang, without breaking other compilers.
  */
-
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wreserved-id-macro"
-#endif
-
 #ifndef __has_attribute
   #define __has_attribute(x) 0
 #endif
@@ -110,10 +111,6 @@
   #define __check_format__(type, format_parameter, other_parameters) __attribute__ ((format (type, format_parameter, other_parameters)))
 #else
   #define __check_format__(type, format_parameter, other_parameters) /* type, format_parameter, other_parameters */
-#endif
-
-#ifdef __clang__
-#pragma clang diagnostic pop
 #endif
 
 /*
@@ -186,17 +183,12 @@
 #define _override
 #endif
 
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wreserved-id-macro"
-#endif
-
 /* MinGW-w64 prefers to act like Visual C++, but we want the ANSI behaviors instead */
 #undef __USE_MINGW_ANSI_STDIO
 #define __USE_MINGW_ANSI_STDIO 1
 
 #ifdef __clang__
-#pragma clang diagnostic pop
+ #pragma clang diagnostic pop
 #endif
 
 /* Should be the only #include here. Standard C library wrappers */

--- a/include/CppUTest/CppUTestConfig.h
+++ b/include/CppUTest/CppUTestConfig.h
@@ -91,8 +91,10 @@
  * This is needed for compiling with clang, without breaking other compilers.
  */
 
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wreserved-id-macro"
+#endif
 
 #ifndef __has_attribute
   #define __has_attribute(x) 0
@@ -110,7 +112,9 @@
   #define __check_format__(type, format_parameter, other_parameters) /* type, format_parameter, other_parameters */
 #endif
 
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
 
 /*
  * When we don't link Standard C++, then we won't throw exceptions as we assume the compiler might not support that!
@@ -182,14 +186,18 @@
 #define _override
 #endif
 
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wreserved-id-macro"
+#endif
 
 /* MinGW-w64 prefers to act like Visual C++, but we want the ANSI behaviors instead */
 #undef __USE_MINGW_ANSI_STDIO
 #define __USE_MINGW_ANSI_STDIO 1
 
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
 
 /* Should be the only #include here. Standard C library wrappers */
 #include "StandardCLibrary.h"

--- a/include/CppUTest/MemoryLeakDetectorNewMacros.h
+++ b/include/CppUTest/MemoryLeakDetectorNewMacros.h
@@ -45,7 +45,12 @@
 
 #endif
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wkeyword-macro"
+
 #define new new(__FILE__, __LINE__)
+
+#pragma clang diagnostic pop
 
 #define CPPUTEST_USE_NEW_MACROS 1
 

--- a/include/CppUTest/MemoryLeakDetectorNewMacros.h
+++ b/include/CppUTest/MemoryLeakDetectorNewMacros.h
@@ -45,15 +45,18 @@
 
 #endif
 
+
 #ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wkeyword-macro"
+ #pragma clang diagnostic push
+ #if __clang_major__ >= 3 && __clang_minor__ >= 6
+  #pragma clang diagnostic ignored "-Wkeyword-macro"
+ #endif
 #endif
 
 #define new new(__FILE__, __LINE__)
 
 #ifdef __clang__
-#pragma clang diagnostic pop
+ #pragma clang diagnostic pop
 #endif
 
 #define CPPUTEST_USE_NEW_MACROS 1

--- a/include/CppUTest/MemoryLeakDetectorNewMacros.h
+++ b/include/CppUTest/MemoryLeakDetectorNewMacros.h
@@ -45,12 +45,16 @@
 
 #endif
 
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wkeyword-macro"
+#endif
 
 #define new new(__FILE__, __LINE__)
 
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
 
 #define CPPUTEST_USE_NEW_MACROS 1
 

--- a/include/CppUTest/Utest.h
+++ b/include/CppUTest/Utest.h
@@ -177,7 +177,7 @@ class ExecFunctionTest : public Utest
 {
 public:
     ExecFunctionTest(ExecFunctionTestShell* shell);
-    void testBody();
+    void testBody() _override;
     virtual void setup() _override;
     virtual void teardown() _override;
 private:
@@ -219,7 +219,7 @@ public:
     virtual ~IgnoredUtestShell();
     explicit IgnoredUtestShell(const char* groupName, const char* testName,
             const char* fileName, int lineNumber);
-    virtual bool willRun() const;
+    virtual bool willRun() const _override;
     protected:  virtual SimpleString getMacroName() const _override;
     virtual void runOneTest(TestPlugin* plugin, TestResult& result) _override;
 

--- a/include/CppUTestExt/MockCheckedExpectedCall.h
+++ b/include/CppUTestExt/MockCheckedExpectedCall.h
@@ -180,8 +180,8 @@ public:
     virtual MockExpectedCall& withPointerParameter(const SimpleString& , void*) _override { return *this; }
     virtual MockExpectedCall& withConstPointerParameter(const SimpleString& , const void*) _override { return *this; }
     virtual MockExpectedCall& withParameterOfType(const SimpleString&, const SimpleString&, const void*) _override { return *this; }
-    virtual MockExpectedCall& withOutputParameterReturning(const SimpleString&, const void*, size_t) { return *this; }
-    virtual MockExpectedCall& ignoreOtherParameters() { return *this;}
+    virtual MockExpectedCall& withOutputParameterReturning(const SimpleString&, const void*, size_t) _override { return *this; }
+    virtual MockExpectedCall& ignoreOtherParameters() _override { return *this;}
 
     virtual MockExpectedCall& andReturnValue(int) _override { return *this; }
     virtual MockExpectedCall& andReturnValue(unsigned int) _override { return *this; }


### PR DESCRIPTION
While compiling with Clang 3.6 I got some warnings.

These changes will suppress these warnings.