### PR TITLE
Remove ugly dependency

### DIFF
--- a/tests/CppUTestExt/MockFailureTest.cpp
+++ b/tests/CppUTestExt/MockFailureTest.cpp
@@ -31,12 +31,6 @@
 #include "CppUTestExt/MockExpectedCallsList.h"
 #include "MockFailureTest.h"
 
-MockFailureReporterForTest* MockFailureReporterForTest::getReporter()
-{
-    static MockFailureReporterForTest reporter;
-    return &reporter;
-}
-
 TEST_GROUP(MockFailureTest)
 {
     MockFailureReporter reporter;

--- a/tests/CppUTestExt/MockFailureTest.h
+++ b/tests/CppUTestExt/MockFailureTest.h
@@ -44,7 +44,7 @@ public:
         mockFailureString = failure.getMessage();
     }
 
-    static MockFailureReporterForTest* MockFailureReporterForTest::getReporter()
+    static MockFailureReporterForTest* getReporter()
     {
         static MockFailureReporterForTest reporter;
         return &reporter;

--- a/tests/CppUTestExt/MockFailureTest.h
+++ b/tests/CppUTestExt/MockFailureTest.h
@@ -44,7 +44,11 @@ public:
         mockFailureString = failure.getMessage();
     }
 
-    static MockFailureReporterForTest* getReporter();
+    static MockFailureReporterForTest* MockFailureReporterForTest::getReporter()
+    {
+        static MockFailureReporterForTest reporter;
+        return &reporter;
+    }
 };
 
 inline UtestShell* mockFailureTest()


### PR DESCRIPTION
from MockSupportTest.cpp to MockFailureTest.cpp

(MockFailureReporterForTest is used in MockSupportTest, too, but getReporter() was defined in MockFailureTest.cpp).