### PR TITLE
Custom Copiers - Alternative Implementation

### DIFF
--- a/examples/AllTests/EventDispatcherTest.cpp
+++ b/examples/AllTests/EventDispatcherTest.cpp
@@ -72,7 +72,7 @@ TEST_GROUP(EventDispatcher)
     void teardown()
     {
         delete dispatcher;
-        mock().removeAllComparators();
+        mock().removeAllHandlers();
     }
 };
 

--- a/examples/AllTests/EventDispatcherTest.cpp
+++ b/examples/AllTests/EventDispatcherTest.cpp
@@ -76,7 +76,6 @@ TEST_GROUP(EventDispatcher)
     }
 };
 
-
 TEST(EventDispatcher, EventWithoutRegistrationsResultsIntoNoCalls)
 {
     dispatcher->dispatchEvent(event, 10);

--- a/examples/AllTests/EventDispatcherTest.cpp
+++ b/examples/AllTests/EventDispatcherTest.cpp
@@ -67,7 +67,7 @@ TEST_GROUP(EventDispatcher)
     void setup()
     {
         dispatcher = new EventDispatcher;
-        mock().installComparator("Event", eventComparator);
+        mock().installHandler("Event", eventComparator);
     }
     void teardown()
     {

--- a/examples/AllTests/MockDocumentationTest.cpp
+++ b/examples/AllTests/MockDocumentationTest.cpp
@@ -192,11 +192,10 @@ TEST(MockDocumentation, CInterface)
     double d = mock_c()->actualCall("foo")->withIntParameters("integer", 10)->returnValue().value.doubleValue;
     DOUBLES_EQUAL(1.11, d, 0.00001);
 
-
-    mock_c()->installComparator("type", equalMethod, toStringMethod);
+    mock_c()->installComparatorHandler("type", equalMethod, toStringMethod);
     mock_scope_c("scope")->expectOneCall("bar")->withParameterOfType("type", "name", object);
     mock_scope_c("scope")->actualCall("bar")->withParameterOfType("type", "name", object);
-    mock_c()->removeAllComparators();
+    mock_c()->removeAllHandlers();
 
     mock_c()->setIntData("important", 10);
     mock_c()->checkExpectations();

--- a/examples/AllTests/MockDocumentationTest.cpp
+++ b/examples/AllTests/MockDocumentationTest.cpp
@@ -118,7 +118,7 @@ TEST(MockDocumentation, ObjectParameters)
 {
     void* object = (void*) 1;
     MyTypeComparator comparator;
-    mock().installComparator("myType", comparator);
+    mock().installHandler("myType", comparator);
     mock().expectOneCall("function").withParameterOfType("myType", "parameterName", object);
     mock().clear();
     mock().removeAllHandlers();

--- a/examples/AllTests/MockDocumentationTest.cpp
+++ b/examples/AllTests/MockDocumentationTest.cpp
@@ -121,7 +121,7 @@ TEST(MockDocumentation, ObjectParameters)
     mock().installComparator("myType", comparator);
     mock().expectOneCall("function").withParameterOfType("myType", "parameterName", object);
     mock().clear();
-    mock().removeAllComparators();
+    mock().removeAllHandlers();
 }
 
 TEST(MockDocumentation, returnValue)

--- a/include/CppUTestExt/MockActualCall.h
+++ b/include/CppUTestExt/MockActualCall.h
@@ -53,6 +53,7 @@ public:
     MockActualCall& withParameter(const SimpleString& name, const void* value) { return withConstPointerParameter(name, value); }
     virtual MockActualCall& withParameterOfType(const SimpleString& typeName, const SimpleString& name, const void* value)=0;
     virtual MockActualCall& withOutputParameter(const SimpleString& name, void* output)=0;
+    virtual MockActualCall& withOutputParameterOfType(const SimpleString& typeName, const SimpleString& name, void* output)=0;
 
     virtual MockActualCall& withIntParameter(const SimpleString& name, int value)=0;
     virtual MockActualCall& withUnsignedIntParameter(const SimpleString& name, unsigned int value)=0;

--- a/include/CppUTestExt/MockCheckedActualCall.h
+++ b/include/CppUTestExt/MockCheckedActualCall.h
@@ -49,6 +49,7 @@ public:
     virtual MockActualCall& withConstPointerParameter(const SimpleString& name, const void* value) _override;
     virtual MockActualCall& withParameterOfType(const SimpleString& type, const SimpleString& name, const void* value) _override;
     virtual MockActualCall& withOutputParameter(const SimpleString& name, void* output) _override;
+    virtual MockActualCall& withOutputParameterOfType(const SimpleString& type, const SimpleString& name, void* output) _override;
 
     virtual bool hasReturnValue() _override;
     virtual MockNamedValue returnValue() _override;
@@ -149,6 +150,7 @@ public:
     virtual MockActualCall& withConstPointerParameter(const SimpleString& name, const void* value) _override;
     virtual MockActualCall& withParameterOfType(const SimpleString& typeName, const SimpleString& name, const void* value) _override;
     virtual MockActualCall& withOutputParameter(const SimpleString& name, void* output) _override;
+    virtual MockActualCall& withOutputParameterOfType(const SimpleString& typeName, const SimpleString& name, void* output) _override;
 
     virtual bool hasReturnValue() _override;
     virtual MockNamedValue returnValue() _override;
@@ -204,6 +206,7 @@ public:
     virtual MockActualCall& withConstPointerParameter(const SimpleString& , const void*) _override { return *this; }
     virtual MockActualCall& withParameterOfType(const SimpleString&, const SimpleString&, const void*) _override { return *this; }
     virtual MockActualCall& withOutputParameter(const SimpleString&, void*) _override { return *this; }
+    virtual MockActualCall& withOutputParameterOfType(const SimpleString&, const SimpleString&, void*) _override { return *this; }
 
     virtual bool hasReturnValue() _override { return false; }
     virtual MockNamedValue returnValue() _override { return MockNamedValue(""); }

--- a/include/CppUTestExt/MockCheckedExpectedCall.h
+++ b/include/CppUTestExt/MockCheckedExpectedCall.h
@@ -49,8 +49,9 @@ public:
     virtual MockExpectedCall& withPointerParameter(const SimpleString& name, void* value) _override;
     virtual MockExpectedCall& withConstPointerParameter(const SimpleString& name, const void* value) _override;
     virtual MockExpectedCall& withParameterOfType(const SimpleString& typeName, const SimpleString& name, const void* value) _override;
-    virtual MockExpectedCall& ignoreOtherParameters() _override;
     virtual MockExpectedCall& withOutputParameterReturning(const SimpleString& name, const void* value, size_t size) _override;
+    virtual MockExpectedCall& withOutputParameterOfTypeReturning(const SimpleString& typeName, const SimpleString& name, const void* value) _override;
+    virtual MockExpectedCall& ignoreOtherParameters() _override;
 
     virtual MockExpectedCall& andReturnValue(int value) _override;
     virtual MockExpectedCall& andReturnValue(unsigned int value) _override;
@@ -146,6 +147,7 @@ public:
     virtual MockExpectedCall& withPointerParameter(const SimpleString& name, void* value) _override;
     virtual MockExpectedCall& withParameterOfType(const SimpleString& typeName, const SimpleString& name, const void* value) _override;
     virtual MockExpectedCall& withOutputParameterReturning(const SimpleString& name, const void* value, size_t size) _override;
+    virtual MockExpectedCall& withOutputParameterOfTypeReturning(const SimpleString& typeName, const SimpleString& name, const void* value) _override;
     virtual MockExpectedCall& ignoreOtherParameters() _override;
 
     virtual MockExpectedCall& andReturnValue(int value) _override;
@@ -181,6 +183,7 @@ public:
     virtual MockExpectedCall& withConstPointerParameter(const SimpleString& , const void*) _override { return *this; }
     virtual MockExpectedCall& withParameterOfType(const SimpleString&, const SimpleString&, const void*) _override { return *this; }
     virtual MockExpectedCall& withOutputParameterReturning(const SimpleString&, const void*, size_t) _override { return *this; }
+    virtual MockExpectedCall& withOutputParameterOfTypeReturning(const SimpleString&, const SimpleString&, const void*) _override { return *this; }
     virtual MockExpectedCall& ignoreOtherParameters() _override { return *this;}
 
     virtual MockExpectedCall& andReturnValue(int) _override { return *this; }

--- a/include/CppUTestExt/MockExpectedCall.h
+++ b/include/CppUTestExt/MockExpectedCall.h
@@ -50,6 +50,7 @@ public:
     MockExpectedCall& withParameter(const SimpleString& name, const void* value) { return withConstPointerParameter(name, value); }
     virtual MockExpectedCall& withParameterOfType(const SimpleString& typeName, const SimpleString& name, const void* value)=0;
     virtual MockExpectedCall& withOutputParameterReturning(const SimpleString& name, const void* value, size_t size)=0;
+    virtual MockExpectedCall& withOutputParameterOfTypeReturning(const SimpleString& typeName, const SimpleString& name, const void* value)=0;
     virtual MockExpectedCall& ignoreOtherParameters()=0;
 
     virtual MockExpectedCall& withIntParameter(const SimpleString& name, int value)=0;

--- a/include/CppUTestExt/MockNamedValue.h
+++ b/include/CppUTestExt/MockNamedValue.h
@@ -32,26 +32,6 @@
  * This is needed when comparing values of non-native type.
  */
 
-class MockNamedValueComparator;
-class MockNamedValueCopier;
-
-class MockNamedValueHandler
-{
-public:
-    MockNamedValueHandler() : comparator_(NULL), copier_(NULL) {}
-    MockNamedValueHandler(MockNamedValueComparator* comparator) : comparator_(comparator) {}
-    MockNamedValueHandler(MockNamedValueCopier* copier) : copier_(copier) {}
-    MockNamedValueHandler(MockNamedValueComparator* comparator, MockNamedValueCopier* copier) : comparator_(comparator), copier_(copier) {}
-    void setComparator(MockNamedValueComparator* comparator) { comparator_ = comparator; }
-    void setCopier(MockNamedValueCopier* copier) { copier_ = copier; }
-    MockNamedValueComparator* getComparator() { return comparator_; }
-    MockNamedValueCopier* getCopier() { return copier_; }
-    ~MockNamedValueHandler() {}
-private:
-    MockNamedValueComparator* comparator_;
-    MockNamedValueCopier* copier_;
-};
-
 class MockNamedValueComparator
 {
 public:
@@ -166,7 +146,8 @@ private:
         const void* outputPointerValue_;
     } value_;
     size_t size_;
-    MockNamedValueHandler* handler_;
+    MockNamedValueComparator* comparator_;
+    MockNamedValueCopier* copier_;
     static MockNamedValueHandlerRepository* defaultRepository_;
 };
 
@@ -220,12 +201,13 @@ public:
     virtual void installComparator(const SimpleString& name, MockNamedValueComparator& comparator);
     virtual void installCopier(const SimpleString& name, MockNamedValueCopier& copier);
     virtual void installHandlers(const MockNamedValueHandlerRepository& repository);
-    virtual MockNamedValueHandler* getHandlerForType(const SimpleString& name);
+    virtual MockNamedValueComparator* getComparatorForType(const SimpleString& name);
+    virtual MockNamedValueCopier* getCopierForType(const SimpleString& name);
 
     void clear();
 private:
-    virtual void installHandler(const SimpleString& name, MockNamedValueHandler& handler);
-    MockNamedValueHandler* addHandler(const SimpleString& name);
+    MockNamedValueHandlerRepositoryNode* getNodeForType(const SimpleString& name);
+    MockNamedValueHandlerRepositoryNode* insertNodeTorType(const SimpleString& name);
 };
 
 #endif

--- a/include/CppUTestExt/MockNamedValue.h
+++ b/include/CppUTestExt/MockNamedValue.h
@@ -93,7 +93,7 @@ class MockFunctionCopier : public MockNamedValueCopier
 public:
     typedef void (*copyFunction)(const void*, const void*);
 
-    MockFunctionCopier(copyFunction copy) : copy_(copy) {}
+    MockFunctionCopier(copyFunction copyFunc) : copy_(copyFunc) {}
     virtual ~MockFunctionCopier(){}
 
     virtual void copy(const void* object1, const void* object2) _override { copy_(object1, object2); }

--- a/include/CppUTestExt/MockSupport.h
+++ b/include/CppUTestExt/MockSupport.h
@@ -103,11 +103,12 @@ public:
 
     virtual void setMockFailureStandardReporter(MockFailureReporter* reporter);
     virtual void setActiveReporter(MockFailureReporter* activeReporter);
-    virtual void setDefaultComparatorRepository();
+    virtual void setDefaultHandlerRepository();
 
     virtual void installComparator(const SimpleString& typeName, MockNamedValueComparator& comparator);
-    virtual void installComparators(const MockNamedValueComparatorRepository& repository);
-    virtual void removeAllComparators();
+    virtual void installCopier(const SimpleString& typeName, MockNamedValueCopier& copier);
+    virtual void installHandlers(const MockNamedValueHandlerRepository& repository);
+    virtual void removeAllHandlers();
 
 protected:
     MockSupport* clone();
@@ -127,7 +128,7 @@ private:
     bool enabled_;
     MockCheckedActualCall *lastActualFunctionCall_;
     MockExpectedCallComposite compositeCalls_;
-    MockNamedValueComparatorRepository comparatorRepository_;
+    MockNamedValueHandlerRepository handlerRepository_;
     MockNamedValueList data_;
 
     bool tracing_;

--- a/include/CppUTestExt/MockSupport.h
+++ b/include/CppUTestExt/MockSupport.h
@@ -105,8 +105,8 @@ public:
     virtual void setActiveReporter(MockFailureReporter* activeReporter);
     virtual void setDefaultHandlerRepository();
 
-    virtual void installComparator(const SimpleString& typeName, MockNamedValueComparator& comparator);
-    virtual void installCopier(const SimpleString& typeName, MockNamedValueCopier& copier);
+    virtual void installHandler(const SimpleString& typeName, MockNamedValueComparator& comparator);
+    virtual void installHandler(const SimpleString& typeName, MockNamedValueCopier& copier);
     virtual void installHandlers(const MockNamedValueHandlerRepository& repository);
     virtual void removeAllHandlers();
 

--- a/include/CppUTestExt/MockSupportPlugin.h
+++ b/include/CppUTestExt/MockSupportPlugin.h
@@ -41,8 +41,9 @@ public:
     virtual void postTestAction(UtestShell&, TestResult&) _override;
 
     virtual void installComparator(const SimpleString& name, MockNamedValueComparator& comparator);
+    virtual void installCopier(const SimpleString& name, MockNamedValueCopier& copier);
 private:
-    MockNamedValueComparatorRepository repository_;
+    MockNamedValueHandlerRepository repository_;
 };
 
 #endif

--- a/include/CppUTestExt/MockSupport_c.h
+++ b/include/CppUTestExt/MockSupport_c.h
@@ -131,9 +131,9 @@ struct SMockSupport_c
     void (*clear)(void);
     void (*crashOnFailure)(unsigned shouldCrash);
 
-    void (*installComparator) (const char* typeName, MockTypeEqualFunction_c isEqual, MockTypeValueToStringFunction_c valueToString);
-    void (*installCopier) (const char* typeName, MockTypeCopyFunction_c copy);
-    void (*removeAllComparators)(void);
+    void (*installComparatorHandler) (const char* typeName, MockTypeEqualFunction_c isEqual, MockTypeValueToStringFunction_c valueToString);
+    void (*installCopierHandler) (const char* typeName, MockTypeCopyFunction_c copy);
+    void (*removeAllHandlers)(void);
 };
 
 

--- a/include/CppUTestExt/MockSupport_c.h
+++ b/include/CppUTestExt/MockSupport_c.h
@@ -105,6 +105,7 @@ struct SMockExpectedCall_c
 
 typedef int (*MockTypeEqualFunction_c)(const void* object1, const void* object2);
 typedef char* (*MockTypeValueToStringFunction_c)(const void* object1);
+typedef void (*MockTypeCopyFunction_c)(const void* object1, const void* object2);
 
 typedef struct SMockSupport_c MockSupport_c;
 struct SMockSupport_c
@@ -131,6 +132,7 @@ struct SMockSupport_c
     void (*crashOnFailure)(unsigned shouldCrash);
 
     void (*installComparator) (const char* typeName, MockTypeEqualFunction_c isEqual, MockTypeValueToStringFunction_c valueToString);
+    void (*installCopier) (const char* typeName, MockTypeCopyFunction_c copy);
     void (*removeAllComparators)(void);
 };
 

--- a/src/CppUTestExt/MockExpectedCall.cpp
+++ b/src/CppUTestExt/MockExpectedCall.cpp
@@ -154,6 +154,14 @@ MockExpectedCall& MockCheckedExpectedCall::withOutputParameterReturning(const Si
     return *this;
 }
 
+MockExpectedCall& MockCheckedExpectedCall::withOutputParameterOfTypeReturning(const SimpleString& type, const SimpleString& name, const void* value)
+{
+    MockNamedValue* newParameter = new MockExpectedFunctionParameter(name);
+    outputParameters_->add(newParameter);
+    newParameter->setObjectPointer(type, value);
+    return *this;
+}
+
 SimpleString MockCheckedExpectedCall::getInputParameterType(const SimpleString& name)
 {
     MockNamedValue * p = inputParameters_->getValueByName(name);
@@ -562,6 +570,13 @@ MockExpectedCall& MockExpectedCallComposite::withOutputParameterReturning(const 
 {
     for (MockExpectedCallCompositeNode* node = head_; node != NULL; node = node->next_)
         node->call_.withOutputParameterReturning(name, value, size);
+    return *this;
+}
+
+MockExpectedCall& MockExpectedCallComposite::withOutputParameterOfTypeReturning(const SimpleString& type, const SimpleString& name, const void* value)
+{
+    for (MockExpectedCallCompositeNode* node = head_; node != NULL; node = node->next_)
+        node->call_.withOutputParameterOfTypeReturning(type, name, value);
     return *this;
 }
 

--- a/src/CppUTestExt/MockNamedValue.cpp
+++ b/src/CppUTestExt/MockNamedValue.cpp
@@ -284,8 +284,8 @@ SimpleString MockNamedValue::toString() const
     else if (type_ == "double")
         return StringFrom(value_.doubleValue_);
 
-    if (getComparator())
-        return getComparator()->valueToString(value_.objectPointerValue_);
+    if (comparator_)
+        return comparator_->valueToString(value_.objectPointerValue_);
 
     return StringFromFormat("No comparator found for type: \"%s\"", type_.asCharString());
 

--- a/src/CppUTestExt/MockNamedValue.cpp
+++ b/src/CppUTestExt/MockNamedValue.cpp
@@ -37,7 +37,7 @@ void MockNamedValue::setDefaultComparatorRepository(MockNamedValueComparatorRepo
     defaultRepository_ = repository;
 }
 
-MockNamedValue::MockNamedValue(const SimpleString& name) : name_(name), type_("int"), comparator_(NULL)
+MockNamedValue::MockNamedValue(const SimpleString& name) : name_(name), type_("int"), size_(0), comparator_(NULL)
 {
     value_.intValue_ = 0;
 }

--- a/src/CppUTestExt/MockSupport.cpp
+++ b/src/CppUTestExt/MockSupport.cpp
@@ -79,20 +79,20 @@ void MockSupport::setDefaultHandlerRepository()
     MockNamedValue::setDefaultHandlerRepository(&handlerRepository_);
 }
 
-void MockSupport::installComparator(const SimpleString& typeName, MockNamedValueComparator& comparator)
+void MockSupport::installHandler(const SimpleString& typeName, MockNamedValueComparator& comparator)
 {
     handlerRepository_.installComparator(typeName, comparator);
 
     for (MockNamedValueListNode* p = data_.begin(); p; p = p->next())
-        if (getMockSupport(p)) getMockSupport(p)->installComparator(typeName, comparator);
+        if (getMockSupport(p)) getMockSupport(p)->installHandler(typeName, comparator);
 }
 
-void MockSupport::installCopier(const SimpleString& typeName, MockNamedValueCopier& copier)
+void MockSupport::installHandler(const SimpleString& typeName, MockNamedValueCopier& copier)
 {
     handlerRepository_.installCopier(typeName, copier);
 
     for (MockNamedValueListNode* p = data_.begin(); p; p = p->next())
-        if (getMockSupport(p)) getMockSupport(p)->installCopier(typeName, copier);
+        if (getMockSupport(p)) getMockSupport(p)->installHandler(typeName, copier);
 }
 
 void MockSupport::installHandlers(const MockNamedValueHandlerRepository& repository)

--- a/src/CppUTestExt/MockSupportPlugin.cpp
+++ b/src/CppUTestExt/MockSupportPlugin.cpp
@@ -62,7 +62,7 @@ MockSupportPlugin::~MockSupportPlugin()
 
 void MockSupportPlugin::preTestAction(UtestShell&, TestResult&)
 {
-    mock().installComparators(repository_);
+    mock().installHandlers(repository_);
 }
 
 void MockSupportPlugin::postTestAction(UtestShell& test, TestResult& result)
@@ -72,7 +72,7 @@ void MockSupportPlugin::postTestAction(UtestShell& test, TestResult& result)
     mock().checkExpectations();
     mock().clear();
     mock().setMockFailureStandardReporter(NULL);
-    mock().removeAllComparators();
+    mock().removeAllHandlers();
 }
 
 void MockSupportPlugin::installComparator(const SimpleString& name, MockNamedValueComparator& comparator)
@@ -80,3 +80,7 @@ void MockSupportPlugin::installComparator(const SimpleString& name, MockNamedVal
     repository_.installComparator(name, comparator);
 }
 
+void MockSupportPlugin::installCopier(const SimpleString& name, MockNamedValueCopier& copier)
+{
+    repository_.installCopier(name, copier);
+}

--- a/src/CppUTestExt/MockSupport_c.cpp
+++ b/src/CppUTestExt/MockSupport_c.cpp
@@ -168,13 +168,13 @@ MockValue_c actualReturnValue_c();
 static void installComparator_c (const char* typeName, MockTypeEqualFunction_c isEqual, MockTypeValueToStringFunction_c valueToString)
 {
     comparatorList_ = new MockCFunctionComparatorNode(comparatorList_, isEqual, valueToString);
-    currentMockSupport->installComparator(typeName, *comparatorList_);
+    currentMockSupport->installHandler(typeName, *comparatorList_);
 }
 
 static void installCopier_c (const char* typeName, MockTypeCopyFunction_c copy)
 {
     copierList_ = new MockCFunctionCopierNode(copierList_, copy);
-    currentMockSupport->installCopier(typeName, *copierList_);
+    currentMockSupport->installHandler(typeName, *copierList_);
 }
 
 static void removeAllHandlers_c()

--- a/src/CppUTestExt/MockSupport_c.cpp
+++ b/src/CppUTestExt/MockSupport_c.cpp
@@ -96,8 +96,8 @@ public:
 class MockCFunctionCopierNode : public MockNamedValueCopier
 {
 public:
-    MockCFunctionCopierNode(MockCFunctionCopierNode* next, MockTypeCopyFunction_c copy)
-        : next_(next), copy_(copy) {}
+    MockCFunctionCopierNode(MockCFunctionCopierNode* next, MockTypeCopyFunction_c copyFunc)
+        : next_(next), copy_(copyFunc) {}
     virtual ~MockCFunctionCopierNode() {}
 
     virtual void copy(const void* object1, const void* object2) _override

--- a/tests/CppUTestExt/MemoryReporterPluginTest.cpp
+++ b/tests/CppUTestExt/MemoryReporterPluginTest.cpp
@@ -131,7 +131,7 @@ TEST_GROUP(MemoryReporterPlugin)
         test = new UtestShell("groupname", "testname", "filename", 1);
         reporter = new MemoryReporterPluginUnderTest;
 
-        mock("formatter").installComparator("TestMemoryAllocator", memLeakAllocatorComparator);
+        mock("formatter").installHandler("TestMemoryAllocator", memLeakAllocatorComparator);
 
         mock("reporter").disable();
         const char *cmd_line[] = {"-pmemoryreport=normal"};

--- a/tests/CppUTestExt/MockExpectedCallTest.cpp
+++ b/tests/CppUTestExt/MockExpectedCallTest.cpp
@@ -53,7 +53,7 @@ public:
     }
 };
 
-TEST_GROUP(MockNamedValueComparatorRepository)
+TEST_GROUP(MockNamedValueHandlerRepository)
 {
     void teardown()
     {
@@ -61,30 +61,30 @@ TEST_GROUP(MockNamedValueComparatorRepository)
     }
 };
 
-TEST(MockNamedValueComparatorRepository, getComparatorForNonExistingName)
+TEST(MockNamedValueHandlerRepository, getHandlerForNonExistingName)
 {
-    MockNamedValueComparatorRepository repository;
-    POINTERS_EQUAL(NULL, repository.getComparatorForType("typeName"));
+    MockNamedValueHandlerRepository repository;
+    POINTERS_EQUAL(NULL, repository.getHandlerForType("typeName"));
 }
 
-TEST(MockNamedValueComparatorRepository, installComparator)
+TEST(MockNamedValueHandlerRepository, installComparator)
 {
     TypeForTestingExpectedFunctionCallComparator comparator;
-    MockNamedValueComparatorRepository repository;
+    MockNamedValueHandlerRepository repository;
     repository.installComparator("typeName", comparator);
-    POINTERS_EQUAL(&comparator, repository.getComparatorForType("typeName"));
+    POINTERS_EQUAL(&comparator, repository.getHandlerForType("typeName")->getComparator());
 }
 
-TEST(MockNamedValueComparatorRepository, installMultipleComparator)
+TEST(MockNamedValueHandlerRepository, installMultipleHandlers)
 {
     TypeForTestingExpectedFunctionCallComparator comparator1, comparator2, comparator3;
-    MockNamedValueComparatorRepository repository;
+    MockNamedValueHandlerRepository repository;
     repository.installComparator("type1", comparator1);
     repository.installComparator("type2", comparator2);
     repository.installComparator("type3", comparator3);
-    POINTERS_EQUAL(&comparator3, repository.getComparatorForType("type3"));
-    POINTERS_EQUAL(&comparator2, repository.getComparatorForType("type2"));
-    POINTERS_EQUAL(&comparator1, repository.getComparatorForType("type1"));
+    POINTERS_EQUAL(&comparator3, repository.getHandlerForType("type3")->getComparator());
+    POINTERS_EQUAL(&comparator2, repository.getHandlerForType("type2")->getComparator());
+    POINTERS_EQUAL(&comparator1, repository.getHandlerForType("type1")->getComparator());
 }
 
 TEST_GROUP(MockExpectedCall)
@@ -204,8 +204,8 @@ TEST(MockExpectedCall, callWithObjectParameterEqualComparisonButFailsWithoutRepo
 
 TEST(MockExpectedCall, callWithObjectParameterEqualComparisonButFailsWithoutComparator)
 {
-    MockNamedValueComparatorRepository repository;
-    MockNamedValue::setDefaultComparatorRepository(&repository);
+    MockNamedValueHandlerRepository repository;
+    MockNamedValue::setDefaultHandlerRepository(&repository);
 
     TypeForTestingExpectedFunctionCall type(1), equalType(1);
     MockNamedValue parameter("name");
@@ -217,8 +217,8 @@ TEST(MockExpectedCall, callWithObjectParameterEqualComparisonButFailsWithoutComp
 TEST(MockExpectedCall, callWithObjectParameterEqualComparison)
 {
     TypeForTestingExpectedFunctionCallComparator comparator;
-    MockNamedValueComparatorRepository repository;
-    MockNamedValue::setDefaultComparatorRepository(&repository);
+    MockNamedValueHandlerRepository repository;
+    MockNamedValue::setDefaultHandlerRepository(&repository);
     repository.installComparator("type", comparator);
 
     TypeForTestingExpectedFunctionCall type(1), equalType(1);
@@ -232,8 +232,8 @@ TEST(MockExpectedCall, callWithObjectParameterEqualComparison)
 TEST(MockExpectedCall, getParameterValueOfObjectType)
 {
     TypeForTestingExpectedFunctionCallComparator comparator;
-    MockNamedValueComparatorRepository repository;
-    MockNamedValue::setDefaultComparatorRepository(&repository);
+    MockNamedValueHandlerRepository repository;
+    MockNamedValue::setDefaultHandlerRepository(&repository);
     repository.installComparator("type", comparator);
 
     TypeForTestingExpectedFunctionCall type(1);
@@ -252,8 +252,8 @@ TEST(MockExpectedCall, getParameterValueOfObjectTypeWithoutRepository)
 TEST(MockExpectedCall, getParameterValueOfObjectTypeWithoutComparator)
 {
     TypeForTestingExpectedFunctionCall type(1);
-    MockNamedValueComparatorRepository repository;
-    MockNamedValue::setDefaultComparatorRepository(&repository);
+    MockNamedValueHandlerRepository repository;
+    MockNamedValue::setDefaultHandlerRepository(&repository);
     call->withParameterOfType("type", "name", &type);
     STRCMP_EQUAL("No comparator found for type: \"type\"", call->getInputParameterValueString("name").asCharString());
 }

--- a/tests/CppUTestExt/MockExpectedCallTest.cpp
+++ b/tests/CppUTestExt/MockExpectedCallTest.cpp
@@ -61,10 +61,16 @@ TEST_GROUP(MockNamedValueHandlerRepository)
     }
 };
 
-TEST(MockNamedValueHandlerRepository, getHandlerForNonExistingName)
+TEST(MockNamedValueHandlerRepository, getComparatorForNonExistingName)
 {
     MockNamedValueHandlerRepository repository;
-    POINTERS_EQUAL(NULL, repository.getHandlerForType("typeName"));
+    POINTERS_EQUAL(NULL, repository.getComparatorForType("typeName"));
+}
+
+TEST(MockNamedValueHandlerRepository, getCopierrForNonExistingName)
+{
+    MockNamedValueHandlerRepository repository;
+    POINTERS_EQUAL(NULL, repository.getCopierForType("typeName"));
 }
 
 TEST(MockNamedValueHandlerRepository, installComparator)
@@ -72,7 +78,7 @@ TEST(MockNamedValueHandlerRepository, installComparator)
     TypeForTestingExpectedFunctionCallComparator comparator;
     MockNamedValueHandlerRepository repository;
     repository.installComparator("typeName", comparator);
-    POINTERS_EQUAL(&comparator, repository.getHandlerForType("typeName")->getComparator());
+    POINTERS_EQUAL(&comparator, repository.getComparatorForType("typeName"));
 }
 
 TEST(MockNamedValueHandlerRepository, installMultipleHandlers)
@@ -82,9 +88,9 @@ TEST(MockNamedValueHandlerRepository, installMultipleHandlers)
     repository.installComparator("type1", comparator1);
     repository.installComparator("type2", comparator2);
     repository.installComparator("type3", comparator3);
-    POINTERS_EQUAL(&comparator3, repository.getHandlerForType("type3")->getComparator());
-    POINTERS_EQUAL(&comparator2, repository.getHandlerForType("type2")->getComparator());
-    POINTERS_EQUAL(&comparator1, repository.getHandlerForType("type1")->getComparator());
+    POINTERS_EQUAL(&comparator3, repository.getComparatorForType("type3"));
+    POINTERS_EQUAL(&comparator2, repository.getComparatorForType("type2"));
+    POINTERS_EQUAL(&comparator1, repository.getComparatorForType("type1"));
 }
 
 TEST_GROUP(MockExpectedCall)

--- a/tests/CppUTestExt/MockPluginTest.cpp
+++ b/tests/CppUTestExt/MockPluginTest.cpp
@@ -128,9 +128,9 @@ TEST(MockPlugin, preTestActionWillEnableMultipleComparatorsToTheGlobalMockSuppor
 
     plugin->preTestAction(*test, *result);
     mock().expectOneCall("foo").withParameterOfType("myType", "name", &comparator);
-    mock().expectOneCall("foo").withParameterOfType("myOtherType", "name", &comparator2);
+    mock().expectOneCall("foo").withParameterOfType("myOtherType", "name", &comparator);
     mock().actualCall("foo").withParameterOfType("myType", "name", &comparator);
-    mock().actualCall("foo").withParameterOfType("myOtherType", "name", &comparator2);
+    mock().actualCall("foo").withParameterOfType("myOtherType", "name", &comparator);
 
     mock().checkExpectations();
     CHECK_NO_MOCK_FAILURE();

--- a/tests/CppUTestExt/MockPluginTest.cpp
+++ b/tests/CppUTestExt/MockPluginTest.cpp
@@ -128,9 +128,9 @@ TEST(MockPlugin, preTestActionWillEnableMultipleComparatorsToTheGlobalMockSuppor
 
     plugin->preTestAction(*test, *result);
     mock().expectOneCall("foo").withParameterOfType("myType", "name", &comparator);
-    mock().expectOneCall("foo").withParameterOfType("myOtherType", "name", &comparator);
+    mock().expectOneCall("foo").withParameterOfType("myOtherType", "name", &comparator2);
     mock().actualCall("foo").withParameterOfType("myType", "name", &comparator);
-    mock().actualCall("foo").withParameterOfType("myOtherType", "name", &comparator);
+    mock().actualCall("foo").withParameterOfType("myOtherType", "name", &comparator2);
 
     mock().checkExpectations();
     CHECK_NO_MOCK_FAILURE();

--- a/tests/CppUTestExt/MockSupportTest.cpp
+++ b/tests/CppUTestExt/MockSupportTest.cpp
@@ -700,7 +700,7 @@ TEST(MockSupportTest, customObjectParameterSucceeds)
 {
     MyTypeForTesting object(1);
     MyTypeForTestingComparator comparator;
-    mock().installComparator("MyTypeForTesting", comparator);
+    mock().installHandler("MyTypeForTesting", comparator);
     mock().expectOneCall("function").withParameterOfType("MyTypeForTesting", "parameterName", &object);
     mock().actualCall("function").withParameterOfType("MyTypeForTesting", "parameterName", &object);
     mock().checkExpectations();
@@ -725,7 +725,7 @@ TEST(MockSupportTest, customObjectOutputParameterShouldSucceed)
     MyTypeForTesting source(1);
     MyTypeForTesting target(2);
     MyTypeForTestingCopier copier;
-    mock().installCopier("MyTypeForTesting", copier);
+    mock().installHandler("MyTypeForTesting", copier);
     mock().expectOneCall("function").withOutputParameterOfTypeReturning("MyTypeForTesting", "parameterName", &source);
     mock().actualCall("function").withOutputParameterOfType("MyTypeForTesting", "parameterName", &target);
     mock().checkExpectations();
@@ -919,7 +919,7 @@ TEST(MockSupportTest, customObjectWithFunctionComparator)
 {
     MyTypeForTesting object(1);
     MockFunctionComparator comparator(myTypeIsEqual, myTypeValueToString);
-    mock().installComparator("MyTypeForTesting", comparator);
+    mock().installHandler("MyTypeForTesting", comparator);
     mock().expectOneCall("function").withParameterOfType("MyTypeForTesting", "parameterName", &object);
     mock().actualCall("function").withParameterOfType("MyTypeForTesting", "parameterName", &object);
     mock().checkExpectations();
@@ -931,7 +931,7 @@ TEST(MockSupportTest, customObjectWithFunctionComparatorThatFailsCoversValueToSt
 {
     MyTypeForTesting object(5);
     MockFunctionComparator comparator(myTypeIsEqual, myTypeValueToString);
-    mock().installComparator("MyTypeForTesting", comparator);
+    mock().installHandler("MyTypeForTesting", comparator);
     addFunctionToExpectationsList("function")->withParameterOfType("MyTypeForTesting", "parameterName", &object);
     MockExpectedCallsDidntHappenFailure failure(UtestShell::getCurrent(), *expectationsList);
     mock().expectOneCall("function").withParameterOfType("MyTypeForTesting", "parameterName", &object);
@@ -1150,7 +1150,7 @@ TEST(MockSupportTest, installComparatorWorksHierarchicalOnBothExistingAndDynamic
     MyTypeForTestingComparator comparator;
 
     mock("existing");
-    mock().installComparator("MyTypeForTesting", comparator);
+    mock().installHandler("MyTypeForTesting", comparator);
     mock("existing").expectOneCall("function").withParameterOfType("MyTypeForTesting", "parameterName", &object);
     mock("existing").actualCall("function").withParameterOfType("MyTypeForTesting", "parameterName", &object);
     mock("dynamic").expectOneCall("function").withParameterOfType("MyTypeForTesting", "parameterName", &object);
@@ -1183,7 +1183,7 @@ TEST(MockSupportTest, removeComparatorsWorksHierachically)
     MyTypeForTesting object(1);
     MyTypeForTestingComparator comparator;
 
-    mock("scope").installComparator("MyTypeForTesting", comparator);
+    mock("scope").installHandler("MyTypeForTesting", comparator);
     mock().removeAllHandlers();
     mock("scope").expectOneCall("function").withParameterOfType("MyTypeForTesting", "parameterName", &object);
     mock("scope").actualCall("function").withParameterOfType("MyTypeForTesting", "parameterName", &object);
@@ -1744,7 +1744,7 @@ static void functionWithConstParam(const SomeClass param)
 TEST(MockSupportTest, shouldSupportConstParameters)
 {
     StubComparator comparator;
-    mock().installComparator("SomeClass", comparator);
+    mock().installHandler("SomeClass", comparator);
 
     SomeClass param;
     mock().expectOneCall("functionWithConstParam").withParameterOfType("SomeClass", "param", &param);

--- a/tests/CppUTestExt/MockSupport_cTest.cpp
+++ b/tests/CppUTestExt/MockSupport_cTest.cpp
@@ -67,11 +67,11 @@ extern "C"{
 
 TEST(MockSupport_c, expectAndActualParametersOnObject)
 {
-    mock_c()->installComparator("typeName", typeNameIsEqual, typeNameValueToString);
+    mock_c()->installComparatorHandler("typeName", typeNameIsEqual, typeNameValueToString);
     mock_c()->expectOneCall("boo")->withParameterOfType("typeName", "name", (const void*) 1);
     mock_c()->actualCall("boo")->withParameterOfType("typeName", "name", (const void*) 1);
     mock_c()->checkExpectations();
-    mock_c()->removeAllComparators();
+    mock_c()->removeAllHandlers();
 }
 
 TEST(MockSupport_c, unsignedIntParameter)
@@ -265,11 +265,11 @@ TEST_ORDERED(MockSupport_c, shouldCrashOnFailure, 21)
     UtestShell::setCrashMethod(crashMethod);
     mock_c()->crashOnFailure(true);
     fixture.setTestFunction(failedCallToMockC);
-    
+
     fixture.runAllTests();
 
     CHECK(cpputestHasCrashed);
-    
+
     UtestShell::resetCrashMethod();
     mock_c()->crashOnFailure(false);
 }
@@ -280,7 +280,7 @@ TEST_ORDERED(MockSupport_c, nextTestShouldNotCrashOnFailure, 22)
     TestTestingFixture fixture;
     UtestShell::setCrashMethod(crashMethod);
     fixture.setTestFunction(failedCallToMockC);
-    
+
     fixture.runAllTests();
 
     CHECK_FALSE(cpputestHasCrashed);
@@ -297,9 +297,9 @@ static void failingCallToMockCWithParameterOfType_()
 TEST(MockSupport_c, failureWithParameterOfTypeCoversValueToString)
 {
     TestTestingFixture fixture;
-    mock_c()->installComparator("typeName", typeNameIsEqual, typeNameValueToString);
+    mock_c()->installComparatorHandler("typeName", typeNameIsEqual, typeNameValueToString);
     fixture.setTestFunction(failingCallToMockCWithParameterOfType_);
     fixture.runAllTests();
     fixture.assertPrintContains("typeName name: <valueToString>");
-    mock_c()->removeAllComparators();
+    mock_c()->removeAllHandlers();
 }

--- a/tests/CppUTestExt/MockSupport_cTestCFile.c
+++ b/tests/CppUTestExt/MockSupport_cTestCFile.c
@@ -51,11 +51,11 @@ void all_mock_support_c_calls(void)
             withStringParameters("string", "string")->withPointerParameters("pointer", (void*) 1)->
             withConstPointerParameters("constpointer", (const void*) 1);
 
-    mock_c()->installComparator("typeName", typeNameIsEqual, typeNameValueToString);
+    mock_c()->installComparatorHandler("typeName", typeNameIsEqual, typeNameValueToString);
     mock_c()->expectOneCall("boo")->withParameterOfType("typeName", "name", (void*) 1);
     mock_c()->actualCall("boo")->withParameterOfType("typeName", "name", (void*) 1);
     mock_c()->clear();
-    mock_c()->removeAllComparators();
+    mock_c()->removeAllHandlers();
 
     mock_c()->expectOneCall("boo")->andReturnIntValue(10);
     mock_c()->actualCall("boo")->returnValue();


### PR DESCRIPTION
Okay -- here goes. This is the version that has separate copiers and comparators, aggregated into a MockNamedValueHandler class.

The nice thing is that existing user code need (almost) not be changed. The only thing that changed is that `mock().removeAllComparators()` became `mock().removeAllHandlers()`.

Also, a custom class can have both a Comparator and a Copier.

All in all, I like this implementation better myself.

BUT -- there's a downside. It means a lot of changes, even though I made sure to change as little as possible.

Suggestions for improvements welcome :)

