### PR TITLE
For Discussion: Refactor MockFunctionComparator / MockCFunctionComparatorNode

### DIFF
--- a/include/CppUTestExt/MockNamedValue.h
+++ b/include/CppUTestExt/MockNamedValue.h
@@ -28,7 +28,7 @@
 #ifndef D_MockNamedValue_h
 #define D_MockNamedValue_h
 /*
- * MockParameterComparator is an interface that needs to be used when creating Comparators.
+ * MockNamedValueComparator is an interface that needs to be used when creating Comparators.
  * This is needed when comparing values of non-native type.
  */
 
@@ -42,12 +42,12 @@ public:
     virtual SimpleString valueToString(const void* object)=0;
 };
 
+extern "C" typedef int (*isEqualFunction)(const void*, const void*);
+extern "C" typedef const char* (*valueToStringFunction)(const void*);
+
 class MockFunctionComparator : public MockNamedValueComparator
 {
 public:
-    typedef bool (*isEqualFunction)(const void*, const void*);
-    typedef SimpleString (*valueToStringFunction)(const void*);
-
     MockFunctionComparator(isEqualFunction equal, valueToStringFunction valToString)
         : equal_(equal), valueToString_(valToString) {}
     virtual ~MockFunctionComparator(){}

--- a/include/CppUTestExt/MockSupport_c.h
+++ b/include/CppUTestExt/MockSupport_c.h
@@ -104,7 +104,7 @@ struct SMockExpectedCall_c
 };
 
 typedef int (*MockTypeEqualFunction_c)(const void* object1, const void* object2);
-typedef char* (*MockTypeValueToStringFunction_c)(const void* object1);
+typedef const char* (*MockTypeValueToStringFunction_c)(const void* object1);
 
 typedef struct SMockSupport_c MockSupport_c;
 struct SMockSupport_c

--- a/src/CppUTestExt/MockSupport_c.cpp
+++ b/src/CppUTestExt/MockSupport_c.cpp
@@ -72,25 +72,14 @@ static MockExpectedCall* expectedCall = NULL;
 static MockActualCall* actualCall = NULL;
 static MockFailureReporterForInCOnlyCode failureReporterForC;
 
-class MockCFunctionComparatorNode : public MockNamedValueComparator
+class MockCFunctionComparatorNode : public MockFunctionComparator
 {
 public:
     MockCFunctionComparatorNode(MockCFunctionComparatorNode* next, MockTypeEqualFunction_c equal, MockTypeValueToStringFunction_c toString)
-        : next_(next), equal_(equal), toString_(toString) {}
+        : MockFunctionComparator(equal, toString), next_(next) {}
     virtual ~MockCFunctionComparatorNode() {}
 
-    virtual bool isEqual(const void* object1, const void* object2) _override
-    {
-        return equal_(object1, object2) != 0;
-    }
-    virtual SimpleString valueToString(const void* object) _override
-    {
-        return SimpleString(toString_(object));
-    }
-
     MockCFunctionComparatorNode* next_;
-    MockTypeEqualFunction_c equal_;
-    MockTypeValueToStringFunction_c toString_;
 };
 
 static MockCFunctionComparatorNode* comparatorList_ = NULL;

--- a/tests/CppUTestExt/MockSupportTest.cpp
+++ b/tests/CppUTestExt/MockSupportTest.cpp
@@ -875,14 +875,15 @@ TEST(MockSupportTest, outputParameterWithIgnoredParameters)
     LONGS_EQUAL(param, retval);
 }
 
-static bool myTypeIsEqual(const void* object1, const void* object2)
+static int myTypeIsEqual(const void* object1, const void* object2)
 {
     return ((MyTypeForTesting*)object1)->value == ((MyTypeForTesting*)object2)->value;
 }
 
-static SimpleString myTypeValueToString(const void* object)
+static const char* myTypeValueToString(const void* object)
 {
-    return StringFrom(((MyTypeForTesting*)object)->value);
+    static SimpleString valString = StringFrom(((MyTypeForTesting*)object)->value);
+    return valString.asCharString();
 }
 
 TEST(MockSupportTest, customObjectWithFunctionComparator)

--- a/tests/CppUTestExt/MockSupport_cTest.cpp
+++ b/tests/CppUTestExt/MockSupport_cTest.cpp
@@ -60,7 +60,7 @@ extern "C"{
 
     static const char* typeNameValueToString(const void* PUNUSED(object))
     {
-        return (const char*) "valueToString";
+        return "valueToString";
     }
 
 }

--- a/tests/CppUTestExt/MockSupport_cTest.cpp
+++ b/tests/CppUTestExt/MockSupport_cTest.cpp
@@ -58,9 +58,9 @@ extern "C"{
         return object1 == object2;
     }
 
-    static char* typeNameValueToString(const void* PUNUSED(object))
+    static const char* typeNameValueToString(const void* PUNUSED(object))
     {
-        return (char*) "valueToString";
+        return (const char*) "valueToString";
     }
 
 }

--- a/tests/CppUTestExt/MockSupport_cTestCFile.c
+++ b/tests/CppUTestExt/MockSupport_cTestCFile.c
@@ -33,9 +33,9 @@ static int typeNameIsEqual(const void* object1, const void* object2)
     return object1 == object2;
 }
 
-static char* typeNameValueToString(const void* object)
+static const char* typeNameValueToString(const void* object)
 {
-    return (char*) object;
+    return (const char*) object;
 }
 
 void all_mock_support_c_calls(void)


### PR DESCRIPTION
I noticed that `MockFunctionComparator is more or less duplicated by `MockCFunctionComparatorNode`. I was wondering whether this could be improved:

Why do we have MockCFunctionComparatorNode? Why do we duplicate the list in MockSupport_c? I came up with two reasons:
1. We need some way to delete the comparators that we create from MockSupport_c. The list keeps track of them, so we can delete them.
2. We need them to be compatible to `MockTypeEqualFunction_c & Co, so we can't use the C++ function types.

To make this (hopefully), I see two options.
1. Remove MockFunctionComparator. It "might" be used be user code, of course. But it is not used by CppUTest.
2. Refactor MockFunctionComparator, so it can be used in MockSupport_c. This is what is attempted in this pull request.

The motivation is to simplify the upcoming changes for Copiers.
