### PR TITLE
Check macros with custom messages

### DIFF
--- a/include/CppUTest/TestFailure.h
+++ b/include/CppUTest/TestFailure.h
@@ -70,6 +70,7 @@ protected:
 
     SimpleString createButWasString(const SimpleString& expected, const SimpleString& actual);
     SimpleString createDifferenceAtPosString(const SimpleString& actual, size_t position, DifferenceFormat format = DIFFERENCE_STRING);
+    SimpleString createUserText(const SimpleString& text);
 
     SimpleString testName_;
     SimpleString fileName_;
@@ -85,26 +86,26 @@ protected:
 class EqualsFailure: public TestFailure
 {
 public:
-    EqualsFailure(UtestShell*, const char* fileName, int lineNumber, const char* expected, const char* actual);
-    EqualsFailure(UtestShell*, const char* fileName, int lineNumber, const SimpleString& expected, const SimpleString& actual);
+    EqualsFailure(UtestShell*, const char* fileName, int lineNumber, const char* expected, const char* actual, const SimpleString& text);
+    EqualsFailure(UtestShell*, const char* fileName, int lineNumber, const SimpleString& expected, const SimpleString& actual, const SimpleString& text);
 };
 
 class DoublesEqualFailure: public TestFailure
 {
 public:
-    DoublesEqualFailure(UtestShell*, const char* fileName, int lineNumber, double expected, double actual, double threshold);
+    DoublesEqualFailure(UtestShell*, const char* fileName, int lineNumber, double expected, double actual, double threshold, const SimpleString& text);
 };
 
 class CheckEqualFailure : public TestFailure
 {
 public:
-    CheckEqualFailure(UtestShell* test, const char* fileName, int lineNumber, const SimpleString& expected, const SimpleString& actual);
+    CheckEqualFailure(UtestShell* test, const char* fileName, int lineNumber, const SimpleString& expected, const SimpleString& actual, const SimpleString& text);
 };
 
 class ContainsFailure: public TestFailure
 {
 public:
-    ContainsFailure(UtestShell*, const char* fileName, int lineNumber, const SimpleString& expected, const SimpleString& actual);
+    ContainsFailure(UtestShell*, const char* fileName, int lineNumber, const SimpleString& expected, const SimpleString& actual, const SimpleString& text);
 
 };
 
@@ -123,37 +124,37 @@ public:
 class LongsEqualFailure : public TestFailure
 {
 public:
-    LongsEqualFailure(UtestShell* test, const char* fileName, int lineNumber, long expected, long actual);
+    LongsEqualFailure(UtestShell* test, const char* fileName, int lineNumber, long expected, long actual, const SimpleString& text);
 };
 
 class UnsignedLongsEqualFailure : public TestFailure
 {
 public:
-    UnsignedLongsEqualFailure(UtestShell* test, const char* fileName, int lineNumber, unsigned long expected, unsigned long actual);
+    UnsignedLongsEqualFailure(UtestShell* test, const char* fileName, int lineNumber, unsigned long expected, unsigned long actual, const SimpleString& text);
 };
 
 class StringEqualFailure : public TestFailure
 {
 public:
-    StringEqualFailure(UtestShell* test, const char* fileName, int lineNumber, const char* expected, const char* actual);
+    StringEqualFailure(UtestShell* test, const char* fileName, int lineNumber, const char* expected, const char* actual, const SimpleString& text);
 };
 
 class StringEqualNoCaseFailure : public TestFailure
 {
 public:
-    StringEqualNoCaseFailure(UtestShell* test, const char* fileName, int lineNumber, const char* expected, const char* actual);
+    StringEqualNoCaseFailure(UtestShell* test, const char* fileName, int lineNumber, const char* expected, const char* actual, const SimpleString& text);
 };
 
 class BinaryEqualFailure : public TestFailure
 {
 public:
-	BinaryEqualFailure(UtestShell* test, const char* fileName, int lineNumber, const unsigned char* expected, const unsigned char* actual, size_t size);
+	BinaryEqualFailure(UtestShell* test, const char* fileName, int lineNumber, const unsigned char* expected, const unsigned char* actual, size_t size, const SimpleString& text);
 };
 
 class BitsEqualFailure : public TestFailure
 {
 public:
-	BitsEqualFailure(UtestShell* test, const char* fileName, int lineNumber, unsigned long expected, unsigned long actual, unsigned long mask, size_t byteCount);
+	BitsEqualFailure(UtestShell* test, const char* fileName, int lineNumber, unsigned long expected, unsigned long actual, unsigned long mask, size_t byteCount, const SimpleString& text);
 };
 
 #endif

--- a/include/CppUTest/Utest.h
+++ b/include/CppUTest/Utest.h
@@ -107,18 +107,18 @@ public:
 
     virtual void assertTrue(bool condition, const char *checkString, const char *conditionString, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
     virtual void assertTrueText(bool condition, const char *checkString, const char *conditionString, const char* text, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
-    virtual void assertCstrEqual(const char *expected, const char *actual, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
-    virtual void assertCstrNEqual(const char *expected, const char *actual, size_t length, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
-    virtual void assertCstrNoCaseEqual(const char *expected, const char *actual, const char *fileName, int lineNumber);
-    virtual void assertCstrContains(const char *expected, const char *actual, const char *fileName, int lineNumber);
-    virtual void assertCstrNoCaseContains(const char *expected, const char *actual, const char *fileName, int lineNumber);
-    virtual void assertLongsEqual(long expected, long actual, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
-    virtual void assertUnsignedLongsEqual(unsigned long expected, unsigned long actual, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
-    virtual void assertPointersEqual(const void *expected, const void *actual, const char *fileName, int lineNumber);
-    virtual void assertDoublesEqual(double expected, double actual, double threshold, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
-    virtual void assertEquals(bool failed, const char* expected, const char* actual, const char* file, int line, const TestTerminator& testTerminator = NormalTestTerminator());
-    virtual void assertBinaryEqual(const void *expected, const void *actual, size_t length, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
-    virtual void assertBitsEqual(unsigned long expected, unsigned long actual, unsigned long mask, size_t byteCount, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
+    virtual void assertCstrEqual(const char *expected, const char *actual, const char* text, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
+    virtual void assertCstrNEqual(const char *expected, const char *actual, size_t length, const char* text, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
+    virtual void assertCstrNoCaseEqual(const char *expected, const char *actual, const char* text, const char *fileName, int lineNumber);
+    virtual void assertCstrContains(const char *expected, const char *actual, const char* text, const char *fileName, int lineNumber);
+    virtual void assertCstrNoCaseContains(const char *expected, const char *actual, const char* text, const char *fileName, int lineNumber);
+    virtual void assertLongsEqual(long expected, long actual, const char* text, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
+    virtual void assertUnsignedLongsEqual(unsigned long expected, unsigned long actual, const char* text, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
+    virtual void assertPointersEqual(const void *expected, const void *actual, const char* text, const char *fileName, int lineNumber);
+    virtual void assertDoublesEqual(double expected, double actual, double threshold, const char* text, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
+    virtual void assertEquals(bool failed, const char* expected, const char* actual, const char* text, const char* file, int line, const TestTerminator& testTerminator = NormalTestTerminator());
+    virtual void assertBinaryEqual(const void *expected, const void *actual, size_t length, const char* text, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
+    virtual void assertBitsEqual(unsigned long expected, unsigned long actual, unsigned long mask, size_t byteCount, const char* text, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
     virtual void fail(const char *text, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
 
     virtual void print(const char *text, const char *fileName, int lineNumber);

--- a/include/CppUTest/Utest.h
+++ b/include/CppUTest/Utest.h
@@ -105,8 +105,7 @@ public:
     virtual bool hasFailed() const;
     void countCheck();
 
-    virtual void assertTrue(bool condition, const char *checkString, const char *conditionString, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
-    virtual void assertTrueText(bool condition, const char *checkString, const char *conditionString, const char* text, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
+    virtual void assertTrue(bool condition, const char *checkString, const char *conditionString, const char* text, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
     virtual void assertCstrEqual(const char *expected, const char *actual, const char* text, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
     virtual void assertCstrNEqual(const char *expected, const char *actual, size_t length, const char* text, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
     virtual void assertCstrNoCaseEqual(const char *expected, const char *actual, const char* text, const char *fileName, int lineNumber);

--- a/include/CppUTest/UtestMacros.h
+++ b/include/CppUTest/UtestMacros.h
@@ -91,115 +91,157 @@
 // Different checking macros
 
 #define CHECK(condition)\
-  CHECK_LOCATION_TRUE(condition, "CHECK", #condition, __FILE__, __LINE__)
+  CHECK_TRUE_LOCATION(condition, "CHECK", #condition, "", __FILE__, __LINE__)
 
 #define CHECK_TEXT(condition, text) \
-  CHECK_LOCATION_TEXT(condition, "CHECK", #condition, text, __FILE__, __LINE__)
+  CHECK_TRUE_LOCATION(condition, "CHECK", #condition, text, __FILE__, __LINE__)
 
 #define CHECK_TRUE(condition)\
-  CHECK_LOCATION_TRUE(condition, "CHECK_TRUE", #condition, __FILE__, __LINE__)
+  CHECK_TRUE_LOCATION(condition, "CHECK_TRUE", #condition, "", __FILE__, __LINE__)
+
+#define CHECK_TRUE_TEXT(condition, text)\
+  CHECK_TRUE_LOCATION(condition, "CHECK_TRUE", #condition, text, __FILE__, __LINE__)
 
 #define CHECK_FALSE(condition)\
-  CHECK_LOCATION_FALSE(condition, "CHECK_FALSE", #condition, __FILE__, __LINE__)
+  CHECK_FALSE_LOCATION(condition, "CHECK_FALSE", #condition, "", __FILE__, __LINE__)
 
-#define CHECK_LOCATION_TEXT(condition, checkString, conditionString, text, file, line) \
-    { UtestShell::getCurrent()->assertTrueText((condition) != 0, checkString, conditionString, text, file, line); }
+#define CHECK_FALSE_TEXT(condition, text)\
+  CHECK_FALSE_LOCATION(condition, "CHECK_FALSE", #condition, text, __FILE__, __LINE__)
 
-#define CHECK_LOCATION_TRUE(condition, checkString, conditionString, file, line)\
-  { UtestShell::getCurrent()->assertTrue((condition) != 0, checkString, conditionString, file, line); }
+#define CHECK_TRUE_LOCATION(condition, checkString, conditionString, text, file, line)\
+  { UtestShell::getCurrent()->assertTrueText((condition) != 0, checkString, conditionString, text, file, line); }
 
-#define CHECK_LOCATION_FALSE(condition, checkString, conditionString, file, line)\
-  { UtestShell::getCurrent()->assertTrue((condition) == 0, checkString, conditionString, file, line); }
+#define CHECK_FALSE_LOCATION(condition, checkString, conditionString, text, file, line)\
+  { UtestShell::getCurrent()->assertTrueText((condition) == 0, checkString, conditionString, text, file, line); }
 
 //This check needs the operator!=(), and a StringFrom(YourType) function
-#define CHECK_EQUAL(expected,actual)\
-  CHECK_EQUAL_LOCATION(expected, actual, __FILE__, __LINE__)
+#define CHECK_EQUAL(expected, actual)\
+  CHECK_EQUAL_LOCATION(expected, actual, "", __FILE__, __LINE__)
 
-#define CHECK_EQUAL_LOCATION(expected,actual, file, line)\
+#define CHECK_EQUAL_TEXT(expected, actual, text)\
+  CHECK_EQUAL_LOCATION(expected, actual, text, __FILE__, __LINE__)
+
+#define CHECK_EQUAL_LOCATION(expected, actual, text, file, line)\
   { if ((expected) != (actual)) { \
       if ((actual) != (actual)) \
       	  UtestShell::getCurrent()->print("WARNING:\n\tThe \"Actual Parameter\" parameter is evaluated multiple times resulting in different values.\n\tThus the value in the error message is probably incorrect.", file, line); \
       if ((expected) != (expected)) \
       	  UtestShell::getCurrent()->print("WARNING:\n\tThe \"Expected Parameter\" parameter is evaluated multiple times resulting in different values.\n\tThus the value in the error message is probably incorrect.", file, line); \
-      UtestShell::getCurrent()->assertEquals(true, StringFrom(expected).asCharString(), StringFrom(actual).asCharString(), file, line); \
+      UtestShell::getCurrent()->assertEquals(true, StringFrom(expected).asCharString(), StringFrom(actual).asCharString(), text, file, line); \
   } \
   else \
   { \
-    UtestShell::getCurrent()->assertLongsEqual((long)0, (long)0, file, line); \
+    UtestShell::getCurrent()->assertLongsEqual((long)0, (long)0, "", file, line); \
   } }
 
 //This check checks for char* string equality using strcmp.
 //This makes up for the fact that CHECK_EQUAL only compares the pointers to char*'s
-#define STRCMP_EQUAL(expected,actual)\
-  STRCMP_EQUAL_LOCATION(expected, actual, __FILE__, __LINE__)
+#define STRCMP_EQUAL(expected, actual)\
+  STRCMP_EQUAL_LOCATION(expected, actual, "", __FILE__, __LINE__)
 
-#define STRCMP_EQUAL_LOCATION(expected,actual, file, line)\
-  { UtestShell::getCurrent()->assertCstrEqual(expected, actual, file, line); }
+#define STRCMP_EQUAL_TEXT(expected, actual, text)\
+  STRCMP_EQUAL_LOCATION(expected, actual, text, __FILE__, __LINE__)
+
+#define STRCMP_EQUAL_LOCATION(expected, actual, text, file, line)\
+  { UtestShell::getCurrent()->assertCstrEqual(expected, actual, text, file, line); }
 
 #define STRNCMP_EQUAL(expected, actual, length)\
-  STRNCMP_EQUAL_LOCATION(expected, actual, length, __FILE__, __LINE__)
+  STRNCMP_EQUAL_LOCATION(expected, actual, length, "", __FILE__, __LINE__)
 
-#define STRNCMP_EQUAL_LOCATION(expected, actual, length, file, line)\
-  { UtestShell::getCurrent()->assertCstrNEqual(expected, actual, length, file, line); }
+#define STRNCMP_EQUAL_TEXT(expected, actual, length, text)\
+  STRNCMP_EQUAL_LOCATION(expected, actual, length, text, __FILE__, __LINE__)
 
-#define STRCMP_NOCASE_EQUAL(expected,actual)\
-  STRCMP_NOCASE_EQUAL_LOCATION(expected, actual, __FILE__, __LINE__)
+#define STRNCMP_EQUAL_LOCATION(expected, actual, length, text, file, line)\
+  { UtestShell::getCurrent()->assertCstrNEqual(expected, actual, length, text, file, line); }
 
-#define STRCMP_NOCASE_EQUAL_LOCATION(expected,actual, file, line)\
-  { UtestShell::getCurrent()->assertCstrNoCaseEqual(expected, actual, file, line); }
+#define STRCMP_NOCASE_EQUAL(expected, actual)\
+  STRCMP_NOCASE_EQUAL_LOCATION(expected, actual, "", __FILE__, __LINE__)
 
-#define STRCMP_CONTAINS(expected,actual)\
-  STRCMP_CONTAINS_LOCATION(expected, actual, __FILE__, __LINE__)
+#define STRCMP_NOCASE_EQUAL_TEXT(expected, actual, text)\
+  STRCMP_NOCASE_EQUAL_LOCATION(expected, actual, text, __FILE__, __LINE__)
 
-#define STRCMP_CONTAINS_LOCATION(expected,actual, file, line)\
-  { UtestShell::getCurrent()->assertCstrContains(expected, actual, file, line); }
+#define STRCMP_NOCASE_EQUAL_LOCATION(expected, actual, text, file, line)\
+  { UtestShell::getCurrent()->assertCstrNoCaseEqual(expected, actual, text, file, line); }
 
-#define STRCMP_NOCASE_CONTAINS(expected,actual)\
-  STRCMP_NOCASE_CONTAINS_LOCATION(expected, actual, __FILE__, __LINE__)
+#define STRCMP_CONTAINS(expected, actual)\
+  STRCMP_CONTAINS_LOCATION(expected, actual, "", __FILE__, __LINE__)
 
-#define STRCMP_NOCASE_CONTAINS_LOCATION(expected,actual, file, line)\
-  { UtestShell::getCurrent()->assertCstrNoCaseContains(expected, actual, file, line); }
+#define STRCMP_CONTAINS_TEXT(expected, actual, text)\
+  STRCMP_CONTAINS_LOCATION(expected, actual, text, __FILE__, __LINE__)
+
+#define STRCMP_CONTAINS_LOCATION(expected, actual, text, file, line)\
+  { UtestShell::getCurrent()->assertCstrContains(expected, actual, text, file, line); }
+
+#define STRCMP_NOCASE_CONTAINS(expected, actual)\
+  STRCMP_NOCASE_CONTAINS_LOCATION(expected, actual, "", __FILE__, __LINE__)
+
+#define STRCMP_NOCASE_CONTAINS_TEXT(expected, actual, text)\
+  STRCMP_NOCASE_CONTAINS_LOCATION(expected, actual, text, __FILE__, __LINE__)
+
+#define STRCMP_NOCASE_CONTAINS_LOCATION(expected, actual, text, file, line)\
+  { UtestShell::getCurrent()->assertCstrNoCaseContains(expected, actual, text, file, line); }
 
 //Check two long integers for equality
-#define LONGS_EQUAL(expected,actual)\
-  LONGS_EQUAL_LOCATION(expected,actual,__FILE__, __LINE__)
+#define LONGS_EQUAL(expected, actual)\
+  LONGS_EQUAL_LOCATION(expected, actual, "", __FILE__, __LINE__)
 
-#define UNSIGNED_LONGS_EQUAL(expected,actual)\
-  UNSIGNED_LONGS_EQUAL_LOCATION(expected,actual,__FILE__, __LINE__)
+#define LONGS_EQUAL_TEXT(expected, actual, text)\
+  LONGS_EQUAL_LOCATION(expected, actual, text, __FILE__, __LINE__)
 
-#define LONGS_EQUAL_LOCATION(expected,actual,file,line)\
-  { UtestShell::getCurrent()->assertLongsEqual((long)expected, (long)actual,  file, line); }
+#define UNSIGNED_LONGS_EQUAL(expected, actual)\
+  UNSIGNED_LONGS_EQUAL_LOCATION(expected, actual, "", __FILE__, __LINE__)
 
-#define UNSIGNED_LONGS_EQUAL_LOCATION(expected,actual,file,line)\
-  { UtestShell::getCurrent()->assertUnsignedLongsEqual((unsigned long)expected, (unsigned long)actual,  file, line); }
+#define UNSIGNED_LONGS_EQUAL_TEXT(expected, actual, text)\
+  UNSIGNED_LONGS_EQUAL_LOCATION(expected, actual, text, __FILE__, __LINE__)
+
+#define LONGS_EQUAL_LOCATION(expected, actual, text, file, line)\
+  { UtestShell::getCurrent()->assertLongsEqual((long)expected, (long)actual, text, file, line); }
+
+#define UNSIGNED_LONGS_EQUAL_LOCATION(expected, actual, text, file, line)\
+  { UtestShell::getCurrent()->assertUnsignedLongsEqual((unsigned long)expected, (unsigned long)actual, text, file, line); }
 
 #define BYTES_EQUAL(expected, actual)\
     LONGS_EQUAL((expected) & 0xff,(actual) & 0xff)
 
-#define POINTERS_EQUAL(expected, actual)\
-    POINTERS_EQUAL_LOCATION((expected),(actual), __FILE__, __LINE__)
+#define BYTES_EQUAL_TEXT(expected, actual, text)\
+    LONGS_EQUAL_TEXT((expected) & 0xff, (actual) & 0xff, text)
 
-#define POINTERS_EQUAL_LOCATION(expected,actual,file,line)\
-  { UtestShell::getCurrent()->assertPointersEqual((void *)expected, (void *)actual,  file, line); }
+#define POINTERS_EQUAL(expected, actual)\
+    POINTERS_EQUAL_LOCATION((expected), (actual), "", __FILE__, __LINE__)
+
+#define POINTERS_EQUAL_TEXT(expected, actual, text)\
+    POINTERS_EQUAL_LOCATION((expected), (actual), text, __FILE__, __LINE__)
+
+#define POINTERS_EQUAL_LOCATION(expected, actual, text, file, line)\
+  { UtestShell::getCurrent()->assertPointersEqual((void *)expected, (void *)actual, text, file, line); }
 
 //Check two doubles for equality within a tolerance threshold
-#define DOUBLES_EQUAL(expected,actual,threshold)\
-  DOUBLES_EQUAL_LOCATION(expected,actual,threshold,__FILE__,__LINE__)
+#define DOUBLES_EQUAL(expected, actual, threshold)\
+  DOUBLES_EQUAL_LOCATION(expected, actual, threshold, "", __FILE__, __LINE__)
 
-#define DOUBLES_EQUAL_LOCATION(expected,actual,threshold,file,line)\
-  { UtestShell::getCurrent()->assertDoublesEqual(expected, actual, threshold,  file, line); }
+#define DOUBLES_EQUAL_TEXT(expected, actual, threshold, text)\
+  DOUBLES_EQUAL_LOCATION(expected, actual, threshold, text, __FILE__, __LINE__)
 
-#define MEMCMP_EQUAL(expected,actual,size)\
-  MEMCMP_EQUAL_LOCATION(expected,actual,size,__FILE__,__LINE__)
+#define DOUBLES_EQUAL_LOCATION(expected, actual, threshold, text, file, line)\
+  { UtestShell::getCurrent()->assertDoublesEqual(expected, actual, threshold, text, file, line); }
 
-#define MEMCMP_EQUAL_LOCATION(expected,actual,size,file,line)\
-  { UtestShell::getCurrent()->assertBinaryEqual(expected, actual, size, file, line); }
+#define MEMCMP_EQUAL(expected, actual, size)\
+  MEMCMP_EQUAL_LOCATION(expected, actual, size, "", __FILE__, __LINE__)
 
-#define BITS_EQUAL(expected,actual,mask)\
-  BITS_LOCATION(expected,actual,mask,__FILE__,__LINE__)
+#define MEMCMP_EQUAL_TEXT(expected, actual, size, text)\
+  MEMCMP_EQUAL_LOCATION(expected, actual, size, text, __FILE__, __LINE__)
 
-#define BITS_LOCATION(expected,actual,mask,file,line)\
-  { UtestShell::getCurrent()->assertBitsEqual(expected, actual, mask, sizeof(actual), file, line); }
+#define MEMCMP_EQUAL_LOCATION(expected, actual, size, text, file, line)\
+  { UtestShell::getCurrent()->assertBinaryEqual(expected, actual, size, text, file, line); }
+
+#define BITS_EQUAL(expected, actual, mask)\
+  BITS_LOCATION(expected, actual, mask, "", __FILE__, __LINE__)
+
+#define BITS_EQUAL_TEXT(expected, actual, mask, text)\
+  BITS_LOCATION(expected, actual, mask, text, __FILE__, __LINE__)
+
+#define BITS_LOCATION(expected, actual, mask, text, file, line)\
+  { UtestShell::getCurrent()->assertBitsEqual(expected, actual, mask, sizeof(actual), text, file, line); }
 
 //Fail if you get to this macro
 //The macro FAIL may already be taken, so allow FAIL_TEST too

--- a/include/CppUTest/UtestMacros.h
+++ b/include/CppUTest/UtestMacros.h
@@ -91,19 +91,19 @@
 // Different checking macros
 
 #define CHECK(condition)\
-  CHECK_TRUE_LOCATION(condition, "CHECK", #condition, "", __FILE__, __LINE__)
+  CHECK_TRUE_LOCATION(condition, "CHECK", #condition, NULL, __FILE__, __LINE__)
 
 #define CHECK_TEXT(condition, text) \
   CHECK_TRUE_LOCATION(condition, "CHECK", #condition, text, __FILE__, __LINE__)
 
 #define CHECK_TRUE(condition)\
-  CHECK_TRUE_LOCATION(condition, "CHECK_TRUE", #condition, "", __FILE__, __LINE__)
+  CHECK_TRUE_LOCATION(condition, "CHECK_TRUE", #condition, NULL, __FILE__, __LINE__)
 
 #define CHECK_TRUE_TEXT(condition, text)\
   CHECK_TRUE_LOCATION(condition, "CHECK_TRUE", #condition, text, __FILE__, __LINE__)
 
 #define CHECK_FALSE(condition)\
-  CHECK_FALSE_LOCATION(condition, "CHECK_FALSE", #condition, "", __FILE__, __LINE__)
+  CHECK_FALSE_LOCATION(condition, "CHECK_FALSE", #condition, NULL, __FILE__, __LINE__)
 
 #define CHECK_FALSE_TEXT(condition, text)\
   CHECK_FALSE_LOCATION(condition, "CHECK_FALSE", #condition, text, __FILE__, __LINE__)
@@ -116,7 +116,7 @@
 
 //This check needs the operator!=(), and a StringFrom(YourType) function
 #define CHECK_EQUAL(expected, actual)\
-  CHECK_EQUAL_LOCATION(expected, actual, "", __FILE__, __LINE__)
+  CHECK_EQUAL_LOCATION(expected, actual, NULL, __FILE__, __LINE__)
 
 #define CHECK_EQUAL_TEXT(expected, actual, text)\
   CHECK_EQUAL_LOCATION(expected, actual, text, __FILE__, __LINE__)
@@ -131,13 +131,13 @@
   } \
   else \
   { \
-    UtestShell::getCurrent()->assertLongsEqual((long)0, (long)0, "", file, line); \
+    UtestShell::getCurrent()->assertLongsEqual((long)0, (long)0, NULL, file, line); \
   } }
 
 //This check checks for char* string equality using strcmp.
 //This makes up for the fact that CHECK_EQUAL only compares the pointers to char*'s
 #define STRCMP_EQUAL(expected, actual)\
-  STRCMP_EQUAL_LOCATION(expected, actual, "", __FILE__, __LINE__)
+  STRCMP_EQUAL_LOCATION(expected, actual, NULL, __FILE__, __LINE__)
 
 #define STRCMP_EQUAL_TEXT(expected, actual, text)\
   STRCMP_EQUAL_LOCATION(expected, actual, text, __FILE__, __LINE__)
@@ -146,7 +146,7 @@
   { UtestShell::getCurrent()->assertCstrEqual(expected, actual, text, file, line); }
 
 #define STRNCMP_EQUAL(expected, actual, length)\
-  STRNCMP_EQUAL_LOCATION(expected, actual, length, "", __FILE__, __LINE__)
+  STRNCMP_EQUAL_LOCATION(expected, actual, length, NULL, __FILE__, __LINE__)
 
 #define STRNCMP_EQUAL_TEXT(expected, actual, length, text)\
   STRNCMP_EQUAL_LOCATION(expected, actual, length, text, __FILE__, __LINE__)
@@ -155,7 +155,7 @@
   { UtestShell::getCurrent()->assertCstrNEqual(expected, actual, length, text, file, line); }
 
 #define STRCMP_NOCASE_EQUAL(expected, actual)\
-  STRCMP_NOCASE_EQUAL_LOCATION(expected, actual, "", __FILE__, __LINE__)
+  STRCMP_NOCASE_EQUAL_LOCATION(expected, actual, NULL, __FILE__, __LINE__)
 
 #define STRCMP_NOCASE_EQUAL_TEXT(expected, actual, text)\
   STRCMP_NOCASE_EQUAL_LOCATION(expected, actual, text, __FILE__, __LINE__)
@@ -164,7 +164,7 @@
   { UtestShell::getCurrent()->assertCstrNoCaseEqual(expected, actual, text, file, line); }
 
 #define STRCMP_CONTAINS(expected, actual)\
-  STRCMP_CONTAINS_LOCATION(expected, actual, "", __FILE__, __LINE__)
+  STRCMP_CONTAINS_LOCATION(expected, actual, NULL, __FILE__, __LINE__)
 
 #define STRCMP_CONTAINS_TEXT(expected, actual, text)\
   STRCMP_CONTAINS_LOCATION(expected, actual, text, __FILE__, __LINE__)
@@ -173,7 +173,7 @@
   { UtestShell::getCurrent()->assertCstrContains(expected, actual, text, file, line); }
 
 #define STRCMP_NOCASE_CONTAINS(expected, actual)\
-  STRCMP_NOCASE_CONTAINS_LOCATION(expected, actual, "", __FILE__, __LINE__)
+  STRCMP_NOCASE_CONTAINS_LOCATION(expected, actual, NULL, __FILE__, __LINE__)
 
 #define STRCMP_NOCASE_CONTAINS_TEXT(expected, actual, text)\
   STRCMP_NOCASE_CONTAINS_LOCATION(expected, actual, text, __FILE__, __LINE__)
@@ -183,13 +183,13 @@
 
 //Check two long integers for equality
 #define LONGS_EQUAL(expected, actual)\
-  LONGS_EQUAL_LOCATION(expected, actual, "", __FILE__, __LINE__)
+  LONGS_EQUAL_LOCATION(expected, actual, NULL, __FILE__, __LINE__)
 
 #define LONGS_EQUAL_TEXT(expected, actual, text)\
   LONGS_EQUAL_LOCATION(expected, actual, text, __FILE__, __LINE__)
 
 #define UNSIGNED_LONGS_EQUAL(expected, actual)\
-  UNSIGNED_LONGS_EQUAL_LOCATION(expected, actual, "", __FILE__, __LINE__)
+  UNSIGNED_LONGS_EQUAL_LOCATION(expected, actual, NULL, __FILE__, __LINE__)
 
 #define UNSIGNED_LONGS_EQUAL_TEXT(expected, actual, text)\
   UNSIGNED_LONGS_EQUAL_LOCATION(expected, actual, text, __FILE__, __LINE__)
@@ -207,7 +207,7 @@
     LONGS_EQUAL_TEXT((expected) & 0xff, (actual) & 0xff, text)
 
 #define POINTERS_EQUAL(expected, actual)\
-    POINTERS_EQUAL_LOCATION((expected), (actual), "", __FILE__, __LINE__)
+    POINTERS_EQUAL_LOCATION((expected), (actual), NULL, __FILE__, __LINE__)
 
 #define POINTERS_EQUAL_TEXT(expected, actual, text)\
     POINTERS_EQUAL_LOCATION((expected), (actual), text, __FILE__, __LINE__)
@@ -217,7 +217,7 @@
 
 //Check two doubles for equality within a tolerance threshold
 #define DOUBLES_EQUAL(expected, actual, threshold)\
-  DOUBLES_EQUAL_LOCATION(expected, actual, threshold, "", __FILE__, __LINE__)
+  DOUBLES_EQUAL_LOCATION(expected, actual, threshold, NULL, __FILE__, __LINE__)
 
 #define DOUBLES_EQUAL_TEXT(expected, actual, threshold, text)\
   DOUBLES_EQUAL_LOCATION(expected, actual, threshold, text, __FILE__, __LINE__)
@@ -226,7 +226,7 @@
   { UtestShell::getCurrent()->assertDoublesEqual(expected, actual, threshold, text, file, line); }
 
 #define MEMCMP_EQUAL(expected, actual, size)\
-  MEMCMP_EQUAL_LOCATION(expected, actual, size, "", __FILE__, __LINE__)
+  MEMCMP_EQUAL_LOCATION(expected, actual, size, NULL, __FILE__, __LINE__)
 
 #define MEMCMP_EQUAL_TEXT(expected, actual, size, text)\
   MEMCMP_EQUAL_LOCATION(expected, actual, size, text, __FILE__, __LINE__)
@@ -235,7 +235,7 @@
   { UtestShell::getCurrent()->assertBinaryEqual(expected, actual, size, text, file, line); }
 
 #define BITS_EQUAL(expected, actual, mask)\
-  BITS_LOCATION(expected, actual, mask, "", __FILE__, __LINE__)
+  BITS_LOCATION(expected, actual, mask, NULL, __FILE__, __LINE__)
 
 #define BITS_EQUAL_TEXT(expected, actual, mask, text)\
   BITS_LOCATION(expected, actual, mask, text, __FILE__, __LINE__)

--- a/include/CppUTest/UtestMacros.h
+++ b/include/CppUTest/UtestMacros.h
@@ -109,10 +109,10 @@
   CHECK_FALSE_LOCATION(condition, "CHECK_FALSE", #condition, text, __FILE__, __LINE__)
 
 #define CHECK_TRUE_LOCATION(condition, checkString, conditionString, text, file, line)\
-  { UtestShell::getCurrent()->assertTrueText((condition) != 0, checkString, conditionString, text, file, line); }
+  { UtestShell::getCurrent()->assertTrue((condition) != 0, checkString, conditionString, text, file, line); }
 
 #define CHECK_FALSE_LOCATION(condition, checkString, conditionString, text, file, line)\
-  { UtestShell::getCurrent()->assertTrueText((condition) == 0, checkString, conditionString, text, file, line); }
+  { UtestShell::getCurrent()->assertTrue((condition) == 0, checkString, conditionString, text, file, line); }
 
 //This check needs the operator!=(), and a StringFrom(YourType) function
 #define CHECK_EQUAL(expected, actual)\

--- a/src/CppUTest/TestFailure.cpp
+++ b/src/CppUTest/TestFailure.cpp
@@ -152,16 +152,32 @@ SimpleString TestFailure::createDifferenceAtPosString(const SimpleString& actual
     return result;
 }
 
-EqualsFailure::EqualsFailure(UtestShell* test, const char* fileName, int lineNumber, const char* expected, const char* actual) :
-    TestFailure(test, fileName, lineNumber)
+SimpleString TestFailure::createUserText(const SimpleString& text)
 {
-    message_ = createButWasString(StringFromOrNull(expected), StringFromOrNull(actual));
+    SimpleString userMessage = "";
+    if (!text.isEmpty())
+    {
+        userMessage += "Message: ";
+        userMessage += text;
+        userMessage += "\n\t";
+    }
+    return userMessage;
 }
 
-EqualsFailure::EqualsFailure(UtestShell* test, const char* fileName, int lineNumber, const SimpleString& expected, const SimpleString& actual)
+EqualsFailure::EqualsFailure(UtestShell* test, const char* fileName, int lineNumber, const char* expected, const char* actual, const SimpleString& text) :
+    TestFailure(test, fileName, lineNumber)
+{
+    message_ = createUserText(text);
+
+    message_ += createButWasString(StringFromOrNull(expected), StringFromOrNull(actual));
+}
+
+EqualsFailure::EqualsFailure(UtestShell* test, const char* fileName, int lineNumber, const SimpleString& expected, const SimpleString& actual, const SimpleString& text)
     : TestFailure(test, fileName, lineNumber)
 {
-    message_ = createButWasString(expected, actual);
+    message_ = createUserText(text);
+
+    message_ += createButWasString(expected, actual);
 }
 
 static SimpleString StringFromOrNanOrInf(double d)
@@ -173,9 +189,12 @@ static SimpleString StringFromOrNanOrInf(double d)
     return StringFrom(d);
 }
 
-DoublesEqualFailure::DoublesEqualFailure(UtestShell* test, const char* fileName, int lineNumber, double expected, double actual, double threshold)  : TestFailure(test, fileName, lineNumber)
+DoublesEqualFailure::DoublesEqualFailure(UtestShell* test, const char* fileName, int lineNumber, double expected, double actual, double threshold, const SimpleString& text)
+: TestFailure(test, fileName, lineNumber)
 {
-    message_ = createButWasString(StringFromOrNanOrInf(expected), StringFromOrNanOrInf(actual));
+    message_ = createUserText(text);
+
+    message_ += createButWasString(StringFromOrNanOrInf(expected), StringFromOrNanOrInf(actual));
     message_ += " threshold used was <";
     message_ += StringFromOrNanOrInf(threshold);
     message_ += ">";
@@ -184,30 +203,32 @@ DoublesEqualFailure::DoublesEqualFailure(UtestShell* test, const char* fileName,
         message_ += "\n\tCannot make comparisons with Nan";
 }
 
-CheckEqualFailure::CheckEqualFailure(UtestShell* test, const char* fileName, int lineNumber, const SimpleString& expected, const SimpleString& actual) : TestFailure(test, fileName, lineNumber)
+CheckEqualFailure::CheckEqualFailure(UtestShell* test, const char* fileName, int lineNumber, const SimpleString& expected, const SimpleString& actual, const SimpleString& text)
+: TestFailure(test, fileName, lineNumber)
 {
+    message_ = createUserText(text);
+
     size_t failStart;
     for (failStart = 0; actual.asCharString()[failStart] == expected.asCharString()[failStart]; failStart++)
         ;
-    message_ = createButWasString(expected, actual);
+    message_ += createButWasString(expected, actual);
     message_ += createDifferenceAtPosString(actual, failStart);
 
 }
 
-ContainsFailure::ContainsFailure(UtestShell* test, const char* fileName, int lineNumber, const SimpleString& expected, const SimpleString& actual) :
-    TestFailure(test, fileName, lineNumber)
+ContainsFailure::ContainsFailure(UtestShell* test, const char* fileName, int lineNumber, const SimpleString& expected, const SimpleString& actual, const SimpleString& text)
+: TestFailure(test, fileName, lineNumber)
 {
-    message_ = StringFromFormat("actual <%s>\n\tdid not contain  <%s>", actual.asCharString(), expected.asCharString());
+    message_ = createUserText(text);
+
+    message_ += StringFromFormat("actual <%s>\n\tdid not contain  <%s>", actual.asCharString(), expected.asCharString());
 }
 
-CheckFailure::CheckFailure(UtestShell* test, const char* fileName, int lineNumber, const SimpleString& checkString, const SimpleString& conditionString, const SimpleString& text) : TestFailure(test, fileName, lineNumber)
+CheckFailure::CheckFailure(UtestShell* test, const char* fileName, int lineNumber, const SimpleString& checkString, const SimpleString& conditionString, const SimpleString& text)
+: TestFailure(test, fileName, lineNumber)
 {
-    message_ = "";
-    if (!text.isEmpty()) {
-        message_ += "Message: ";
-        message_ += text;
-        message_ += "\n\t";
-    }
+    message_ = createUserText(text);
+
     message_ += checkString;
     message_ += "(";
     message_ += conditionString;
@@ -219,8 +240,11 @@ FailFailure::FailFailure(UtestShell* test, const char* fileName, int lineNumber,
     message_ = message;
 }
 
-LongsEqualFailure::LongsEqualFailure(UtestShell* test, const char* fileName, int lineNumber, long expected, long actual) : TestFailure(test, fileName, lineNumber)
+LongsEqualFailure::LongsEqualFailure(UtestShell* test, const char* fileName, int lineNumber, long expected, long actual, const SimpleString& text)
+: TestFailure(test, fileName, lineNumber)
 {
+    message_ = createUserText(text);
+
     SimpleString aDecimal = StringFrom(actual);
     SimpleString aHex = HexStringFrom(actual);
     SimpleString eDecimal = StringFrom(expected);
@@ -231,11 +255,14 @@ LongsEqualFailure::LongsEqualFailure(UtestShell* test, const char* fileName, int
 
     SimpleString actualReported = aDecimal + " 0x" + aHex;
     SimpleString expectedReported = eDecimal + " 0x" + eHex;
-    message_ = createButWasString(expectedReported, actualReported);
+    message_ += createButWasString(expectedReported, actualReported);
 }
 
-UnsignedLongsEqualFailure::UnsignedLongsEqualFailure(UtestShell* test, const char* fileName, int lineNumber, unsigned long expected, unsigned long actual) : TestFailure(test, fileName, lineNumber)
+UnsignedLongsEqualFailure::UnsignedLongsEqualFailure(UtestShell* test, const char* fileName, int lineNumber, unsigned long expected, unsigned long actual, const SimpleString& text)
+: TestFailure(test, fileName, lineNumber)
 {
+    message_ = createUserText(text);
+
     SimpleString aDecimal = StringFrom(actual);
     SimpleString aHex = HexStringFrom(actual);
     SimpleString eDecimal = StringFrom(expected);
@@ -246,12 +273,15 @@ UnsignedLongsEqualFailure::UnsignedLongsEqualFailure(UtestShell* test, const cha
 
     SimpleString actualReported = aDecimal + " 0x" + aHex;
     SimpleString expectedReported = eDecimal + " 0x" + eHex;
-    message_ = createButWasString(expectedReported, actualReported);
+    message_ += createButWasString(expectedReported, actualReported);
 }
 
-StringEqualFailure::StringEqualFailure(UtestShell* test, const char* fileName, int lineNumber, const char* expected, const char* actual) : TestFailure(test, fileName, lineNumber)
+StringEqualFailure::StringEqualFailure(UtestShell* test, const char* fileName, int lineNumber, const char* expected, const char* actual, const SimpleString& text)
+: TestFailure(test, fileName, lineNumber)
 {
-    message_ = createButWasString(StringFromOrNull(expected), StringFromOrNull(actual));
+    message_ = createUserText(text);
+
+    message_ += createButWasString(StringFromOrNull(expected), StringFromOrNull(actual));
     if((expected) && (actual))
     {
         size_t failStart;
@@ -261,9 +291,12 @@ StringEqualFailure::StringEqualFailure(UtestShell* test, const char* fileName, i
     }
 }
 
-StringEqualNoCaseFailure::StringEqualNoCaseFailure(UtestShell* test, const char* fileName, int lineNumber, const char* expected, const char* actual) : TestFailure(test, fileName, lineNumber)
+StringEqualNoCaseFailure::StringEqualNoCaseFailure(UtestShell* test, const char* fileName, int lineNumber, const char* expected, const char* actual, const SimpleString& text)
+: TestFailure(test, fileName, lineNumber)
 {
-    message_ = createButWasString(StringFromOrNull(expected), StringFromOrNull(actual));
+    message_ = createUserText(text);
+
+    message_ += createButWasString(StringFromOrNull(expected), StringFromOrNull(actual));
     if((expected) && (actual))
     {
         size_t failStart;
@@ -273,10 +306,13 @@ StringEqualNoCaseFailure::StringEqualNoCaseFailure(UtestShell* test, const char*
     }
 }
 
-BinaryEqualFailure::BinaryEqualFailure(UtestShell* test, const char* fileName, int lineNumber, const unsigned char* expected, const unsigned char* actual, size_t size) :
-		TestFailure(test, fileName, lineNumber)
+BinaryEqualFailure::BinaryEqualFailure(UtestShell* test, const char* fileName, int lineNumber, const unsigned char* expected,
+                                       const unsigned char* actual, size_t size, const SimpleString& text)
+: TestFailure(test, fileName, lineNumber)
 {
-	message_ = createButWasString(StringFromBinaryOrNull(expected, size), StringFromBinaryOrNull(actual, size));
+    message_ = createUserText(text);
+
+	message_ += createButWasString(StringFromBinaryOrNull(expected, size), StringFromBinaryOrNull(actual, size));
 	if ((expected) && (actual))
 	{
 		size_t failStart;
@@ -286,8 +322,11 @@ BinaryEqualFailure::BinaryEqualFailure(UtestShell* test, const char* fileName, i
 	}
 }
 
-BitsEqualFailure::BitsEqualFailure(UtestShell* test, const char* fileName, int lineNumber, unsigned long expected, unsigned long actual, unsigned long mask, size_t byteCount) :
-        TestFailure(test, fileName, lineNumber)
+BitsEqualFailure::BitsEqualFailure(UtestShell* test, const char* fileName, int lineNumber, unsigned long expected, unsigned long actual,
+                                   unsigned long mask, size_t byteCount, const SimpleString& text)
+: TestFailure(test, fileName, lineNumber)
 {
-    message_ = createButWasString(StringFromMaskedBits(expected, mask, byteCount), StringFromMaskedBits(actual, mask, byteCount));
+    message_ = createUserText(text);
+
+    message_ += createButWasString(StringFromMaskedBits(expected, mask, byteCount), StringFromMaskedBits(actual, mask, byteCount));
 }

--- a/src/CppUTest/TestHarness_c.cpp
+++ b/src/CppUTest/TestHarness_c.cpp
@@ -37,22 +37,22 @@ extern "C"
 
 void CHECK_EQUAL_C_INT_LOCATION(int expected, int actual, const char* fileName, int lineNumber)
 {
-    UtestShell::getCurrent()->assertLongsEqual((long)expected, (long)actual, "", fileName, lineNumber, TestTerminatorWithoutExceptions());
+    UtestShell::getCurrent()->assertLongsEqual((long)expected, (long)actual, NULL, fileName, lineNumber, TestTerminatorWithoutExceptions());
 }
 
 void CHECK_EQUAL_C_REAL_LOCATION(double expected, double actual, double threshold, const char* fileName, int lineNumber)
 {
-    UtestShell::getCurrent()->assertDoublesEqual(expected, actual, threshold, "", fileName, lineNumber, TestTerminatorWithoutExceptions());
+    UtestShell::getCurrent()->assertDoublesEqual(expected, actual, threshold, NULL, fileName, lineNumber, TestTerminatorWithoutExceptions());
 }
 
 void CHECK_EQUAL_C_CHAR_LOCATION(char expected, char actual, const char* fileName, int lineNumber)
 {
-    UtestShell::getCurrent()->assertEquals(((expected) != (actual)), StringFrom(expected).asCharString(), StringFrom(actual).asCharString(), "", fileName, lineNumber, TestTerminatorWithoutExceptions());
+    UtestShell::getCurrent()->assertEquals(((expected) != (actual)), StringFrom(expected).asCharString(), StringFrom(actual).asCharString(), NULL, fileName, lineNumber, TestTerminatorWithoutExceptions());
 }
 
 void CHECK_EQUAL_C_STRING_LOCATION(const char* expected, const char* actual, const char* fileName, int lineNumber)
 {
-    UtestShell::getCurrent()->assertCstrEqual(expected, actual, "", fileName, lineNumber, TestTerminatorWithoutExceptions());
+    UtestShell::getCurrent()->assertCstrEqual(expected, actual, NULL, fileName, lineNumber, TestTerminatorWithoutExceptions());
 }
 
 void FAIL_TEXT_C_LOCATION(const char* text, const char* fileName, int lineNumber)
@@ -67,7 +67,7 @@ void FAIL_C_LOCATION(const char* fileName, int lineNumber)
 
 void CHECK_C_LOCATION(int condition, const char* conditionString, const char* fileName, int lineNumber)
 {
-    UtestShell::getCurrent()->assertTrue(condition != 0, "CHECK_C", conditionString, "", fileName, lineNumber, TestTerminatorWithoutExceptions());
+    UtestShell::getCurrent()->assertTrue(condition != 0, "CHECK_C", conditionString, NULL, fileName, lineNumber, TestTerminatorWithoutExceptions());
 }
 
 enum { NO_COUNTDOWN = -1, OUT_OF_MEMORRY = 0 };

--- a/src/CppUTest/TestHarness_c.cpp
+++ b/src/CppUTest/TestHarness_c.cpp
@@ -37,22 +37,22 @@ extern "C"
 
 void CHECK_EQUAL_C_INT_LOCATION(int expected, int actual, const char* fileName, int lineNumber)
 {
-    UtestShell::getCurrent()->assertLongsEqual((long)expected, (long)actual,  fileName, lineNumber, TestTerminatorWithoutExceptions());
+    UtestShell::getCurrent()->assertLongsEqual((long)expected, (long)actual, "", fileName, lineNumber, TestTerminatorWithoutExceptions());
 }
 
 void CHECK_EQUAL_C_REAL_LOCATION(double expected, double actual, double threshold, const char* fileName, int lineNumber)
 {
-    UtestShell::getCurrent()->assertDoublesEqual(expected, actual, threshold,  fileName, lineNumber, TestTerminatorWithoutExceptions());
+    UtestShell::getCurrent()->assertDoublesEqual(expected, actual, threshold, "", fileName, lineNumber, TestTerminatorWithoutExceptions());
 }
 
 void CHECK_EQUAL_C_CHAR_LOCATION(char expected, char actual, const char* fileName, int lineNumber)
 {
-    UtestShell::getCurrent()->assertEquals(((expected) != (actual)), StringFrom(expected).asCharString(), StringFrom(actual).asCharString(), fileName, lineNumber, TestTerminatorWithoutExceptions());
+    UtestShell::getCurrent()->assertEquals(((expected) != (actual)), StringFrom(expected).asCharString(), StringFrom(actual).asCharString(), "", fileName, lineNumber, TestTerminatorWithoutExceptions());
 }
 
 void CHECK_EQUAL_C_STRING_LOCATION(const char* expected, const char* actual, const char* fileName, int lineNumber)
 {
-    UtestShell::getCurrent()->assertCstrEqual(expected, actual, fileName, lineNumber, TestTerminatorWithoutExceptions());
+    UtestShell::getCurrent()->assertCstrEqual(expected, actual, "", fileName, lineNumber, TestTerminatorWithoutExceptions());
 }
 
 void FAIL_TEXT_C_LOCATION(const char* text, const char* fileName, int lineNumber)

--- a/src/CppUTest/TestHarness_c.cpp
+++ b/src/CppUTest/TestHarness_c.cpp
@@ -67,7 +67,7 @@ void FAIL_C_LOCATION(const char* fileName, int lineNumber)
 
 void CHECK_C_LOCATION(int condition, const char* conditionString, const char* fileName, int lineNumber)
 {
-    UtestShell::getCurrent()->assertTrue(condition != 0, "CHECK_C", conditionString, fileName, lineNumber, TestTerminatorWithoutExceptions());
+    UtestShell::getCurrent()->assertTrue(condition != 0, "CHECK_C", conditionString, "", fileName, lineNumber, TestTerminatorWithoutExceptions());
 }
 
 enum { NO_COUNTDOWN = -1, OUT_OF_MEMORRY = 0 };

--- a/src/CppUTest/Utest.cpp
+++ b/src/CppUTest/Utest.cpp
@@ -341,12 +341,7 @@ void UtestShell::failWith(const TestFailure& failure, const TestTerminator& term
     terminator.exitCurrentTest();
 } // LCOV_EXCL_LINE
 
-void UtestShell::assertTrue(bool condition, const char * checkString, const char* conditionString, const char* fileName, int lineNumber, const TestTerminator& testTerminator)
-{
-    assertTrueText(condition, checkString, conditionString, "", fileName, lineNumber, testTerminator);
-}
-
-void UtestShell::assertTrueText(bool condition, const char *checkString, const char *conditionString, const char* text, const char *fileName, int lineNumber, const TestTerminator& testTerminator)
+void UtestShell::assertTrue(bool condition, const char *checkString, const char *conditionString, const char* text, const char *fileName, int lineNumber, const TestTerminator& testTerminator)
 {
     getTestResult()->countCheck();
     if (!condition)

--- a/src/CppUTest/Utest.cpp
+++ b/src/CppUTest/Utest.cpp
@@ -359,106 +359,106 @@ void UtestShell::fail(const char *text, const char* fileName, int lineNumber, co
     failWith(FailFailure(this, fileName, lineNumber, text), testTerminator);
 } // LCOV_EXCL_LINE
 
-void UtestShell::assertCstrEqual(const char* expected, const char* actual, const char* fileName, int lineNumber, const TestTerminator& testTerminator)
+void UtestShell::assertCstrEqual(const char* expected, const char* actual, const char* text, const char* fileName, int lineNumber, const TestTerminator& testTerminator)
 {
     getTestResult()->countCheck();
     if (actual == 0 && expected == 0) return;
     if (actual == 0 || expected == 0)
-        failWith(StringEqualFailure(this, fileName, lineNumber, expected, actual), testTerminator);
+        failWith(StringEqualFailure(this, fileName, lineNumber, expected, actual, text), testTerminator);
     if (SimpleString::StrCmp(expected, actual) != 0)
-        failWith(StringEqualFailure(this, fileName, lineNumber, expected, actual), testTerminator);
+        failWith(StringEqualFailure(this, fileName, lineNumber, expected, actual, text), testTerminator);
 }
 
-void UtestShell::assertCstrNEqual(const char* expected, const char* actual, size_t length, const char* fileName, int lineNumber, const TestTerminator& testTerminator)
+void UtestShell::assertCstrNEqual(const char* expected, const char* actual, size_t length, const char* text, const char* fileName, int lineNumber, const TestTerminator& testTerminator)
 {
     getTestResult()->countCheck();
     if (actual == 0 && expected == 0) return;
     if (actual == 0 || expected == 0)
-        failWith(StringEqualFailure(this, fileName, lineNumber, expected, actual), testTerminator);
+        failWith(StringEqualFailure(this, fileName, lineNumber, expected, actual, text), testTerminator);
     if (SimpleString::StrNCmp(expected, actual, length) != 0)
-        failWith(StringEqualFailure(this, fileName, lineNumber, expected, actual), testTerminator);
+        failWith(StringEqualFailure(this, fileName, lineNumber, expected, actual, text), testTerminator);
 }
 
-void UtestShell::assertCstrNoCaseEqual(const char* expected, const char* actual, const char* fileName, int lineNumber)
+void UtestShell::assertCstrNoCaseEqual(const char* expected, const char* actual, const char* text, const char* fileName, int lineNumber)
 {
     getTestResult()->countCheck();
     if (actual == 0 && expected == 0) return;
     if (actual == 0 || expected == 0)
-        failWith(StringEqualNoCaseFailure(this, fileName, lineNumber, expected, actual));
+        failWith(StringEqualNoCaseFailure(this, fileName, lineNumber, expected, actual, text));
     if (!SimpleString(expected).equalsNoCase(actual))
-        failWith(StringEqualNoCaseFailure(this, fileName, lineNumber, expected, actual));
+        failWith(StringEqualNoCaseFailure(this, fileName, lineNumber, expected, actual, text));
 }
 
-void UtestShell::assertCstrContains(const char* expected, const char* actual, const char* fileName, int lineNumber)
+void UtestShell::assertCstrContains(const char* expected, const char* actual, const char* text, const char* fileName, int lineNumber)
 {
     getTestResult()->countCheck();
     if (actual == 0 && expected == 0) return;
     if(actual == 0 || expected == 0)
-    	failWith(ContainsFailure(this, fileName, lineNumber, expected, actual));
+        failWith(ContainsFailure(this, fileName, lineNumber, expected, actual, text));
     if (!SimpleString(actual).contains(expected))
-    	failWith(ContainsFailure(this, fileName, lineNumber, expected, actual));
+        failWith(ContainsFailure(this, fileName, lineNumber, expected, actual, text));
 }
 
-void UtestShell::assertCstrNoCaseContains(const char* expected, const char* actual, const char* fileName, int lineNumber)
+void UtestShell::assertCstrNoCaseContains(const char* expected, const char* actual, const char* text, const char* fileName, int lineNumber)
 {
     getTestResult()->countCheck();
     if (actual == 0 && expected == 0) return;
     if(actual == 0 || expected == 0)
-    	failWith(ContainsFailure(this, fileName, lineNumber, expected, actual));
+        failWith(ContainsFailure(this, fileName, lineNumber, expected, actual, text));
     if (!SimpleString(actual).containsNoCase(expected))
-    	failWith(ContainsFailure(this, fileName, lineNumber, expected, actual));
+        failWith(ContainsFailure(this, fileName, lineNumber, expected, actual, text));
 }
 
-void UtestShell::assertLongsEqual(long expected, long actual, const char* fileName, int lineNumber, const TestTerminator& testTerminator)
+void UtestShell::assertLongsEqual(long expected, long actual, const char* text, const char* fileName, int lineNumber, const TestTerminator& testTerminator)
 {
     getTestResult()->countCheck();
     if (expected != actual)
-        failWith(LongsEqualFailure (this, fileName, lineNumber, expected, actual), testTerminator);
+        failWith(LongsEqualFailure (this, fileName, lineNumber, expected, actual, text), testTerminator);
 }
 
-void UtestShell::assertUnsignedLongsEqual(unsigned long expected, unsigned long actual, const char* fileName, int lineNumber, const TestTerminator& testTerminator)
+void UtestShell::assertUnsignedLongsEqual(unsigned long expected, unsigned long actual, const char* text, const char* fileName, int lineNumber, const TestTerminator& testTerminator)
 {
     getTestResult()->countCheck();
     if (expected != actual)
-        failWith(UnsignedLongsEqualFailure (this, fileName, lineNumber, expected, actual), testTerminator);
+        failWith(UnsignedLongsEqualFailure (this, fileName, lineNumber, expected, actual, text), testTerminator);
 }
 
-void UtestShell::assertPointersEqual(const void* expected, const void* actual, const char* fileName, int lineNumber)
+void UtestShell::assertPointersEqual(const void* expected, const void* actual, const char* text, const char* fileName, int lineNumber)
 {
     getTestResult()->countCheck();
     if (expected != actual)
-        failWith(EqualsFailure(this, fileName, lineNumber, StringFrom(expected), StringFrom(actual)));
+        failWith(EqualsFailure(this, fileName, lineNumber, StringFrom(expected), StringFrom(actual), text));
 }
 
-void UtestShell::assertDoublesEqual(double expected, double actual, double threshold, const char* fileName, int lineNumber, const TestTerminator& testTerminator)
+void UtestShell::assertDoublesEqual(double expected, double actual, double threshold, const char* text, const char* fileName, int lineNumber, const TestTerminator& testTerminator)
 {
     getTestResult()->countCheck();
     if (!doubles_equal(expected, actual, threshold))
-        failWith(DoublesEqualFailure(this, fileName, lineNumber, expected, actual, threshold), testTerminator);
+        failWith(DoublesEqualFailure(this, fileName, lineNumber, expected, actual, threshold, text), testTerminator);
 }
 
-void UtestShell::assertBinaryEqual(const void *expected, const void *actual, size_t length, const char *fileName, int lineNumber, const TestTerminator& testTerminator)
+void UtestShell::assertBinaryEqual(const void *expected, const void *actual, size_t length, const char* text, const char *fileName, int lineNumber, const TestTerminator& testTerminator)
 {
     getTestResult()->countCheck();
     if (actual == 0 && expected == 0) return;
     if (actual == 0 || expected == 0)
-        failWith(BinaryEqualFailure(this, fileName, lineNumber, (const unsigned char *) expected, (const unsigned char *) actual, length), testTerminator);
+        failWith(BinaryEqualFailure(this, fileName, lineNumber, (const unsigned char *) expected, (const unsigned char *) actual, length, text), testTerminator);
     if (SimpleString::MemCmp(expected, actual, length) != 0)
-        failWith(BinaryEqualFailure(this, fileName, lineNumber, (const unsigned char *) expected, (const unsigned char *) actual, length), testTerminator);
+        failWith(BinaryEqualFailure(this, fileName, lineNumber, (const unsigned char *) expected, (const unsigned char *) actual, length, text), testTerminator);
 }
 
-void UtestShell::assertBitsEqual(unsigned long expected, unsigned long actual, unsigned long mask, size_t byteCount, const char *fileName, int lineNumber, const TestTerminator& testTerminator)
+void UtestShell::assertBitsEqual(unsigned long expected, unsigned long actual, unsigned long mask, size_t byteCount, const char* text, const char *fileName, int lineNumber, const TestTerminator& testTerminator)
 {
     getTestResult()->countCheck();
     if ((expected & mask) != (actual & mask))
-        failWith(BitsEqualFailure(this, fileName, lineNumber, expected, actual, mask, byteCount), testTerminator);
+        failWith(BitsEqualFailure(this, fileName, lineNumber, expected, actual, mask, byteCount, text), testTerminator);
 }
 
-void UtestShell::assertEquals(bool failed, const char* expected, const char* actual, const char* file, int line, const TestTerminator& testTerminator)
+void UtestShell::assertEquals(bool failed, const char* expected, const char* actual, const char* text, const char* file, int line, const TestTerminator& testTerminator)
 {
     getTestResult()->countCheck();
     if (failed)
-        failWith(CheckEqualFailure(this, file, line, expected, actual), testTerminator);
+        failWith(CheckEqualFailure(this, file, line, expected, actual, text), testTerminator);
 }
 
 

--- a/tests/CppUTestExt/CodeMemoryReportFormatterTest.cpp
+++ b/tests/CppUTestExt/CodeMemoryReportFormatterTest.cpp
@@ -30,8 +30,8 @@
 #include "CppUTestExt/MemoryReportAllocator.h"
 #include "CppUTestExt/CodeMemoryReportFormatter.h"
 
-#define TESTOUPUT_EQUAL(a) STRCMP_EQUAL_LOCATION(a, testOutput.getOutput().asCharString(), __FILE__, __LINE__);
-#define TESTOUPUT_CONTAINS(a) STRCMP_CONTAINS_LOCATION(a, testOutput.getOutput().asCharString(), __FILE__, __LINE__);
+#define TESTOUPUT_EQUAL(a) STRCMP_EQUAL_LOCATION(a, testOutput.getOutput().asCharString(), "", __FILE__, __LINE__);
+#define TESTOUPUT_CONTAINS(a) STRCMP_CONTAINS_LOCATION(a, testOutput.getOutput().asCharString(), "", __FILE__, __LINE__);
 
 TEST_GROUP(CodeMemoryReportFormatter)
 {

--- a/tests/CppUTestExt/MemoryReportFormatterTest.cpp
+++ b/tests/CppUTestExt/MemoryReportFormatterTest.cpp
@@ -30,7 +30,7 @@
 #include "CppUTestExt/MemoryReportAllocator.h"
 #include "CppUTestExt/MemoryReportFormatter.h"
 
-#define TESTOUPUT_EQUAL(a) STRCMP_EQUAL_LOCATION(a, testOutput.getOutput().asCharString(), __FILE__, __LINE__);
+#define TESTOUPUT_EQUAL(a) STRCMP_EQUAL_LOCATION(a, testOutput.getOutput().asCharString(), "", __FILE__, __LINE__);
 
 TEST_GROUP(NormalMemoryReportFormatter)
 {

--- a/tests/TestFailureNaNTest.cpp
+++ b/tests/TestFailureNaNTest.cpp
@@ -62,12 +62,11 @@ TEST_GROUP(TestFailureNanAndInf)
         delete test;
     }
 };
-
-#define FAILURE_EQUAL(a, b) STRCMP_EQUAL_LOCATION(a, b.getMessage().asCharString(), __FILE__, __LINE__)
+#define FAILURE_EQUAL(a, b) STRCMP_EQUAL_LOCATION(a, b.getMessage().asCharString(), "", __FILE__, __LINE__)
 
 TEST(TestFailureNanAndInf, DoublesEqualExpectedIsNaN)
 {
-    DoublesEqualFailure  f(test, failFileName, failLineNumber, not_a_number, 2.0, 3.0);
+    DoublesEqualFailure f(test, failFileName, failLineNumber, not_a_number, 2.0, 3.0, "");
     FAILURE_EQUAL("expected <Nan - Not a number>\n"
                 "\tbut was  <2> threshold used was <3>\n"
                 "\tCannot make comparisons with Nan", f);
@@ -75,7 +74,7 @@ TEST(TestFailureNanAndInf, DoublesEqualExpectedIsNaN)
 
 TEST(TestFailureNanAndInf, DoublesEqualActualIsNaN)
 {
-    DoublesEqualFailure  f(test, failFileName, failLineNumber, 1.0, not_a_number, 3.0);
+    DoublesEqualFailure f(test, failFileName, failLineNumber, 1.0, not_a_number, 3.0, "");
     FAILURE_EQUAL("expected <1>\n"
                 "\tbut was  <Nan - Not a number> threshold used was <3>\n"
                 "\tCannot make comparisons with Nan", f);
@@ -83,7 +82,7 @@ TEST(TestFailureNanAndInf, DoublesEqualActualIsNaN)
 
 TEST(TestFailureNanAndInf, DoublesEqualThresholdIsNaN)
 {
-    DoublesEqualFailure f(test, failFileName, failLineNumber, 1.0, 2.0, not_a_number);
+    DoublesEqualFailure f(test, failFileName, failLineNumber, 1.0, 2.0, not_a_number, "");
     FAILURE_EQUAL("expected <1>\n"
                 "\tbut was  <2> threshold used was <Nan - Not a number>\n"
                 "\tCannot make comparisons with Nan", f);
@@ -91,21 +90,21 @@ TEST(TestFailureNanAndInf, DoublesEqualThresholdIsNaN)
 
 TEST(TestFailureNanAndInf, DoublesEqualExpectedIsInf)
 {
-    DoublesEqualFailure f(test, failFileName, failLineNumber, infinity, 2.0, 3.0);
+    DoublesEqualFailure f(test, failFileName, failLineNumber, infinity, 2.0, 3.0, "");
     FAILURE_EQUAL("expected <Inf - Infinity>\n"
                 "\tbut was  <2> threshold used was <3>", f);
 }
 
 TEST(TestFailureNanAndInf, DoublesEqualActualIsInf)
 {
-    DoublesEqualFailure f(test, failFileName, failLineNumber, 1.0, infinity, 3.0);
+    DoublesEqualFailure f(test, failFileName, failLineNumber, 1.0, infinity, 3.0, "");
     FAILURE_EQUAL("expected <1>\n"
                 "\tbut was  <Inf - Infinity> threshold used was <3>", f);
 }
 
 TEST(TestFailureNanAndInf, DoublesEqualThresholdIsInf)
 {
-    DoublesEqualFailure f(test, failFileName, failLineNumber, 1.0, not_a_number, infinity);
+    DoublesEqualFailure f(test, failFileName, failLineNumber, 1.0, not_a_number, infinity, "");
     FAILURE_EQUAL("expected <1>\n"
                 "\tbut was  <Nan - Not a number> threshold used was <Inf - Infinity>\n"
                 "\tCannot make comparisons with Nan", f);

--- a/tests/TestFailureTest.cpp
+++ b/tests/TestFailureTest.cpp
@@ -47,7 +47,7 @@ TEST_GROUP(TestFailure)
         delete test;
     }
 };
-#define FAILURE_EQUAL(a, b) STRCMP_EQUAL_LOCATION(a, b.getMessage().asCharString(), __FILE__, __LINE__)
+#define FAILURE_EQUAL(a, b) STRCMP_EQUAL_LOCATION(a, b.getMessage().asCharString(), "", __FILE__, __LINE__)
 
 TEST(TestFailure, CreateFailure)
 {
@@ -63,27 +63,44 @@ TEST(TestFailure, GetTestFileAndLineFromFailure)
     LONGS_EQUAL(1, f1.getTestLineNumber());
 }
 
-TEST(TestFailure, CreatePassingEqualsFailure)
+TEST(TestFailure, EqualsFailureWithText)
 {
-    EqualsFailure f(test, failFileName, failLineNumber, "expected", "actual");
+    EqualsFailure f(test, failFileName, failLineNumber, "expected", "actual", "text");
+    FAILURE_EQUAL("Message: text\n"
+                  "\texpected <expected>\n\tbut was  <actual>", f);
+}
+
+TEST(TestFailure, EqualsFailure)
+{
+    EqualsFailure f(test, failFileName, failLineNumber, "expected", "actual", "");
     FAILURE_EQUAL("expected <expected>\n\tbut was  <actual>", f);
 }
 
 TEST(TestFailure, EqualsFailureWithNullAsActual)
 {
-    EqualsFailure f(test, failFileName, failLineNumber, "expected", NULL);
+    EqualsFailure f(test, failFileName, failLineNumber, "expected", NULL, "");
     FAILURE_EQUAL("expected <expected>\n\tbut was  <(null)>", f);
 }
 
 TEST(TestFailure, EqualsFailureWithNullAsExpected)
 {
-    EqualsFailure f(test, failFileName, failLineNumber, NULL, "actual");
+    EqualsFailure f(test, failFileName, failLineNumber, NULL, "actual", "");
     FAILURE_EQUAL("expected <(null)>\n\tbut was  <actual>", f);
+}
+
+TEST(TestFailure, CheckEqualFailureWithText)
+{
+    CheckEqualFailure f(test, failFileName, failLineNumber, "expected", "actual", "text");
+    FAILURE_EQUAL("Message: text\n"
+                  "\texpected <expected>\n"
+                  "\tbut was  <actual>\n"
+                  "\tdifference starts at position 0 at: <          actual    >\n"
+                  "\t                                               ^", f);
 }
 
 TEST(TestFailure, CheckEqualFailure)
 {
-    CheckEqualFailure f(test, failFileName, failLineNumber, "expected", "actual");
+    CheckEqualFailure f(test, failFileName, failLineNumber, "expected", "actual", "");
     FAILURE_EQUAL("expected <expected>\n"
                   "\tbut was  <actual>\n"
                   "\tdifference starts at position 0 at: <          actual    >\n"
@@ -109,15 +126,32 @@ TEST(TestFailure, FailFailure)
     FAILURE_EQUAL("chk", f);
 }
 
+TEST(TestFailure, LongsEqualFailureWithText)
+{
+    LongsEqualFailure f(test, failFileName, failLineNumber, 1, 2, "text");
+    FAILURE_EQUAL("Message: text\n"
+                  "\texpected <1 0x1>\n\tbut was  <2 0x2>", f);
+}
+
 TEST(TestFailure, LongsEqualFailure)
 {
-    LongsEqualFailure f(test, failFileName, failLineNumber, 1, 2);
+    LongsEqualFailure f(test, failFileName, failLineNumber, 1, 2, "");
     FAILURE_EQUAL("expected <1 0x1>\n\tbut was  <2 0x2>", f);
+}
+
+TEST(TestFailure, StringsEqualFailureWithText)
+{
+    StringEqualFailure f(test, failFileName, failLineNumber, "abc", "abd", "text");
+    FAILURE_EQUAL("Message: text\n"
+                  "\texpected <abc>\n"
+                  "\tbut was  <abd>\n"
+                  "\tdifference starts at position 2 at: <        abd         >\n"
+                  "\t                                               ^", f);
 }
 
 TEST(TestFailure, StringsEqualFailure)
 {
-    StringEqualFailure f(test, failFileName, failLineNumber, "abc", "abd");
+    StringEqualFailure f(test, failFileName, failLineNumber, "abc", "abd", "");
     FAILURE_EQUAL("expected <abc>\n"
                 "\tbut was  <abd>\n"
                 "\tdifference starts at position 2 at: <        abd         >\n"
@@ -126,7 +160,7 @@ TEST(TestFailure, StringsEqualFailure)
 
 TEST(TestFailure, StringsEqualFailureAtTheEnd)
 {
-    StringEqualFailure f(test, failFileName, failLineNumber, "abc", "ab");
+    StringEqualFailure f(test, failFileName, failLineNumber, "abc", "ab", "");
     FAILURE_EQUAL("expected <abc>\n"
                 "\tbut was  <ab>\n"
                 "\tdifference starts at position 2 at: <        ab          >\n"
@@ -135,7 +169,7 @@ TEST(TestFailure, StringsEqualFailureAtTheEnd)
 
 TEST(TestFailure, StringsEqualFailureNewVariantAtTheEnd)
 {
-    StringEqualFailure f(test, failFileName, failLineNumber, "EndOfALongerString", "EndOfALongerStrinG");
+    StringEqualFailure f(test, failFileName, failLineNumber, "EndOfALongerString", "EndOfALongerStrinG", "");
     FAILURE_EQUAL("expected <EndOfALongerString>\n"
                 "\tbut was  <EndOfALongerStrinG>\n"
                 "\tdifference starts at position 17 at: <ongerStrinG         >\n"
@@ -146,7 +180,7 @@ TEST(TestFailure, StringsEqualFailureWithNewLinesAndTabs)
 {
     StringEqualFailure f(test, failFileName, failLineNumber,
             "StringWith\t\nDifferentString",
-            "StringWith\t\ndifferentString");
+            "StringWith\t\ndifferentString", "");
 
     FAILURE_EQUAL("expected <StringWith\t\nDifferentString>\n"
                 "\tbut was  <StringWith\t\ndifferentString>\n"
@@ -156,7 +190,7 @@ TEST(TestFailure, StringsEqualFailureWithNewLinesAndTabs)
 
 TEST(TestFailure, StringsEqualFailureInTheMiddle)
 {
-    StringEqualFailure f(test, failFileName, failLineNumber, "aa", "ab");
+    StringEqualFailure f(test, failFileName, failLineNumber, "aa", "ab", "");
     FAILURE_EQUAL("expected <aa>\n"
                 "\tbut was  <ab>\n"
                 "\tdifference starts at position 1 at: <         ab         >\n"
@@ -165,7 +199,7 @@ TEST(TestFailure, StringsEqualFailureInTheMiddle)
 
 TEST(TestFailure, StringsEqualFailureAtTheBeginning)
 {
-    StringEqualFailure f(test, failFileName, failLineNumber, "aaa", "bbb");
+    StringEqualFailure f(test, failFileName, failLineNumber, "aaa", "bbb", "");
     FAILURE_EQUAL("expected <aaa>\n"
                 "\tbut was  <bbb>\n"
                 "\tdifference starts at position 0 at: <          bbb       >\n"
@@ -174,21 +208,31 @@ TEST(TestFailure, StringsEqualFailureAtTheBeginning)
 
 TEST(TestFailure, StringsEqualFailureWithNullAsActual)
 {
-    StringEqualFailure f(test, failFileName, failLineNumber, "abc", NULL);
+    StringEqualFailure f(test, failFileName, failLineNumber, "abc", NULL, "");
     FAILURE_EQUAL("expected <abc>\n"
                 "\tbut was  <(null)>", f);
 }
 
 TEST(TestFailure, StringsEqualFailureWithNullAsExpected)
 {
-    StringEqualFailure f(test, failFileName, failLineNumber, NULL, "abd");
+    StringEqualFailure f(test, failFileName, failLineNumber, NULL, "abd", "");
     FAILURE_EQUAL("expected <(null)>\n"
                 "\tbut was  <abd>", f);
 }
 
+TEST(TestFailure, StringsEqualNoCaseFailureWithText)
+{
+    StringEqualNoCaseFailure f(test, failFileName, failLineNumber, "ABC", "abd", "text");
+    FAILURE_EQUAL("Message: text\n"
+                  "\texpected <ABC>\n"
+                  "\tbut was  <abd>\n"
+                  "\tdifference starts at position 2 at: <        abd         >\n"
+                  "\t                                               ^", f);
+}
+
 TEST(TestFailure, StringsEqualNoCaseFailure)
 {
-    StringEqualNoCaseFailure f(test, failFileName, failLineNumber, "ABC", "abd");
+    StringEqualNoCaseFailure f(test, failFileName, failLineNumber, "ABC", "abd", "");
     FAILURE_EQUAL("expected <ABC>\n"
                 "\tbut was  <abd>\n"
                 "\tdifference starts at position 2 at: <        abd         >\n"
@@ -197,39 +241,59 @@ TEST(TestFailure, StringsEqualNoCaseFailure)
 
 TEST(TestFailure, StringsEqualNoCaseFailureWithActualAsNull)
 {
-    StringEqualNoCaseFailure f(test, failFileName, failLineNumber, "ABC", NULL);
+    StringEqualNoCaseFailure f(test, failFileName, failLineNumber, "ABC", NULL, "");
     FAILURE_EQUAL("expected <ABC>\n"
                 "\tbut was  <(null)>", f);
 }
 
 TEST(TestFailure, StringsEqualNoCaseFailureWithExpectedAsNull)
 {
-    StringEqualNoCaseFailure f(test, failFileName, failLineNumber, NULL, "abd");
+    StringEqualNoCaseFailure f(test, failFileName, failLineNumber, NULL, "abd", "");
     FAILURE_EQUAL("expected <(null)>\n"
                 "\tbut was  <abd>", f);
 }
 
 TEST(TestFailure, StringsEqualNoCaseFailure2)
 {
-    StringEqualNoCaseFailure f(test, failFileName, failLineNumber, "ac", "AB");
+    StringEqualNoCaseFailure f(test, failFileName, failLineNumber, "ac", "AB", "");
     FAILURE_EQUAL("expected <ac>\n"
                 "\tbut was  <AB>\n"
                 "\tdifference starts at position 1 at: <         AB         >\n"
                 "\t                                               ^", f);
 }
 
+TEST(TestFailure, DoublesEqualNormalWithText)
+{
+    DoublesEqualFailure f(test, failFileName, failLineNumber, 1.0, 2.0, 3.0, "text");
+    FAILURE_EQUAL("Message: text\n"
+                  "\texpected <1>\n"
+                  "\tbut was  <2> threshold used was <3>", f);
+}
+
 TEST(TestFailure, DoublesEqualNormal)
 {
-    DoublesEqualFailure f(test, failFileName, failLineNumber, 1.0, 2.0, 3.0);
+    DoublesEqualFailure f(test, failFileName, failLineNumber, 1.0, 2.0, 3.0, "");
     FAILURE_EQUAL("expected <1>\n"
                 "\tbut was  <2> threshold used was <3>", f);
+}
+
+TEST(TestFailure, BinaryEqualWithText)
+{
+    const unsigned char expectedData[] = { 0x00 };
+    const unsigned char actualData[] = { 0x01 };
+    BinaryEqualFailure f(test, failFileName, failLineNumber, expectedData, actualData, sizeof(expectedData), "text");
+    FAILURE_EQUAL("Message: text\n"
+                  "\texpected <00>\n"
+                  "\tbut was  <01>\n"
+                  "\tdifference starts at position 0 at: <         01         >\n"
+                  "\t                                               ^", f);
 }
 
 TEST(TestFailure, BinaryEqualOneByte)
 {
     const unsigned char expectedData[] = { 0x00 };
     const unsigned char actualData[] = { 0x01 };
-    BinaryEqualFailure f(test, failFileName, failLineNumber, expectedData, actualData, sizeof(expectedData));
+    BinaryEqualFailure f(test, failFileName, failLineNumber, expectedData, actualData, sizeof(expectedData), "");
     FAILURE_EQUAL("expected <00>\n"
                 "\tbut was  <01>\n"
     			"\tdifference starts at position 0 at: <         01         >\n"
@@ -240,7 +304,7 @@ TEST(TestFailure, BinaryEqualTwoBytes)
 {
     const unsigned char expectedData[] = {0x00, 0x01};
     const unsigned char actualData[] = {0x00, 0x02};
-    BinaryEqualFailure f(test, failFileName, failLineNumber, expectedData, actualData, sizeof(expectedData));
+    BinaryEqualFailure f(test, failFileName, failLineNumber, expectedData, actualData, sizeof(expectedData), "");
     FAILURE_EQUAL("expected <00 01>\n"
                 "\tbut was  <00 02>\n"
     			"\tdifference starts at position 1 at: <      00 02         >\n"
@@ -251,7 +315,7 @@ TEST(TestFailure, BinaryEqualThreeBytes)
 {
     const unsigned char expectedData[] = {0x00, 0x01, 0x00};
     const unsigned char actualData[] = {0x00, 0x02, 0x00};
-    BinaryEqualFailure f(test, failFileName, failLineNumber, expectedData, actualData, sizeof(expectedData));
+    BinaryEqualFailure f(test, failFileName, failLineNumber, expectedData, actualData, sizeof(expectedData), "");
     FAILURE_EQUAL("expected <00 01 00>\n"
                 "\tbut was  <00 02 00>\n"
     			"\tdifference starts at position 1 at: <      00 02 00      >\n"
@@ -262,7 +326,7 @@ TEST(TestFailure, BinaryEqualFullWidth)
 {
     const unsigned char expectedData[] = {0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00};
     const unsigned char actualData[] = {0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00};
-    BinaryEqualFailure f(test, failFileName, failLineNumber, expectedData, actualData, sizeof(expectedData));
+    BinaryEqualFailure f(test, failFileName, failLineNumber, expectedData, actualData, sizeof(expectedData), "");
     FAILURE_EQUAL("expected <00 00 00 01 00 00 00>\n"
                 "\tbut was  <00 00 00 02 00 00 00>\n"
     			"\tdifference starts at position 3 at: <00 00 00 02 00 00 00>\n"
@@ -273,7 +337,7 @@ TEST(TestFailure, BinaryEqualLast)
 {
     const unsigned char expectedData[] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
 	const unsigned char actualData[] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01};
-    BinaryEqualFailure f(test, failFileName, failLineNumber, expectedData, actualData, sizeof(expectedData));
+    BinaryEqualFailure f(test, failFileName, failLineNumber, expectedData, actualData, sizeof(expectedData), "");
     FAILURE_EQUAL("expected <00 00 00 00 00 00 00>\n"
                 "\tbut was  <00 00 00 00 00 00 01>\n"
     			"\tdifference starts at position 6 at: <00 00 00 01         >\n"
@@ -283,32 +347,39 @@ TEST(TestFailure, BinaryEqualLast)
 TEST(TestFailure, BinaryEqualActualNull)
 {
     const unsigned char expectedData[] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
-    BinaryEqualFailure f(test, failFileName, failLineNumber, expectedData, NULL, sizeof(expectedData));
+    BinaryEqualFailure f(test, failFileName, failLineNumber, expectedData, NULL, sizeof(expectedData), "");
     FAILURE_EQUAL("expected <00 00 00 00 00 00 00>\n\tbut was  <(null)>", f);
 }
 
 TEST(TestFailure, BinaryEqualExpectedNull)
 {
     const unsigned char actualData[] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01};
-    BinaryEqualFailure f(test, failFileName, failLineNumber, NULL, actualData, sizeof(actualData));
+    BinaryEqualFailure f(test, failFileName, failLineNumber, NULL, actualData, sizeof(actualData), "");
     FAILURE_EQUAL("expected <(null)>\n\tbut was  <00 00 00 00 00 00 01>", f);
+}
+
+TEST(TestFailure, BitsEqualWithText)
+{
+    BitsEqualFailure f(test, failFileName, failLineNumber, 0x01, 0x03, 0xFF, 1, "text");
+    FAILURE_EQUAL("Message: text\n"
+                  "\texpected <00000001>\n\tbut was  <00000011>", f);
 }
 
 TEST(TestFailure, BitsEqual1byte)
 {
-    BitsEqualFailure f(test, failFileName, failLineNumber, 0x01, 0x03, 0xFF, 1);
+    BitsEqualFailure f(test, failFileName, failLineNumber, 0x01, 0x03, 0xFF, 1, "");
     FAILURE_EQUAL("expected <00000001>\n\tbut was  <00000011>", f);
 }
 
 TEST(TestFailure, BitsEqual2bytes)
 {
-    BitsEqualFailure f(test, failFileName, failLineNumber, 0x0001, 0x0003, 0xFFFF, 2);
+    BitsEqualFailure f(test, failFileName, failLineNumber, 0x0001, 0x0003, 0xFFFF, 2, "");
     FAILURE_EQUAL("expected <00000000 00000001>\n\tbut was  <00000000 00000011>", f);
 }
 
 TEST(TestFailure, BitsEqual4bytes)
 {
-    BitsEqualFailure f(test, failFileName, failLineNumber, 0x00000001, 0x00000003, 0xFFFFFFFF, 4);
+    BitsEqualFailure f(test, failFileName, failLineNumber, 0x00000001, 0x00000003, 0xFFFFFFFF, 4, "");
     if (sizeof(long) < 4)
         FAILURE_EQUAL("expected <00000000 00000001>\n\tbut was  <00000000 00000011>", f)
     else

--- a/tests/TestHarness_cTest.cpp
+++ b/tests/TestHarness_cTest.cpp
@@ -143,7 +143,7 @@ TEST(TestHarness_c, checkString)
     fixture->setTestFunction(_failStringMethod);
     fixture->runAllTests();
 
-    StringEqualFailure failure(UtestShell::getCurrent(), "file", 1, "Hello", "Hello World");
+    StringEqualFailure failure(UtestShell::getCurrent(), "file", 1, "Hello", "Hello World", "");
     fixture->assertPrintContains(failure.getMessage());
     fixture->assertPrintContains("arness_c");
     CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)

--- a/tests/TestUTestMacro.cpp
+++ b/tests/TestUTestMacro.cpp
@@ -222,8 +222,44 @@ static void _UNSIGNED_LONGS_EQUALTestMethod()
 TEST(UnitTestMacros, TestUNSIGNED_LONGS_EQUAL)
 {
     runTestWithMethod(_UNSIGNED_LONGS_EQUALTestMethod);
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <1 (0x1) 0x1>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <0 (0x0) 0x0>");
 }
+
+TEST(UnitTestMacros, UNSIGNED_LONGS_EQUALBehavesAsProperMacro)
+{
+    if (false) UNSIGNED_LONGS_EQUAL(1, 0)
+    else UNSIGNED_LONGS_EQUAL(1, 1)
+}
+
+IGNORE_TEST(UnitTestMacros, UNSIGNED_LONGS_EQUALWorksInAnIgnoredTest)
+{
+    UNSIGNED_LONGS_EQUAL(1, 0); // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
+static void _UNSIGNED_LONGS_EQUAL_TEXTTestMethod()
+{
+    UNSIGNED_LONGS_EQUAL_TEXT(1, 0, "Failed because it failed");
+} // LCOV_EXCL_LINE
+
+TEST(UnitTestMacros, TestUNSIGNED_LONGS_EQUAL_TEXT)
+{
+    runTestWithMethod(_UNSIGNED_LONGS_EQUAL_TEXTTestMethod);
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <1 (0x1) 0x1>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <0 (0x0) 0x0>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("Failed because it failed");
+}
+
+TEST(UnitTestMacros, UNSIGNED_LONGS_EQUAL_TEXTBehavesAsProperMacro)
+{
+    if (false) UNSIGNED_LONGS_EQUAL_TEXT(1, 0, "Failed because it failed")
+    else UNSIGNED_LONGS_EQUAL_TEXT(1, 1, "Failed because it failed")
+}
+
+IGNORE_TEST(UnitTestMacros, UNSIGNED_LONGS_EQUAL_TEXTWorksInAnIgnoredTest)
+{
+    UNSIGNED_LONGS_EQUAL_TEXT(1, 0, "Failed because it failed"); // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
 
 static void _failingTestMethodWithCHECK()
 {
@@ -234,7 +270,7 @@ static void _failingTestMethodWithCHECK()
 TEST(UnitTestMacros, FailureWithCHECK)
 {
     runTestWithMethod(_failingTestMethodWithCHECK);
-    CHECK_TEST_FAILS_PROPER_WITH_TEXT("false");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("CHECK(false) failed");
 }
 
 TEST(UnitTestMacros, CHECKBehavesAsProperMacro)
@@ -242,6 +278,11 @@ TEST(UnitTestMacros, CHECKBehavesAsProperMacro)
     if (false) CHECK(false)
     else CHECK(true)
 }
+
+IGNORE_TEST(UnitTestMacros, CHECKWorksInAnIgnoredTest)
+{
+    CHECK(false); // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
 
 static void _failingTestMethodWithCHECK_TEXT()
 {
@@ -252,6 +293,7 @@ static void _failingTestMethodWithCHECK_TEXT()
 TEST(UnitTestMacros, FailureWithCHECK_TEXT)
 {
     runTestWithMethod(_failingTestMethodWithCHECK_TEXT);
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("CHECK(false) failed");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("Failed because it failed");
 }
 
@@ -261,7 +303,7 @@ TEST(UnitTestMacros, CHECK_TEXTBehavesAsProperMacro)
     else CHECK_TEXT(true, "true")
 }
 
-IGNORE_TEST(UnitTestMacros, CHECKWorksInAnIgnoredTest)
+IGNORE_TEST(UnitTestMacros, CHECK_TEXTWorksInAnIgnoredTest)
 {
     CHECK_TEXT(false, "false"); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
@@ -275,7 +317,7 @@ static void _failingTestMethodWithCHECK_TRUE()
 TEST(UnitTestMacros, FailureWithCHECK_TRUE)
 {
     runTestWithMethod(_failingTestMethodWithCHECK_TRUE);
-    CHECK_TEST_FAILS_PROPER_WITH_TEXT("CHECK_TRUE");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("CHECK_TRUE(false) failed");
 }
 
 TEST(UnitTestMacros, CHECK_TRUEBehavesAsProperMacro)
@@ -289,6 +331,30 @@ IGNORE_TEST(UnitTestMacros, CHECK_TRUEWorksInAnIgnoredTest)
     CHECK_TRUE(false) // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
+static void _failingTestMethodWithCHECK_TRUE_TEXT()
+{
+    CHECK_TRUE_TEXT(false, "Failed because it failed");
+    lineOfCodeExecutedAfterCheck = true; // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
+TEST(UnitTestMacros, FailureWithCHECK_TRUE_TEXT)
+{
+    runTestWithMethod(_failingTestMethodWithCHECK_TRUE_TEXT);
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("CHECK_TRUE(false) failed");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("Failed because it failed");
+}
+
+TEST(UnitTestMacros, CHECK_TRUE_TEXTBehavesAsProperMacro)
+{
+    if (false) CHECK_TRUE_TEXT(false, "Failed because it failed")
+    else CHECK_TRUE_TEXT(true, "Failed because it failed")
+}
+
+IGNORE_TEST(UnitTestMacros, CHECK_TRUE_TEXTWorksInAnIgnoredTest)
+{
+    CHECK_TRUE_TEXT(false, "Failed because it failed") // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
 static void _failingTestMethodWithCHECK_FALSE()
 {
     CHECK_FALSE(true);
@@ -298,7 +364,7 @@ static void _failingTestMethodWithCHECK_FALSE()
 TEST(UnitTestMacros, FailureWithCHECK_FALSE)
 {
     runTestWithMethod(_failingTestMethodWithCHECK_FALSE);
-    CHECK_TEST_FAILS_PROPER_WITH_TEXT("CHECK_FALSE");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("CHECK_FALSE(true) failed");
 }
 
 TEST(UnitTestMacros, CHECK_FALSEBehavesAsProperMacro)
@@ -312,6 +378,30 @@ IGNORE_TEST(UnitTestMacros, CHECK_FALSEWorksInAnIgnoredTest)
     CHECK_FALSE(true) // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
+static void _failingTestMethodWithCHECK_FALSE_TEXT()
+{
+    CHECK_FALSE_TEXT(true, "Failed because it failed");
+    lineOfCodeExecutedAfterCheck = true; // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
+TEST(UnitTestMacros, FailureWithCHECK_FALSE_TEXT)
+{
+    runTestWithMethod(_failingTestMethodWithCHECK_FALSE_TEXT);
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("CHECK_FALSE(true)");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("Failed because it failed");
+}
+
+TEST(UnitTestMacros, CHECK_FALSE_TEXTBehavesAsProperMacro)
+{
+    if (false) CHECK_FALSE_TEXT(true, "Failed because it failed")
+    else CHECK_FALSE_TEXT(false, "Failed because it failed")
+}
+
+IGNORE_TEST(UnitTestMacros, CHECK_FALSE_TEXTWorksInAnIgnoredTest)
+{
+    CHECK_FALSE_TEXT(true, "Failed because it failed") // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
 static void _failingTestMethodWithCHECK_EQUAL()
 {
     CHECK_EQUAL(1, 2);
@@ -322,6 +412,7 @@ TEST(UnitTestMacros, FailureWithCHECK_EQUAL)
 {
     runTestWithMethod(_failingTestMethodWithCHECK_EQUAL);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <1>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <2>");
 }
 
 static int countInCountingMethod;
@@ -377,6 +468,178 @@ IGNORE_TEST(UnitTestMacros, CHECK_EQUALWorksInAnIgnoredTest)
     CHECK_EQUAL(1, 2) // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
+static void _failingTestMethodWithCHECK_EQUAL_TEXT()
+{
+    CHECK_EQUAL_TEXT(1, 2, "Failed because it failed");
+    lineOfCodeExecutedAfterCheck = true; // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
+TEST(UnitTestMacros, FailureWithCHECK_EQUAL_TEXT)
+{
+    runTestWithMethod(_failingTestMethodWithCHECK_EQUAL_TEXT);
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <1>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <2>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("Failed because it failed");
+}
+
+TEST(UnitTestMacros, CHECK_EQUAL_TEXTBehavesAsProperMacro)
+{
+    if (false) CHECK_EQUAL_TEXT(1, 2, "Failed because it failed")
+    else CHECK_EQUAL_TEXT(1, 1, "Failed because it failed")
+}
+
+IGNORE_TEST(UnitTestMacros, CHECK_EQUAL_TEXTWorksInAnIgnoredTest)
+{
+    CHECK_EQUAL_TEXT(1, 2, "Failed because it failed") // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
+static void _failingTestMethodWithSTRCMP_EQUAL()
+{
+    STRCMP_EQUAL("hello", "hell");
+    lineOfCodeExecutedAfterCheck = true; // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
+TEST(UnitTestMacros, FailureWithSTRCMP_EQUAL)
+{
+    runTestWithMethod(_failingTestMethodWithSTRCMP_EQUAL);
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <hello>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <hell>");
+}
+
+TEST(UnitTestMacros, STRCMP_EQUALBehavesAsProperMacro)
+{
+    if (false) STRCMP_EQUAL("1", "2")
+    else STRCMP_EQUAL("1", "1")
+}
+
+IGNORE_TEST(UnitTestMacros, STRCMP_EQUALWorksInAnIgnoredTest)
+{
+    STRCMP_EQUAL("Hello", "World") // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
+static void _failingTestMethodWithSTRCMP_EQUAL_TEXT()
+{
+    STRCMP_EQUAL_TEXT("hello", "hell", "Failed because it failed");
+    lineOfCodeExecutedAfterCheck = true; // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
+TEST(UnitTestMacros, FailureWithSTRCMP_EQUAL_TEXT)
+{
+    runTestWithMethod(_failingTestMethodWithSTRCMP_EQUAL_TEXT);
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <hello>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <hell>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("Failed because it failed");
+}
+
+TEST(UnitTestMacros, STRCMP_EQUAL_TEXTBehavesAsProperMacro)
+{
+    if (false) STRCMP_EQUAL_TEXT("1", "2", "Failed because it failed")
+    else STRCMP_EQUAL_TEXT("1", "1", "Failed because it failed")
+}
+
+IGNORE_TEST(UnitTestMacros, STRCMP_EQUAL_TEXTWorksInAnIgnoredTest)
+{
+    STRCMP_EQUAL_TEXT("Hello", "World", "Failed because it failed") // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
+static void _failingTestMethodWithSTRNCMP_EQUAL()
+{
+    STRNCMP_EQUAL("hello", "hallo", 5);
+    lineOfCodeExecutedAfterCheck = true; // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
+TEST(UnitTestMacros, FailureWithSTRNCMP_EQUAL)
+{
+    runTestWithMethod(_failingTestMethodWithSTRNCMP_EQUAL);
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <hello>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <hallo>");
+}
+
+TEST(UnitTestMacros, STRNCMP_EQUALBehavesAsProperMacro)
+{
+    if (false) STRNCMP_EQUAL("1", "2", 1)
+    else STRNCMP_EQUAL("1", "1", 1)
+}
+
+IGNORE_TEST(UnitTestMacros, STRNCMP_EQUALWorksInAnIgnoredTest)
+{
+    STRNCMP_EQUAL("Hello", "World", 3) // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
+static void _failingTestMethodWithSTRNCMP_EQUAL_TEXT()
+{
+    STRNCMP_EQUAL_TEXT("hello", "hallo", 5, "Failed because it failed");
+    lineOfCodeExecutedAfterCheck = true; // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
+TEST(UnitTestMacros, FailureWithSTRNCMP_EQUAL_TEXT)
+{
+    runTestWithMethod(_failingTestMethodWithSTRNCMP_EQUAL_TEXT);
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <hello>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <hallo>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("Failed because it failed");
+}
+
+TEST(UnitTestMacros, STRNCMP_EQUAL_TEXTBehavesAsProperMacro)
+{
+    if (false) STRNCMP_EQUAL_TEXT("1", "2", 1, "Failed because it failed")
+    else STRNCMP_EQUAL_TEXT("1", "1", 1, "Failed because it failed")
+}
+
+IGNORE_TEST(UnitTestMacros, STRNCMP_EQUAL_TEXTWorksInAnIgnoredTest)
+{
+    STRNCMP_EQUAL_TEXT("Hello", "World", 3, "Failed because it failed") // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
+static void _failingTestMethodWithSTRCMP_NOCASE_EQUAL()
+{
+    STRCMP_NOCASE_EQUAL("hello", "Hell");
+    lineOfCodeExecutedAfterCheck = true; // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
+TEST(UnitTestMacros, FailureWithSTRCMP_NOCASE_EQUAL)
+{
+    runTestWithMethod(_failingTestMethodWithSTRCMP_NOCASE_EQUAL);
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <hello>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <Hell>");
+}
+
+TEST(UnitTestMacros, STRCMP_NOCASE_EQUALBehavesAsProperMacro)
+{
+    if (false) STRCMP_NOCASE_EQUAL("1", "2")
+    else STRCMP_NOCASE_EQUAL("1", "1")
+}
+
+IGNORE_TEST(UnitTestMacros, STRCMP_NOCASE_EQUALWorksInAnIgnoredTest)
+{
+    STRCMP_NOCASE_EQUAL("Hello", "World") // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
+static void _failingTestMethodWithSTRCMP_NOCASE_EQUAL_TEXT()
+{
+    STRCMP_NOCASE_EQUAL_TEXT("hello", "hell", "Failed because it failed");
+    lineOfCodeExecutedAfterCheck = true; // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
+TEST(UnitTestMacros, FailureWithSTRCMP_NOCASE_EQUAL_TEXT)
+{
+    runTestWithMethod(_failingTestMethodWithSTRCMP_NOCASE_EQUAL_TEXT);
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <hello>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <hell>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("Failed because it failed");
+}
+
+TEST(UnitTestMacros, STRCMP_NOCASE_EQUAL_TEXTBehavesAsProperMacro)
+{
+    if (false) STRCMP_NOCASE_EQUAL_TEXT("1", "2", "Failed because it failed")
+    else STRCMP_NOCASE_EQUAL_TEXT("1", "1", "Failed because it failed")
+}
+
+IGNORE_TEST(UnitTestMacros, STRCMP_NOCASE_EQUAL_TEXTWorksInAnIgnoredTest)
+{
+    STRCMP_NOCASE_EQUAL_TEXT("Hello", "World", "Failed because it failed") // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
 static void _failingTestMethodWithSTRCMP_CONTAINS()
 {
     STRCMP_CONTAINS("hello", "world");
@@ -387,6 +650,7 @@ TEST(UnitTestMacros, FailureWithSTRCMP_CONTAINS)
 {
     runTestWithMethod(_failingTestMethodWithSTRCMP_CONTAINS);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("actual <world>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("did not contain  <hello>");
 }
 
 TEST(UnitTestMacros, STRCMP_CONTAINSBehavesAsProperMacro)
@@ -400,6 +664,31 @@ IGNORE_TEST(UnitTestMacros, STRCMP_CONTAINSWorksInAnIgnoredTest)
     STRCMP_CONTAINS("Hello", "World") // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
+static void _failingTestMethodWithSTRCMP_CONTAINS_TEXT()
+{
+    STRCMP_CONTAINS_TEXT("hello", "world", "Failed because it failed");
+    lineOfCodeExecutedAfterCheck = true; // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
+TEST(UnitTestMacros, FailureWithSTRCMP_CONTAINS_TEXT)
+{
+    runTestWithMethod(_failingTestMethodWithSTRCMP_CONTAINS_TEXT);
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("actual <world>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("did not contain  <hello>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("Failed because it failed");
+}
+
+TEST(UnitTestMacros, STRCMP_CONTAINS_TEXTBehavesAsProperMacro)
+{
+    if (false) STRCMP_CONTAINS_TEXT("1", "2", "Failed because it failed")
+    else STRCMP_CONTAINS_TEXT("1", "1", "Failed because it failed")
+}
+
+IGNORE_TEST(UnitTestMacros, STRCMP_CONTAINS_TEXTWorksInAnIgnoredTest)
+{
+    STRCMP_CONTAINS_TEXT("Hello", "World", "Failed because it failed") // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
 static void _failingTestMethodWithSTRCMP_NOCASE_CONTAINS()
 {
     STRCMP_NOCASE_CONTAINS("hello", "WORLD");
@@ -409,7 +698,8 @@ static void _failingTestMethodWithSTRCMP_NOCASE_CONTAINS()
 TEST(UnitTestMacros, FailureWithSTRCMP_NOCASE_CONTAINS)
 {
     runTestWithMethod(_failingTestMethodWithSTRCMP_NOCASE_CONTAINS);
-    CHECK_TEST_FAILS_PROPER_WITH_TEXT("<WORLD>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("actual <WORLD>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("did not contain  <hello>");
 }
 
 TEST(UnitTestMacros, STRCMP_NOCASE_CONTAINSBehavesAsProperMacro)
@@ -423,13 +713,38 @@ IGNORE_TEST(UnitTestMacros, STRCMP_NO_CASE_CONTAINSWorksInAnIgnoredTest)
     STRCMP_NOCASE_CONTAINS("Hello", "World") // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
+static void _failingTestMethodWithSTRCMP_NOCASE_CONTAINS_TEXT()
+{
+    STRCMP_NOCASE_CONTAINS_TEXT("hello", "WORLD", "Failed because it failed");
+    lineOfCodeExecutedAfterCheck = true;
+}
+
+TEST(UnitTestMacros, FailureWithSTRCMP_NOCASE_CONTAINS_TEXT)
+{
+    runTestWithMethod(_failingTestMethodWithSTRCMP_NOCASE_CONTAINS_TEXT);
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("actual <WORLD>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("did not contain  <hello>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("Failed because it failed");
+}
+
+TEST(UnitTestMacros, STRCMP_NOCASE_CONTAINS_TEXTBehavesAsProperMacro)
+{
+    if (false) STRCMP_NOCASE_CONTAINS_TEXT("never", "executed", "Failed because it failed")
+    else STRCMP_NOCASE_CONTAINS_TEXT("hello", "HELLO WORLD", "Failed because it failed")
+}
+
+IGNORE_TEST(UnitTestMacros, STRCMP_NO_CASE_CONTAINS_TEXTWorksInAnIgnoredTest)
+{
+    STRCMP_NOCASE_CONTAINS_TEXT("Hello", "World", "Failed because it failed") // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
 static void _failingTestMethodWithLONGS_EQUAL()
 {
     LONGS_EQUAL(1, 0xff);
     lineOfCodeExecutedAfterCheck = true; // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
-TEST(UnitTestMacros, FailurePrintHexOutputForLongInts)
+TEST(UnitTestMacros, FailureWithLONGS_EQUALS)
 {
     runTestWithMethod(_failingTestMethodWithLONGS_EQUAL);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <  1 0x01>");
@@ -447,6 +762,31 @@ IGNORE_TEST(UnitTestMacros, LONGS_EQUALWorksInAnIgnoredTest)
     LONGS_EQUAL(11, 22) // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
+static void _failingTestMethodWithLONGS_EQUAL_TEXT()
+{
+    LONGS_EQUAL_TEXT(1, 0xff, "Failed because it failed");
+    lineOfCodeExecutedAfterCheck = true; // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
+TEST(UnitTestMacros, FailureWithLONGS_EQUALS_TEXT)
+{
+    runTestWithMethod(_failingTestMethodWithLONGS_EQUAL_TEXT);
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <  1 0x01>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <255 0xff>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("Failed because it failed");
+}
+
+TEST(UnitTestMacros, LONGS_EQUAL_TEXTBehavesAsProperMacro)
+{
+    if (false) LONGS_EQUAL_TEXT(1, 2, "Failed because it failed")
+    else LONGS_EQUAL_TEXT(10, 10, "Failed because it failed")
+}
+
+IGNORE_TEST(UnitTestMacros, LONGS_EQUAL_TEXTWorksInAnIgnoredTest)
+{
+    LONGS_EQUAL_TEXT(11, 22, "Failed because it failed") // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
 static void _failingTestMethodWithBYTES_EQUAL()
 {
     BYTES_EQUAL('a', 'b');
@@ -456,7 +796,8 @@ static void _failingTestMethodWithBYTES_EQUAL()
 TEST(UnitTestMacros, FailureWithBYTES_EQUAL)
 {
     runTestWithMethod(_failingTestMethodWithBYTES_EQUAL);
-    CHECK_TEST_FAILS_PROPER_WITH_TEXT("<97 0x61>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <97 0x61>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <98 0x62>");
 }
 
 TEST(UnitTestMacros, BYTES_EQUALBehavesAsProperMacro)
@@ -470,13 +811,38 @@ IGNORE_TEST(UnitTestMacros, BYTES_EQUALWorksInAnIgnoredTest)
     BYTES_EQUAL('q', 'w') // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
+static void _failingTestMethodWithBYTES_EQUAL_TEXT()
+{
+    BYTES_EQUAL_TEXT('a', 'b', "Failed because it failed");
+    lineOfCodeExecutedAfterCheck = true;
+}
+
+TEST(UnitTestMacros, FailureWithBYTES_EQUAL_TEXT)
+{
+    runTestWithMethod(_failingTestMethodWithBYTES_EQUAL_TEXT);
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <97 0x61>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <98 0x62>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("Failed because it failed");
+}
+
+TEST(UnitTestMacros, BYTES_EQUAL_TEXTBehavesAsProperMacro)
+{
+    if (false) BYTES_EQUAL_TEXT('a', 'b', "Failed because it failed")
+    else BYTES_EQUAL_TEXT('c', 'c', "Failed because it failed")
+}
+
+IGNORE_TEST(UnitTestMacros, BYTES_EQUAL_TEXTWorksInAnIgnoredTest)
+{
+    BYTES_EQUAL_TEXT('q', 'w', "Failed because it failed") // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
 static void _failingTestMethodWithPOINTERS_EQUAL()
 {
     POINTERS_EQUAL((void*)0xa5a5, (void*)0xf0f0);
     lineOfCodeExecutedAfterCheck = true; // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
-TEST(UnitTestMacros, FailurePrintHexOutputForPointers)
+TEST(UnitTestMacros, FailureWithPOINTERS_EQUAL)
 {
     runTestWithMethod(_failingTestMethodWithPOINTERS_EQUAL);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <0xa5a5>");
@@ -494,6 +860,31 @@ IGNORE_TEST(UnitTestMacros, POINTERS_EQUALWorksInAnIgnoredTest)
     POINTERS_EQUAL((void*) 0xbeef, (void*) 0xdead) // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
+static void _failingTestMethodWithPOINTERS_EQUAL_TEXT()
+{
+    POINTERS_EQUAL_TEXT((void*)0xa5a5, (void*)0xf0f0, "Failed because it failed");
+    lineOfCodeExecutedAfterCheck = true; // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
+TEST(UnitTestMacros, FailureWithPOINTERS_EQUAL_TEXT)
+{
+    runTestWithMethod(_failingTestMethodWithPOINTERS_EQUAL_TEXT);
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <0xa5a5>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <0xf0f0>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("Failed because it failed");
+}
+
+TEST(UnitTestMacros, POINTERS_EQUAL_TEXTBehavesAsProperMacro)
+{
+    if (false) POINTERS_EQUAL_TEXT(0, (void*) 0xbeefbeef, "Failed because it failed")
+    else POINTERS_EQUAL_TEXT((void*)0xdeadbeef, (void*)0xdeadbeef, "Failed because it failed")
+}
+
+IGNORE_TEST(UnitTestMacros, POINTERS_EQUAL_TEXTWorksInAnIgnoredTest)
+{
+    POINTERS_EQUAL_TEXT((void*) 0xbeef, (void*) 0xdead, "Failed because it failed") // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
 static void _failingTestMethodWithDOUBLES_EQUAL()
 {
     DOUBLES_EQUAL(0.12, 44.1, 0.3);
@@ -503,8 +894,9 @@ static void _failingTestMethodWithDOUBLES_EQUAL()
 TEST(UnitTestMacros, FailureWithDOUBLES_EQUAL)
 {
     runTestWithMethod(_failingTestMethodWithDOUBLES_EQUAL);
-    CHECK_TEST_FAILS_PROPER_WITH_TEXT("0.12");
-    CHECK_TEST_FAILS_PROPER_WITH_TEXT("44.1");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <0.12>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <44.1>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("threshold used was <0.3>");
 }
 
 TEST(UnitTestMacros, DOUBLES_EQUALBehavesAsProperMacro)
@@ -516,6 +908,32 @@ TEST(UnitTestMacros, DOUBLES_EQUALBehavesAsProperMacro)
 IGNORE_TEST(UnitTestMacros, DOUBLES_EQUALWorksInAnIgnoredTest)
 {
     DOUBLES_EQUAL(100.0, 0.0, 0.2) // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
+static void _failingTestMethodWithDOUBLES_EQUAL_TEXT()
+{
+    DOUBLES_EQUAL_TEXT(0.12, 44.1, 0.3, "Failed because it failed");
+    lineOfCodeExecutedAfterCheck = true; // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
+TEST(UnitTestMacros, FailureWithDOUBLES_EQUAL_TEXT)
+{
+    runTestWithMethod(_failingTestMethodWithDOUBLES_EQUAL_TEXT);
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <0.12>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <44.1>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("threshold used was <0.3>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("Failed because it failed");
+}
+
+TEST(UnitTestMacros, DOUBLES_EQUAL_TEXTBehavesAsProperMacro)
+{
+    if (false) DOUBLES_EQUAL_TEXT(0.0, 1.1, 0.0005, "Failed because it failed")
+    else DOUBLES_EQUAL_TEXT(0.1, 0.2, 0.2, "Failed because it failed")
+}
+
+IGNORE_TEST(UnitTestMacros, DOUBLES_EQUAL_TEXTWorksInAnIgnoredTest)
+{
+    DOUBLES_EQUAL_TEXT(100.0, 0.0, 0.2, "Failed because it failed") // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
 static void _passingTestMethod()
@@ -561,16 +979,29 @@ TEST(UnitTestMacros, PrintPrintsSimpleStringsForExampleThoseReturnedByFromString
 static int functionThatReturnsAValue()
 {
     CHECK(0 == 0);
+    CHECK_TEXT(0 == 0, "Shouldn't fail");
+    CHECK_TRUE(0 == 0);
+    CHECK_TRUE_TEXT(0 == 0, "Shouldn't fail");
+    CHECK_FALSE(0 != 0);
+    CHECK_FALSE_TEXT(0 != 0, "Shouldn't fail");
     LONGS_EQUAL(1,1);
+    LONGS_EQUAL_TEXT(1, 1, "Shouldn't fail");
     BYTES_EQUAL(0xab,0xab);
+    BYTES_EQUAL_TEXT(0xab, 0xab, "Shouldn't fail");
     CHECK_EQUAL(100,100);
+    CHECK_EQUAL_TEXT(100, 100, "Shouldn't fail");
     STRCMP_EQUAL("THIS", "THIS");
+    STRCMP_EQUAL_TEXT("THIS", "THIS", "Shouldn't fail");
     DOUBLES_EQUAL(1.0, 1.0, .01);
+    DOUBLES_EQUAL_TEXT(1.0, 1.0, .01, "Shouldn't fail");
     POINTERS_EQUAL(0, 0);
+    POINTERS_EQUAL_TEXT(0, 0, "Shouldn't fail");
     MEMCMP_EQUAL("THIS", "THIS", 5);
+    MEMCMP_EQUAL_TEXT("THIS", "THIS", 5, "Shouldn't fail");
     BITS_EQUAL(0x01, (unsigned char )0x01, 0xFF);
     BITS_EQUAL(0x0001, (unsigned short )0x0001, 0xFFFF);
     BITS_EQUAL(0x00000001, (unsigned long )0x00000001, 0xFFFFFFFF);
+    BITS_EQUAL_TEXT(0x01, (unsigned char )0x01, 0xFF, "Shouldn't fail");
     return 0;
 }
 
@@ -707,6 +1138,35 @@ TEST(UnitTestMacros, MEMCMP_EQUALNullExpectedNullActual)
     MEMCMP_EQUAL(NULL, NULL, 1024);
 }
 
+static void _failingTestMethodWithMEMCMP_EQUAL_TEXT()
+{
+    unsigned char expectedData[] = { 0x00, 0x01, 0x02, 0x03 };
+    unsigned char actualData[] = { 0x00, 0x01, 0x03, 0x03 };
+
+    MEMCMP_EQUAL_TEXT(expectedData, actualData, sizeof(expectedData), "Failed because it failed");
+    lineOfCodeExecutedAfterCheck = true; // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
+TEST(UnitTestMacros, FailureWithMEMCMP_EQUAL_TEXT)
+{
+    runTestWithMethod(_failingTestMethodWithMEMCMP_EQUAL_TEXT);
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <00 01 02 03>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <00 01 03 03>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("difference starts at position 2");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("Failed because it failed");
+}
+
+TEST(UnitTestMacros, MEMCMP_EQUAL_TEXTBehavesAsAProperMacro)
+{
+    if (false) MEMCMP_EQUAL_TEXT("TEST", "test", 5, "Failed because it failed")
+    else MEMCMP_EQUAL_TEXT("TEST", "TEST", 5, "Failed because it failed")
+}
+
+IGNORE_TEST(UnitTestMacros, MEMCMP_EQUAL_TEXTWorksInAnIgnoredTest)
+{
+    MEMCMP_EQUAL_TEXT("TEST", "test", 5, "Failed because it failed"); // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
 TEST(UnitTestMacros, BITS_EQUALBehavesAsAProperMacro)
 {
     if (false) BITS_EQUAL(0x00, 0xFF, 0xFF)
@@ -735,6 +1195,31 @@ TEST(UnitTestMacros, BITS_EQUALZeroMaskEqual)
 {
     BITS_EQUAL(0x00, 0xFF, 0x00);
 }
+
+static void _failingTestMethodWithBITS_EQUAL_TEXT()
+{
+    BITS_EQUAL_TEXT(0x00, 0xFF, 0xFF, "Failed because it failed");
+    lineOfCodeExecutedAfterCheck = true; // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
+TEST(UnitTestMacros, FailureWithBITS_EQUAL_TEXT)
+{
+    runTestWithMethod(_failingTestMethodWithBITS_EQUAL_TEXT);
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <xxxxxxxx xxxxxxxx xxxxxxxx 00000000>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <xxxxxxxx xxxxxxxx xxxxxxxx 11111111>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("Failed because it failed");
+}
+
+TEST(UnitTestMacros, BITS_EQUAL_TEXTBehavesAsAProperMacro)
+{
+    if (false) BITS_EQUAL_TEXT(0x00, 0xFF, 0xFF, "Failed because it failed")
+    else BITS_EQUAL_TEXT(0x00, 0x00, 0xFF, "Failed because it failed")
+}
+
+IGNORE_TEST(UnitTestMacros, BITS_EQUAL_TEXTWorksInAnIgnoredTest)
+{
+    BITS_EQUAL_TEXT(0x00, 0xFF, 0xFF, "Failed because it failed"); // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
 
 #if CPPUTEST_USE_STD_CPP_LIB
 static void _failingTestMethod_NoThrowWithCHECK_THROWS()

--- a/tests/TestUTestMacro.cpp
+++ b/tests/TestUTestMacro.cpp
@@ -38,7 +38,7 @@ static void CHECK_TEST_FAILS_PROPER_WITH_TEXT_LOCATION(const char* text, TestTes
     if (fixture.getFailureCount() != 1)
         FAIL_LOCATION(StringFromFormat("Expected one test failure, but got %d amount of test failures", fixture.getFailureCount()).asCharString(), file, line);
 
-    STRCMP_CONTAINS_LOCATION(text, fixture.output_->getOutput().asCharString(), file, line);
+    STRCMP_CONTAINS_LOCATION(text, fixture.output_->getOutput().asCharString(), "", file, line);
 
     if (lineOfCodeExecutedAfterCheck)
         FAIL_LOCATION("The test should jump/throw on failure and not execute the next line. However, the next line was executed.", file, line)


### PR DESCRIPTION
Added the missing complementary macros for all the current assert macros. 

The new ones accept a user message that is printed if the assertion fails (like CHECK_TEXT or CHECK_TRUE_TEXT), and follow the same nomenclature (CHECK_xxx_TEXT).