### PR TITLE
First shot at Custom Copiers

### DIFF
--- a/include/CppUTestExt/MockActualCall.h
+++ b/include/CppUTestExt/MockActualCall.h
@@ -53,6 +53,7 @@ public:
     MockActualCall& withParameter(const SimpleString& name, const void* value) { return withConstPointerParameter(name, value); }
     virtual MockActualCall& withParameterOfType(const SimpleString& typeName, const SimpleString& name, const void* value)=0;
     virtual MockActualCall& withOutputParameter(const SimpleString& name, void* output)=0;
+    virtual MockActualCall& withOutputParameterOfType(const SimpleString& typeName, const SimpleString& name, void* output)=0;
 
     virtual MockActualCall& withIntParameter(const SimpleString& name, int value)=0;
     virtual MockActualCall& withUnsignedIntParameter(const SimpleString& name, unsigned int value)=0;

--- a/include/CppUTestExt/MockCheckedActualCall.h
+++ b/include/CppUTestExt/MockCheckedActualCall.h
@@ -49,6 +49,7 @@ public:
     virtual MockActualCall& withConstPointerParameter(const SimpleString& name, const void* value) _override;
     virtual MockActualCall& withParameterOfType(const SimpleString& type, const SimpleString& name, const void* value) _override;
     virtual MockActualCall& withOutputParameter(const SimpleString& name, void* output) _override;
+    virtual MockActualCall& withOutputParameterOfType(const SimpleString& type, const SimpleString& name, void* output) _override;
 
     virtual bool hasReturnValue() _override;
     virtual MockNamedValue returnValue() _override;
@@ -149,6 +150,7 @@ public:
     virtual MockActualCall& withConstPointerParameter(const SimpleString& name, const void* value) _override;
     virtual MockActualCall& withParameterOfType(const SimpleString& typeName, const SimpleString& name, const void* value) _override;
     virtual MockActualCall& withOutputParameter(const SimpleString& name, void* output) _override;
+    virtual MockActualCall& withOutputParameterOfType(const SimpleString& typeName, const SimpleString& name, void* output) _override;
 
     virtual bool hasReturnValue() _override;
     virtual MockNamedValue returnValue() _override;
@@ -204,6 +206,7 @@ public:
     virtual MockActualCall& withConstPointerParameter(const SimpleString& , const void*) _override { return *this; }
     virtual MockActualCall& withParameterOfType(const SimpleString&, const SimpleString&, const void*) _override { return *this; }
     virtual MockActualCall& withOutputParameter(const SimpleString&, void*) _override { return *this; }
+    virtual MockActualCall& withOutputParameterOfType(const SimpleString&, const SimpleString&, void*) _override { return *this; }
 
     virtual bool hasReturnValue() _override { return false; }
     virtual MockNamedValue returnValue() _override { return MockNamedValue(""); }

--- a/include/CppUTestExt/MockCheckedExpectedCall.h
+++ b/include/CppUTestExt/MockCheckedExpectedCall.h
@@ -49,8 +49,9 @@ public:
     virtual MockExpectedCall& withPointerParameter(const SimpleString& name, void* value) _override;
     virtual MockExpectedCall& withConstPointerParameter(const SimpleString& name, const void* value) _override;
     virtual MockExpectedCall& withParameterOfType(const SimpleString& typeName, const SimpleString& name, const void* value) _override;
-    virtual MockExpectedCall& ignoreOtherParameters() _override;
     virtual MockExpectedCall& withOutputParameterReturning(const SimpleString& name, const void* value, size_t size) _override;
+    virtual MockExpectedCall& withOutputParameterOfTypeReturning(const SimpleString& typeName, const SimpleString& name, const void* value) _override;
+    virtual MockExpectedCall& ignoreOtherParameters() _override;
 
     virtual MockExpectedCall& andReturnValue(int value) _override;
     virtual MockExpectedCall& andReturnValue(unsigned int value) _override;
@@ -146,6 +147,7 @@ public:
     virtual MockExpectedCall& withPointerParameter(const SimpleString& name, void* value) _override;
     virtual MockExpectedCall& withParameterOfType(const SimpleString& typeName, const SimpleString& name, const void* value) _override;
     virtual MockExpectedCall& withOutputParameterReturning(const SimpleString& name, const void* value, size_t size) _override;
+    virtual MockExpectedCall& withOutputParameterOfTypeReturning(const SimpleString& typeName, const SimpleString& name, const void* value) _override;
     virtual MockExpectedCall& ignoreOtherParameters() _override;
 
     virtual MockExpectedCall& andReturnValue(int value) _override;
@@ -181,6 +183,7 @@ public:
     virtual MockExpectedCall& withConstPointerParameter(const SimpleString& , const void*) _override { return *this; }
     virtual MockExpectedCall& withParameterOfType(const SimpleString&, const SimpleString&, const void*) _override { return *this; }
     virtual MockExpectedCall& withOutputParameterReturning(const SimpleString&, const void*, size_t) _override { return *this; }
+    virtual MockExpectedCall& withOutputParameterOfTypeReturning(const SimpleString&, const SimpleString&, const void*) _override { return *this; }
     virtual MockExpectedCall& ignoreOtherParameters() _override { return *this;}
 
     virtual MockExpectedCall& andReturnValue(int) _override { return *this; }

--- a/include/CppUTestExt/MockExpectedCall.h
+++ b/include/CppUTestExt/MockExpectedCall.h
@@ -50,6 +50,7 @@ public:
     MockExpectedCall& withParameter(const SimpleString& name, const void* value) { return withConstPointerParameter(name, value); }
     virtual MockExpectedCall& withParameterOfType(const SimpleString& typeName, const SimpleString& name, const void* value)=0;
     virtual MockExpectedCall& withOutputParameterReturning(const SimpleString& name, const void* value, size_t size)=0;
+    virtual MockExpectedCall& withOutputParameterOfTypeReturning(const SimpleString& typeName, const SimpleString& name, const void* value)=0;
     virtual MockExpectedCall& ignoreOtherParameters()=0;
 
     virtual MockExpectedCall& withIntParameter(const SimpleString& name, int value)=0;

--- a/include/CppUTestExt/MockFailure.h
+++ b/include/CppUTestExt/MockFailure.h
@@ -109,6 +109,13 @@ public:
     virtual ~MockNoWayToCompareCustomTypeFailure(){}
 };
 
+class MockNoWayToCopyCustomTypeFailure : public MockFailure
+{
+public:
+    MockNoWayToCopyCustomTypeFailure(UtestShell* test, const SimpleString& typeName);
+    virtual ~MockNoWayToCopyCustomTypeFailure() {}
+};
+
 class MockUnexpectedObjectFailure : public MockFailure
 {
 public:

--- a/include/CppUTestExt/MockNamedValue.h
+++ b/include/CppUTestExt/MockNamedValue.h
@@ -40,7 +40,7 @@ public:
 
     virtual bool isEqual(const void* object1, const void* object2)=0;
     virtual SimpleString valueToString(const void* object)=0;
-    virtual void* copy(const void*, const void*) { return 0; }
+    virtual bool copy(const void*, const void*) { return false; }
 };
 
 class MockFunctionComparator : public MockNamedValueComparator

--- a/include/CppUTestExt/MockNamedValue.h
+++ b/include/CppUTestExt/MockNamedValue.h
@@ -40,6 +40,7 @@ public:
 
     virtual bool isEqual(const void* object1, const void* object2)=0;
     virtual SimpleString valueToString(const void* object)=0;
+    virtual void* copy(const void*, const void*) { return 0; }
 };
 
 class MockFunctionComparator : public MockNamedValueComparator

--- a/src/CppUTestExt/MockActualCall.cpp
+++ b/src/CppUTestExt/MockActualCall.cpp
@@ -85,7 +85,11 @@ void MockCheckedActualCall::finalizeOutputParameters(MockCheckedExpectedCall* ex
         MockNamedValue outputParameter = expectedCall->getOutputParameter(*p->name_);
         MockNamedValueComparator* comparator = outputParameter.getComparator();
         if (comparator) {
-            comparator->copy(p->ptr_, expectedCall->getOutputParameter(*p->name_).getObjectPointer());
+            if(!comparator->copy(p->ptr_, expectedCall->getOutputParameter(*p->name_).getObjectPointer())) {
+                SimpleString type = expectedCall->getOutputParameter(*p->name_).getType();
+                MockNoWayToCopyCustomTypeFailure failure(getTest(), type);
+                failTest(failure);
+            }
         }
         else {
             const void* data = expectedCall->getOutputParameter(*p->name_).getConstPointerValue();

--- a/src/CppUTestExt/MockActualCall.cpp
+++ b/src/CppUTestExt/MockActualCall.cpp
@@ -82,9 +82,16 @@ void MockCheckedActualCall::finalizeOutputParameters(MockCheckedExpectedCall* ex
 {
     for (MockOutputParametersListNode* p = outputParameterExpectations_; p; p = p->next_)
     {
-        const void* data = expectedCall->getOutputParameter(*p->name_).getConstPointerValue();
-        size_t size = expectedCall->getOutputParameter(*p->name_).getSize();
-        PlatformSpecificMemCpy(p->ptr_, data, size);
+        MockNamedValue outputParameter = expectedCall->getOutputParameter(*p->name_);
+        MockNamedValueComparator* comparator = outputParameter.getComparator();
+        if (comparator) {
+            comparator->copy(p->ptr_, expectedCall->getOutputParameter(*p->name_).getObjectPointer());
+        }
+        else {
+            const void* data = expectedCall->getOutputParameter(*p->name_).getConstPointerValue();
+            size_t size = expectedCall->getOutputParameter(*p->name_).getSize();
+            PlatformSpecificMemCpy(p->ptr_, data, size);
+        }
     }
 }
 
@@ -246,6 +253,18 @@ MockActualCall& MockCheckedActualCall::withOutputParameter(const SimpleString& n
 
     return *this;
 }
+
+MockActualCall& MockCheckedActualCall::withOutputParameterOfType(const SimpleString& type, const SimpleString& name, void* output)
+{
+    addOutputParameter(name, output);
+
+    MockNamedValue outputParameter(name);
+    outputParameter.setObjectPointer(type, output);
+    checkOutputParameter(outputParameter);
+
+    return *this;
+}
+
 
 bool MockCheckedActualCall::isFulfilled() const
 {
@@ -545,6 +564,11 @@ MockActualCall& MockActualCallTrace::withOutputParameter(const SimpleString& nam
     addParameterName(name);
     traceBuffer_ += StringFrom(output);
     return *this;
+}
+
+MockActualCall& MockActualCallTrace::withOutputParameterOfType(const SimpleString&, const SimpleString& name, void* output)
+{
+    return MockActualCallTrace::withOutputParameter(name, output);
 }
 
 bool MockActualCallTrace::hasReturnValue()

--- a/src/CppUTestExt/MockExpectedCall.cpp
+++ b/src/CppUTestExt/MockExpectedCall.cpp
@@ -154,6 +154,14 @@ MockExpectedCall& MockCheckedExpectedCall::withOutputParameterReturning(const Si
     return *this;
 }
 
+MockExpectedCall& MockCheckedExpectedCall::withOutputParameterOfTypeReturning(const SimpleString& type, const SimpleString& name, const void* value)
+{
+    MockNamedValue* newParameter = new MockExpectedFunctionParameter(name);
+    outputParameters_->add(newParameter);
+    newParameter->setObjectPointer(type, value);
+    return *this;
+}
+
 SimpleString MockCheckedExpectedCall::getInputParameterType(const SimpleString& name)
 {
     MockNamedValue * p = inputParameters_->getValueByName(name);
@@ -562,6 +570,13 @@ MockExpectedCall& MockExpectedCallComposite::withOutputParameterReturning(const 
 {
     for (MockExpectedCallCompositeNode* node = head_; node != NULL; node = node->next_)
         node->call_.withOutputParameterReturning(name, value, size);
+    return *this;
+}
+
+MockExpectedCall& MockExpectedCallComposite::withOutputParameterOfTypeReturning(const SimpleString& type, const SimpleString& name, const void* value)
+{
+    for (MockExpectedCallCompositeNode* node = head_; node != NULL; node = node->next_)
+        node->call_.withOutputParameterOfTypeReturning(type, name, value);
     return *this;
 }
 

--- a/src/CppUTestExt/MockFailure.cpp
+++ b/src/CppUTestExt/MockFailure.cpp
@@ -199,6 +199,11 @@ MockNoWayToCompareCustomTypeFailure::MockNoWayToCompareCustomTypeFailure(UtestSh
     message_ = StringFromFormat("MockFailure: No way to compare type <%s>. Please install a ParameterTypeComparator.", typeName.asCharString());
 }
 
+MockNoWayToCopyCustomTypeFailure::MockNoWayToCopyCustomTypeFailure(UtestShell* test, const SimpleString& typeName) : MockFailure(test)
+{
+    message_ = StringFromFormat("MockFailure: No way to copy type <%s>. Please override the copy() method.", typeName.asCharString());
+}
+
 MockUnexpectedObjectFailure::MockUnexpectedObjectFailure(UtestShell* test, const SimpleString& functionName, void* actual, const MockExpectedCallsList& expectations) : MockFailure(test)
 {
     message_ = StringFromFormat ("MockFailure: Function called on a unexpected object: %s\n"

--- a/src/CppUTestExt/MockNamedValue.cpp
+++ b/src/CppUTestExt/MockNamedValue.cpp
@@ -27,8 +27,6 @@
 
 #include "CppUTest/TestHarness.h"
 #include "CppUTestExt/MockNamedValue.h"
-#include "CppUTest/PlatformSpecificFunctions.h"
-
 
 MockNamedValueComparatorRepository* MockNamedValue::defaultRepository_ = NULL;
 
@@ -40,6 +38,7 @@ void MockNamedValue::setDefaultComparatorRepository(MockNamedValueComparatorRepo
 MockNamedValue::MockNamedValue(const SimpleString& name) : name_(name), type_("int"), comparator_(NULL)
 {
     value_.intValue_ = 0;
+    size_ = sizeof(int);
 }
 
 MockNamedValue::~MockNamedValue()

--- a/src/CppUTestExt/MockNamedValue.cpp
+++ b/src/CppUTestExt/MockNamedValue.cpp
@@ -35,10 +35,9 @@ void MockNamedValue::setDefaultComparatorRepository(MockNamedValueComparatorRepo
     defaultRepository_ = repository;
 }
 
-MockNamedValue::MockNamedValue(const SimpleString& name) : name_(name), type_("int"), comparator_(NULL)
+MockNamedValue::MockNamedValue(const SimpleString& name) : name_(name), type_("int"), size_(0), comparator_(NULL)
 {
     value_.intValue_ = 0;
-    size_ = sizeof(int);
 }
 
 MockNamedValue::~MockNamedValue()


### PR DESCRIPTION
I tried to go for the solution with the fewest changes. There were some tradeoffs:
+ A new MockCopier class vs. a new method in NamedValueComparator. I chose the latter.
+ Reusing some of the original output parameter test vs. creating a totally new one with its own object for copying. I reused the existing one.
