### PR TITLE
Custom Copiers #7: Changes for MockSupport_c

### DIFF
--- a/include/CppUTestExt/MockActualCall.h
+++ b/include/CppUTestExt/MockActualCall.h
@@ -53,6 +53,7 @@ public:
     MockActualCall& withParameter(const SimpleString& name, const void* value) { return withConstPointerParameter(name, value); }
     virtual MockActualCall& withParameterOfType(const SimpleString& typeName, const SimpleString& name, const void* value)=0;
     virtual MockActualCall& withOutputParameter(const SimpleString& name, void* output)=0;
+    virtual MockActualCall& withOutputParameterOfType(const SimpleString& typeName, const SimpleString& name, void* output)=0;
 
     virtual MockActualCall& withIntParameter(const SimpleString& name, int value)=0;
     virtual MockActualCall& withUnsignedIntParameter(const SimpleString& name, unsigned int value)=0;

--- a/include/CppUTestExt/MockCheckedActualCall.h
+++ b/include/CppUTestExt/MockCheckedActualCall.h
@@ -49,6 +49,7 @@ public:
     virtual MockActualCall& withConstPointerParameter(const SimpleString& name, const void* value) _override;
     virtual MockActualCall& withParameterOfType(const SimpleString& type, const SimpleString& name, const void* value) _override;
     virtual MockActualCall& withOutputParameter(const SimpleString& name, void* output) _override;
+    virtual MockActualCall& withOutputParameterOfType(const SimpleString& type, const SimpleString& name, void* output) _override;
 
     virtual bool hasReturnValue() _override;
     virtual MockNamedValue returnValue() _override;
@@ -117,17 +118,18 @@ private:
     class MockOutputParametersListNode
     {
     public:
-        SimpleString* name_;
+        SimpleString name_;
+        SimpleString type_;
         void* ptr_;
 
         MockOutputParametersListNode* next_;
-        MockOutputParametersListNode(SimpleString* name, void* ptr)
-            : name_(name), ptr_(ptr), next_(NULL) {}
+        MockOutputParametersListNode(const SimpleString& name, const SimpleString& type, void* ptr)
+            : name_(name), type_(type), ptr_(ptr), next_(NULL) {}
     };
 
     MockOutputParametersListNode* outputParameterExpectations_;
 
-    virtual void addOutputParameter(const SimpleString& name, void* ptr);
+    virtual void addOutputParameter(const SimpleString& name, const SimpleString& type, void* ptr);
     virtual void cleanUpOutputParameterList();
 };
 
@@ -149,6 +151,7 @@ public:
     virtual MockActualCall& withConstPointerParameter(const SimpleString& name, const void* value) _override;
     virtual MockActualCall& withParameterOfType(const SimpleString& typeName, const SimpleString& name, const void* value) _override;
     virtual MockActualCall& withOutputParameter(const SimpleString& name, void* output) _override;
+    virtual MockActualCall& withOutputParameterOfType(const SimpleString& typeName, const SimpleString& name, void* output) _override;
 
     virtual bool hasReturnValue() _override;
     virtual MockNamedValue returnValue() _override;
@@ -204,6 +207,7 @@ public:
     virtual MockActualCall& withConstPointerParameter(const SimpleString& , const void*) _override { return *this; }
     virtual MockActualCall& withParameterOfType(const SimpleString&, const SimpleString&, const void*) _override { return *this; }
     virtual MockActualCall& withOutputParameter(const SimpleString&, void*) _override { return *this; }
+    virtual MockActualCall& withOutputParameterOfType(const SimpleString&, const SimpleString&, void*) _override { return *this; }
 
     virtual bool hasReturnValue() _override { return false; }
     virtual MockNamedValue returnValue() _override { return MockNamedValue(""); }

--- a/include/CppUTestExt/MockCheckedExpectedCall.h
+++ b/include/CppUTestExt/MockCheckedExpectedCall.h
@@ -49,8 +49,9 @@ public:
     virtual MockExpectedCall& withPointerParameter(const SimpleString& name, void* value) _override;
     virtual MockExpectedCall& withConstPointerParameter(const SimpleString& name, const void* value) _override;
     virtual MockExpectedCall& withParameterOfType(const SimpleString& typeName, const SimpleString& name, const void* value) _override;
-    virtual MockExpectedCall& ignoreOtherParameters() _override;
     virtual MockExpectedCall& withOutputParameterReturning(const SimpleString& name, const void* value, size_t size) _override;
+    virtual MockExpectedCall& withOutputParameterOfTypeReturning(const SimpleString& typeName, const SimpleString& name, const void* value) _override;
+    virtual MockExpectedCall& ignoreOtherParameters() _override;
 
     virtual MockExpectedCall& andReturnValue(int value) _override;
     virtual MockExpectedCall& andReturnValue(unsigned int value) _override;
@@ -72,6 +73,7 @@ public:
 
     virtual bool hasInputParameterWithName(const SimpleString& name);
     virtual bool hasInputParameter(const MockNamedValue& parameter);
+    virtual bool hasOutputParameterWithName(const SimpleString& name);
     virtual bool hasOutputParameter(const MockNamedValue& parameter);
     virtual bool relatesTo(const SimpleString& functionName);
     virtual bool relatesToObject(void*objectPtr) const;
@@ -146,6 +148,7 @@ public:
     virtual MockExpectedCall& withPointerParameter(const SimpleString& name, void* value) _override;
     virtual MockExpectedCall& withParameterOfType(const SimpleString& typeName, const SimpleString& name, const void* value) _override;
     virtual MockExpectedCall& withOutputParameterReturning(const SimpleString& name, const void* value, size_t size) _override;
+    virtual MockExpectedCall& withOutputParameterOfTypeReturning(const SimpleString& typeName, const SimpleString& name, const void* value) _override;
     virtual MockExpectedCall& ignoreOtherParameters() _override;
 
     virtual MockExpectedCall& andReturnValue(int value) _override;
@@ -181,6 +184,7 @@ public:
     virtual MockExpectedCall& withConstPointerParameter(const SimpleString& , const void*) _override { return *this; }
     virtual MockExpectedCall& withParameterOfType(const SimpleString&, const SimpleString&, const void*) _override { return *this; }
     virtual MockExpectedCall& withOutputParameterReturning(const SimpleString&, const void*, size_t) _override { return *this; }
+    virtual MockExpectedCall& withOutputParameterOfTypeReturning(const SimpleString&, const SimpleString&, const void*) _override { return *this; }
     virtual MockExpectedCall& ignoreOtherParameters() _override { return *this;}
 
     virtual MockExpectedCall& andReturnValue(int) _override { return *this; }

--- a/include/CppUTestExt/MockExpectedCall.h
+++ b/include/CppUTestExt/MockExpectedCall.h
@@ -50,6 +50,7 @@ public:
     MockExpectedCall& withParameter(const SimpleString& name, const void* value) { return withConstPointerParameter(name, value); }
     virtual MockExpectedCall& withParameterOfType(const SimpleString& typeName, const SimpleString& name, const void* value)=0;
     virtual MockExpectedCall& withOutputParameterReturning(const SimpleString& name, const void* value, size_t size)=0;
+    virtual MockExpectedCall& withOutputParameterOfTypeReturning(const SimpleString& typeName, const SimpleString& name, const void* value)=0;
     virtual MockExpectedCall& ignoreOtherParameters()=0;
 
     virtual MockExpectedCall& withIntParameter(const SimpleString& name, int value)=0;

--- a/include/CppUTestExt/MockExpectedCallsList.h
+++ b/include/CppUTestExt/MockExpectedCallsList.h
@@ -58,6 +58,7 @@ public:
     virtual void onlyKeepExpectationsRelatedTo(const SimpleString& name);
     virtual void onlyKeepExpectationsWithInputParameter(const MockNamedValue& parameter);
     virtual void onlyKeepExpectationsWithInputParameterName(const SimpleString& name);
+    virtual void onlyKeepExpectationsWithOutputParameter(const MockNamedValue& parameter);
     virtual void onlyKeepExpectationsWithOutputParameterName(const SimpleString& name);
     virtual void onlyKeepExpectationsOnObject(void* objectPtr);
     virtual void onlyKeepUnfulfilledExpectations();

--- a/include/CppUTestExt/MockFailure.h
+++ b/include/CppUTestExt/MockFailure.h
@@ -109,6 +109,13 @@ public:
     virtual ~MockNoWayToCompareCustomTypeFailure(){}
 };
 
+class MockNoWayToCopyCustomTypeFailure : public MockFailure
+{
+public:
+    MockNoWayToCopyCustomTypeFailure(UtestShell* test, const SimpleString& typeName);
+    virtual ~MockNoWayToCopyCustomTypeFailure(){}
+};
+
 class MockUnexpectedObjectFailure : public MockFailure
 {
 public:

--- a/include/CppUTestExt/MockNamedValue.h
+++ b/include/CppUTestExt/MockNamedValue.h
@@ -28,7 +28,7 @@
 #ifndef D_MockNamedValue_h
 #define D_MockNamedValue_h
 /*
- * MockParameterComparator is an interface that needs to be used when creating Comparators.
+ * MockNamedValueComparator is an interface that needs to be used when creating Comparators.
  * This is needed when comparing values of non-native type.
  */
 
@@ -66,7 +66,7 @@ private:
  * Basically this class ties together a Name, a Value, a Type, and a Comparator
  */
 
-class MockNamedValueComparatorRepository;
+class MockNamedValueHandlerRepository;
 class MockNamedValue
 {
 public:
@@ -106,7 +106,7 @@ public:
     virtual size_t getSize() const;
     virtual MockNamedValueComparator* getComparator() const;
 
-    static void setDefaultComparatorRepository(MockNamedValueComparatorRepository* repository);
+    static void setDefaultHandlerRepository(MockNamedValueHandlerRepository* repository);
 private:
     SimpleString name_;
     SimpleString type_;
@@ -124,7 +124,7 @@ private:
     } value_;
     size_t size_;
     MockNamedValueComparator* comparator_;
-    static MockNamedValueComparatorRepository* defaultRepository_;
+    static MockNamedValueHandlerRepository* defaultRepository_;
 };
 
 class MockNamedValueListNode
@@ -167,18 +167,19 @@ private:
  */
 
 struct MockNamedValueComparatorRepositoryNode;
-class MockNamedValueComparatorRepository
+class MockNamedValueHandlerRepository
 {
-    MockNamedValueComparatorRepositoryNode* head_;
+private:
+    MockNamedValueComparatorRepositoryNode* comparatorsHead_;
 public:
-    MockNamedValueComparatorRepository();
-    virtual ~MockNamedValueComparatorRepository();
+    MockNamedValueHandlerRepository();
+    virtual ~MockNamedValueHandlerRepository();
 
     virtual void installComparator(const SimpleString& name, MockNamedValueComparator& comparator);
-    virtual void installComparators(const MockNamedValueComparatorRepository& repository);
+    virtual void installHandlers(const MockNamedValueHandlerRepository& repository);
     virtual MockNamedValueComparator* getComparatorForType(const SimpleString& name);
 
-    void clear();
+    void clearComparators();
 };
 
 #endif

--- a/include/CppUTestExt/MockSupport.h
+++ b/include/CppUTestExt/MockSupport.h
@@ -106,7 +106,7 @@ public:
     virtual void setDefaultComparatorRepository();
 
     virtual void installComparator(const SimpleString& typeName, MockNamedValueComparator& comparator);
-    virtual void installComparators(const MockNamedValueComparatorRepository& repository);
+    virtual void installHandlers(const MockNamedValueHandlerRepository& repository);
     virtual void removeAllComparators();
 
 protected:
@@ -127,7 +127,7 @@ private:
     bool enabled_;
     MockCheckedActualCall *lastActualFunctionCall_;
     MockExpectedCallComposite compositeCalls_;
-    MockNamedValueComparatorRepository comparatorRepository_;
+    MockNamedValueHandlerRepository handlerRepository_;
     MockNamedValueList data_;
 
     bool tracing_;

--- a/include/CppUTestExt/MockSupport.h
+++ b/include/CppUTestExt/MockSupport.h
@@ -106,8 +106,12 @@ public:
     virtual void setDefaultComparatorRepository();
 
     virtual void installComparator(const SimpleString& typeName, MockNamedValueComparator& comparator);
+    virtual void installCopier(const SimpleString& typeName, MockNamedValueCopier& copier);
     virtual void installHandlers(const MockNamedValueHandlerRepository& repository);
+
     virtual void removeAllComparators();
+    virtual void removeAllCopiers();
+    virtual void removeAllHandlers();
 
 protected:
     MockSupport* clone();

--- a/include/CppUTestExt/MockSupportPlugin.h
+++ b/include/CppUTestExt/MockSupportPlugin.h
@@ -42,7 +42,7 @@ public:
 
     virtual void installComparator(const SimpleString& name, MockNamedValueComparator& comparator);
 private:
-    MockNamedValueComparatorRepository repository_;
+    MockNamedValueHandlerRepository repository_;
 };
 
 #endif

--- a/include/CppUTestExt/MockSupport_c.h
+++ b/include/CppUTestExt/MockSupport_c.h
@@ -105,6 +105,7 @@ struct SMockExpectedCall_c
 
 typedef int (*MockTypeEqualFunction_c)(const void* object1, const void* object2);
 typedef char* (*MockTypeValueToStringFunction_c)(const void* object1);
+typedef void (*MockTypeCopyFunction_c)(void* dst, const void* src);
 
 typedef struct SMockSupport_c MockSupport_c;
 struct SMockSupport_c
@@ -131,7 +132,9 @@ struct SMockSupport_c
     void (*crashOnFailure)(unsigned shouldCrash);
 
     void (*installComparator) (const char* typeName, MockTypeEqualFunction_c isEqual, MockTypeValueToStringFunction_c valueToString);
+    void (*installCopier) (const char* typeName, MockTypeCopyFunction_c copier);
     void (*removeAllComparators)(void);
+    void (*removeAllCopiers)(void);
 };
 
 

--- a/src/CppUTestExt/MockActualCall.cpp
+++ b/src/CppUTestExt/MockActualCall.cpp
@@ -82,9 +82,24 @@ void MockCheckedActualCall::finalizeOutputParameters(MockCheckedExpectedCall* ex
 {
     for (MockOutputParametersListNode* p = outputParameterExpectations_; p; p = p->next_)
     {
-        const void* data = expectedCall->getOutputParameter(*p->name_).getConstPointerValue();
-        size_t size = expectedCall->getOutputParameter(*p->name_).getSize();
-        PlatformSpecificMemCpy(p->ptr_, data, size);
+        MockNamedValue outputParameter = expectedCall->getOutputParameter(p->name_);
+        MockNamedValueCopier* copier = outputParameter.getCopier();
+        if (copier)
+        {
+            copier->copy(p->ptr_, outputParameter.getObjectPointer());
+        }
+        else if ((outputParameter.getType() == "const void*") && (p->type_ == "void*"))
+        {
+            const void* data = outputParameter.getConstPointerValue();
+            size_t size = outputParameter.getSize();
+            PlatformSpecificMemCpy(p->ptr_, data, size);
+        }
+        else
+        {
+            SimpleString type = expectedCall->getOutputParameter(p->name_).getType();
+            MockNoWayToCopyCustomTypeFailure failure(getTest(), type);
+            failTest(failure);
+        }
     }
 }
 
@@ -238,10 +253,21 @@ MockActualCall& MockCheckedActualCall::withParameterOfType(const SimpleString& t
 
 MockActualCall& MockCheckedActualCall::withOutputParameter(const SimpleString& name, void* output)
 {
-    addOutputParameter(name, output);
+    addOutputParameter(name, "void*", output);
 
     MockNamedValue outputParameter(name);
     outputParameter.setValue(output);
+    checkOutputParameter(outputParameter);
+
+    return *this;
+}
+
+MockActualCall& MockCheckedActualCall::withOutputParameterOfType(const SimpleString& type, const SimpleString& name, void* output)
+{
+    addOutputParameter(name, type, output);
+
+    MockNamedValue outputParameter(name);
+    outputParameter.setObjectPointer(type, output);
     checkOutputParameter(outputParameter);
 
     return *this;
@@ -418,10 +444,9 @@ MockActualCall& MockCheckedActualCall::onObject(void* objectPtr)
     return *this;
 }
 
-void MockCheckedActualCall::addOutputParameter(const SimpleString& name, void* ptr)
+void MockCheckedActualCall::addOutputParameter(const SimpleString& name, const SimpleString& type, void* ptr)
 {
-    SimpleString* nameCopy = new SimpleString(name);
-    MockOutputParametersListNode* newNode = new MockOutputParametersListNode(nameCopy, ptr);
+    MockOutputParametersListNode* newNode = new MockOutputParametersListNode(name, type, ptr);
 
     if (outputParameterExpectations_ == NULL)
         outputParameterExpectations_ = newNode;
@@ -440,7 +465,6 @@ void MockCheckedActualCall::cleanUpOutputParameterList()
     while (current) {
         toBeDeleted = current;
         outputParameterExpectations_ = current = current->next_;
-        delete toBeDeleted->name_;
         delete toBeDeleted;
     }
 }
@@ -542,6 +566,15 @@ MockActualCall& MockActualCallTrace::withParameterOfType(const SimpleString& typ
 
 MockActualCall& MockActualCallTrace::withOutputParameter(const SimpleString& name, void* output)
 {
+    addParameterName(name);
+    traceBuffer_ += StringFrom(output);
+    return *this;
+}
+
+MockActualCall& MockActualCallTrace::withOutputParameterOfType(const SimpleString& typeName, const SimpleString& name, void* output)
+{
+    traceBuffer_ += " ";
+    traceBuffer_ += typeName;
     addParameterName(name);
     traceBuffer_ += StringFrom(output);
     return *this;

--- a/src/CppUTestExt/MockExpectedCall.cpp
+++ b/src/CppUTestExt/MockExpectedCall.cpp
@@ -154,6 +154,14 @@ MockExpectedCall& MockCheckedExpectedCall::withOutputParameterReturning(const Si
     return *this;
 }
 
+MockExpectedCall& MockCheckedExpectedCall::withOutputParameterOfTypeReturning(const SimpleString& type, const SimpleString& name, const void* value)
+{
+    MockNamedValue* newParameter = new MockExpectedFunctionParameter(name);
+    outputParameters_->add(newParameter);
+    newParameter->setObjectPointer(type, value);
+    return *this;
+}
+
 SimpleString MockCheckedExpectedCall::getInputParameterType(const SimpleString& name)
 {
     MockNamedValue * p = inputParameters_->getValueByName(name);
@@ -163,6 +171,12 @@ SimpleString MockCheckedExpectedCall::getInputParameterType(const SimpleString& 
 bool MockCheckedExpectedCall::hasInputParameterWithName(const SimpleString& name)
 {
     MockNamedValue * p = inputParameters_->getValueByName(name);
+    return p != NULL;
+}
+
+bool MockCheckedExpectedCall::hasOutputParameterWithName(const SimpleString& name)
+{
+    MockNamedValue * p = outputParameters_->getValueByName(name);
     return p != NULL;
 }
 
@@ -279,7 +293,7 @@ bool MockCheckedExpectedCall::hasInputParameter(const MockNamedValue& parameter)
 bool MockCheckedExpectedCall::hasOutputParameter(const MockNamedValue& parameter)
 {
     MockNamedValue * p = outputParameters_->getValueByName(parameter.getName());
-    return (p) ? true : ignoreOtherParameters_;
+    return (p) ? p->compatibleForCopying(parameter) : ignoreOtherParameters_;
 }
 
 SimpleString MockCheckedExpectedCall::callToString()
@@ -562,6 +576,13 @@ MockExpectedCall& MockExpectedCallComposite::withOutputParameterReturning(const 
 {
     for (MockExpectedCallCompositeNode* node = head_; node != NULL; node = node->next_)
         node->call_.withOutputParameterReturning(name, value, size);
+    return *this;
+}
+
+MockExpectedCall& MockExpectedCallComposite::withOutputParameterOfTypeReturning(const SimpleString& typeName, const SimpleString& name, const void* value)
+{
+    for (MockExpectedCallCompositeNode* node = head_; node != NULL; node = node->next_)
+        node->call_.withOutputParameterOfTypeReturning(typeName, name, value);
     return *this;
 }
 

--- a/src/CppUTestExt/MockExpectedCallsList.cpp
+++ b/src/CppUTestExt/MockExpectedCallsList.cpp
@@ -175,7 +175,7 @@ void MockExpectedCallsList::onlyKeepExpectationsWithInputParameterName(const Sim
 void MockExpectedCallsList::onlyKeepExpectationsWithOutputParameterName(const SimpleString& name)
 {
     for (MockExpectedCallsListNode* p = head_; p; p = p->next_)
-        if (! p->expectedCall_->hasOutputParameter(name))
+        if (! p->expectedCall_->hasOutputParameterWithName(name))
             p->expectedCall_ = NULL;
     pruneEmptyNodeFromList();
 }
@@ -184,6 +184,14 @@ void MockExpectedCallsList::onlyKeepExpectationsWithInputParameter(const MockNam
 {
     for (MockExpectedCallsListNode* p = head_; p; p = p->next_)
         if (! p->expectedCall_->hasInputParameter(parameter))
+            p->expectedCall_ = NULL;
+    pruneEmptyNodeFromList();
+}
+
+void MockExpectedCallsList::onlyKeepExpectationsWithOutputParameter(const MockNamedValue& parameter)
+{
+    for (MockExpectedCallsListNode* p = head_; p; p = p->next_)
+        if (! p->expectedCall_->hasOutputParameter(parameter))
             p->expectedCall_ = NULL;
     pruneEmptyNodeFromList();
 }
@@ -206,7 +214,7 @@ void MockExpectedCallsList::onlyKeepUnfulfilledExpectationsWithInputParameter(co
 void MockExpectedCallsList::onlyKeepUnfulfilledExpectationsWithOutputParameter(const MockNamedValue& parameter)
 {
     onlyKeepUnfulfilledExpectations();
-    onlyKeepExpectationsWithOutputParameterName(parameter.getName());
+    onlyKeepExpectationsWithOutputParameter(parameter);
 }
 
 void MockExpectedCallsList::onlyKeepUnfulfilledExpectationsOnObject(void* objectPtr)

--- a/src/CppUTestExt/MockFailure.cpp
+++ b/src/CppUTestExt/MockFailure.cpp
@@ -160,10 +160,25 @@ MockUnexpectedInputParameterFailure::MockUnexpectedInputParameterFailure(UtestSh
 
 MockUnexpectedOutputParameterFailure::MockUnexpectedOutputParameterFailure(UtestShell* test, const SimpleString& functionName, const MockNamedValue& parameter, const MockExpectedCallsList& expectations)  : MockFailure(test)
 {
-    message_ = "Mock Failure: Unexpected output parameter name to function \"";
-    message_ += functionName;
-    message_ += "\": ";
-    message_ += parameter.getName();
+    MockExpectedCallsList expectationsForFunctionWithParameterName;
+    expectationsForFunctionWithParameterName.addExpectationsRelatedTo(functionName, expectations);
+    expectationsForFunctionWithParameterName.onlyKeepExpectationsWithOutputParameterName(parameter.getName());
+
+    if (expectationsForFunctionWithParameterName.isEmpty()) {
+        message_ = "Mock Failure: Unexpected output parameter name to function \"";
+        message_ += functionName;
+        message_ += "\": ";
+        message_ += parameter.getName();
+    }
+    else {
+        message_ = "Mock Failure: Unexpected parameter type \"";
+        message_ += parameter.getType();
+        message_ += "\" to output parameter \"";
+        message_ += parameter.getName();
+        message_ += "\" to function \"";
+        message_ += functionName;
+        message_ += "\"";
+    }
 
     message_ += "\n";
     addExpectationsAndCallHistoryRelatedTo(functionName, expectations);
@@ -196,7 +211,12 @@ MockExpectedParameterDidntHappenFailure::MockExpectedParameterDidntHappenFailure
 
 MockNoWayToCompareCustomTypeFailure::MockNoWayToCompareCustomTypeFailure(UtestShell* test, const SimpleString& typeName) : MockFailure(test)
 {
-    message_ = StringFromFormat("MockFailure: No way to compare type <%s>. Please install a ParameterTypeComparator.", typeName.asCharString());
+    message_ = StringFromFormat("MockFailure: No way to compare type <%s>. Please install a MockNamedValueComparator.", typeName.asCharString());
+}
+
+MockNoWayToCopyCustomTypeFailure::MockNoWayToCopyCustomTypeFailure(UtestShell* test, const SimpleString& typeName) : MockFailure(test)
+{
+    message_ = StringFromFormat("MockFailure: No way to copy type <%s>. Please install a MockNamedValueCopier.", typeName.asCharString());
 }
 
 MockUnexpectedObjectFailure::MockUnexpectedObjectFailure(UtestShell* test, const SimpleString& functionName, void* actual, const MockExpectedCallsList& expectations) : MockFailure(test)

--- a/src/CppUTestExt/MockNamedValue.cpp
+++ b/src/CppUTestExt/MockNamedValue.cpp
@@ -30,9 +30,9 @@
 #include "CppUTest/PlatformSpecificFunctions.h"
 
 
-MockNamedValueComparatorRepository* MockNamedValue::defaultRepository_ = NULL;
+MockNamedValueHandlerRepository* MockNamedValue::defaultRepository_ = NULL;
 
-void MockNamedValue::setDefaultComparatorRepository(MockNamedValueComparatorRepository* repository)
+void MockNamedValue::setDefaultHandlerRepository(MockNamedValueHandlerRepository* repository)
 {
     defaultRepository_ = repository;
 }
@@ -367,40 +367,40 @@ struct MockNamedValueComparatorRepositoryNode
     MockNamedValueComparatorRepositoryNode* next_;
 };
 
-MockNamedValueComparatorRepository::MockNamedValueComparatorRepository() : head_(NULL)
+MockNamedValueHandlerRepository::MockNamedValueHandlerRepository() : comparatorsHead_(NULL)
 {
 
 }
 
-MockNamedValueComparatorRepository::~MockNamedValueComparatorRepository()
+MockNamedValueHandlerRepository::~MockNamedValueHandlerRepository()
 {
-    clear();
+    clearComparators();
 }
 
-void MockNamedValueComparatorRepository::clear()
+void MockNamedValueHandlerRepository::clearComparators()
 {
-    while (head_) {
-        MockNamedValueComparatorRepositoryNode* next = head_->next_;
-        delete head_;
-        head_ = next;
+    while (comparatorsHead_) {
+        MockNamedValueComparatorRepositoryNode* next = comparatorsHead_->next_;
+        delete comparatorsHead_;
+        comparatorsHead_ = next;
     }
 }
 
-void MockNamedValueComparatorRepository::installComparator(const SimpleString& name, MockNamedValueComparator& comparator)
+void MockNamedValueHandlerRepository::installComparator(const SimpleString& name, MockNamedValueComparator& comparator)
 {
-    head_ = new MockNamedValueComparatorRepositoryNode(name, comparator, head_);
+    comparatorsHead_ = new MockNamedValueComparatorRepositoryNode(name, comparator, comparatorsHead_);
 }
 
-MockNamedValueComparator* MockNamedValueComparatorRepository::getComparatorForType(const SimpleString& name)
+MockNamedValueComparator* MockNamedValueHandlerRepository::getComparatorForType(const SimpleString& name)
 {
-    for (MockNamedValueComparatorRepositoryNode* p = head_; p; p = p->next_)
+    for (MockNamedValueComparatorRepositoryNode* p = comparatorsHead_; p; p = p->next_)
             if (p->name_ == name) return &p->comparator_;
     return NULL;
 }
 
-void MockNamedValueComparatorRepository::installComparators(const MockNamedValueComparatorRepository& repository)
+void MockNamedValueHandlerRepository::installHandlers(const MockNamedValueHandlerRepository& repository)
 {
-    for (MockNamedValueComparatorRepositoryNode* p = repository.head_; p; p = p->next_)
+    for (MockNamedValueComparatorRepositoryNode* p = repository.comparatorsHead_; p; p = p->next_)
             installComparator(p->name_, p->comparator_);
 }
 

--- a/src/CppUTestExt/MockNamedValue.cpp
+++ b/src/CppUTestExt/MockNamedValue.cpp
@@ -37,7 +37,7 @@ void MockNamedValue::setDefaultHandlerRepository(MockNamedValueHandlerRepository
     defaultRepository_ = repository;
 }
 
-MockNamedValue::MockNamedValue(const SimpleString& name) : name_(name), type_("int"), comparator_(NULL)
+MockNamedValue::MockNamedValue(const SimpleString& name) : name_(name), type_("int"), size_(0), comparator_(NULL)
 {
     value_.intValue_ = 0;
 }
@@ -403,4 +403,3 @@ void MockNamedValueHandlerRepository::installHandlers(const MockNamedValueHandle
     for (MockNamedValueComparatorRepositoryNode* p = repository.comparatorsHead_; p; p = p->next_)
             installComparator(p->name_, p->comparator_);
 }
-

--- a/src/CppUTestExt/MockSupport.cpp
+++ b/src/CppUTestExt/MockSupport.cpp
@@ -87,6 +87,14 @@ void MockSupport::installComparator(const SimpleString& typeName, MockNamedValue
         if (getMockSupport(p)) getMockSupport(p)->installComparator(typeName, comparator);
 }
 
+void MockSupport::installCopier(const SimpleString& typeName, MockNamedValueCopier& copier)
+{
+    handlerRepository_.installCopier(typeName, copier);
+
+    for (MockNamedValueListNode* p = data_.begin(); p; p = p->next())
+        if (getMockSupport(p)) getMockSupport(p)->installCopier(typeName, copier);
+}
+
 void MockSupport::installHandlers(const MockNamedValueHandlerRepository& repository)
 {
     handlerRepository_.installHandlers(repository);
@@ -100,6 +108,20 @@ void MockSupport::removeAllComparators()
     handlerRepository_.clearComparators();
     for (MockNamedValueListNode* p = data_.begin(); p; p = p->next())
         if (getMockSupport(p)) getMockSupport(p)->removeAllComparators();
+}
+
+void MockSupport::removeAllCopiers()
+{
+    handlerRepository_.clearCopiers();
+    for (MockNamedValueListNode* p = data_.begin(); p; p = p->next())
+        if (getMockSupport(p)) getMockSupport(p)->removeAllCopiers();
+}
+
+void MockSupport::removeAllHandlers()
+{
+    handlerRepository_.clearAll();
+    for (MockNamedValueListNode* p = data_.begin(); p; p = p->next())
+        if (getMockSupport(p)) getMockSupport(p)->removeAllHandlers();
 }
 
 void MockSupport::clear()

--- a/src/CppUTestExt/MockSupport.cpp
+++ b/src/CppUTestExt/MockSupport.cpp
@@ -76,28 +76,28 @@ void MockSupport::setActiveReporter(MockFailureReporter* reporter)
 
 void MockSupport::setDefaultComparatorRepository()
 {
-    MockNamedValue::setDefaultComparatorRepository(&comparatorRepository_);
+    MockNamedValue::setDefaultHandlerRepository(&handlerRepository_);
 }
 
 void MockSupport::installComparator(const SimpleString& typeName, MockNamedValueComparator& comparator)
 {
-    comparatorRepository_.installComparator(typeName, comparator);
+    handlerRepository_.installComparator(typeName, comparator);
 
     for (MockNamedValueListNode* p = data_.begin(); p; p = p->next())
         if (getMockSupport(p)) getMockSupport(p)->installComparator(typeName, comparator);
 }
 
-void MockSupport::installComparators(const MockNamedValueComparatorRepository& repository)
+void MockSupport::installHandlers(const MockNamedValueHandlerRepository& repository)
 {
-    comparatorRepository_.installComparators(repository);
+    handlerRepository_.installHandlers(repository);
 
     for (MockNamedValueListNode* p = data_.begin(); p; p = p->next())
-        if (getMockSupport(p)) getMockSupport(p)->installComparators(repository);
+        if (getMockSupport(p)) getMockSupport(p)->installHandlers(repository);
 }
 
 void MockSupport::removeAllComparators()
 {
-    comparatorRepository_.clear();
+    handlerRepository_.clearComparators();
     for (MockNamedValueListNode* p = data_.begin(); p; p = p->next())
         if (getMockSupport(p)) getMockSupport(p)->removeAllComparators();
 }
@@ -377,7 +377,7 @@ MockSupport* MockSupport::clone()
     if (strictOrdering_) newMock->strictOrder();
 
     newMock->tracing(tracing_);
-    newMock->installComparators(comparatorRepository_);
+    newMock->installHandlers(handlerRepository_);
     return newMock;
 }
 

--- a/src/CppUTestExt/MockSupportPlugin.cpp
+++ b/src/CppUTestExt/MockSupportPlugin.cpp
@@ -57,12 +57,12 @@ MockSupportPlugin::MockSupportPlugin(const SimpleString& name)
 
 MockSupportPlugin::~MockSupportPlugin()
 {
-    repository_.clear();
+    repository_.clearComparators();
 }
 
 void MockSupportPlugin::preTestAction(UtestShell&, TestResult&)
 {
-    mock().installComparators(repository_);
+    mock().installHandlers(repository_);
 }
 
 void MockSupportPlugin::postTestAction(UtestShell& test, TestResult& result)

--- a/tests/CppUTestExt/MockExpectedCallTest.cpp
+++ b/tests/CppUTestExt/MockExpectedCallTest.cpp
@@ -53,7 +53,7 @@ public:
     }
 };
 
-TEST_GROUP(MockNamedValueComparatorRepository)
+TEST_GROUP(MockNamedValueHandlerRepository)
 {
     void teardown()
     {
@@ -61,24 +61,24 @@ TEST_GROUP(MockNamedValueComparatorRepository)
     }
 };
 
-TEST(MockNamedValueComparatorRepository, getComparatorForNonExistingName)
+TEST(MockNamedValueHandlerRepository, getComparatorForNonExistingName)
 {
-    MockNamedValueComparatorRepository repository;
+    MockNamedValueHandlerRepository repository;
     POINTERS_EQUAL(NULL, repository.getComparatorForType("typeName"));
 }
 
-TEST(MockNamedValueComparatorRepository, installComparator)
+TEST(MockNamedValueHandlerRepository, installComparator)
 {
     TypeForTestingExpectedFunctionCallComparator comparator;
-    MockNamedValueComparatorRepository repository;
+    MockNamedValueHandlerRepository repository;
     repository.installComparator("typeName", comparator);
     POINTERS_EQUAL(&comparator, repository.getComparatorForType("typeName"));
 }
 
-TEST(MockNamedValueComparatorRepository, installMultipleComparator)
+TEST(MockNamedValueHandlerRepository, installMultipleComparator)
 {
     TypeForTestingExpectedFunctionCallComparator comparator1, comparator2, comparator3;
-    MockNamedValueComparatorRepository repository;
+    MockNamedValueHandlerRepository repository;
     repository.installComparator("type1", comparator1);
     repository.installComparator("type2", comparator2);
     repository.installComparator("type3", comparator3);
@@ -204,8 +204,8 @@ TEST(MockExpectedCall, callWithObjectParameterEqualComparisonButFailsWithoutRepo
 
 TEST(MockExpectedCall, callWithObjectParameterEqualComparisonButFailsWithoutComparator)
 {
-    MockNamedValueComparatorRepository repository;
-    MockNamedValue::setDefaultComparatorRepository(&repository);
+    MockNamedValueHandlerRepository repository;
+    MockNamedValue::setDefaultHandlerRepository(&repository);
 
     TypeForTestingExpectedFunctionCall type(1), equalType(1);
     MockNamedValue parameter("name");
@@ -217,8 +217,8 @@ TEST(MockExpectedCall, callWithObjectParameterEqualComparisonButFailsWithoutComp
 TEST(MockExpectedCall, callWithObjectParameterEqualComparison)
 {
     TypeForTestingExpectedFunctionCallComparator comparator;
-    MockNamedValueComparatorRepository repository;
-    MockNamedValue::setDefaultComparatorRepository(&repository);
+    MockNamedValueHandlerRepository repository;
+    MockNamedValue::setDefaultHandlerRepository(&repository);
     repository.installComparator("type", comparator);
 
     TypeForTestingExpectedFunctionCall type(1), equalType(1);
@@ -232,8 +232,8 @@ TEST(MockExpectedCall, callWithObjectParameterEqualComparison)
 TEST(MockExpectedCall, getParameterValueOfObjectType)
 {
     TypeForTestingExpectedFunctionCallComparator comparator;
-    MockNamedValueComparatorRepository repository;
-    MockNamedValue::setDefaultComparatorRepository(&repository);
+    MockNamedValueHandlerRepository repository;
+    MockNamedValue::setDefaultHandlerRepository(&repository);
     repository.installComparator("type", comparator);
 
     TypeForTestingExpectedFunctionCall type(1);
@@ -252,8 +252,8 @@ TEST(MockExpectedCall, getParameterValueOfObjectTypeWithoutRepository)
 TEST(MockExpectedCall, getParameterValueOfObjectTypeWithoutComparator)
 {
     TypeForTestingExpectedFunctionCall type(1);
-    MockNamedValueComparatorRepository repository;
-    MockNamedValue::setDefaultComparatorRepository(&repository);
+    MockNamedValueHandlerRepository repository;
+    MockNamedValue::setDefaultHandlerRepository(&repository);
     call->withParameterOfType("type", "name", &type);
     STRCMP_EQUAL("No comparator found for type: \"type\"", call->getInputParameterValueString("name").asCharString());
 }

--- a/tests/CppUTestExt/MockFailureTest.cpp
+++ b/tests/CppUTestExt/MockFailureTest.cpp
@@ -200,7 +200,13 @@ TEST(MockFailureTest, MockExpectedParameterDidntHappenFailure)
 TEST(MockFailureTest, MockNoWayToCompareCustomTypeFailure)
 {
     MockNoWayToCompareCustomTypeFailure failure(UtestShell::getCurrent(), "myType");
-    STRCMP_EQUAL("MockFailure: No way to compare type <myType>. Please install a ParameterTypeComparator.", failure.getMessage().asCharString());
+    STRCMP_EQUAL("MockFailure: No way to compare type <myType>. Please install a MockNamedValueComparator.", failure.getMessage().asCharString());
+}
+
+TEST(MockFailureTest, MockNoWayToCopyCustomTypeFailure)
+{
+    MockNoWayToCopyCustomTypeFailure failure(UtestShell::getCurrent(), "myType");
+    STRCMP_EQUAL("MockFailure: No way to copy type <myType>. Please install a MockNamedValueCopier.", failure.getMessage().asCharString());
 }
 
 TEST(MockFailureTest, MockUnexpectedObjectFailure)

--- a/tests/CppUTestExt/MockPluginTest.cpp
+++ b/tests/CppUTestExt/MockPluginTest.cpp
@@ -105,15 +105,14 @@ public:
     {
         return "string";
     }
-
 };
 
 TEST(MockPlugin, installComparatorRecordsTheComparatorButNotInstallsItYet)
 {
     DummyComparator comparator;
     plugin->installComparator("myType", comparator);
-    mock().expectOneCall("foo").withParameterOfType("myType", "name", &comparator);
-    mock().actualCall("foo").withParameterOfType("myType", "name", &comparator);
+    mock().expectOneCall("foo").withParameterOfType("myType", "name", NULL);
+    mock().actualCall("foo").withParameterOfType("myType", "name", NULL);
 
     MockNoWayToCompareCustomTypeFailure failure(test, "myType");
     CHECK_EXPECTED_MOCK_FAILURE(failure);

--- a/tests/CppUTestExt/MockSupportTest.cpp
+++ b/tests/CppUTestExt/MockSupportTest.cpp
@@ -645,8 +645,15 @@ TEST(MockSupportTest, threeExpectedAndActual)
 class MyTypeForTesting
 {
 public:
-    MyTypeForTesting(int val) : value(val) {}
-    int value;
+    MyTypeForTesting(int val)
+    {
+        value = new int(val);
+    }
+    virtual ~MyTypeForTesting()
+    {
+        delete value;
+    }
+    int *value;
 };
 
 class MyTypeForTestingComparator : public MockNamedValueComparator
@@ -656,12 +663,12 @@ public:
     {
         const MyTypeForTesting* obj1 = (const MyTypeForTesting*) object1;
         const MyTypeForTesting* obj2 = (const MyTypeForTesting*) object2;
-        return obj1->value == obj2->value;
+        return *(obj1->value) == *(obj2->value);
     }
     virtual SimpleString valueToString(const void* object)
     {
         const MyTypeForTesting* obj = (const MyTypeForTesting*) object;
-        return StringFrom(obj->value);
+        return StringFrom(*(obj->value));
     }
 };
 

--- a/tests/CppUTestExt/MockSupportTest.cpp
+++ b/tests/CppUTestExt/MockSupportTest.cpp
@@ -645,7 +645,7 @@ TEST(MockSupportTest, threeExpectedAndActual)
 class MyTypeForTesting
 {
 public:
-    MyTypeForTesting(int val) : value(val){}
+    MyTypeForTesting(int val) : value(val) {}
     int value;
 };
 
@@ -654,14 +654,16 @@ class MyTypeForTestingComparator : public MockNamedValueComparator
 public:
     virtual bool isEqual(const void* object1, const void* object2)
     {
-        return ((MyTypeForTesting*)object1)->value == ((MyTypeForTesting*)object2)->value;
+        const MyTypeForTesting* obj1 = (const MyTypeForTesting*) object1;
+        const MyTypeForTesting* obj2 = (const MyTypeForTesting*) object2;
+        return obj1->value == obj2->value;
     }
     virtual SimpleString valueToString(const void* object)
     {
-        return StringFrom(((MyTypeForTesting*)object)->value);
+        const MyTypeForTesting* obj = (const MyTypeForTesting*) object;
+        return StringFrom(obj->value);
     }
 };
-
 
 TEST(MockSupportTest, customObjectParameterFailsWhenNotHavingAComparisonRepository)
 {
@@ -829,7 +831,6 @@ TEST(MockSupportTest, twoOutputParametersOfSameNameInDifferentFunctionsSucceeds)
     mock().expectOneCall("foo2").withIntParameter("bar", 25);
     mock().actualCall("foo1").withOutputParameter("bar", &param);
     mock().actualCall("foo2").withIntParameter("bar", 25);
-    MyTypeForTestingComparator comparator;
     CHECK_EQUAL(2, retval);
     CHECK_EQUAL(2, param);
     mock().checkExpectations();
@@ -844,6 +845,7 @@ TEST(MockSupportTest, outputAndInputParameter)
     mock().actualCall("foo").withParameter("bar", 10).withOutputParameter("bar", &returned_value);
 
     LONGS_EQUAL(5, returned_value);
+    mock().checkExpectations();
     CHECK_NO_MOCK_FAILURE();
 }
 
@@ -1772,7 +1774,7 @@ TEST(MockSupportTestWithFixture, CHECK_EXPECTED_MOCK_FAILURE_LOCATION_failed)
 
 static void CHECK_NO_MOCK_FAILURE_LOCATION_failedTestMethod_()
 {
-    mock().actualCall("boo");    
+    mock().actualCall("boo");
     CHECK_NO_MOCK_FAILURE_LOCATION("file", 1);
 }
 
@@ -1804,11 +1806,11 @@ TEST_ORDERED(MockSupportTestWithFixture, shouldCrashOnFailure, 10)
     mock().crashOnFailure(true);
     UtestShell::setCrashMethod(crashMethod);
     fixture.setTestFunction(crashOnFailureTestFunction_);
-    
+
     fixture.runAllTests();
-    
+
     CHECK(cpputestHasCrashed);
-    
+
     mock().crashOnFailure(false);
     UtestShell::resetCrashMethod();
 }
@@ -1818,11 +1820,11 @@ TEST_ORDERED(MockSupportTestWithFixture, nextTestShouldNotCrashOnFailure, 11)
     cpputestHasCrashed = false;
     UtestShell::setCrashMethod(crashMethod);
     fixture.setTestFunction(crashOnFailureTestFunction_);
-    
+
     fixture.runAllTests();
-    
+
     fixture.assertPrintContains("Unexpected call to function: unexpected");
     CHECK_FALSE(cpputestHasCrashed);
-    
+
     UtestShell::resetCrashMethod();
 }

--- a/tests/CppUTestExt/MockSupportTest.cpp
+++ b/tests/CppUTestExt/MockSupportTest.cpp
@@ -642,6 +642,7 @@ TEST(MockSupportTest, threeExpectedAndActual)
     CHECK_NO_MOCK_FAILURE();
 }
 
+
 class MyTypeForTesting
 {
 public:
@@ -672,6 +673,17 @@ public:
     }
 };
 
+class MyTypeForTestingCopier : public MockNamedValueCopier
+{
+public:
+    virtual void copy(void* dst_, const void* src_)
+    {
+        MyTypeForTesting* dst = (MyTypeForTesting*) dst_;
+        const MyTypeForTesting* src = (const MyTypeForTesting*) src_;
+        *(dst->value) = *(src->value);
+    }
+};
+
 TEST(MockSupportTest, customObjectParameterFailsWhenNotHavingAComparisonRepository)
 {
     MyTypeForTesting object(1);
@@ -679,6 +691,16 @@ TEST(MockSupportTest, customObjectParameterFailsWhenNotHavingAComparisonReposito
     mock().actualCall("function").withParameterOfType("MyTypeForTesting", "parameterName", &object);
 
     MockNoWayToCompareCustomTypeFailure expectedFailure(mockFailureTest(), "MyTypeForTesting");
+    CHECK_EXPECTED_MOCK_FAILURE(expectedFailure);
+}
+
+TEST(MockSupportTest, customObjectParameterFailsWhenNotHavingACopierRepository)
+{
+    MyTypeForTesting object(1);
+    mock().expectOneCall("function").withOutputParameterOfTypeReturning("MyTypeForTesting", "parameterName", &object);
+    mock().actualCall("function").withOutputParameterOfType("MyTypeForTesting", "parameterName", &object);
+
+    MockNoWayToCopyCustomTypeFailure expectedFailure(mockFailureTest(), "MyTypeForTesting");
     CHECK_EXPECTED_MOCK_FAILURE(expectedFailure);
 }
 
@@ -910,6 +932,391 @@ TEST(MockSupportTest, customObjectWithFunctionComparatorThatFailsCoversValueToSt
     mock().checkExpectations();
     CHECK_EXPECTED_MOCK_FAILURE_LOCATION(failure, __FILE__, __LINE__);
 }
+
+TEST(MockSupportTest, customTypeOutputParameterSucceeds)
+{
+    // Prepare
+    MyTypeForTesting expectedObject(55);
+    MyTypeForTesting actualObject(99);
+    MyTypeForTestingCopier copier;
+    mock().installCopier("MyTypeForTesting", copier);
+
+    // Exercise
+    mock().expectOneCall("function").withOutputParameterOfTypeReturning("MyTypeForTesting", "parameterName", &expectedObject);
+    mock().actualCall("function").withOutputParameterOfType("MyTypeForTesting", "parameterName", &actualObject);
+    mock().checkExpectations();
+
+    // Verify
+    CHECK_EQUAL(55, *(expectedObject.value));
+    CHECK_EQUAL(55, *(actualObject.value));
+    CHECK_NO_MOCK_FAILURE();
+
+    // Cleanup
+    mock().removeAllCopiers();
+}
+
+TEST(MockSupportTest, noActualCallForCustomTypeOutputParameter)
+{
+    // Prepare
+    MyTypeForTesting expectedObject(1);
+    MyTypeForTestingCopier copier;
+    mock().installCopier("MyTypeForTesting", copier);
+
+    addFunctionToExpectationsList("foo")->withOutputParameterOfTypeReturning("MyTypeForTesting", "output", &expectedObject);
+    MockExpectedCallsDidntHappenFailure expectedFailure(mockFailureTest(), *expectationsList);
+
+    // Exercise
+    mock().expectOneCall("foo").withOutputParameterOfTypeReturning("MyTypeForTesting", "output", &expectedObject);
+    mock().checkExpectations();
+
+    // Verify
+    CHECK_EXPECTED_MOCK_FAILURE(expectedFailure);
+
+    // Cleanup
+    mock().removeAllCopiers();
+}
+
+TEST(MockSupportTest, unexpectedCustomTypeOutputParameter)
+{
+    // Prepare
+    MyTypeForTesting actualObject(8834);
+    MyTypeForTestingCopier copier;
+    mock().installCopier("MyTypeForTesting", copier);
+
+    addFunctionToExpectationsList("foo")->callWasMade(1);
+    MockNamedValue parameter("parameterName");
+    parameter.setObjectPointer("MyTypeForTesting", &actualObject);
+    MockUnexpectedOutputParameterFailure expectedFailure(mockFailureTest(), "foo", parameter, *expectationsList);
+
+    // Exercise
+    mock().expectOneCall("foo");
+    mock().actualCall("foo").withOutputParameterOfType("MyTypeForTesting", "parameterName", &actualObject);
+    mock().checkExpectations();
+
+    // Verify
+    CHECK_EXPECTED_MOCK_FAILURE(expectedFailure);
+
+    // Cleanup
+    mock().removeAllCopiers();
+}
+
+TEST(MockSupportTest, customTypeOutputParameterMissing)
+{
+    // Prepare
+    MyTypeForTesting expectedObject(123464);
+    MyTypeForTestingCopier copier;
+    mock().installCopier("MyTypeForTesting", copier);
+
+    addFunctionToExpectationsList("foo")->withOutputParameterOfTypeReturning("MyTypeForTesting", "output", &expectedObject);
+    MockExpectedParameterDidntHappenFailure expectedFailure(mockFailureTest(), "foo", *expectationsList);
+
+    // Exercise
+    mock().expectOneCall("foo").withOutputParameterOfTypeReturning("MyTypeForTesting", "output", &expectedObject);
+    mock().actualCall("foo");
+    mock().checkExpectations();
+
+    // Verify
+    CHECK_EXPECTED_MOCK_FAILURE(expectedFailure);
+
+    // Cleanup
+    mock().removeAllCopiers();
+}
+
+TEST(MockSupportTest, customTypeOutputParameterOfWrongType)
+{
+    // Prepare
+    MyTypeForTesting expectedObject(123464);
+    MyTypeForTesting actualObject(75646);
+    MyTypeForTestingCopier copier;
+    mock().installCopier("MyTypeForTesting", copier);
+
+    addFunctionToExpectationsList("foo")->withOutputParameterOfTypeReturning("MyTypeForTesting", "output", &expectedObject);
+    MockNamedValue parameter("output");
+    parameter.setObjectPointer("OtherTypeForTesting", &actualObject);
+    MockUnexpectedOutputParameterFailure expectedFailure(mockFailureTest(), "foo", parameter, *expectationsList);
+
+    // Exercise
+    mock().expectOneCall("foo").withOutputParameterOfTypeReturning("MyTypeForTesting", "output", &expectedObject);
+    mock().actualCall("foo").withOutputParameterOfType("OtherTypeForTesting", "output", &actualObject);
+    mock().checkExpectations();
+
+    // Verify
+    CHECK_EXPECTED_MOCK_FAILURE(expectedFailure);
+
+    // Cleanup
+    mock().removeAllCopiers();
+}
+
+TEST(MockSupportTest, noCopierForCustomTypeOutputParameter)
+{
+    // Prepare
+    MyTypeForTesting expectedObject(123464);
+    MyTypeForTesting actualObject(8834);
+
+    addFunctionToExpectationsList("foo")->withOutputParameterOfTypeReturning("MyTypeForTesting", "output", &expectedObject);
+    MockNoWayToCopyCustomTypeFailure expectedFailure(mockFailureTest(), "MyTypeForTesting");
+
+    // Exercise
+    mock().expectOneCall("foo").withOutputParameterOfTypeReturning("MyTypeForTesting", "output", &expectedObject);
+    mock().actualCall("foo").withOutputParameterOfType("MyTypeForTesting", "output", &actualObject);
+    mock().checkExpectations();
+
+    // Verify
+    CHECK_EXPECTED_MOCK_FAILURE(expectedFailure);
+}
+
+TEST(MockSupportTest, twoCustomTypeOutputParameters)
+{
+    // Prepare
+    MyTypeForTesting expectedObject1(545);
+    MyTypeForTesting actualObject1(979);
+    MyTypeForTesting expectedObject2(123);
+    MyTypeForTesting actualObject2(4567);
+    MyTypeForTestingCopier copier;
+    mock().installCopier("MyTypeForTesting", copier);
+
+    // Exercise
+    mock().expectOneCall("function").withOutputParameterOfTypeReturning("MyTypeForTesting", "parameterName", &expectedObject1).withParameter("id", 1);
+    mock().expectOneCall("function").withOutputParameterOfTypeReturning("MyTypeForTesting", "parameterName", &expectedObject2).withParameter("id", 2);
+    mock().actualCall("function").withOutputParameterOfType("MyTypeForTesting", "parameterName", &actualObject1).withParameter("id", 1);
+    mock().actualCall("function").withOutputParameterOfType("MyTypeForTesting", "parameterName", &actualObject2).withParameter("id", 2);
+    mock().checkExpectations();
+
+    // Verify
+    CHECK_EQUAL(545, *(expectedObject1.value));
+    CHECK_EQUAL(545, *(actualObject1.value));
+    CHECK_EQUAL(123, *(expectedObject2.value));
+    CHECK_EQUAL(123, *(actualObject2.value));
+    CHECK_NO_MOCK_FAILURE();
+
+    // Cleanup
+    mock().removeAllCopiers();
+}
+
+TEST(MockSupportTest, twoInterleavedCustomTypeOutputParameters)
+{
+    // Prepare
+    MyTypeForTesting expectedObject1(9545);
+    MyTypeForTesting actualObject1(79);
+    MyTypeForTesting expectedObject2(132);
+    MyTypeForTesting actualObject2(743);
+    MyTypeForTestingCopier copier;
+
+    // Exercise
+    mock().installCopier("MyTypeForTesting", copier);
+    mock().expectOneCall("function").withOutputParameterOfTypeReturning("MyTypeForTesting", "parameterName", &expectedObject1).withParameter("id", 1);
+    mock().expectOneCall("function").withOutputParameterOfTypeReturning("MyTypeForTesting", "parameterName", &expectedObject2).withParameter("id", 2);
+    mock().actualCall("function").withOutputParameterOfType("MyTypeForTesting", "parameterName", &actualObject2).withParameter("id", 2);
+    mock().actualCall("function").withOutputParameterOfType("MyTypeForTesting", "parameterName", &actualObject1).withParameter("id", 1);
+    mock().checkExpectations();
+
+    // Verify
+    CHECK_EQUAL(9545, *(expectedObject1.value));
+    CHECK_EQUAL(9545, *(actualObject1.value));
+    CHECK_EQUAL(132, *(expectedObject2.value));
+    CHECK_EQUAL(132, *(actualObject2.value));
+    CHECK_NO_MOCK_FAILURE();
+
+    // Cleanup
+    mock().removeAllCopiers();
+}
+
+TEST(MockSupportTest, twoDifferentCustomTypeOutputParametersInSameFunctionCallSucceeds)
+{
+    // Prepare
+    MyTypeForTesting expectedObject1(11);
+    MyTypeForTesting actualObject1(22);
+    MyTypeForTesting expectedObject2(33);
+    MyTypeForTesting actualObject2(44);
+    MyTypeForTestingCopier copier;
+    mock().installCopier("MyTypeForTesting", copier);
+
+    // Exercise
+    mock().expectOneCall("foo")
+        .withOutputParameterOfTypeReturning("MyTypeForTesting", "bar", &expectedObject1)
+        .withOutputParameterOfTypeReturning("MyTypeForTesting", "foobar", &expectedObject2);
+    mock().actualCall("foo")
+        .withOutputParameterOfType("MyTypeForTesting", "bar", &actualObject1)
+        .withOutputParameterOfType("MyTypeForTesting", "foobar", &actualObject2);
+    mock().checkExpectations();
+
+    // Verify
+    CHECK_EQUAL(11, *(expectedObject1.value));
+    CHECK_EQUAL(11, *(actualObject1.value));
+    CHECK_EQUAL(33, *(expectedObject2.value));
+    CHECK_EQUAL(33, *(actualObject2.value));
+    CHECK_NO_MOCK_FAILURE();
+
+    // Cleanup
+    mock().removeAllCopiers();
+}
+
+TEST(MockSupportTest, customTypeOutputAndInputParametersOfSameNameInDifferentFunctionCallsOfSameFunctionSucceeds)
+{
+    // Prepare
+    MyTypeForTesting expectedObject1(911);
+    MyTypeForTesting actualObject1(6576878);
+    MyTypeForTesting expectedObject2(123);
+    MyTypeForTesting actualObject2(123);
+    MyTypeForTestingCopier copier;
+    MyTypeForTestingComparator comparator;
+    mock().installCopier("MyTypeForTesting", copier);
+    mock().installComparator("MyTypeForTesting", comparator);
+
+    // Exercise
+    mock().expectOneCall("foo").withOutputParameterOfTypeReturning("MyTypeForTesting", "bar", &expectedObject1);
+    mock().expectOneCall("foo").withParameterOfType("MyTypeForTesting", "bar", &expectedObject2);
+    mock().actualCall("foo").withOutputParameterOfType("MyTypeForTesting", "bar", &actualObject1);
+    mock().actualCall("foo").withParameterOfType("MyTypeForTesting", "bar", &actualObject2);
+    mock().checkExpectations();
+
+    // Verify
+    CHECK_EQUAL(911, *(expectedObject1.value));
+    CHECK_EQUAL(911, *(actualObject1.value));
+    CHECK_EQUAL(123, *(expectedObject2.value));
+    CHECK_EQUAL(123, *(actualObject2.value));
+    CHECK_NO_MOCK_FAILURE();
+
+    // Cleanup
+    mock().removeAllCopiers();
+    mock().removeAllComparators();
+}
+
+TEST(MockSupportTest, twoCustomTypeOutputParametersOfSameNameInDifferentFunctionsSucceeds)
+{
+    // Prepare
+    MyTypeForTesting expectedObject1(657);
+    MyTypeForTesting actualObject1(984465);
+    MyTypeForTesting expectedObject2(987);
+    MyTypeForTesting actualObject2(987);
+    MyTypeForTestingCopier copier;
+    MyTypeForTestingComparator comparator;
+    mock().installCopier("MyTypeForTesting", copier);
+    mock().installComparator("MyTypeForTesting", comparator);
+
+    // Exercise
+    mock().expectOneCall("foo1").withOutputParameterOfTypeReturning("MyTypeForTesting", "bar", &expectedObject1);
+    mock().expectOneCall("foo2").withParameterOfType("MyTypeForTesting", "bar", &expectedObject2);
+    mock().actualCall("foo1").withOutputParameterOfType("MyTypeForTesting", "bar", &actualObject1);
+    mock().actualCall("foo2").withParameterOfType("MyTypeForTesting", "bar", &actualObject2);
+    mock().checkExpectations();
+
+    // Verify
+    CHECK_EQUAL(657, *(expectedObject1.value));
+    CHECK_EQUAL(657, *(actualObject1.value));
+    CHECK_EQUAL(987, *(expectedObject2.value));
+    CHECK_EQUAL(987, *(actualObject2.value));
+    CHECK_NO_MOCK_FAILURE();
+
+    // Cleanup
+    mock().removeAllCopiers();
+    mock().removeAllComparators();
+}
+
+TEST(MockSupportTest, customTypeOutputAndInputParameterOfSameTypeInSameFunctionCall)
+{
+    // Prepare
+    MyTypeForTesting expectedObject1(45);
+    MyTypeForTesting actualObject1(45);
+    MyTypeForTesting expectedObject2(987765443);
+    MyTypeForTesting actualObject2(0);
+    MyTypeForTestingCopier copier;
+    MyTypeForTestingComparator comparator;
+    mock().installCopier("MyTypeForTesting", copier);
+    mock().installComparator("MyTypeForTesting", comparator);
+
+    // Exercise
+    mock().expectOneCall("foo")
+          .withParameterOfType("MyTypeForTesting", "bar", &expectedObject1)
+          .withOutputParameterOfTypeReturning("MyTypeForTesting", "bar", &expectedObject2);
+    mock().actualCall("foo")
+          .withParameterOfType("MyTypeForTesting", "bar", &actualObject1)
+          .withOutputParameterOfType("MyTypeForTesting", "bar", &actualObject2);
+    mock().checkExpectations();
+
+    // Verify
+    CHECK_EQUAL(45, *(expectedObject1.value));
+    CHECK_EQUAL(45, *(actualObject1.value));
+    CHECK_EQUAL(987765443, *(expectedObject2.value));
+    CHECK_EQUAL(987765443, *(actualObject2.value));
+    CHECK_NO_MOCK_FAILURE();
+
+    // Cleanup
+    mock().removeAllCopiers();
+    mock().removeAllComparators();
+}
+
+TEST(MockSupportTest, customTypeOutputParameterTraced)
+{
+    // Prepare
+    MyTypeForTesting actualObject(676789);
+    MyTypeForTestingCopier copier;
+    mock().installCopier("MyTypeForTesting", copier);
+    mock().tracing(true);
+
+    // Exercise
+    mock().actualCall("someFunc").withOutputParameterOfType("MyTypeForTesting", "someParameter", &actualObject);
+    mock().checkExpectations();
+
+    // Verify
+    STRCMP_CONTAINS("Function name:someFunc MyTypeForTesting someParameter:", mock().getTraceOutput());
+    CHECK_NO_MOCK_FAILURE();
+
+    // Cleanup
+    mock().removeAllCopiers();
+}
+
+TEST(MockSupportTest, customTypeOutputParameterWithIgnoredParameters)
+{
+    // Prepare
+    MyTypeForTesting expectedObject(444537909);
+    MyTypeForTesting actualObject(98765);
+    MyTypeForTestingCopier copier;
+    mock().installCopier("MyTypeForTesting", copier);
+
+    // Exercise
+    mock().expectOneCall("foo").withOutputParameterOfTypeReturning("MyTypeForTesting", "bar", &expectedObject).ignoreOtherParameters();
+    mock().actualCall("foo").withOutputParameterOfType("MyTypeForTesting", "bar", &actualObject).withParameter("other", 1);
+    mock().checkExpectations();
+
+    // Verify
+    CHECK_EQUAL(444537909, *(expectedObject.value));
+    CHECK_EQUAL(444537909, *(actualObject.value));
+    CHECK_NO_MOCK_FAILURE();
+
+    // Cleanup
+    mock().removeAllCopiers();
+}
+
+static void myTypeCopy(void* dst_, const void* src_)
+{
+    MyTypeForTesting* dst = (MyTypeForTesting*) dst_;
+    const MyTypeForTesting* src = (const MyTypeForTesting*) src_;
+    *(dst->value) = *(src->value);
+}
+
+TEST(MockSupportTest, customObjectWithFunctionCopier)
+{
+    // Prepare
+    MyTypeForTesting expectedObject(9874452);
+    MyTypeForTesting actualObject(2034);
+    MockFunctionCopier copier(myTypeCopy);
+    mock().installCopier("MyTypeForTesting", copier);
+
+    // Exercise
+    mock().expectOneCall("function").withOutputParameterOfTypeReturning("MyTypeForTesting", "parameterName", &expectedObject);
+    mock().actualCall("function").withOutputParameterOfType("MyTypeForTesting", "parameterName", &actualObject);
+    mock().checkExpectations();
+
+    // Verify
+    CHECK_EQUAL(9874452, *(expectedObject.value));
+    CHECK_EQUAL(9874452, *(actualObject.value));
+    CHECK_NO_MOCK_FAILURE();
+
+    // Cleanup
+    mock().removeAllCopiers();
+}
+
 
 TEST(MockSupportTest, disableEnable)
 {
@@ -1161,6 +1568,20 @@ TEST(MockSupportTest, removeComparatorsWorksHierachically)
     mock("scope").actualCall("function").withParameterOfType("MyTypeForTesting", "parameterName", &object);
 
     MockNoWayToCompareCustomTypeFailure expectedFailure(mockFailureTest(), "MyTypeForTesting");
+    CHECK_EXPECTED_MOCK_FAILURE(expectedFailure);
+}
+
+TEST(MockSupportTest, removeCopiersWorksHierachically)
+{
+    MyTypeForTesting object(1);
+    MyTypeForTestingCopier copier;
+
+    mock("scope").installCopier("MyTypeForTesting", copier);
+    mock().removeAllCopiers();
+    mock("scope").expectOneCall("function").withOutputParameterOfTypeReturning("MyTypeForTesting", "parameterName", &object);
+    mock("scope").actualCall("function").withOutputParameterOfType("MyTypeForTesting", "parameterName", &object);
+
+    MockNoWayToCopyCustomTypeFailure expectedFailure(mockFailureTest(), "MyTypeForTesting");
     CHECK_EXPECTED_MOCK_FAILURE(expectedFailure);
 }
 
@@ -1781,7 +2202,7 @@ TEST(MockSupportTestWithFixture, CHECK_EXPECTED_MOCK_FAILURE_LOCATION_failed)
 
 static void CHECK_NO_MOCK_FAILURE_LOCATION_failedTestMethod_()
 {
-    mock().actualCall("boo");
+    mock().actualCall("boo");    
     CHECK_NO_MOCK_FAILURE_LOCATION("file", 1);
 }
 
@@ -1813,11 +2234,11 @@ TEST_ORDERED(MockSupportTestWithFixture, shouldCrashOnFailure, 10)
     mock().crashOnFailure(true);
     UtestShell::setCrashMethod(crashMethod);
     fixture.setTestFunction(crashOnFailureTestFunction_);
-
+    
     fixture.runAllTests();
-
+    
     CHECK(cpputestHasCrashed);
-
+    
     mock().crashOnFailure(false);
     UtestShell::resetCrashMethod();
 }
@@ -1827,11 +2248,11 @@ TEST_ORDERED(MockSupportTestWithFixture, nextTestShouldNotCrashOnFailure, 11)
     cpputestHasCrashed = false;
     UtestShell::setCrashMethod(crashMethod);
     fixture.setTestFunction(crashOnFailureTestFunction_);
-
+    
     fixture.runAllTests();
-
+    
     fixture.assertPrintContains("Unexpected call to function: unexpected");
     CHECK_FALSE(cpputestHasCrashed);
-
+    
     UtestShell::resetCrashMethod();
 }

--- a/tests/CppUTestExt/MockSupportTest.cpp
+++ b/tests/CppUTestExt/MockSupportTest.cpp
@@ -1128,11 +1128,11 @@ TEST(MockSupportTest, installComparatorsWorksHierarchical)
 {
     MyTypeForTesting object(1);
     MyTypeForTestingComparator comparator;
-    MockNamedValueComparatorRepository repos;
+    MockNamedValueHandlerRepository repos;
     repos.installComparator("MyTypeForTesting", comparator);
 
     mock("existing");
-    mock().installComparators(repos);
+    mock().installHandlers(repos);
     mock("existing").expectOneCall("function").withParameterOfType("MyTypeForTesting", "parameterName", &object);
     mock("existing").actualCall("function").withParameterOfType("MyTypeForTesting", "parameterName", &object);
 


### PR DESCRIPTION
in order to support copiers to copy non-native types.

Attempt to break up the work by @jgonzalezdr and myself (#676 and #675) into smaller, more manageable chunks.

TODO: Don't we need some tests for MockSupport_c?