### PR TITLE
Put 16-bit Build Dummy Into Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,7 +51,7 @@ builds/*gcc*
 /.deps
 CppUTestExtTests
 CppUTestTests
-Makefile
+/Makefile
 config.h
 config.h.in
 config.status

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,5 @@ before_script:
 - wcl --version
 - export CPPUTEST_BUILD_DIR=$TRAVIS_BUILD_DIR/cpputest_build
 - mkdir -p $CPPUTEST_BUILD_DIR && cd $CPPUTEST_BUILD_DIR
-
 script:
 - "../scripts/travis_ci_build.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,35 @@
 language: cpp
+os:
+ - linux
 compiler:
 - clang
 - gcc
+- wcl
 rvm:
 - 1.9.3
 env:
-  matrix:
   - BUILDTOOL=autotools
+  - BUILDTOOL=autotools_old_compilers
   - BUILDTOOL=cmake
   - BUILDTOOL=cmake-coverage
-#  - BUILDTOOL=autotools_old_compilers
-  global:
-  - secure: |-
+  - BUILDTOOL=make-dos
+matrix:
+    exclude:
+    - env: BUILDTOOL=cmake-coverage
+    - env: BUILDTOOL=autotools_old_compilers
+    - env: BUILDTOOL=make-dos
+    - compiler: wcl
+    include:
+    - env: BUILDTOOL=cmake-coverage
+      compiler: gcc
+    - env: BUILDTOOL=make-dos
+      compiler: wcl
+global:
+- secure: |-
       P05xUfJVw5YM4hF7hzQLjyMzDD4Q1/fyWP9Uk5aK5VrSWNY99EuxldXI5QK/
       vA1NkcW49tQW1wQvBlRtdlLNOmUfDP/oiJFXPwNn4dqwOIOEet2P7JO/5hnH
       MNHlZmGu2WpoZREhOFBfsIhK0IP8mloqLDq2XemBdga/LWygrLU=
-  - secure: Y/8iNkf6uEbE3qltnM+7mGlCvFWzyttwwRGgVGw1m9xOiUJcobvOImQRU8XZ91dgO+Fz0A3mljqs1sK1OPjpXmFGE1jP/NlotMw0WlDOuSIDjQ4ubwdTNGAwNY53R9ygbIjEmqxHAJm9mOZqxW2hNaoI7TcX6oX248/hLibyx8M=
+- secure: Y/8iNkf6uEbE3qltnM+7mGlCvFWzyttwwRGgVGw1m9xOiUJcobvOImQRU8XZ91dgO+Fz0A3mljqs1sK1OPjpXmFGE1jP/NlotMw0WlDOuSIDjQ4ubwdTNGAwNY53R9ygbIjEmqxHAJm9mOZqxW2hNaoI7TcX6oX248/hLibyx8M=
 before_install:
 - sudo pip install cpp-coveralls
 install:
@@ -27,3 +41,4 @@ before_script:
 - mkdir -p $CPPUTEST_BUILD_DIR && cd $CPPUTEST_BUILD_DIR
 script:
 - "../scripts/travis_ci_build.sh"
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,12 @@ install:
 - sudo apt-get update --fix-missing
 - sudo apt-get install valgrind
 before_script:
+- wget ftp://ftp.openwatcom.org/pub/open-watcom-c-linux-1.9 -O /tmp/watcom.zip
+- mkdir -p watcom && unzip -a -d watcom /tmp/watcom.zip && sudo chmod -R 755 watcom/binl
+- export PATH=$PATH:$PWD/watcom/binl/
+- wcl --version
 - export CPPUTEST_BUILD_DIR=$TRAVIS_BUILD_DIR/cpputest_build
 - mkdir -p $CPPUTEST_BUILD_DIR && cd $CPPUTEST_BUILD_DIR
+
 script:
 - "../scripts/travis_ci_build.sh"
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,11 +32,11 @@ global:
 - secure: Y/8iNkf6uEbE3qltnM+7mGlCvFWzyttwwRGgVGw1m9xOiUJcobvOImQRU8XZ91dgO+Fz0A3mljqs1sK1OPjpXmFGE1jP/NlotMw0WlDOuSIDjQ4ubwdTNGAwNY53R9ygbIjEmqxHAJm9mOZqxW2hNaoI7TcX6oX248/hLibyx8M=
 before_install:
 - sudo pip install cpp-coveralls
+- sudo apt-get install dosbox -y
 install:
 - gem install travis_github_deployer
 - sudo apt-get update --fix-missing
 - sudo apt-get install valgrind
-- sudo apt-get install dosbox
 before_script:
 - export CPPUTEST_BUILD_DIR=$TRAVIS_BUILD_DIR/cpputest_build
 - mkdir -p $CPPUTEST_BUILD_DIR && cd $CPPUTEST_BUILD_DIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ install:
 - gem install travis_github_deployer
 - sudo apt-get update --fix-missing
 - sudo apt-get install valgrind
+- sudo apt-get install dosbox
 before_script:
 - export CPPUTEST_BUILD_DIR=$TRAVIS_BUILD_DIR/cpputest_build
 - mkdir -p $CPPUTEST_BUILD_DIR && cd $CPPUTEST_BUILD_DIR

--- a/platforms/Dos/Makefile
+++ b/platforms/Dos/Makefile
@@ -1,2 +1,2 @@
-all:
-	@echo "\n  Dos target not implemented yet\n"
+dummy:
+	echo "\n  *** Pretending to build CPPU1.EXE ***\n"

--- a/platforms/Dos/Makefile
+++ b/platforms/Dos/Makefile
@@ -1,0 +1,2 @@
+all:
+	@echo "\n  Dos target not implemented yet\n"

--- a/platforms/Dos/dosbox-0.74.conf
+++ b/platforms/Dos/dosbox-0.74.conf
@@ -1,0 +1,240 @@
+# This is the configurationfile for DOSBox 0.74. (Please use the latest version of DOSBox)
+# Lines starting with a # are commentlines and are ignored by DOSBox.
+# They are used to (briefly) document the effect of each option.
+
+[sdl]
+#       fullscreen: Start dosbox directly in fullscreen. (Press ALT-Enter to go back)
+#       fulldouble: Use double buffering in fullscreen. It can reduce screen flickering, but it can also result in a slow DOSBox.
+#   fullresolution: What resolution to use for fullscreen: original or fixed size (e.g. 1024x768).
+#                     Using your monitor's native resolution with aspect=true might give the best results.
+#                     If you end up with small window on a large screen, try an output different from surface.
+# windowresolution: Scale the window to this size IF the output device supports hardware scaling.
+#                     (output=surface does not!)
+#           output: What video system to use for output.
+#                   Possible values: surface, overlay, opengl, openglnb.
+#         autolock: Mouse will automatically lock, if you click on the screen. (Press CTRL-F10 to unlock)
+#      sensitivity: Mouse sensitivity.
+#      waitonerror: Wait before closing the console if dosbox has an error.
+#         priority: Priority levels for dosbox. Second entry behind the comma is for when dosbox is not focused/minimized.
+#                     pause is only valid for the second entry.
+#                   Possible values: lowest, lower, normal, higher, highest, pause.
+#       mapperfile: File used to load/save the key/event mappings from. Resetmapper only works with the defaul value.
+#     usescancodes: Avoid usage of symkeys, might not work on all operating systems.
+
+fullscreen=false
+fulldouble=false
+fullresolution=1366x768
+windowresulultion=900x675
+output=surface
+autolock=false
+sensitivity=50
+waitonerror=true
+priority=higher,normal
+mapperfile=mapper-0.74.map
+usescancodes=true
+
+[dosbox]
+# language: Select another language file.
+#  machine: The type of machine tries to emulate.
+#           Possible values: hercules, cga, tandy, pcjr, ega, vgaonly, svga_s3, svga_et3000, svga_et4000, svga_paradise, vesa_nolfb, vesa_oldvbe.
+# captures: Directory where things like wave, midi, screenshot get captured.
+#  memsize: Amount of memory DOSBox has in megabytes.
+#             This value is best left at its default to avoid problems with some games,
+#             though few games might require a higher value.
+#             There is generally no speed advantage when raising this value.
+
+language=
+machine=svga_s3
+captures=capture
+memsize=16
+
+[render]
+# frameskip: How many frames DOSBox skips before drawing one.
+#    aspect: Do aspect correction, if your output method doesn't support scaling this can slow things down!.
+#    scaler: Scaler used to enlarge/enhance low resolution modes.
+#              If 'forced' is appended, then the scaler will be used even if the result might not be desired.
+#            Possible values: none, normal2x, normal3x, advmame2x, advmame3x, advinterp2x, advinterp3x, hq2x, hq3x, 2xsai, super2xsai, supereagle, tv2x, tv3x, rgb2x, rgb3x, scan2x, scan3x.
+
+frameskip=0
+aspect=false
+scaler=normal2x
+
+[cpu]
+#      core: CPU Core used in emulation. auto will switch to dynamic if available and appropriate.
+#            Possible values: auto, dynamic, normal, simple.
+#   cputype: CPU Type used in emulation. auto is the fastest choice.
+#            Possible values: auto, 386, 386_slow, 486_slow, pentium_slow, 386_prefetch.
+#    cycles: Amount of instructions DOSBox tries to emulate each millisecond.
+#            Setting this value too high results in sound dropouts and lags.
+#            Cycles can be set in 3 ways:
+#              'auto'          tries to guess what a game needs.
+#                              It usually works, but can fail for certain games.
+#              'fixed #number' will set a fixed amount of cycles. This is what you usually need if 'auto' fails.
+#                              (Example: fixed 4000).
+#              'max'           will allocate as much cycles as your computer is able to handle.
+#
+#            Possible values: auto, fixed, max.
+#   cycleup: Amount of cycles to decrease/increase with keycombo.(CTRL-F11/CTRL-F12)
+# cycledown: Setting it lower than 100 will be a percentage.
+
+core=auto
+cputype=auto
+cycles=max
+cycleup=10
+cycledown=20
+
+[mixer]
+#   nosound: Enable silent mode, sound is still emulated though.
+#      rate: Mixer sample rate, setting any device's rate higher than this will probably lower their sound quality.
+#            Possible values: 44100, 48000, 32000, 22050, 16000, 11025, 8000, 49716.
+# blocksize: Mixer block size, larger blocks might help sound stuttering but sound will also be more lagged.
+#            Possible values: 1024, 2048, 4096, 8192, 512, 256.
+# prebuffer: How many milliseconds of data to keep on top of the blocksize.
+
+nosound=true
+rate=44100
+blocksize=1024
+prebuffer=20
+
+[midi]
+#     mpu401: Type of MPU-401 to emulate.
+#             Possible values: intelligent, uart, none.
+# mididevice: Device that will receive the MIDI data from MPU-401.
+#             Possible values: default, win32, alsa, oss, coreaudio, coremidi, none.
+# midiconfig: Special configuration options for the device driver. This is usually the id of the device you want to use.
+#               See the README/Manual for more details.
+
+mpu401=none
+mididevice=default
+midiconfig=
+
+[sblaster]
+#  sbtype: Type of Soundblaster to emulate. gb is Gameblaster.
+#          Possible values: sb1, sb2, sbpro1, sbpro2, sb16, gb, none.
+#  sbbase: The IO address of the soundblaster.
+#          Possible values: 220, 240, 260, 280, 2a0, 2c0, 2e0, 300.
+#     irq: The IRQ number of the soundblaster.
+#          Possible values: 7, 5, 3, 9, 10, 11, 12.
+#     dma: The DMA number of the soundblaster.
+#          Possible values: 1, 5, 0, 3, 6, 7.
+#    hdma: The High DMA number of the soundblaster.
+#          Possible values: 1, 5, 0, 3, 6, 7.
+# sbmixer: Allow the soundblaster mixer to modify the DOSBox mixer.
+# oplmode: Type of OPL emulation. On 'auto' the mode is determined by sblaster type. All OPL modes are Adlib-compatible, except for 'cms'.
+#          Possible values: auto, cms, opl2, dualopl2, opl3, none.
+#  oplemu: Provider for the OPL emulation. compat might provide better quality (see oplrate as well).
+#          Possible values: default, compat, fast.
+# oplrate: Sample rate of OPL music emulation. Use 49716 for highest quality (set the mixer rate accordingly).
+#          Possible values: 44100, 49716, 48000, 32000, 22050, 16000, 11025, 8000.
+
+sbtype=none
+sbbase=220
+irq=7
+dma=1
+hdma=5
+sbmixer=false
+oplmode=none
+oplemu=default
+oplrate=44100
+
+[gus]
+#      gus: Enable the Gravis Ultrasound emulation.
+#  gusrate: Sample rate of Ultrasound emulation.
+#           Possible values: 44100, 48000, 32000, 22050, 16000, 11025, 8000, 49716.
+#  gusbase: The IO base address of the Gravis Ultrasound.
+#           Possible values: 240, 220, 260, 280, 2a0, 2c0, 2e0, 300.
+#   gusirq: The IRQ number of the Gravis Ultrasound.
+#           Possible values: 5, 3, 7, 9, 10, 11, 12.
+#   gusdma: The DMA channel of the Gravis Ultrasound.
+#           Possible values: 3, 0, 1, 5, 6, 7.
+# ultradir: Path to Ultrasound directory. In this directory
+#           there should be a MIDI directory that contains
+#           the patch files for GUS playback. Patch sets used
+#           with Timidity should work fine.
+
+gus=false
+gusrate=44100
+gusbase=240
+gusirq=5
+gusdma=3
+ultradir=~
+
+[speaker]
+# pcspeaker: Enable PC-Speaker emulation.
+#    pcrate: Sample rate of the PC-Speaker sound generation.
+#            Possible values: 44100, 48000, 32000, 22050, 16000, 11025, 8000, 49716.
+#     tandy: Enable Tandy Sound System emulation. For 'auto', emulation is present only if machine is set to 'tandy'.
+#            Possible values: auto, on, off.
+# tandyrate: Sample rate of the Tandy 3-Voice generation.
+#            Possible values: 44100, 48000, 32000, 22050, 16000, 11025, 8000, 49716.
+#    disney: Enable Disney Sound Source emulation. (Covox Voice Master and Speech Thing compatible).
+
+pcspeaker=false
+pcrate=44100
+tandy=auto
+tandyrate=44100
+disney=false
+
+[joystick]
+# joysticktype: Type of joystick to emulate: auto (default), none,
+#               2axis (supports two joysticks),
+#               4axis (supports one joystick, first joystick used),
+#               4axis_2 (supports one joystick, second joystick used),
+#               fcs (Thrustmaster), ch (CH Flightstick).
+#               none disables joystick emulation.
+#               auto chooses emulation depending on real joystick(s).
+#               (Remember to reset dosbox's mapperfile if you saved it earlier)
+#               Possible values: auto, 2axis, 4axis, 4axis_2, fcs, ch, none.
+#        timed: enable timed intervals for axis. Experiment with this option, if your joystick drifts (away).
+#     autofire: continuously fires as long as you keep the button pressed.
+#       swap34: swap the 3rd and the 4th axis. can be useful for certain joysticks.
+#   buttonwrap: enable button wrapping at the number of emulated buttons.
+
+joysticktype=none
+
+[serial]
+# serial1: set type of device connected to com port.
+#          Can be disabled, dummy, modem, nullmodem, directserial.
+#          Additional parameters must be in the same line in the form of
+#          parameter:value. Parameter for all types is irq (optional).
+#          for directserial: realport (required), rxdelay (optional).
+#                           (realport:COM1 realport:ttyS0).
+#          for modem: listenport (optional).
+#          for nullmodem: server, rxdelay, txdelay, telnet, usedtr,
+#                         transparent, port, inhsocket (all optional).
+#          Example: serial1=modem listenport:5000
+#          Possible values: dummy, disabled, modem, nullmodem, directserial.
+# serial2: see serial1
+#          Possible values: dummy, disabled, modem, nullmodem, directserial.
+# serial3: see serial1
+#          Possible values: dummy, disabled, modem, nullmodem, directserial.
+# serial4: see serial1
+#          Possible values: dummy, disabled, modem, nullmodem, directserial.
+
+serial1=dummy
+serial2=dummy
+serial3=disabled
+serial4=disabled
+
+[dos]
+#            xms: Enable XMS support.
+#            ems: Enable EMS support.
+#            umb: Enable UMB support.
+# keyboardlayout: Language code of the keyboard layout (or none).
+
+xms=true
+ems=true
+umb=true
+keyboardlayout=auto
+
+[ipx]
+# ipx: Enable ipx over UDP/IP emulation.
+
+ipx=false
+
+[autoexec]
+# Lines in this section will be run at startup.
+# You can put your MOUNT lines here.
+mount d .
+d:
+cd \

--- a/scripts/travis_ci_build.sh
+++ b/scripts/travis_ci_build.sh
@@ -61,9 +61,21 @@ if [ "x$BUILDTOOL" = "xcmake-coverage" ]; then
 fi
 
 if [ "x$BUILDTOOL" = "xmake-dos" ]; then
+    export CC=wcl
+    export CXX=wcl
+    # $(CC) --version
     make -f ../platforms/Dos/Makefile || exit 1
-        # 1. Build the six targets (all)
-        # 2. Run the six targets (tdd), writing to ALLTESTS.LOG
-        # cat ALLTESTS.LOG to console
+	echo "" > exit  # has to be there so dosbox will do 'exit' correctly
+	echo "\n" > ./ALLTESTS.LOG
+    dosbox -conf ../platforms/Dos/dosbox-0.74.conf exit \
+      -c "echo.>>ALLTESTS.LOG" \
+      -c "echo.>>ALLTESTS.LOG" \
+      -c "echo *** Pretending to run CPPU1.EXE ***>>ALLTESTS.LOG" \
+      -c "echo ...!......>>ALLTESTS.LOG" \
+      -c "echo OK (10 tests, 9 ran, 10 checks, 1 ignored, 0 filtered out, 100 ms)>>ALLTESTS.LOG" \
+      -c "echo.>>ALLTESTS.LOG" \
+      -noconsole -exit
+    cat ALLTESTS.LOG
+    # Generate an error here if failures occur in ALLTESTS.LOG
 fi
 

--- a/scripts/travis_ci_build.sh
+++ b/scripts/travis_ci_build.sh
@@ -52,11 +52,18 @@ if [ "x$BUILDTOOL" = "xcmake" ]; then
     ctest -V || exit 1
 fi
 
-if [ "x$BUILDTOOL" = "xcmake-coverage" -a "x$CXX" = "xg++" ]; then
+if [ "x$BUILDTOOL" = "xcmake-coverage" ]; then
     cmake .. -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE -DCOVERAGE=ON
     make || exit 1
     ctest || exit 1
 
     coveralls -b . -r .. -i "src" -i "include" --gcov-options="-bc" || true
+fi
+
+if [ "x$BUILDTOOL" = "xmake-dos" ]; then
+    make -f ../platforms/Dos/Makefile || exit 1
+        # 1. Build the six targets (all)
+        # 2. Run the six targets (tdd), writing to ALLTESTS.LOG
+        # cat ALLTESTS.LOG to console
 fi
 


### PR DESCRIPTION
At this point, it's just a dummy stiil.

What it does do
+ Install Dosbox
+ Invoke the appropriate build
+ Run the proper Makefile
+ Run Dosbox & produce dummy test output from within to a log
+ Print the log

What's still missing
+ Watcom compiler install
+ Proper implementation of Makefile
+ Script to run the actual 6 targets in Dosbox
+ Fail the test if "Failure" is found in the log.
