### PR TITLE
Fix bug when ignoreOtherParameters() is combined with withOutputParameter()

### DIFF
--- a/src/CppUTestExt/MockActualCall.cpp
+++ b/src/CppUTestExt/MockActualCall.cpp
@@ -82,9 +82,12 @@ void MockCheckedActualCall::finalizeOutputParameters(MockCheckedExpectedCall* ex
 {
     for (MockOutputParametersListNode* p = outputParameterExpectations_; p; p = p->next_)
     {
-        const void* data = expectedCall->getOutputParameter(*p->name_).getConstPointerValue();
-        size_t size = expectedCall->getOutputParameter(*p->name_).getSize();
-        PlatformSpecificMemCpy(p->ptr_, data, size);
+        MockNamedValue expectedParameter = expectedCall->getOutputParameter(*p->name_);
+        if (expectedParameter.getName() != "") {
+            const void* data = expectedCall->getOutputParameter(*p->name_).getConstPointerValue();
+            size_t size = expectedCall->getOutputParameter(*p->name_).getSize();
+            PlatformSpecificMemCpy(p->ptr_, data, size);
+        }
     }
 }
 

--- a/tests/CppUTestExt/MockSupportTest.cpp
+++ b/tests/CppUTestExt/MockSupportTest.cpp
@@ -857,6 +857,13 @@ TEST(MockSupportTest, outputParameterTraced)
     STRCMP_CONTAINS("Function name:someFunc someParameter:", mock().getTraceOutput());
 }
 
+TEST(MockSupportTest, outputParameterThatIsIgnoredShouldNotFail)
+{
+    int param;
+    mock().expectOneCall("function").ignoreOtherParameters();
+    mock().actualCall("function").withOutputParameter("parameterName", &param);
+}
+
 TEST(MockSupportTest, outputParameterWithIgnoredParameters)
 {
     int param = 1;


### PR DESCRIPTION
This fixes #686.

