### PR TITLE
Fix ignored output parameter

### DIFF
--- a/src/CppUTestExt/MockActualCall.cpp
+++ b/src/CppUTestExt/MockActualCall.cpp
@@ -82,9 +82,12 @@ void MockCheckedActualCall::finalizeOutputParameters(MockCheckedExpectedCall* ex
 {
     for (MockOutputParametersListNode* p = outputParameterExpectations_; p; p = p->next_)
     {
-        const void* data = expectedCall->getOutputParameter(*p->name_).getConstPointerValue();
-        size_t size = expectedCall->getOutputParameter(*p->name_).getSize();
-        PlatformSpecificMemCpy(p->ptr_, data, size);
+        MockNamedValue expectedParameter = expectedCall->getOutputParameter(*p->name_);
+        if (expectedParameter.getName() != "") {
+            const void* data = expectedCall->getOutputParameter(*p->name_).getConstPointerValue();
+            size_t size = expectedCall->getOutputParameter(*p->name_).getSize();
+            PlatformSpecificMemCpy(p->ptr_, data, size);
+        }
     }
 }
 

--- a/tests/CppUTestExt/MockSupportTest.cpp
+++ b/tests/CppUTestExt/MockSupportTest.cpp
@@ -857,6 +857,13 @@ TEST(MockSupportTest, outputParameterTraced)
     STRCMP_CONTAINS("Function name:someFunc someParameter:", mock().getTraceOutput());
 }
 
+TEST(MockSupportTest, outputParameterThatIsIgnoredShouldNotFail)
+{
+    int param;
+    mock().expectOneCall("function").ignoreOtherParameters();
+    mock().actualCall("function").withOutputParameter("parameterName", &param);
+}
+
 TEST(MockSupportTest, outputParameterWithIgnoredParameters)
 {
     int param = 1;


### PR DESCRIPTION
As @itavero pointed out in #686, an attempt is made to copy the object, even though no expectation was specified and the actual call should have been ignored.

A strange failure occurs in the test, because an attempt is made to retrieve a `const void*` value from a nameless default `MockNamedValue`, which holds an `int` value.

So far, this pull request contains only the failing test that proves this behavior -- @ryanplusplus could you perhaps help with fixing this?