### PR TITLE
Length specifier fixed for C++98

### DIFF
--- a/src/CppUTest/MemoryLeakDetector.cpp
+++ b/src/CppUTest/MemoryLeakDetector.cpp
@@ -74,7 +74,7 @@ void SimpleStringBuffer::addMemoryDump(const void* memory, size_t memorySize)
         const size_t leftoverBytes = maxLineBytes - bytesInLine;
 
         for (p = 0; p < bytesInLine; p++) {
-            add("%02hhx ", byteMemory[currentPos + p]);
+            add("%02hx ", byteMemory[currentPos + p]);
             if (p == ((maxLineBytes / 2) - 1)) {
                 add(" ");
             }

--- a/src/CppUTest/MemoryLeakDetector.cpp
+++ b/src/CppUTest/MemoryLeakDetector.cpp
@@ -74,7 +74,7 @@ void SimpleStringBuffer::addMemoryDump(const void* memory, size_t memorySize)
         const size_t leftoverBytes = maxLineBytes - bytesInLine;
 
         for (p = 0; p < bytesInLine; p++) {
-            add("%02hx ", byteMemory[currentPos + p]);
+            add("%02hx ", (unsigned short) byteMemory[currentPos + p]);
             if (p == ((maxLineBytes / 2) - 1)) {
                 add(" ");
             }


### PR DESCRIPTION
The length specifier `hh` was [introduced with C99](http://www.cplusplus.com/reference/cstdio/fprintf/) and is not supported by C++98.

Therefore compiling CppUTest with C++11 *disabled* fails.

--------

Tested with GCC 5.2 and `cmake -DC++11=OFF`.