### PR TITLE
Custom Copiers #4: Additions to MockFailure

### DIFF
--- a/include/CppUTestExt/MockFailure.h
+++ b/include/CppUTestExt/MockFailure.h
@@ -109,6 +109,13 @@ public:
     virtual ~MockNoWayToCompareCustomTypeFailure(){}
 };
 
+class MockNoWayToCopyCustomTypeFailure : public MockFailure
+{
+public:
+    MockNoWayToCopyCustomTypeFailure(UtestShell* test, const SimpleString& typeName);
+    virtual ~MockNoWayToCopyCustomTypeFailure(){}
+};
+
 class MockUnexpectedObjectFailure : public MockFailure
 {
 public:

--- a/include/CppUTestExt/MockNamedValue.h
+++ b/include/CppUTestExt/MockNamedValue.h
@@ -28,7 +28,7 @@
 #ifndef D_MockNamedValue_h
 #define D_MockNamedValue_h
 /*
- * MockParameterComparator is an interface that needs to be used when creating Comparators.
+ * MockNamedValueComparator is an interface that needs to be used when creating Comparators.
  * This is needed when comparing values of non-native type.
  */
 
@@ -66,7 +66,7 @@ private:
  * Basically this class ties together a Name, a Value, a Type, and a Comparator
  */
 
-class MockNamedValueComparatorRepository;
+class MockNamedValueHandlerRepository;
 class MockNamedValue
 {
 public:
@@ -106,7 +106,7 @@ public:
     virtual size_t getSize() const;
     virtual MockNamedValueComparator* getComparator() const;
 
-    static void setDefaultComparatorRepository(MockNamedValueComparatorRepository* repository);
+    static void setDefaultHandlerRepository(MockNamedValueHandlerRepository* repository);
 private:
     SimpleString name_;
     SimpleString type_;
@@ -124,7 +124,7 @@ private:
     } value_;
     size_t size_;
     MockNamedValueComparator* comparator_;
-    static MockNamedValueComparatorRepository* defaultRepository_;
+    static MockNamedValueHandlerRepository* defaultRepository_;
 };
 
 class MockNamedValueListNode
@@ -167,18 +167,19 @@ private:
  */
 
 struct MockNamedValueComparatorRepositoryNode;
-class MockNamedValueComparatorRepository
+class MockNamedValueHandlerRepository
 {
-    MockNamedValueComparatorRepositoryNode* head_;
+private:
+    MockNamedValueComparatorRepositoryNode* comparatorsHead_;
 public:
-    MockNamedValueComparatorRepository();
-    virtual ~MockNamedValueComparatorRepository();
+    MockNamedValueHandlerRepository();
+    virtual ~MockNamedValueHandlerRepository();
 
     virtual void installComparator(const SimpleString& name, MockNamedValueComparator& comparator);
-    virtual void installComparators(const MockNamedValueComparatorRepository& repository);
+    virtual void installHandlers(const MockNamedValueHandlerRepository& repository);
     virtual MockNamedValueComparator* getComparatorForType(const SimpleString& name);
 
-    void clear();
+    void clearComparators();
 };
 
 #endif

--- a/include/CppUTestExt/MockSupport.h
+++ b/include/CppUTestExt/MockSupport.h
@@ -106,7 +106,7 @@ public:
     virtual void setDefaultComparatorRepository();
 
     virtual void installComparator(const SimpleString& typeName, MockNamedValueComparator& comparator);
-    virtual void installComparators(const MockNamedValueComparatorRepository& repository);
+    virtual void installHandlers(const MockNamedValueHandlerRepository& repository);
     virtual void removeAllComparators();
 
 protected:
@@ -127,7 +127,7 @@ private:
     bool enabled_;
     MockCheckedActualCall *lastActualFunctionCall_;
     MockExpectedCallComposite compositeCalls_;
-    MockNamedValueComparatorRepository comparatorRepository_;
+    MockNamedValueHandlerRepository handlerRepository_;
     MockNamedValueList data_;
 
     bool tracing_;

--- a/include/CppUTestExt/MockSupportPlugin.h
+++ b/include/CppUTestExt/MockSupportPlugin.h
@@ -42,7 +42,7 @@ public:
 
     virtual void installComparator(const SimpleString& name, MockNamedValueComparator& comparator);
 private:
-    MockNamedValueComparatorRepository repository_;
+    MockNamedValueHandlerRepository repository_;
 };
 
 #endif

--- a/src/CppUTestExt/MockFailure.cpp
+++ b/src/CppUTestExt/MockFailure.cpp
@@ -160,10 +160,25 @@ MockUnexpectedInputParameterFailure::MockUnexpectedInputParameterFailure(UtestSh
 
 MockUnexpectedOutputParameterFailure::MockUnexpectedOutputParameterFailure(UtestShell* test, const SimpleString& functionName, const MockNamedValue& parameter, const MockExpectedCallsList& expectations)  : MockFailure(test)
 {
-    message_ = "Mock Failure: Unexpected output parameter name to function \"";
-    message_ += functionName;
-    message_ += "\": ";
-    message_ += parameter.getName();
+    MockExpectedCallsList expectationsForFunctionWithParameterName;
+    expectationsForFunctionWithParameterName.addExpectationsRelatedTo(functionName, expectations);
+    expectationsForFunctionWithParameterName.onlyKeepExpectationsWithOutputParameterName(parameter.getName());
+
+    if (expectationsForFunctionWithParameterName.isEmpty()) {
+        message_ = "Mock Failure: Unexpected output parameter name to function \"";
+        message_ += functionName;
+        message_ += "\": ";
+        message_ += parameter.getName();
+    }
+    else {
+        message_ = "Mock Failure: Unexpected parameter type \"";
+        message_ += parameter.getType();
+        message_ += "\" to output parameter \"";
+        message_ += parameter.getName();
+        message_ += "\" to function \"";
+        message_ += functionName;
+        message_ += "\"";
+    }
 
     message_ += "\n";
     addExpectationsAndCallHistoryRelatedTo(functionName, expectations);
@@ -196,7 +211,12 @@ MockExpectedParameterDidntHappenFailure::MockExpectedParameterDidntHappenFailure
 
 MockNoWayToCompareCustomTypeFailure::MockNoWayToCompareCustomTypeFailure(UtestShell* test, const SimpleString& typeName) : MockFailure(test)
 {
-    message_ = StringFromFormat("MockFailure: No way to compare type <%s>. Please install a ParameterTypeComparator.", typeName.asCharString());
+    message_ = StringFromFormat("MockFailure: No way to compare type <%s>. Please install a MockNamedValueComparator.", typeName.asCharString());
+}
+
+MockNoWayToCopyCustomTypeFailure::MockNoWayToCopyCustomTypeFailure(UtestShell* test, const SimpleString& typeName) : MockFailure(test)
+{
+    message_ = StringFromFormat("MockFailure: No way to copy type <%s>. Please install a MockNamedValueCopier.", typeName.asCharString());
 }
 
 MockUnexpectedObjectFailure::MockUnexpectedObjectFailure(UtestShell* test, const SimpleString& functionName, void* actual, const MockExpectedCallsList& expectations) : MockFailure(test)

--- a/src/CppUTestExt/MockNamedValue.cpp
+++ b/src/CppUTestExt/MockNamedValue.cpp
@@ -30,9 +30,9 @@
 #include "CppUTest/PlatformSpecificFunctions.h"
 
 
-MockNamedValueComparatorRepository* MockNamedValue::defaultRepository_ = NULL;
+MockNamedValueHandlerRepository* MockNamedValue::defaultRepository_ = NULL;
 
-void MockNamedValue::setDefaultComparatorRepository(MockNamedValueComparatorRepository* repository)
+void MockNamedValue::setDefaultHandlerRepository(MockNamedValueHandlerRepository* repository)
 {
     defaultRepository_ = repository;
 }
@@ -367,40 +367,40 @@ struct MockNamedValueComparatorRepositoryNode
     MockNamedValueComparatorRepositoryNode* next_;
 };
 
-MockNamedValueComparatorRepository::MockNamedValueComparatorRepository() : head_(NULL)
+MockNamedValueHandlerRepository::MockNamedValueHandlerRepository() : comparatorsHead_(NULL)
 {
 
 }
 
-MockNamedValueComparatorRepository::~MockNamedValueComparatorRepository()
+MockNamedValueHandlerRepository::~MockNamedValueHandlerRepository()
 {
-    clear();
+    clearComparators();
 }
 
-void MockNamedValueComparatorRepository::clear()
+void MockNamedValueHandlerRepository::clearComparators()
 {
-    while (head_) {
-        MockNamedValueComparatorRepositoryNode* next = head_->next_;
-        delete head_;
-        head_ = next;
+    while (comparatorsHead_) {
+        MockNamedValueComparatorRepositoryNode* next = comparatorsHead_->next_;
+        delete comparatorsHead_;
+        comparatorsHead_ = next;
     }
 }
 
-void MockNamedValueComparatorRepository::installComparator(const SimpleString& name, MockNamedValueComparator& comparator)
+void MockNamedValueHandlerRepository::installComparator(const SimpleString& name, MockNamedValueComparator& comparator)
 {
-    head_ = new MockNamedValueComparatorRepositoryNode(name, comparator, head_);
+    comparatorsHead_ = new MockNamedValueComparatorRepositoryNode(name, comparator, comparatorsHead_);
 }
 
-MockNamedValueComparator* MockNamedValueComparatorRepository::getComparatorForType(const SimpleString& name)
+MockNamedValueComparator* MockNamedValueHandlerRepository::getComparatorForType(const SimpleString& name)
 {
-    for (MockNamedValueComparatorRepositoryNode* p = head_; p; p = p->next_)
+    for (MockNamedValueComparatorRepositoryNode* p = comparatorsHead_; p; p = p->next_)
             if (p->name_ == name) return &p->comparator_;
     return NULL;
 }
 
-void MockNamedValueComparatorRepository::installComparators(const MockNamedValueComparatorRepository& repository)
+void MockNamedValueHandlerRepository::installHandlers(const MockNamedValueHandlerRepository& repository)
 {
-    for (MockNamedValueComparatorRepositoryNode* p = repository.head_; p; p = p->next_)
+    for (MockNamedValueComparatorRepositoryNode* p = repository.comparatorsHead_; p; p = p->next_)
             installComparator(p->name_, p->comparator_);
 }
 

--- a/src/CppUTestExt/MockNamedValue.cpp
+++ b/src/CppUTestExt/MockNamedValue.cpp
@@ -37,7 +37,7 @@ void MockNamedValue::setDefaultHandlerRepository(MockNamedValueHandlerRepository
     defaultRepository_ = repository;
 }
 
-MockNamedValue::MockNamedValue(const SimpleString& name) : name_(name), type_("int"), comparator_(NULL)
+MockNamedValue::MockNamedValue(const SimpleString& name) : name_(name), type_("int"), size_(0), comparator_(NULL)
 {
     value_.intValue_ = 0;
 }
@@ -403,4 +403,3 @@ void MockNamedValueHandlerRepository::installHandlers(const MockNamedValueHandle
     for (MockNamedValueComparatorRepositoryNode* p = repository.comparatorsHead_; p; p = p->next_)
             installComparator(p->name_, p->comparator_);
 }
-

--- a/src/CppUTestExt/MockSupport.cpp
+++ b/src/CppUTestExt/MockSupport.cpp
@@ -76,28 +76,28 @@ void MockSupport::setActiveReporter(MockFailureReporter* reporter)
 
 void MockSupport::setDefaultComparatorRepository()
 {
-    MockNamedValue::setDefaultComparatorRepository(&comparatorRepository_);
+    MockNamedValue::setDefaultHandlerRepository(&handlerRepository_);
 }
 
 void MockSupport::installComparator(const SimpleString& typeName, MockNamedValueComparator& comparator)
 {
-    comparatorRepository_.installComparator(typeName, comparator);
+    handlerRepository_.installComparator(typeName, comparator);
 
     for (MockNamedValueListNode* p = data_.begin(); p; p = p->next())
         if (getMockSupport(p)) getMockSupport(p)->installComparator(typeName, comparator);
 }
 
-void MockSupport::installComparators(const MockNamedValueComparatorRepository& repository)
+void MockSupport::installHandlers(const MockNamedValueHandlerRepository& repository)
 {
-    comparatorRepository_.installComparators(repository);
+    handlerRepository_.installHandlers(repository);
 
     for (MockNamedValueListNode* p = data_.begin(); p; p = p->next())
-        if (getMockSupport(p)) getMockSupport(p)->installComparators(repository);
+        if (getMockSupport(p)) getMockSupport(p)->installHandlers(repository);
 }
 
 void MockSupport::removeAllComparators()
 {
-    comparatorRepository_.clear();
+    handlerRepository_.clearComparators();
     for (MockNamedValueListNode* p = data_.begin(); p; p = p->next())
         if (getMockSupport(p)) getMockSupport(p)->removeAllComparators();
 }
@@ -377,7 +377,7 @@ MockSupport* MockSupport::clone()
     if (strictOrdering_) newMock->strictOrder();
 
     newMock->tracing(tracing_);
-    newMock->installComparators(comparatorRepository_);
+    newMock->installHandlers(handlerRepository_);
     return newMock;
 }
 

--- a/src/CppUTestExt/MockSupportPlugin.cpp
+++ b/src/CppUTestExt/MockSupportPlugin.cpp
@@ -57,12 +57,12 @@ MockSupportPlugin::MockSupportPlugin(const SimpleString& name)
 
 MockSupportPlugin::~MockSupportPlugin()
 {
-    repository_.clear();
+    repository_.clearComparators();
 }
 
 void MockSupportPlugin::preTestAction(UtestShell&, TestResult&)
 {
-    mock().installComparators(repository_);
+    mock().installHandlers(repository_);
 }
 
 void MockSupportPlugin::postTestAction(UtestShell& test, TestResult& result)

--- a/tests/CppUTestExt/MockExpectedCallTest.cpp
+++ b/tests/CppUTestExt/MockExpectedCallTest.cpp
@@ -53,7 +53,7 @@ public:
     }
 };
 
-TEST_GROUP(MockNamedValueComparatorRepository)
+TEST_GROUP(MockNamedValueHandlerRepository)
 {
     void teardown()
     {
@@ -61,24 +61,24 @@ TEST_GROUP(MockNamedValueComparatorRepository)
     }
 };
 
-TEST(MockNamedValueComparatorRepository, getComparatorForNonExistingName)
+TEST(MockNamedValueHandlerRepository, getComparatorForNonExistingName)
 {
-    MockNamedValueComparatorRepository repository;
+    MockNamedValueHandlerRepository repository;
     POINTERS_EQUAL(NULL, repository.getComparatorForType("typeName"));
 }
 
-TEST(MockNamedValueComparatorRepository, installComparator)
+TEST(MockNamedValueHandlerRepository, installComparator)
 {
     TypeForTestingExpectedFunctionCallComparator comparator;
-    MockNamedValueComparatorRepository repository;
+    MockNamedValueHandlerRepository repository;
     repository.installComparator("typeName", comparator);
     POINTERS_EQUAL(&comparator, repository.getComparatorForType("typeName"));
 }
 
-TEST(MockNamedValueComparatorRepository, installMultipleComparator)
+TEST(MockNamedValueHandlerRepository, installMultipleComparator)
 {
     TypeForTestingExpectedFunctionCallComparator comparator1, comparator2, comparator3;
-    MockNamedValueComparatorRepository repository;
+    MockNamedValueHandlerRepository repository;
     repository.installComparator("type1", comparator1);
     repository.installComparator("type2", comparator2);
     repository.installComparator("type3", comparator3);
@@ -204,8 +204,8 @@ TEST(MockExpectedCall, callWithObjectParameterEqualComparisonButFailsWithoutRepo
 
 TEST(MockExpectedCall, callWithObjectParameterEqualComparisonButFailsWithoutComparator)
 {
-    MockNamedValueComparatorRepository repository;
-    MockNamedValue::setDefaultComparatorRepository(&repository);
+    MockNamedValueHandlerRepository repository;
+    MockNamedValue::setDefaultHandlerRepository(&repository);
 
     TypeForTestingExpectedFunctionCall type(1), equalType(1);
     MockNamedValue parameter("name");
@@ -217,8 +217,8 @@ TEST(MockExpectedCall, callWithObjectParameterEqualComparisonButFailsWithoutComp
 TEST(MockExpectedCall, callWithObjectParameterEqualComparison)
 {
     TypeForTestingExpectedFunctionCallComparator comparator;
-    MockNamedValueComparatorRepository repository;
-    MockNamedValue::setDefaultComparatorRepository(&repository);
+    MockNamedValueHandlerRepository repository;
+    MockNamedValue::setDefaultHandlerRepository(&repository);
     repository.installComparator("type", comparator);
 
     TypeForTestingExpectedFunctionCall type(1), equalType(1);
@@ -232,8 +232,8 @@ TEST(MockExpectedCall, callWithObjectParameterEqualComparison)
 TEST(MockExpectedCall, getParameterValueOfObjectType)
 {
     TypeForTestingExpectedFunctionCallComparator comparator;
-    MockNamedValueComparatorRepository repository;
-    MockNamedValue::setDefaultComparatorRepository(&repository);
+    MockNamedValueHandlerRepository repository;
+    MockNamedValue::setDefaultHandlerRepository(&repository);
     repository.installComparator("type", comparator);
 
     TypeForTestingExpectedFunctionCall type(1);
@@ -252,8 +252,8 @@ TEST(MockExpectedCall, getParameterValueOfObjectTypeWithoutRepository)
 TEST(MockExpectedCall, getParameterValueOfObjectTypeWithoutComparator)
 {
     TypeForTestingExpectedFunctionCall type(1);
-    MockNamedValueComparatorRepository repository;
-    MockNamedValue::setDefaultComparatorRepository(&repository);
+    MockNamedValueHandlerRepository repository;
+    MockNamedValue::setDefaultHandlerRepository(&repository);
     call->withParameterOfType("type", "name", &type);
     STRCMP_EQUAL("No comparator found for type: \"type\"", call->getInputParameterValueString("name").asCharString());
 }

--- a/tests/CppUTestExt/MockFailureTest.cpp
+++ b/tests/CppUTestExt/MockFailureTest.cpp
@@ -200,7 +200,13 @@ TEST(MockFailureTest, MockExpectedParameterDidntHappenFailure)
 TEST(MockFailureTest, MockNoWayToCompareCustomTypeFailure)
 {
     MockNoWayToCompareCustomTypeFailure failure(UtestShell::getCurrent(), "myType");
-    STRCMP_EQUAL("MockFailure: No way to compare type <myType>. Please install a ParameterTypeComparator.", failure.getMessage().asCharString());
+    STRCMP_EQUAL("MockFailure: No way to compare type <myType>. Please install a MockNamedValueComparator.", failure.getMessage().asCharString());
+}
+
+TEST(MockFailureTest, MockNoWayToCopyCustomTypeFailure)
+{
+    MockNoWayToCopyCustomTypeFailure failure(UtestShell::getCurrent(), "myType");
+    STRCMP_EQUAL("MockFailure: No way to copy type <myType>. Please install a MockNamedValueCopier.", failure.getMessage().asCharString());
 }
 
 TEST(MockFailureTest, MockUnexpectedObjectFailure)

--- a/tests/CppUTestExt/MockPluginTest.cpp
+++ b/tests/CppUTestExt/MockPluginTest.cpp
@@ -105,15 +105,14 @@ public:
     {
         return "string";
     }
-
 };
 
 TEST(MockPlugin, installComparatorRecordsTheComparatorButNotInstallsItYet)
 {
     DummyComparator comparator;
     plugin->installComparator("myType", comparator);
-    mock().expectOneCall("foo").withParameterOfType("myType", "name", &comparator);
-    mock().actualCall("foo").withParameterOfType("myType", "name", &comparator);
+    mock().expectOneCall("foo").withParameterOfType("myType", "name", NULL);
+    mock().actualCall("foo").withParameterOfType("myType", "name", NULL);
 
     MockNoWayToCompareCustomTypeFailure failure(test, "myType");
     CHECK_EXPECTED_MOCK_FAILURE(failure);

--- a/tests/CppUTestExt/MockSupportTest.cpp
+++ b/tests/CppUTestExt/MockSupportTest.cpp
@@ -645,8 +645,15 @@ TEST(MockSupportTest, threeExpectedAndActual)
 class MyTypeForTesting
 {
 public:
-    MyTypeForTesting(int val) : value(val) {}
-    int value;
+    MyTypeForTesting(int val)
+    {
+        value = new int(val);
+    }
+    virtual ~MyTypeForTesting()
+    {
+        delete value;
+    }
+    int *value;
 };
 
 class MyTypeForTestingComparator : public MockNamedValueComparator
@@ -656,12 +663,12 @@ public:
     {
         const MyTypeForTesting* obj1 = (const MyTypeForTesting*) object1;
         const MyTypeForTesting* obj2 = (const MyTypeForTesting*) object2;
-        return obj1->value == obj2->value;
+        return *(obj1->value) == *(obj2->value);
     }
     virtual SimpleString valueToString(const void* object)
     {
         const MyTypeForTesting* obj = (const MyTypeForTesting*) object;
-        return StringFrom(obj->value);
+        return StringFrom(*(obj->value));
     }
 };
 

--- a/tests/CppUTestExt/MockSupportTest.cpp
+++ b/tests/CppUTestExt/MockSupportTest.cpp
@@ -645,7 +645,7 @@ TEST(MockSupportTest, threeExpectedAndActual)
 class MyTypeForTesting
 {
 public:
-    MyTypeForTesting(int val) : value(val){}
+    MyTypeForTesting(int val) : value(val) {}
     int value;
 };
 
@@ -654,14 +654,16 @@ class MyTypeForTestingComparator : public MockNamedValueComparator
 public:
     virtual bool isEqual(const void* object1, const void* object2)
     {
-        return ((MyTypeForTesting*)object1)->value == ((MyTypeForTesting*)object2)->value;
+        const MyTypeForTesting* obj1 = (const MyTypeForTesting*) object1;
+        const MyTypeForTesting* obj2 = (const MyTypeForTesting*) object2;
+        return obj1->value == obj2->value;
     }
     virtual SimpleString valueToString(const void* object)
     {
-        return StringFrom(((MyTypeForTesting*)object)->value);
+        const MyTypeForTesting* obj = (const MyTypeForTesting*) object;
+        return StringFrom(obj->value);
     }
 };
-
 
 TEST(MockSupportTest, customObjectParameterFailsWhenNotHavingAComparisonRepository)
 {
@@ -829,7 +831,6 @@ TEST(MockSupportTest, twoOutputParametersOfSameNameInDifferentFunctionsSucceeds)
     mock().expectOneCall("foo2").withIntParameter("bar", 25);
     mock().actualCall("foo1").withOutputParameter("bar", &param);
     mock().actualCall("foo2").withIntParameter("bar", 25);
-    MyTypeForTestingComparator comparator;
     CHECK_EQUAL(2, retval);
     CHECK_EQUAL(2, param);
     mock().checkExpectations();
@@ -844,6 +845,7 @@ TEST(MockSupportTest, outputAndInputParameter)
     mock().actualCall("foo").withParameter("bar", 10).withOutputParameter("bar", &returned_value);
 
     LONGS_EQUAL(5, returned_value);
+    mock().checkExpectations();
     CHECK_NO_MOCK_FAILURE();
 }
 
@@ -1772,7 +1774,7 @@ TEST(MockSupportTestWithFixture, CHECK_EXPECTED_MOCK_FAILURE_LOCATION_failed)
 
 static void CHECK_NO_MOCK_FAILURE_LOCATION_failedTestMethod_()
 {
-    mock().actualCall("boo");    
+    mock().actualCall("boo");
     CHECK_NO_MOCK_FAILURE_LOCATION("file", 1);
 }
 
@@ -1804,11 +1806,11 @@ TEST_ORDERED(MockSupportTestWithFixture, shouldCrashOnFailure, 10)
     mock().crashOnFailure(true);
     UtestShell::setCrashMethod(crashMethod);
     fixture.setTestFunction(crashOnFailureTestFunction_);
-    
+
     fixture.runAllTests();
-    
+
     CHECK(cpputestHasCrashed);
-    
+
     mock().crashOnFailure(false);
     UtestShell::resetCrashMethod();
 }
@@ -1818,11 +1820,11 @@ TEST_ORDERED(MockSupportTestWithFixture, nextTestShouldNotCrashOnFailure, 11)
     cpputestHasCrashed = false;
     UtestShell::setCrashMethod(crashMethod);
     fixture.setTestFunction(crashOnFailureTestFunction_);
-    
+
     fixture.runAllTests();
-    
+
     fixture.assertPrintContains("Unexpected call to function: unexpected");
     CHECK_FALSE(cpputestHasCrashed);
-    
+
     UtestShell::resetCrashMethod();
 }

--- a/tests/CppUTestExt/MockSupportTest.cpp
+++ b/tests/CppUTestExt/MockSupportTest.cpp
@@ -1128,11 +1128,11 @@ TEST(MockSupportTest, installComparatorsWorksHierarchical)
 {
     MyTypeForTesting object(1);
     MyTypeForTestingComparator comparator;
-    MockNamedValueComparatorRepository repos;
+    MockNamedValueHandlerRepository repos;
     repos.installComparator("MyTypeForTesting", comparator);
 
     mock("existing");
-    mock().installComparators(repos);
+    mock().installHandlers(repos);
     mock("existing").expectOneCall("function").withParameterOfType("MyTypeForTesting", "parameterName", &object);
     mock("existing").actualCall("function").withParameterOfType("MyTypeForTesting", "parameterName", &object);
 


### PR DESCRIPTION
in preparation for addition of copiers to copy non-native types.

Attempt to break up the work by @jgonzalezdr and myself (#676 and #675) into smaller, more manageable chunks.

This one aims at producing more helpful error messages when the proper copier is not installed.