### PR TITLE
Coveralls online code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
   - BUILDTOOL=autotools
   - BUILDTOOL=cmake
   - BUILDTOOL=cmake-coverage
+#  - BUILDTOOL=autotools_old_compilers
   global:
   - secure: |-
       P05xUfJVw5YM4hF7hzQLjyMzDD4Q1/fyWP9Uk5aK5VrSWNY99EuxldXI5QK/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 language: cpp
 compiler:
-#- clang
+- clang
 - gcc
 rvm:
 - 1.9.3
 env:
   matrix:
-#  - BUILDTOOL=autotools
-#  - BUILDTOOL=cmake
+  - BUILDTOOL=autotools
+  - BUILDTOOL=cmake
   - BUILDTOOL=cmake-coverage
   global:
   - secure: |-

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,22 @@
 language: cpp
 compiler:
-- clang
+#- clang
 - gcc
 rvm:
 - 1.9.3
 env:
   matrix:
-  - BUILDTOOL=autotools
-  - BUILDTOOL=cmake
-  - BUILDTOOL=autotools_old_compilers
+#  - BUILDTOOL=autotools
+#  - BUILDTOOL=cmake
+  - BUILDTOOL=cmake-coverage
   global:
   - secure: |-
       P05xUfJVw5YM4hF7hzQLjyMzDD4Q1/fyWP9Uk5aK5VrSWNY99EuxldXI5QK/
       vA1NkcW49tQW1wQvBlRtdlLNOmUfDP/oiJFXPwNn4dqwOIOEet2P7JO/5hnH
       MNHlZmGu2WpoZREhOFBfsIhK0IP8mloqLDq2XemBdga/LWygrLU=
   - secure: Y/8iNkf6uEbE3qltnM+7mGlCvFWzyttwwRGgVGw1m9xOiUJcobvOImQRU8XZ91dgO+Fz0A3mljqs1sK1OPjpXmFGE1jP/NlotMw0WlDOuSIDjQ4ubwdTNGAwNY53R9ygbIjEmqxHAJm9mOZqxW2hNaoI7TcX6oX248/hLibyx8M=
+before_install:
+- sudo pip install cpp-coveralls
 install:
 - gem install travis_github_deployer
 - sudo apt-get update --fix-missing

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Travis Linux build status:
 AppVeyer Windows build status:
 [![Build status](https://ci.appveyor.com/api/projects/status/irh38i4wblsb5tew?svg=true)](https://ci.appveyor.com/project/basvodde/cpputest)
 
+Coverage:
+[![Coverage Status](https://coveralls.io/repos/jgonzalezdr/cpputest/badge.svg?branch=coveralls&service=github)](https://coveralls.io/github/jgonzalezdr/cpputest?branch=coveralls)
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ AppVeyer Windows build status:
 [![Build status](https://ci.appveyor.com/api/projects/status/irh38i4wblsb5tew?svg=true)](https://ci.appveyor.com/project/basvodde/cpputest)
 
 Coverage:
-[![Coverage Status](https://coveralls.io/repos/jgonzalezdr/cpputest/badge.svg?branch=coveralls&service=github)](https://coveralls.io/github/jgonzalezdr/cpputest?branch=coveralls)
+[![Coverage Status](https://coveralls.io/repos/cpputest/cpputest/badge.svg?branch=master&service=github)](https://coveralls.io/github/cpputest/cpputest?branch=master)
 
 ## Getting Started
 

--- a/scripts/travis_ci_build.sh
+++ b/scripts/travis_ci_build.sh
@@ -52,3 +52,11 @@ if [ "x$BUILDTOOL" = "xcmake" ]; then
     ctest -V || exit 1
 fi
 
+if [ "x$BUILDTOOL" = "xcmake-coverage" -a "x$CXX" = "xg++" ]; then
+    cmake .. -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE -DCOVERAGE=ON
+    make || exit 1
+    ctest || exit 1
+
+    coveralls -b . -r .. -i "src" -i "include" --gcov-options="-bc"
+fi
+


### PR DESCRIPTION
I was messing around with [Coveralls](http://coveralls.io) (which if you don't know is an online service that allows tracking code coverage, it's free for open source projects, and really easy to use because you can sign-in with the github account), and I added support to automatically update CppUTest coverage from Travis-CI builds.

It doesn't support branch coverage, but anyway it may be useful to check in a glance PR's proper testing, so I'm PRing this just in case you find it useful.

In case this is merged, remember to enable coverage for the cpputest repo in [Coveralls](http://coveralls.io),