### PR TITLE
Add Dos/Platform.h and checks for defined(__X86__)

### DIFF
--- a/include/Platforms/Dos/Platform.h
+++ b/include/Platforms/Dos/Platform.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2007, Michael Feathers, James Grenning and Bas Vodde
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the <organization> nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE EARLIER MENTIONED AUTHORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL <copyright holder> BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef D_Dos_Platform_H
+#define D_Dos_Platform_H
+
+#endif

--- a/src/Platforms/dos/UtestPlatform.cpp
+++ b/src/Platforms/dos/UtestPlatform.cpp
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2007, Michael Feathers, James Grenning and Bas Vodde
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the <organization> nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE EARLIER MENTIONED AUTHORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL <copyright holder> BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* Un-comment to use buffer instead of std out */
+// #define USE_BUFFER_OUTPUT 1
+#include <cstdlib>
+
+#include "CppUTest/TestHarness.h"
+#undef malloc
+#undef free
+#undef calloc
+#undef realloc
+
+#define  far  // eliminate "meaningless type qualifier" warning
+#include <time.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include <setjmp.h>
+#include <string.h>
+#include <math.h>
+#include <ctype.h>
+#undef far
+
+#include "CppUTest/PlatformSpecificFunctions.h"
+
+static jmp_buf test_exit_jmp_buf[10];
+static int jmp_buf_index = 0;
+
+TestOutput::WorkingEnvironment PlatformSpecificGetWorkingEnvironment()
+{
+    return TestOutput::eclipse;
+}
+
+static void DummyRunTestInASeperateProcess(UtestShell* shell, TestPlugin* plugin, TestResult* result)
+{
+    result->addFailure(TestFailure(shell, "-p doesn't work on this platform, as it is lacking fork.\b"));
+}
+
+void (*PlatformSpecificRunTestInASeperateProcess)(UtestShell*, TestPlugin*, TestResult*) =
+    DummyRunTestInASeperateProcess;
+
+extern "C" {
+
+static int DosSetJmp(void (*function) (void* data), void* data)
+{
+    if (0 == setjmp(test_exit_jmp_buf[jmp_buf_index])) {
+        jmp_buf_index++;
+        function(data);
+        jmp_buf_index--;
+        return 1;
+    }
+    return 0;
+}
+
+static void  DosLongJmp()
+{
+    jmp_buf_index--;
+    longjmp(test_exit_jmp_buf[jmp_buf_index], 1);
+}
+
+static void  DosRestoreJumpBuffer()
+{
+    jmp_buf_index--;
+}
+
+int (*PlatformSpecificSetJmp)(void (*function) (void*), void*) = DosSetJmp;
+void (*PlatformSpecificLongJmp)(void) = DosLongJmp;
+void (*PlatformSpecificRestoreJumpBuffer)(void) = DosRestoreJumpBuffer;
+
+static long DosTimeInMillis()
+{
+    return clock() * 1000 / CLOCKS_PER_SEC;
+}
+
+static const char* TimeStringImplementation()
+{
+    time_t tm = time(NULL);
+    return ctime(&tm);
+}
+
+long (*GetPlatformSpecificTimeInMillis)() = DosTimeInMillis;
+const char* (*GetPlatformSpecificTimeString)() = TimeStringImplementation;
+
+extern int (*PlatformSpecificVSNprintf)(char *, size_t, const char*, va_list) = vsnprintf;
+
+PlatformSpecificFile DosFOpen(const char* filename, const char* flag)
+{
+    return fopen(filename, flag);
+}
+
+static void DosFPuts(const char* str, PlatformSpecificFile file)
+{
+   fputs(str, (FILE*)file);
+}
+
+static void DosFClose(PlatformSpecificFile file)
+{
+   fclose((FILE*)file);
+}
+
+PlatformSpecificFile (*PlatformSpecificFOpen)(const char* filename, const char* flag) = DosFOpen;
+void (*PlatformSpecificFPuts)(const char* str, PlatformSpecificFile file) = DosFPuts;
+void (*PlatformSpecificFClose)(PlatformSpecificFile file) = DosFClose;
+
+static int DosPutchar(int c)
+{
+    return putchar(c);
+}
+
+static void DosFlush()
+{
+  fflush(stdout);
+}
+
+extern int (*PlatformSpecificPutchar)(int c) = DosPutchar;
+extern void (*PlatformSpecificFlush)(void) = DosFlush;
+
+static void* DosMalloc(size_t size)
+{
+   return malloc(size);
+}
+
+static void* DosRealloc (void* memory, size_t size)
+{
+    return realloc(memory, size);
+}
+
+static void DosFree(void* memory)
+{
+    free(memory);
+}
+
+static void* DosMemCpy(void* s1, const void* s2, size_t size)
+{
+    return memcpy(s1, s2, size);
+}
+
+static void* DosMemset(void* mem, int c, size_t size)
+{
+    return memset(mem, c, size);
+}
+
+void* (*PlatformSpecificMalloc)(size_t size) = DosMalloc;
+void* (*PlatformSpecificRealloc)(void* memory, size_t size) = DosRealloc;
+void (*PlatformSpecificFree)(void* memory) = DosFree;
+void* (*PlatformSpecificMemCpy)(void* s1, const void* s2, size_t size) = DosMemCpy;
+void* (*PlatformSpecificMemset)(void* mem, int c, size_t size) = DosMemset;
+
+static int IsNanImplementation(double d)
+{
+    return isnan(d);
+}
+
+static int IsInfImplementation(double d)
+{
+    return isinf(d);
+}
+
+double (*PlatformSpecificFabs)(double) = fabs;
+int (*PlatformSpecificIsNan)(double d) = IsNanImplementation;
+int (*PlatformSpecificIsInf)(double d) = IsInfImplementation;
+
+static PlatformSpecificMutex DummyMutexCreate(void)
+{
+    return 0;
+}
+
+static void DummyMutexLock(PlatformSpecificMutex mtx)
+{
+}
+
+static void DummyMutexUnlock(PlatformSpecificMutex mtx)
+{
+}
+
+static void DummyMutexDestroy(PlatformSpecificMutex mtx)
+{
+}
+
+PlatformSpecificMutex (*PlatformSpecificMutexCreate)(void) = DummyMutexCreate;
+void (*PlatformSpecificMutexLock)(PlatformSpecificMutex) = DummyMutexLock;
+void (*PlatformSpecificMutexUnlock)(PlatformSpecificMutex) = DummyMutexUnlock;
+void (*PlatformSpecificMutexDestroy)(PlatformSpecificMutex) = DummyMutexDestroy;
+
+}

--- a/tests/UtestPlatformTest.cpp
+++ b/tests/UtestPlatformTest.cpp
@@ -35,7 +35,7 @@ TEST_GROUP(UTestPlatformsTest_PlatformSpecificRunTestInASeperateProcess)
     TestTestingFixture fixture;
 };
 
-#if defined(__MINGW32__) || defined(_MSC_VER) || defined(__IAR_SYSTEMS_ICC__) || defined(__ARMCC_VERSION) || defined(__TMS320C2000__)
+#if defined(__MINGW32__) || defined(_MSC_VER) || defined(__IAR_SYSTEMS_ICC__) || defined(__arm__) || defined(__TMS320C2000__) || defined(__X86__)
 
 TEST(UTestPlatformsTest_PlatformSpecificRunTestInASeperateProcess, DummyFailsWithMessage)
 {

--- a/tests/UtestTest.cpp
+++ b/tests/UtestTest.cpp
@@ -178,7 +178,7 @@ TEST(UtestShell, RunInSeparateProcessTest)
     fixture.assertPrintContains("Failed in separate process");
 }
 
-#if defined(__MINGW32__) || defined(_MSC_VER) || defined(__IAR_SYSTEMS_ICC__) || defined(__ARMCC_VERSION) || defined(__TMS320C2000__)
+#if defined(__MINGW32__) || defined(_MSC_VER) || defined(__IAR_SYSTEMS_ICC__) || defined(__ARMCC_VERSION) || defined(__TMS320C2000__) || defined(__X86__)
 
 IGNORE_TEST(UtestShell, TestDefaultCrashMethodInSeparateProcessTest) {}
 


### PR DESCRIPTION
Not sure that one should add Platform.h when it isn't actually used yet -- but there it is.

The defines are there because we can't fork under DOS ;-)

And this Dos/ vs. dos/ thing is killing me -- there should be no dos/UtestPlatform.cpp in this pull! It wasn't in my local diff! Yikes!!!