### PR TITLE
Move printing of Nan and Inf to StringFrom(double)

### DIFF
--- a/src/CppUTest/SimpleString.cpp
+++ b/src/CppUTest/SimpleString.cpp
@@ -491,7 +491,12 @@ SimpleString HexStringFrom(const void* value)
 
 SimpleString StringFrom(double value, int precision)
 {
-    return StringFromFormat("%.*g", precision, value);
+    if (PlatformSpecificIsNan(value))
+        return "Nan - Not a number";
+    else if (PlatformSpecificIsInf(value))
+        return "Inf - Infinity";
+    else
+        return StringFromFormat("%.*g", precision, value);
 }
 
 SimpleString StringFrom(char value)

--- a/src/CppUTest/TestFailure.cpp
+++ b/src/CppUTest/TestFailure.cpp
@@ -164,20 +164,11 @@ EqualsFailure::EqualsFailure(UtestShell* test, const char* fileName, int lineNum
     message_ = createButWasString(expected, actual);
 }
 
-static SimpleString StringFromOrNanOrInf(double d)
-{
-    if (PlatformSpecificIsNan(d))
-        return "Nan - Not a number";
-    if (PlatformSpecificIsInf(d))
-        return "Inf - Infinity";
-    return StringFrom(d);
-}
-
 DoublesEqualFailure::DoublesEqualFailure(UtestShell* test, const char* fileName, int lineNumber, double expected, double actual, double threshold)  : TestFailure(test, fileName, lineNumber)
 {
-    message_ = createButWasString(StringFromOrNanOrInf(expected), StringFromOrNanOrInf(actual));
+    message_ = createButWasString(StringFrom(expected, 10), StringFrom(actual, 10));
     message_ += " threshold used was <";
-    message_ += StringFromOrNanOrInf(threshold);
+    message_ += StringFrom(threshold, 10);
     message_ += ">";
 
     if (PlatformSpecificIsNan(expected) || PlatformSpecificIsNan(actual) || PlatformSpecificIsNan(threshold))

--- a/tests/SimpleStringTest.cpp
+++ b/tests/SimpleStringTest.cpp
@@ -487,6 +487,24 @@ TEST(SimpleString, Doubles)
     STRCMP_EQUAL("1.2", s.asCharString());
 }
 
+extern "C" {
+    static int alwaysTrue(double) { return true; }
+}
+
+TEST(SimpleString, NaN)
+{
+    UT_PTR_SET(PlatformSpecificIsNan, alwaysTrue);
+    SimpleString s(StringFrom(0.0));
+    STRCMP_EQUAL("Nan - Not a number", s.asCharString());
+}
+
+TEST(SimpleString, Inf)
+{
+    UT_PTR_SET(PlatformSpecificIsInf, alwaysTrue);
+    SimpleString s(StringFrom(0.0));
+    STRCMP_EQUAL("Inf - Infinity", s.asCharString());
+}
+
 TEST(SimpleString, SmallDoubles)
 {
     SimpleString s(StringFrom(1.2e-10));


### PR DESCRIPTION
Since NaN and Infinity are full citizens of the floating point universe, I propose to move printing "Nan - Not a number" and "Inf - Infinity" directly into SimpleString.

Actually, under Gcc, StringFromFormat would print "Nan" and "Inf" in any case, so why not allow this little bit of extra verbosity outside of failures as well (actually I found it confusing that sometimes "Nan" would be printed and other times "Nan - Not a number".

This can also be tested very easily in SimpleString by having the platform-specific functions just return `true` always for those tests.