### PR TITLE
Added missing mock_c() withMemoryBufferParameter() interfaces

### DIFF
--- a/include/CppUTestExt/MockSupport_c.h
+++ b/include/CppUTestExt/MockSupport_c.h
@@ -43,6 +43,7 @@ typedef enum {
     MOCKVALUETYPE_STRING,
     MOCKVALUETYPE_POINTER,
     MOCKVALUETYPE_CONST_POINTER,
+    MOCKVALUETYPE_MEMORYBUFFER,
     MOCKVALUETYPE_OBJECT
 } MockValueType_c;
 
@@ -58,6 +59,7 @@ typedef struct SMockValue_c
         const char* stringValue;
         void* pointerValue;
         const void* constPointerValue;
+        const unsigned char* memoryBufferValue;
         const void* objectValue;
     } value;
 } MockValue_c;
@@ -73,6 +75,7 @@ struct SMockActualCall_c
     MockActualCall_c* (*withStringParameters)(const char* name, const char* value);
     MockActualCall_c* (*withPointerParameters)(const char* name, void* value);
     MockActualCall_c* (*withConstPointerParameters)(const char* name, const void* value);
+    MockActualCall_c* (*withMemoryBufferParameter)(const char* name, const unsigned char* value, size_t size);
     MockActualCall_c* (*withParameterOfType)(const char* type, const char* name, const void* value);
     MockActualCall_c* (*withOutputParameter)(const char* name, void* value);
 
@@ -90,6 +93,7 @@ struct SMockExpectedCall_c
     MockExpectedCall_c* (*withStringParameters)(const char* name, const char* value);
     MockExpectedCall_c* (*withPointerParameters)(const char* name, void* value);
     MockExpectedCall_c* (*withConstPointerParameters)(const char* name, const void* value);
+    MockExpectedCall_c* (*withMemoryBufferParameter)(const char* name, const unsigned char* value, size_t size);
     MockExpectedCall_c* (*withParameterOfType)(const char* type, const char* name, const void* value);
     MockExpectedCall_c* (*withOutputParameterReturning)(const char* name, const void* value, size_t size);
 

--- a/src/CppUTestExt/MockSupport_c.cpp
+++ b/src/CppUTestExt/MockSupport_c.cpp
@@ -140,6 +140,7 @@ MockExpectedCall_c* withDoubleParameters_c(const char* name, double value);
 MockExpectedCall_c* withStringParameters_c(const char* name, const char* value);
 MockExpectedCall_c* withPointerParameters_c(const char* name, void* value);
 MockExpectedCall_c* withConstPointerParameters_c(const char* name, const void* value);
+MockExpectedCall_c* withMemoryBufferParameters_c(const char* name, const unsigned char* value, size_t size);
 MockExpectedCall_c* withParameterOfType_c(const char* type, const char* name, const void* value);
 MockExpectedCall_c* withOutputParameterReturning_c(const char* name, const void* value, size_t size);
 MockExpectedCall_c* andReturnIntValue_c(int value);
@@ -160,6 +161,7 @@ MockActualCall_c* withActualDoubleParameters_c(const char* name, double value);
 MockActualCall_c* withActualStringParameters_c(const char* name, const char* value);
 MockActualCall_c* withActualPointerParameters_c(const char* name, void* value);
 MockActualCall_c* withActualConstPointerParameters_c(const char* name, const void* value);
+MockActualCall_c* withActualMemoryBufferParameters_c(const char* name, const unsigned char* value, size_t size);
 MockActualCall_c* withActualParameterOfType_c(const char* type, const char* name, const void* value);
 MockActualCall_c* withActualOutputParameter_c(const char* name, void* value);
 MockValue_c actualReturnValue_c();
@@ -201,6 +203,7 @@ static MockExpectedCall_c gExpectedCall = {
         withStringParameters_c,
         withPointerParameters_c,
         withConstPointerParameters_c,
+        withMemoryBufferParameters_c,
         withParameterOfType_c,
         withOutputParameterReturning_c,
         andReturnUnsignedIntValue_c,
@@ -222,6 +225,7 @@ static MockActualCall_c gActualCall = {
         withActualStringParameters_c,
         withActualPointerParameters_c,
         withActualConstPointerParameters_c,
+        withActualMemoryBufferParameters_c,
         withActualParameterOfType_c,
         withActualOutputParameter_c,
         actualReturnValue_c
@@ -294,6 +298,12 @@ MockExpectedCall_c* withPointerParameters_c(const char* name, void* value)
 MockExpectedCall_c* withConstPointerParameters_c(const char* name, const void* value)
 {
     expectedCall = &expectedCall->withParameter(name, value);
+    return &gExpectedCall;
+}
+
+MockExpectedCall_c* withMemoryBufferParameters_c(const char* name, const unsigned char* value, size_t size)
+{
+    expectedCall = &expectedCall->withParameter(name, value, size);
     return &gExpectedCall;
 }
 
@@ -392,6 +402,10 @@ static MockValue_c getMockValueCFromNamedValue(const MockNamedValue& namedValue)
         returnValue.type = MOCKVALUETYPE_CONST_POINTER;
         returnValue.value.constPointerValue = namedValue.getConstPointerValue();
     }
+    else if (SimpleString::StrCmp(namedValue.getType().asCharString(), "const unsigned char*") == 0) {
+        returnValue.type = MOCKVALUETYPE_MEMORYBUFFER;
+        returnValue.value.memoryBufferValue = namedValue.getMemoryBuffer();
+    }
     else {
         returnValue.type = MOCKVALUETYPE_OBJECT;
         returnValue.value.objectValue = namedValue.getObjectPointer();
@@ -456,6 +470,12 @@ MockActualCall_c* withActualPointerParameters_c(const char* name, void* value)
 MockActualCall_c* withActualConstPointerParameters_c(const char* name, const void* value)
 {
     actualCall = &actualCall->withParameter(name, value);
+    return &gActualCall;
+}
+
+MockActualCall_c* withActualMemoryBufferParameters_c(const char* name, const unsigned char* value, size_t size)
+{
+    actualCall = &actualCall->withParameter(name, value, size);
     return &gActualCall;
 }
 

--- a/tests/CppUTestExt/MockSupport_cTest.cpp
+++ b/tests/CppUTestExt/MockSupport_cTest.cpp
@@ -303,3 +303,20 @@ TEST(MockSupport_c, failureWithParameterOfTypeCoversValueToString)
     fixture.assertPrintContains("typeName name: <valueToString>");
     mock_c()->removeAllComparatorsAndCopiers();
 }
+
+static void failingCallToMockCWithMemoryBuffer_()
+{
+    unsigned char memBuffer1[] = { 0x12, 0x15, 0xFF };
+    unsigned char memBuffer2[] = { 0x12, 0x05, 0xFF };
+    mock_c()->expectOneCall("bar")->withMemoryBufferParameter("name", memBuffer1, sizeof(memBuffer1));
+    mock_c()->actualCall("bar")->withMemoryBufferParameter("name", memBuffer2, sizeof(memBuffer2));
+} // LCOV_EXCL_LINE
+
+TEST(MockSupport_c, expectOneMemBufferParameterAndValueFailsDueToContents)
+{
+    TestTestingFixture fixture;
+    fixture.setTestFunction(failingCallToMockCWithMemoryBuffer_);
+    fixture.runAllTests();
+    fixture.assertPrintContains("Unexpected parameter value to parameter \"name\" "
+                                "to function \"bar\": <Size = 3 | HexContents = 12 05 FF>");
+}

--- a/tests/CppUTestExt/MockSupport_cTestCFile.c
+++ b/tests/CppUTestExt/MockSupport_cTestCFile.c
@@ -51,6 +51,10 @@ void all_mock_support_c_calls(void)
             withStringParameters("string", "string")->withPointerParameters("pointer", (void*) 1)->
             withConstPointerParameters("constpointer", (const void*) 1);
 
+    mock_c()->expectOneCall("boo")->withMemoryBufferParameter("name", (void*) 1, 0);
+    mock_c()->actualCall("boo")->withMemoryBufferParameter("name", (void*) 1, 0);
+    mock_c()->clear();
+
     mock_c()->installComparator("typeName", typeNameIsEqual, typeNameValueToString);
     mock_c()->expectOneCall("boo")->withParameterOfType("typeName", "name", (void*) 1);
     mock_c()->actualCall("boo")->withParameterOfType("typeName", "name", (void*) 1);


### PR DESCRIPTION
@basvodde -- while this does work as is, I am not really sure whether I added enough, or too much. 

Should this be part of `sMockValue_c`?  If so, one could use it as a return value. Should one be able to do that?

Are the tests sufficient? Or too many? I haven't used these interfaces recently, so I am not too sure.