### PR TITLE
Fixes for Cl2000

### DIFF
--- a/src/CppUTest/TestFailure.cpp
+++ b/src/CppUTest/TestFailure.cpp
@@ -166,9 +166,9 @@ EqualsFailure::EqualsFailure(UtestShell* test, const char* fileName, int lineNum
 
 DoublesEqualFailure::DoublesEqualFailure(UtestShell* test, const char* fileName, int lineNumber, double expected, double actual, double threshold)  : TestFailure(test, fileName, lineNumber)
 {
-    message_ = createButWasString(StringFrom(expected, 10), StringFrom(actual, 10));
+    message_ = createButWasString(StringFrom(expected, 7), StringFrom(actual, 7));
     message_ += " threshold used was <";
-    message_ += StringFrom(threshold, 10);
+    message_ += StringFrom(threshold, 7);
     message_ += ">";
 
     if (PlatformSpecificIsNan(expected) || PlatformSpecificIsNan(actual) || PlatformSpecificIsNan(threshold))

--- a/tests/CppUTestExt/MockSupportTest.cpp
+++ b/tests/CppUTestExt/MockSupportTest.cpp
@@ -687,15 +687,15 @@ TEST(MockSupportTest, threeExpectedAndActual)
 class MyTypeForTesting
 {
 public:
-    MyTypeForTesting(int val)
+    MyTypeForTesting(long val)
     {
-        value = new int(val);
+        value = new long(val);
     }
     virtual ~MyTypeForTesting()
     {
         delete value;
     }
-    int *value;
+    long *value;
 };
 
 class MyTypeForTestingComparator : public MockNamedValueComparator

--- a/tests/SimpleStringTest.cpp
+++ b/tests/SimpleStringTest.cpp
@@ -916,8 +916,8 @@ TEST(SimpleString, MaskedBits4bytes)
         STRCMP_EQUAL("xxxxxxxx xxxxxxxx", StringFromMaskedBits(0x00000000, 0x00000000, 4).asCharString());
         STRCMP_EQUAL("00000000 00000000", StringFromMaskedBits(0x00000000, 0xFFFFFFFF, 4).asCharString());
         STRCMP_EQUAL("11111111 11111111", StringFromMaskedBits(0xFFFFFFFF, 0xFFFFFFFF, 4).asCharString());
-        STRCMP_EQUAL("1xxxxxxx xxxxxxxx", StringFromMaskedBits(0x80000000, 0x80000000, 4).asCharString());
-        STRCMP_EQUAL("xxxxxxxx xxxxxxxx", StringFromMaskedBits(0x00000001, 0x00000001, 4).asCharString());
+        STRCMP_EQUAL("1xxxxxxx xxxxxxxx", StringFromMaskedBits(0x00008000, 0x00008000, 4).asCharString());
+        STRCMP_EQUAL("xxxxxxxx xxxxxxx1", StringFromMaskedBits(0x00000001, 0x00000001, 4).asCharString());
         STRCMP_EQUAL("11xx11xx 11xx11xx", StringFromMaskedBits(0xFFFFFFFF, 0xCCCCCCCC, 4).asCharString());
     }
     else {


### PR DESCRIPTION
The 4 byte bit-masked tests contained two errors in the 16 bit branch.

On 16 bit platforms, when floats are promoted to double, the result is in inexact. Due to this, the double test failure test will fail, if we set precision to higher than 7 here.