### PR TITLE
Fixed errors when mocking overloaded functions

### DIFF
--- a/include/CppUTestExt/MockCheckedActualCall.h
+++ b/include/CppUTestExt/MockCheckedActualCall.h
@@ -97,9 +97,10 @@ protected:
     virtual void failTest(const MockFailure& failure);
     virtual void checkInputParameter(const MockNamedValue& actualParameter);
     virtual void checkOutputParameter(const MockNamedValue& outputParameter);
+    virtual void callIsInProgress();
 
     enum ActualCallState {
-        CALL_IN_PROGESS,
+        CALL_IN_PROGRESS,
         CALL_FAILED,
         CALL_SUCCEED
     };

--- a/include/CppUTestExt/MockExpectedCallsList.h
+++ b/include/CppUTestExt/MockExpectedCallsList.h
@@ -42,7 +42,7 @@ public:
     virtual int size() const;
     virtual int amountOfExpectationsFor(const SimpleString& name) const;
     virtual int amountOfUnfulfilledExpectations() const;
-    virtual bool hasUnfullfilledExpectations() const;
+    virtual bool hasUnfulfilledExpectations() const;
     virtual bool hasFulfilledExpectations() const;
     virtual bool hasFulfilledExpectationsWithoutIgnoredParameters() const;
     virtual bool hasUnfulfilledExpectationsBecauseOfMissingParameters() const;
@@ -53,7 +53,7 @@ public:
     virtual void addExpectedCall(MockCheckedExpectedCall* call);
     virtual void addExpectations(const MockExpectedCallsList& list);
     virtual void addExpectationsRelatedTo(const SimpleString& name, const MockExpectedCallsList& list);
-    virtual void addUnfilfilledExpectations(const MockExpectedCallsList& list);
+    virtual void addUnfulfilledExpectations(const MockExpectedCallsList& list);
 
     virtual void onlyKeepExpectationsRelatedTo(const SimpleString& name);
     virtual void onlyKeepExpectationsWithInputParameter(const MockNamedValue& parameter);
@@ -62,10 +62,6 @@ public:
     virtual void onlyKeepExpectationsWithOutputParameterName(const SimpleString& name);
     virtual void onlyKeepExpectationsOnObject(void* objectPtr);
     virtual void onlyKeepUnfulfilledExpectations();
-    virtual void onlyKeepUnfulfilledExpectationsRelatedTo(const SimpleString& name);
-    virtual void onlyKeepUnfulfilledExpectationsWithInputParameter(const MockNamedValue& parameter);
-    virtual void onlyKeepUnfulfilledExpectationsWithOutputParameter(const MockNamedValue& parameter);
-    virtual void onlyKeepUnfulfilledExpectationsOnObject(void* objectPtr);
 
     virtual MockCheckedExpectedCall* removeOneFulfilledExpectation();
     virtual MockCheckedExpectedCall* removeOneFulfilledExpectationWithIgnoredParameters();

--- a/src/CppUTestExt/MockExpectedCallsList.cpp
+++ b/src/CppUTestExt/MockExpectedCallsList.cpp
@@ -94,7 +94,7 @@ bool MockExpectedCallsList::hasFulfilledExpectationsWithoutIgnoredParameters() c
     return false;
 }
 
-bool MockExpectedCallsList::hasUnfullfilledExpectations() const
+bool MockExpectedCallsList::hasUnfulfilledExpectations() const
 {
     return amountOfUnfulfilledExpectations() != 0;
 }
@@ -120,7 +120,7 @@ void MockExpectedCallsList::addExpectedCall(MockCheckedExpectedCall* call)
     }
 }
 
-void MockExpectedCallsList::addUnfilfilledExpectations(const MockExpectedCallsList& list)
+void MockExpectedCallsList::addUnfulfilledExpectations(const MockExpectedCallsList& list)
 {
     for (MockExpectedCallsListNode* p = list.head_; p; p = p->next_)
         if (! p->expectedCall_->isFulfilled())
@@ -153,15 +153,12 @@ void MockExpectedCallsList::onlyKeepUnfulfilledExpectations()
 {
     for (MockExpectedCallsListNode* p = head_; p; p = p->next_)
         if (p->expectedCall_->isFulfilled())
+        {
+            p->expectedCall_->resetExpectation();
             p->expectedCall_ = NULL;
+        }
 
     pruneEmptyNodeFromList();
-}
-
-void MockExpectedCallsList::onlyKeepUnfulfilledExpectationsRelatedTo(const SimpleString& name)
-{
-    onlyKeepUnfulfilledExpectations();
-    onlyKeepExpectationsRelatedTo(name);
 }
 
 void MockExpectedCallsList::onlyKeepExpectationsWithInputParameterName(const SimpleString& name)
@@ -202,25 +199,6 @@ void MockExpectedCallsList::onlyKeepExpectationsOnObject(void* objectPtr)
         if (! p->expectedCall_->relatesToObject(objectPtr))
             p->expectedCall_ = NULL;
     pruneEmptyNodeFromList();
-}
-
-
-void MockExpectedCallsList::onlyKeepUnfulfilledExpectationsWithInputParameter(const MockNamedValue& parameter)
-{
-    onlyKeepUnfulfilledExpectations();
-    onlyKeepExpectationsWithInputParameter(parameter);
-}
-
-void MockExpectedCallsList::onlyKeepUnfulfilledExpectationsWithOutputParameter(const MockNamedValue& parameter)
-{
-    onlyKeepUnfulfilledExpectations();
-    onlyKeepExpectationsWithOutputParameter(parameter);
-}
-
-void MockExpectedCallsList::onlyKeepUnfulfilledExpectationsOnObject(void* objectPtr)
-{
-    onlyKeepUnfulfilledExpectations();
-    onlyKeepExpectationsOnObject(objectPtr);
 }
 
 MockCheckedExpectedCall* MockExpectedCallsList::removeOneFulfilledExpectation()

--- a/src/CppUTestExt/MockSupport.cpp
+++ b/src/CppUTestExt/MockSupport.cpp
@@ -230,7 +230,7 @@ const char* MockSupport::getTraceOutput()
 
 bool MockSupport::expectedCallsLeft()
 {
-    int callsLeft = expectations_.hasUnfullfilledExpectations();
+    int callsLeft = expectations_.hasUnfulfilledExpectations();
 
     for (MockNamedValueListNode* p = data_.begin(); p; p = p->next())
         if (getMockSupport(p)) callsLeft += getMockSupport(p)->expectedCallsLeft();

--- a/tests/CppUTestExt/MockActualCallTest.cpp
+++ b/tests/CppUTestExt/MockActualCallTest.cpp
@@ -105,13 +105,18 @@ TEST(MockCheckedActualCall, multipleSameFunctionsExpectingAndHappenGradually)
     list->addExpectedCall(call1);
     list->addExpectedCall(call2);
 
-    MockCheckedActualCall actualCall1(1, reporter, *list);
-    MockCheckedActualCall actualCall2(2, reporter, *list);
-
     LONGS_EQUAL(2, list->amountOfUnfulfilledExpectations());
+
+    MockCheckedActualCall actualCall1(1, reporter, *list);
     actualCall1.withName("func");
+    actualCall1.checkExpectations();
+
     LONGS_EQUAL(1, list->amountOfUnfulfilledExpectations());
+
+    MockCheckedActualCall actualCall2(2, reporter, *list);
     actualCall2.withName("func");
+    actualCall2.checkExpectations();
+
     LONGS_EQUAL(0, list->amountOfUnfulfilledExpectations());
 
     list->deleteAllExpectationsAndClearList();

--- a/tests/CppUTestExt/MockExpectedFunctionsListTest.cpp
+++ b/tests/CppUTestExt/MockExpectedFunctionsListTest.cpp
@@ -62,7 +62,7 @@ TEST_GROUP(MockExpectedCallsList)
 
 TEST(MockExpectedCallsList, emptyList)
 {
-    CHECK(! list->hasUnfullfilledExpectations());
+    CHECK(! list->hasUnfulfilledExpectations());
     CHECK(! list->hasFulfilledExpectations());
     LONGS_EQUAL(0, list->size());
 }
@@ -80,7 +80,7 @@ TEST(MockExpectedCallsList, listWithFulfilledExpectationHasNoUnfillfilledOnes)
     call2->callWasMade(2);
     list->addExpectedCall(call1);
     list->addExpectedCall(call2);
-    CHECK(! list->hasUnfullfilledExpectations());
+    CHECK(! list->hasUnfulfilledExpectations());
 }
 
 TEST(MockExpectedCallsList, listWithFulfilledExpectationButOutOfOrder)
@@ -91,7 +91,7 @@ TEST(MockExpectedCallsList, listWithFulfilledExpectationButOutOfOrder)
     list->addExpectedCall(call2);
     call2->callWasMade(1);
     call1->callWasMade(2);
-    CHECK(! list->hasUnfullfilledExpectations());
+    CHECK(! list->hasUnfulfilledExpectations());
     CHECK(list->hasCallsOutOfOrder());
 }
 
@@ -102,7 +102,7 @@ TEST(MockExpectedCallsList, listWithUnFulfilledExpectationHasNoUnfillfilledOnes)
     list->addExpectedCall(call1);
     list->addExpectedCall(call2);
     list->addExpectedCall(call3);
-    CHECK(list->hasUnfullfilledExpectations());
+    CHECK(list->hasUnfulfilledExpectations());
 }
 
 TEST(MockExpectedCallsList, deleteAllExpectationsAndClearList)
@@ -112,16 +112,29 @@ TEST(MockExpectedCallsList, deleteAllExpectationsAndClearList)
     list->deleteAllExpectationsAndClearList();
 }
 
-TEST(MockExpectedCallsList, onlyKeepUnfulfilledExpectationsRelatedTo)
+TEST(MockExpectedCallsList, onlyKeepUnfulfilledExpectations)
 {
     call1->withName("relate");
     call2->withName("unrelate");
     call3->withName("relate");
-    call3->callWasMade(1);
+    call2->callWasMade(1);
+    call3->callWasMade(2);
     list->addExpectedCall(call1);
     list->addExpectedCall(call2);
     list->addExpectedCall(call3);
-    list->onlyKeepUnfulfilledExpectationsRelatedTo("relate");
+    list->onlyKeepUnfulfilledExpectations();
+    LONGS_EQUAL(1, list->size());
+}
+
+TEST(MockExpectedCallsList, onlyKeepExpectationsRelatedTo)
+{
+    call1->withName("relate");
+    call2->withName("unrelate");
+    call3->withName("unrelate");
+    list->addExpectedCall(call1);
+    list->addExpectedCall(call2);
+    list->addExpectedCall(call3);
+    list->onlyKeepExpectationsRelatedTo("relate");
     LONGS_EQUAL(1, list->size());
 }
 
@@ -133,7 +146,7 @@ TEST(MockExpectedCallsList, removeAllExpectationsExceptThisThatRelateToTheWoleLi
     list->addExpectedCall(call1);
     list->addExpectedCall(call2);
     list->addExpectedCall(call3);
-    list->onlyKeepUnfulfilledExpectationsRelatedTo("unrelate");
+    list->onlyKeepExpectationsRelatedTo("unrelate");
     LONGS_EQUAL(0, list->size());
 }
 
@@ -143,7 +156,7 @@ TEST(MockExpectedCallsList, removeAllExpectationsExceptThisThatRelateToFirstOne)
     call2->withName("unrelate");
     list->addExpectedCall(call1);
     list->addExpectedCall(call2);
-    list->onlyKeepUnfulfilledExpectationsRelatedTo("unrelate");
+    list->onlyKeepExpectationsRelatedTo("unrelate");
     LONGS_EQUAL(1, list->size());
 }
 
@@ -153,7 +166,7 @@ TEST(MockExpectedCallsList, removeAllExpectationsExceptThisThatRelateToLastOne)
     call2->withName("relate");
     list->addExpectedCall(call1);
     list->addExpectedCall(call2);
-    list->onlyKeepUnfulfilledExpectationsRelatedTo("unrelate");
+    list->onlyKeepExpectationsRelatedTo("unrelate");
     LONGS_EQUAL(1, list->size());
 }
 
@@ -169,7 +182,7 @@ TEST(MockExpectedCallsList, onlyKeepExpectationsWithInputParameterName)
     LONGS_EQUAL(2, list->size());
 }
 
-TEST(MockExpectedCallsList, onlyKeepUnfulfilledExpectationsWithInputParameter)
+TEST(MockExpectedCallsList, onlyKeepExpectationsWithInputParameter)
 {
     MockNamedValue parameter("diffname");
     parameter.setValue(1);
@@ -183,14 +196,14 @@ TEST(MockExpectedCallsList, onlyKeepUnfulfilledExpectationsWithInputParameter)
     list->addExpectedCall(call2);
     list->addExpectedCall(call3);
     list->addExpectedCall(call4);
-    list->onlyKeepUnfulfilledExpectationsWithInputParameter(parameter);
-    LONGS_EQUAL(1, list->size());
+    list->onlyKeepExpectationsWithInputParameter(parameter);
+    LONGS_EQUAL(2, list->size());
 }
 
 TEST(MockExpectedCallsList, addUnfilfilledExpectationsWithEmptyList)
 {
     MockExpectedCallsList newList;
-    newList.addUnfilfilledExpectations(*list);
+    newList.addUnfulfilledExpectations(*list);
     LONGS_EQUAL(0, newList.size());
 }
 
@@ -201,7 +214,7 @@ TEST(MockExpectedCallsList, addUnfilfilledExpectationsMultipleUnfulfilledExpecta
     list->addExpectedCall(call2);
     list->addExpectedCall(call3);
     MockExpectedCallsList newList;
-    newList.addUnfilfilledExpectations(*list);
+    newList.addUnfulfilledExpectations(*list);
     LONGS_EQUAL(2, newList.size());
 }
 

--- a/tests/CppUTestExt/MockSupportTest.cpp
+++ b/tests/CppUTestExt/MockSupportTest.cpp
@@ -787,7 +787,7 @@ TEST(MockSupportTest, unexpectedOutputParameter)
     mock().expectOneCall("foo");
     mock().actualCall("foo").withOutputParameter("parameterName", &param);
 
-    addFunctionToExpectationsList("foo")->callWasMade(1);
+    addFunctionToExpectationsList("foo");
     MockNamedValue parameter("parameterName");
     parameter.setValue(&param);
     MockUnexpectedOutputParameterFailure expectedFailure(mockFailureTest(), "foo", parameter, *expectationsList);
@@ -1022,7 +1022,7 @@ TEST(MockSupportTest, unexpectedCustomTypeOutputParameter)
     MyTypeForTestingCopier copier;
     mock().installCopier("MyTypeForTesting", copier);
 
-    addFunctionToExpectationsList("foo")->callWasMade(1);
+    addFunctionToExpectationsList("foo");
     MockNamedValue parameter("parameterName");
     parameter.setObjectPointer("MyTypeForTesting", &actualObject);
     MockUnexpectedOutputParameterFailure expectedFailure(mockFailureTest(), "foo", parameter, *expectationsList);


### PR DESCRIPTION
This PR fixes the problem detailed in #706.

The changes basically consist in not resetting the "actual call fulfillment state" of other potentially matching calls with more requisites (i.e. parameters) when the first fulfillment is done. 

Instead, each time a parameter is passed, if an expected call was previously fulfilled then it's "unfulfilled" (because it isn't actually matching the actual call), and other expected calls that could be previously fulfilled are also discarded. That way, as parameters are passed, expected calls with too few parameters are discarded, and the set of "fulfillable" expected calls is narrowed down.

Finally, when checkExpectations() is called on the last actual call, the "actual call fulfillment state" of the remaining unfulfilled expected calls is reset. This way, we've got again in pristine "unfulfilled" state all the unfulfilled calls that where not fulfilled by the last call, and they are ready to be fulfilled by the next call. 