### PR TITLE
Added support to get mock data via pointer.

### DIFF
--- a/include/CppUTestExt/MockSupport.h
+++ b/include/CppUTestExt/MockSupport.h
@@ -78,6 +78,8 @@ public:
     void setDataObject(const SimpleString& name, const SimpleString& type, void* value);
     MockNamedValue getData(const SimpleString& name);
 
+    MockNamedValue *getDataPointer(const SimpleString& name);
+
     MockSupport* getMockSupportScope(const SimpleString& name);
 
     const char* getTraceOutput();

--- a/src/CppUTestExt/MockSupport.cpp
+++ b/src/CppUTestExt/MockSupport.cpp
@@ -366,6 +366,11 @@ MockNamedValue MockSupport::getData(const SimpleString& name)
     return *value;
 }
 
+MockNamedValue *MockSupport::getDataPointer(const SimpleString& name)
+{
+   return data_.getValueByName(name);
+}
+
 MockSupport* MockSupport::clone()
 {
     MockSupport* newMock = new MockSupport;


### PR DESCRIPTION
It can be useful to access the actual MockNamedValue object associated with a mock data and not a
copy, e.g., to use the size attribute that is already present in the MockNamedValue, to store the size of the data that the pointer hold by the MockNamedValue object has.