### PR TITLE
Fixed spelling errors in function names and constants.

### DIFF
--- a/include/CppUTestExt/MockCheckedActualCall.h
+++ b/include/CppUTestExt/MockCheckedActualCall.h
@@ -99,7 +99,7 @@ protected:
     virtual void checkOutputParameter(const MockNamedValue& outputParameter);
 
     enum ActualCallState {
-        CALL_IN_PROGESS,
+        CALL_IN_PROGRESS,
         CALL_FAILED,
         CALL_SUCCEED
     };

--- a/include/CppUTestExt/MockExpectedCallsList.h
+++ b/include/CppUTestExt/MockExpectedCallsList.h
@@ -42,7 +42,7 @@ public:
     virtual int size() const;
     virtual int amountOfExpectationsFor(const SimpleString& name) const;
     virtual int amountOfUnfulfilledExpectations() const;
-    virtual bool hasUnfullfilledExpectations() const;
+    virtual bool hasUnfulfilledExpectations() const;
     virtual bool hasFulfilledExpectations() const;
     virtual bool hasFulfilledExpectationsWithoutIgnoredParameters() const;
     virtual bool hasUnfulfilledExpectationsBecauseOfMissingParameters() const;
@@ -53,7 +53,7 @@ public:
     virtual void addExpectedCall(MockCheckedExpectedCall* call);
     virtual void addExpectations(const MockExpectedCallsList& list);
     virtual void addExpectationsRelatedTo(const SimpleString& name, const MockExpectedCallsList& list);
-    virtual void addUnfilfilledExpectations(const MockExpectedCallsList& list);
+    virtual void addUnfulfilledExpectations(const MockExpectedCallsList& list);
 
     virtual void onlyKeepExpectationsRelatedTo(const SimpleString& name);
     virtual void onlyKeepExpectationsWithInputParameter(const MockNamedValue& parameter);

--- a/src/CppUTestExt/MockActualCall.cpp
+++ b/src/CppUTestExt/MockActualCall.cpp
@@ -52,7 +52,7 @@ SimpleString MockCheckedActualCall::getName() const
 MockCheckedActualCall::MockCheckedActualCall(int callOrder, MockFailureReporter* reporter, const MockExpectedCallsList& allExpectations)
     : callOrder_(callOrder), reporter_(reporter), state_(CALL_SUCCEED), fulfilledExpectation_(NULL), allExpectations_(allExpectations), outputParameterExpectations_(NULL)
 {
-    unfulfilledExpectations_.addUnfilfilledExpectations(allExpectations);
+    unfulfilledExpectations_.addUnfulfilledExpectations(allExpectations);
 }
 
 MockCheckedActualCall::~MockCheckedActualCall()
@@ -124,7 +124,7 @@ void MockCheckedActualCall::callHasSucceeded()
 MockActualCall& MockCheckedActualCall::withName(const SimpleString& name)
 {
     setName(name);
-    setState(CALL_IN_PROGESS);
+    setState(CALL_IN_PROGRESS);
 
     unfulfilledExpectations_.onlyKeepUnfulfilledExpectationsRelatedTo(name);
     if (unfulfilledExpectations_.isEmpty()) {
@@ -293,9 +293,9 @@ bool MockCheckedActualCall::hasFailed() const
 
 void MockCheckedActualCall::checkExpectations()
 {
-    if (state_ != CALL_IN_PROGESS) return;
+    if (state_ != CALL_IN_PROGRESS) return;
 
-    if (! unfulfilledExpectations_.hasUnfullfilledExpectations())
+    if (! unfulfilledExpectations_.hasUnfulfilledExpectations())
         FAIL("Actual call is in progress. Checking expectations. But no unfulfilled expectations. Cannot happen.") // LCOV_EXCL_LINE
 
     fulfilledExpectation_ = unfulfilledExpectations_.removeOneFulfilledExpectationWithIgnoredParameters();

--- a/src/CppUTestExt/MockExpectedCallsList.cpp
+++ b/src/CppUTestExt/MockExpectedCallsList.cpp
@@ -94,7 +94,7 @@ bool MockExpectedCallsList::hasFulfilledExpectationsWithoutIgnoredParameters() c
     return false;
 }
 
-bool MockExpectedCallsList::hasUnfullfilledExpectations() const
+bool MockExpectedCallsList::hasUnfulfilledExpectations() const
 {
     return amountOfUnfulfilledExpectations() != 0;
 }
@@ -120,7 +120,7 @@ void MockExpectedCallsList::addExpectedCall(MockCheckedExpectedCall* call)
     }
 }
 
-void MockExpectedCallsList::addUnfilfilledExpectations(const MockExpectedCallsList& list)
+void MockExpectedCallsList::addUnfulfilledExpectations(const MockExpectedCallsList& list)
 {
     for (MockExpectedCallsListNode* p = list.head_; p; p = p->next_)
         if (! p->expectedCall_->isFulfilled())

--- a/src/CppUTestExt/MockSupport.cpp
+++ b/src/CppUTestExt/MockSupport.cpp
@@ -230,7 +230,7 @@ const char* MockSupport::getTraceOutput()
 
 bool MockSupport::expectedCallsLeft()
 {
-    int callsLeft = expectations_.hasUnfullfilledExpectations();
+    int callsLeft = expectations_.hasUnfulfilledExpectations();
 
     for (MockNamedValueListNode* p = data_.begin(); p; p = p->next())
         if (getMockSupport(p)) callsLeft += getMockSupport(p)->expectedCallsLeft();

--- a/tests/CppUTestExt/MockExpectedFunctionsListTest.cpp
+++ b/tests/CppUTestExt/MockExpectedFunctionsListTest.cpp
@@ -62,7 +62,7 @@ TEST_GROUP(MockExpectedCallsList)
 
 TEST(MockExpectedCallsList, emptyList)
 {
-    CHECK(! list->hasUnfullfilledExpectations());
+    CHECK(! list->hasUnfulfilledExpectations());
     CHECK(! list->hasFulfilledExpectations());
     LONGS_EQUAL(0, list->size());
 }
@@ -80,7 +80,7 @@ TEST(MockExpectedCallsList, listWithFulfilledExpectationHasNoUnfillfilledOnes)
     call2->callWasMade(2);
     list->addExpectedCall(call1);
     list->addExpectedCall(call2);
-    CHECK(! list->hasUnfullfilledExpectations());
+    CHECK(! list->hasUnfulfilledExpectations());
 }
 
 TEST(MockExpectedCallsList, listWithFulfilledExpectationButOutOfOrder)
@@ -91,7 +91,7 @@ TEST(MockExpectedCallsList, listWithFulfilledExpectationButOutOfOrder)
     list->addExpectedCall(call2);
     call2->callWasMade(1);
     call1->callWasMade(2);
-    CHECK(! list->hasUnfullfilledExpectations());
+    CHECK(! list->hasUnfulfilledExpectations());
     CHECK(list->hasCallsOutOfOrder());
 }
 
@@ -102,7 +102,7 @@ TEST(MockExpectedCallsList, listWithUnFulfilledExpectationHasNoUnfillfilledOnes)
     list->addExpectedCall(call1);
     list->addExpectedCall(call2);
     list->addExpectedCall(call3);
-    CHECK(list->hasUnfullfilledExpectations());
+    CHECK(list->hasUnfulfilledExpectations());
 }
 
 TEST(MockExpectedCallsList, deleteAllExpectationsAndClearList)
@@ -190,7 +190,7 @@ TEST(MockExpectedCallsList, onlyKeepUnfulfilledExpectationsWithInputParameter)
 TEST(MockExpectedCallsList, addUnfilfilledExpectationsWithEmptyList)
 {
     MockExpectedCallsList newList;
-    newList.addUnfilfilledExpectations(*list);
+    newList.addUnfulfilledExpectations(*list);
     LONGS_EQUAL(0, newList.size());
 }
 
@@ -201,7 +201,7 @@ TEST(MockExpectedCallsList, addUnfilfilledExpectationsMultipleUnfulfilledExpecta
     list->addExpectedCall(call2);
     list->addExpectedCall(call3);
     MockExpectedCallsList newList;
-    newList.addUnfilfilledExpectations(*list);
+    newList.addUnfulfilledExpectations(*list);
     LONGS_EQUAL(2, newList.size());
 }
 


### PR DESCRIPTION
Added this so if it's merged then PR #707 changes will be more readable.