### PR TITLE
fix a compile error

### DIFF
--- a/tests/UtestTest.cpp
+++ b/tests/UtestTest.cpp
@@ -85,7 +85,7 @@ TEST(UtestShell, PassedCheckEqualWillIncreaseTheAmountOfChecks)
 
 IGNORE_TEST(UtestShell, IgnoreTestAccessingFixture)
 {
-    CHECK(&fixture != 0);
+    CHECK(&fixture != NULL);
 }
 
 TEST(UtestShell, MacrosUsedInSetup)


### PR DESCRIPTION
When I build in MacOS using following commands:

```
$cmake
$make
```

I get following error message:
> error: comparison of address of 'this->fixture' not equal to a null pointer is always true [-Werror,-Wtautological-pointer-compare]

The fixes the above error.