### PR TITLE
Dos build: Fix Warnings as Errors

### DIFF
--- a/platforms/Dos/Makefile
+++ b/platforms/Dos/Makefile
@@ -11,8 +11,13 @@ V := /
 -include ../platforms/Dos/platform.mk
 include ../platforms/Dos/sources.mk
 
+# Disable W013 unreachable code - it overreacts to CHECK_EQUAL macros
+# Disable W367 conditional expression in if statement is always true - same
+# Disable W368 conditional expression in if statement is always false - same
+# Disable W391 assignment found in boolean expression - because we do that
+
 CFLAGS := \
-  -q -c -os -oc -d0 -w=3 -ml -zm \
+  -q -c -os -oc -d0 -we -w=3 -wcd=13 -wcd=367 -wcd=368 -wcd391 -ml -zm \
   -dCPPUTEST_MEM_LEAK_DETECTION_DISABLED=1 \
   -dCPPUTEST_STD_CPP_LIB_DISABLED=1 \
   -i$(CPPUTEST_HOME)/include \

--- a/tests/CppUTestExt/MockComparatorCopierTest.cpp
+++ b/tests/CppUTestExt/MockComparatorCopierTest.cpp
@@ -545,7 +545,7 @@ public:
     }
 };
 
-class SomeClass
+struct SomeClass
 {
     int someDummy_;
 };

--- a/tests/SimpleStringTest.cpp
+++ b/tests/SimpleStringTest.cpp
@@ -727,10 +727,10 @@ TEST(SimpleString, StrCmp)
     char blabla[] = "blabla";
     char bla[] = "bla";
     CHECK(SimpleString::StrCmp(empty, empty) == 0);
-    CHECK(SimpleString::StrCmp(bla, blabla) == -'b');
+    CHECK(SimpleString::StrCmp(bla, blabla) == -(int)'b');
     CHECK(SimpleString::StrCmp(blabla, bla) == 'b');
     CHECK(SimpleString::StrCmp(bla, empty) == 'b');
-    CHECK(SimpleString::StrCmp(empty, bla) == -'b');
+    CHECK(SimpleString::StrCmp(empty, bla) == -(int)'b');
     CHECK(SimpleString::StrCmp(bla, bla) == 0);
 }
 


### PR DESCRIPTION
Heed some, squash most, and enable warnings=error

Fixes issue #765.