### PR TITLE
Add function pointer support.

### DIFF
--- a/include/CppUTest/SimpleString.h
+++ b/include/CppUTest/SimpleString.h
@@ -133,6 +133,7 @@ private:
 
 SimpleString StringFrom(bool value);
 SimpleString StringFrom(const void* value);
+SimpleString StringFrom(void (*value)());
 SimpleString StringFrom(char value);
 SimpleString StringFrom(const char *value);
 SimpleString StringFromOrNull(const char * value);
@@ -143,6 +144,7 @@ SimpleString StringFrom(unsigned long value);
 SimpleString HexStringFrom(long value);
 SimpleString HexStringFrom(unsigned long value);
 SimpleString HexStringFrom(const void* value);
+SimpleString HexStringFrom(void (*value)());
 SimpleString StringFrom(double value, int precision = 6);
 SimpleString StringFrom(const SimpleString& other);
 SimpleString StringFromFormat(const char* format, ...) __check_format__(printf, 1, 2);

--- a/include/CppUTest/Utest.h
+++ b/include/CppUTest/Utest.h
@@ -114,6 +114,7 @@ public:
     virtual void assertLongsEqual(long expected, long actual, const char* text, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
     virtual void assertUnsignedLongsEqual(unsigned long expected, unsigned long actual, const char* text, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
     virtual void assertPointersEqual(const void *expected, const void *actual, const char* text, const char *fileName, int lineNumber);
+    virtual void assertFunctionPointersEqual(void (*expected)(), void (*actual)(), const char* text, const char* fileName, int lineNumber);
     virtual void assertDoublesEqual(double expected, double actual, double threshold, const char* text, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
     virtual void assertEquals(bool failed, const char* expected, const char* actual, const char* text, const char* file, int line, const TestTerminator& testTerminator = NormalTestTerminator());
     virtual void assertBinaryEqual(const void *expected, const void *actual, size_t length, const char* text, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());

--- a/include/CppUTest/UtestMacros.h
+++ b/include/CppUTest/UtestMacros.h
@@ -215,6 +215,15 @@
 #define POINTERS_EQUAL_LOCATION(expected, actual, text, file, line)\
   { UtestShell::getCurrent()->assertPointersEqual((void *)expected, (void *)actual, text, file, line); }
 
+#define FUNCTIONPOINTERS_EQUAL(expected, actual)\
+    FUNCTIONPOINTERS_EQUAL_LOCATION((expected), (actual), NULL, __FILE__, __LINE__)
+
+#define FUNCTIONPOINTERS_EQUAL_TEXT(expected, actual, text)\
+    FUNCTIONPOINTERS_EQUAL_LOCATION((expected), (actual), text, __FILE__, __LINE__)
+
+#define FUNCTIONPOINTERS_EQUAL_LOCATION(expected, actual, text, file, line)\
+  { UtestShell::getCurrent()->assertFunctionPointersEqual((void (*)())expected, (void (*)())actual, text, file, line); }
+
 //Check two doubles for equality within a tolerance threshold
 #define DOUBLES_EQUAL(expected, actual, threshold)\
   DOUBLES_EQUAL_LOCATION(expected, actual, threshold, NULL, __FILE__, __LINE__)

--- a/include/CppUTestExt/MockActualCall.h
+++ b/include/CppUTestExt/MockActualCall.h
@@ -50,6 +50,7 @@ public:
     MockActualCall& withParameter(const SimpleString& name, double value) { return withDoubleParameter(name, value); }
     MockActualCall& withParameter(const SimpleString& name, const char* value) { return withStringParameter(name, value); }
     MockActualCall& withParameter(const SimpleString& name, void* value) { return withPointerParameter(name, value); }
+    MockActualCall& withParameter(const SimpleString& name, void (*value)()) { return withFunctionPointerParameter(name, value); }
     MockActualCall& withParameter(const SimpleString& name, const void* value) { return withConstPointerParameter(name, value); }
     MockActualCall& withParameter(const SimpleString& name, const unsigned char* value, size_t size) { return withMemoryBufferParameter(name, value, size); }
     virtual MockActualCall& withParameterOfType(const SimpleString& typeName, const SimpleString& name, const void* value)=0;
@@ -63,6 +64,7 @@ public:
     virtual MockActualCall& withDoubleParameter(const SimpleString& name, double value)=0;
     virtual MockActualCall& withStringParameter(const SimpleString& name, const char* value)=0;
     virtual MockActualCall& withPointerParameter(const SimpleString& name, void* value)=0;
+    virtual MockActualCall& withFunctionPointerParameter(const SimpleString& name, void (*value)())=0;
     virtual MockActualCall& withConstPointerParameter(const SimpleString& name, const void* value)=0;
     virtual MockActualCall& withMemoryBufferParameter(const SimpleString& name, const unsigned char* value, size_t size)=0;
 
@@ -92,6 +94,9 @@ public:
 
     virtual const void * returnConstPointerValue()=0;
     virtual const void * returnConstPointerValueOrDefault(const void * default_value)=0;
+
+    virtual void (*returnFunctionPointerValue())()=0;
+    virtual void (*returnFunctionPointerValueOrDefault(void (*default_value)()))()=0;
 
     virtual MockActualCall& onObject(void* objectPtr)=0;
 };

--- a/include/CppUTestExt/MockCheckedActualCall.h
+++ b/include/CppUTestExt/MockCheckedActualCall.h
@@ -47,6 +47,7 @@ public:
     virtual MockActualCall& withStringParameter(const SimpleString& name, const char* value) _override;
     virtual MockActualCall& withPointerParameter(const SimpleString& name, void* value) _override;
     virtual MockActualCall& withConstPointerParameter(const SimpleString& name, const void* value) _override;
+    virtual MockActualCall& withFunctionPointerParameter(const SimpleString& name, void (*value)()) _override;
     virtual MockActualCall& withMemoryBufferParameter(const SimpleString& name, const unsigned char* value, size_t size) _override;
     virtual MockActualCall& withParameterOfType(const SimpleString& type, const SimpleString& name, const void* value) _override;
     virtual MockActualCall& withOutputParameter(const SimpleString& name, void* output) _override;
@@ -78,6 +79,9 @@ public:
 
     virtual void * returnPointerValue() _override;
     virtual void * returnPointerValueOrDefault(void *) _override;
+
+    virtual void (*returnFunctionPointerValue())() _override;
+    virtual void (*returnFunctionPointerValueOrDefault(void (*)()))() _override;
 
     virtual MockActualCall& onObject(void* objectPtr) _override;
 
@@ -151,6 +155,7 @@ public:
     virtual MockActualCall& withStringParameter(const SimpleString& name, const char* value) _override;
     virtual MockActualCall& withPointerParameter(const SimpleString& name, void* value) _override;
     virtual MockActualCall& withConstPointerParameter(const SimpleString& name, const void* value) _override;
+    virtual MockActualCall& withFunctionPointerParameter(const SimpleString& name, void (*value)()) _override;
     virtual MockActualCall& withMemoryBufferParameter(const SimpleString& name, const unsigned char* value, size_t size) _override;
     virtual MockActualCall& withParameterOfType(const SimpleString& typeName, const SimpleString& name, const void* value) _override;
     virtual MockActualCall& withOutputParameter(const SimpleString& name, void* output) _override;
@@ -183,6 +188,9 @@ public:
     virtual const void * returnConstPointerValue() _override;
     virtual const void * returnConstPointerValueOrDefault(const void * default_value) _override;
 
+    virtual void (*returnFunctionPointerValue())() _override;
+    virtual void (*returnFunctionPointerValueOrDefault(void (*)()))() _override;
+
     virtual MockActualCall& onObject(void* objectPtr) _override;
 
     const char* getTraceOutput();
@@ -208,6 +216,7 @@ public:
     virtual MockActualCall& withStringParameter(const SimpleString&, const char*) _override { return *this; }
     virtual MockActualCall& withPointerParameter(const SimpleString& , void*) _override { return *this; }
     virtual MockActualCall& withConstPointerParameter(const SimpleString& , const void*) _override { return *this; }
+    virtual MockActualCall& withFunctionPointerParameter(const SimpleString& , void (*)()) _override { return *this; }
     virtual MockActualCall& withMemoryBufferParameter(const SimpleString&, const unsigned char*, size_t) _override  { return *this; }
     virtual MockActualCall& withParameterOfType(const SimpleString&, const SimpleString&, const void*) _override { return *this; }
     virtual MockActualCall& withOutputParameter(const SimpleString&, void*) _override { return *this; }
@@ -239,6 +248,9 @@ public:
 
     virtual const void * returnConstPointerValue() _override { return NULL; }
     virtual const void * returnConstPointerValueOrDefault(const void *) _override { return returnConstPointerValue(); }
+
+    virtual void (*returnFunctionPointerValue())() _override { return NULL; }
+    virtual void (*returnFunctionPointerValueOrDefault(void (*)()))() _override { return returnFunctionPointerValue(); }
 
     virtual MockActualCall& onObject(void* ) _override { return *this; }
 

--- a/include/CppUTestExt/MockCheckedExpectedCall.h
+++ b/include/CppUTestExt/MockCheckedExpectedCall.h
@@ -48,6 +48,7 @@ public:
     virtual MockExpectedCall& withStringParameter(const SimpleString& name, const char* value) _override;
     virtual MockExpectedCall& withPointerParameter(const SimpleString& name, void* value) _override;
     virtual MockExpectedCall& withConstPointerParameter(const SimpleString& name, const void* value) _override;
+    virtual MockExpectedCall& withFunctionPointerParameter(const SimpleString& name, void (*value)()) _override;
     virtual MockExpectedCall& withMemoryBufferParameter(const SimpleString& name, const unsigned char* value, size_t size) _override;
     virtual MockExpectedCall& withParameterOfType(const SimpleString& typeName, const SimpleString& name, const void* value) _override;
     virtual MockExpectedCall& withOutputParameterReturning(const SimpleString& name, const void* value, size_t size) _override;
@@ -62,6 +63,7 @@ public:
     virtual MockExpectedCall& andReturnValue(const char* value) _override;
     virtual MockExpectedCall& andReturnValue(void* value) _override;
     virtual MockExpectedCall& andReturnValue(const void* value) _override;
+    virtual MockExpectedCall& andReturnValue(void (*value)()) _override;
 
     virtual MockNamedValue returnValue();
 
@@ -147,6 +149,7 @@ public:
     virtual MockExpectedCall& withStringParameter(const SimpleString& name, const char* value) _override;
     virtual MockExpectedCall& withConstPointerParameter(const SimpleString& name, const void* value) _override;
     virtual MockExpectedCall& withPointerParameter(const SimpleString& name, void* value) _override;
+    virtual MockExpectedCall& withFunctionPointerParameter(const SimpleString& name, void (*value)()) _override;
     virtual MockExpectedCall& withMemoryBufferParameter(const SimpleString& name, const unsigned char* value, size_t size) _override;
     virtual MockExpectedCall& withParameterOfType(const SimpleString& typeName, const SimpleString& name, const void* value) _override;
     virtual MockExpectedCall& withOutputParameterReturning(const SimpleString& name, const void* value, size_t size) _override;
@@ -161,6 +164,7 @@ public:
     virtual MockExpectedCall& andReturnValue(const char* value) _override;
     virtual MockExpectedCall& andReturnValue(void* value) _override;
     virtual MockExpectedCall& andReturnValue(const void* value) _override;
+    virtual MockExpectedCall& andReturnValue(void (*value)()) _override;
 
     virtual MockExpectedCall& onObject(void* objectPtr) _override;
 
@@ -184,6 +188,7 @@ public:
     virtual MockExpectedCall& withStringParameter(const SimpleString&, const char*) _override { return *this; }
     virtual MockExpectedCall& withPointerParameter(const SimpleString& , void*) _override { return *this; }
     virtual MockExpectedCall& withConstPointerParameter(const SimpleString& , const void*) _override { return *this; }
+    virtual MockExpectedCall& withFunctionPointerParameter(const SimpleString& , void(*)()) _override { return *this; }
     virtual MockExpectedCall& withMemoryBufferParameter(const SimpleString&, const unsigned char*, size_t) _override { return *this; }
     virtual MockExpectedCall& withParameterOfType(const SimpleString&, const SimpleString&, const void*) _override { return *this; }
     virtual MockExpectedCall& withOutputParameterReturning(const SimpleString&, const void*, size_t) _override { return *this; }
@@ -198,6 +203,7 @@ public:
     virtual MockExpectedCall& andReturnValue(const char*) _override { return *this; }
     virtual MockExpectedCall& andReturnValue(void*) _override { return *this; }
     virtual MockExpectedCall& andReturnValue(const void*) _override { return *this; }
+    virtual MockExpectedCall& andReturnValue(void (*)()) _override { return *this; }
 
     virtual MockExpectedCall& onObject(void*) _override { return *this; }
 

--- a/include/CppUTestExt/MockExpectedCall.h
+++ b/include/CppUTestExt/MockExpectedCall.h
@@ -48,6 +48,7 @@ public:
     MockExpectedCall& withParameter(const SimpleString& name, const char* value) { return withStringParameter(name, value); }
     MockExpectedCall& withParameter(const SimpleString& name, void* value) { return withPointerParameter(name, value); }
     MockExpectedCall& withParameter(const SimpleString& name, const void* value) { return withConstPointerParameter(name, value); }
+    MockExpectedCall& withParameter(const SimpleString& name, void (*value)()) { return withFunctionPointerParameter(name, value); }
     MockExpectedCall& withParameter(const SimpleString& name, const unsigned char* value, size_t size) { return withMemoryBufferParameter(name, value, size); }
     virtual MockExpectedCall& withParameterOfType(const SimpleString& typeName, const SimpleString& name, const void* value)=0;
     virtual MockExpectedCall& withOutputParameterReturning(const SimpleString& name, const void* value, size_t size)=0;
@@ -61,6 +62,7 @@ public:
     virtual MockExpectedCall& withDoubleParameter(const SimpleString& name, double value)=0;
     virtual MockExpectedCall& withStringParameter(const SimpleString& name, const char* value)=0;
     virtual MockExpectedCall& withPointerParameter(const SimpleString& name, void* value)=0;
+    virtual MockExpectedCall& withFunctionPointerParameter(const SimpleString& name, void (*value)())=0;
     virtual MockExpectedCall& withConstPointerParameter(const SimpleString& name, const void* value)=0;
     virtual MockExpectedCall& withMemoryBufferParameter(const SimpleString& name, const unsigned char* value, size_t size)=0;
     virtual MockExpectedCall& andReturnValue(int value)=0;
@@ -71,6 +73,7 @@ public:
     virtual MockExpectedCall& andReturnValue(const char* value)=0;
     virtual MockExpectedCall& andReturnValue(void* value)=0;
     virtual MockExpectedCall& andReturnValue(const void* value)=0;
+    virtual MockExpectedCall& andReturnValue(void (*value)())=0;
 
     virtual MockExpectedCall& onObject(void* objectPtr)=0;
 };

--- a/include/CppUTestExt/MockNamedValue.h
+++ b/include/CppUTestExt/MockNamedValue.h
@@ -110,6 +110,7 @@ public:
     virtual void setValue(double value);
     virtual void setValue(void* value);
     virtual void setValue(const void* value);
+    virtual void setValue(void (*value)());
     virtual void setValue(const char* value);
     virtual void setMemoryBuffer(const unsigned char* value, size_t size);
     virtual void setObjectPointer(const SimpleString& type, const void* objectPtr);
@@ -133,6 +134,7 @@ public:
     virtual const char* getStringValue() const;
     virtual void* getPointerValue() const;
     virtual const void* getConstPointerValue() const;
+    virtual void (*getFunctionPointerValue() const)();
     virtual const unsigned char* getMemoryBuffer() const;
     virtual const void* getObjectPointer() const;
     virtual size_t getSize() const;
@@ -153,6 +155,7 @@ private:
         const char* stringValue_;
         void* pointerValue_;
         const void* constPointerValue_;
+        void (*functionPointerValue_)();
         const unsigned char* memoryBufferValue_;
         const void* objectPointerValue_;
         const void* outputPointerValue_;

--- a/include/CppUTestExt/MockSupport.h
+++ b/include/CppUTestExt/MockSupport.h
@@ -67,6 +67,8 @@ public:
     virtual void* returnPointerValueOrDefault(void * defaultValue);
     virtual const void* returnConstPointerValueOrDefault(const void * defaultValue);
     virtual const void* constPointerReturnValue();
+    virtual void (*returnFunctionPointerValueOrDefault(void (*defaultValue)()))();
+    virtual void (*functionPointerReturnValue())();
 
     bool hasData(const SimpleString& name);
     void setData(const SimpleString& name, int value);
@@ -75,6 +77,7 @@ public:
     void setData(const SimpleString& name, double value);
     void setData(const SimpleString& name, void* value);
     void setData(const SimpleString& name, const void* value);
+    void setData(const SimpleString& name, void (*value)());
     void setDataObject(const SimpleString& name, const SimpleString& type, void* value);
     MockNamedValue getData(const SimpleString& name);
 

--- a/include/CppUTestExt/MockSupport_c.h
+++ b/include/CppUTestExt/MockSupport_c.h
@@ -43,6 +43,7 @@ typedef enum {
     MOCKVALUETYPE_STRING,
     MOCKVALUETYPE_POINTER,
     MOCKVALUETYPE_CONST_POINTER,
+    MOCKVALUETYPE_FUNCTIONPOINTER,
     MOCKVALUETYPE_MEMORYBUFFER,
     MOCKVALUETYPE_OBJECT
 } MockValueType_c;
@@ -59,6 +60,7 @@ typedef struct SMockValue_c
         const char* stringValue;
         void* pointerValue;
         const void* constPointerValue;
+        void (*functionPointerValue)();
         const unsigned char* memoryBufferValue;
         const void* objectValue;
     } value;
@@ -75,6 +77,7 @@ struct SMockActualCall_c
     MockActualCall_c* (*withStringParameters)(const char* name, const char* value);
     MockActualCall_c* (*withPointerParameters)(const char* name, void* value);
     MockActualCall_c* (*withConstPointerParameters)(const char* name, const void* value);
+    MockActualCall_c* (*withFunctionPointerParameters)(const char* name, void (*value)());
     MockActualCall_c* (*withMemoryBufferParameter)(const char* name, const unsigned char* value, size_t size);
     MockActualCall_c* (*withParameterOfType)(const char* type, const char* name, const void* value);
     MockActualCall_c* (*withOutputParameter)(const char* name, void* value);
@@ -93,6 +96,7 @@ struct SMockExpectedCall_c
     MockExpectedCall_c* (*withStringParameters)(const char* name, const char* value);
     MockExpectedCall_c* (*withPointerParameters)(const char* name, void* value);
     MockExpectedCall_c* (*withConstPointerParameters)(const char* name, const void* value);
+    MockExpectedCall_c* (*withFunctionPointerParameters)(const char* name, void (*value)());
     MockExpectedCall_c* (*withMemoryBufferParameter)(const char* name, const unsigned char* value, size_t size);
     MockExpectedCall_c* (*withParameterOfType)(const char* type, const char* name, const void* value);
     MockExpectedCall_c* (*withOutputParameterReturning)(const char* name, const void* value, size_t size);
@@ -105,6 +109,7 @@ struct SMockExpectedCall_c
     MockExpectedCall_c* (*andReturnStringValue)(const char* value);
     MockExpectedCall_c* (*andReturnPointerValue)(void* value);
     MockExpectedCall_c* (*andReturnConstPointerValue)(const void* value);
+    MockExpectedCall_c* (*andReturnFunctionPointerValue)(void (*value)());
 };
 
 typedef int (*MockTypeEqualFunction_c)(const void* object1, const void* object2);
@@ -126,6 +131,7 @@ struct SMockSupport_c
     void (*setStringData) (const char* name, const char* value);
     void (*setPointerData) (const char* name, void* value);
     void (*setConstPointerData) (const char* name, const void* value);
+    void (*setFunctionPointerData) (const char* name, void (*value)());
     void (*setDataObject) (const char* name, const char* type, void* value);
     MockValue_c (*getData)(const char* name);
 

--- a/include/CppUTestExt/MockSupport_c.h
+++ b/include/CppUTestExt/MockSupport_c.h
@@ -60,7 +60,7 @@ typedef struct SMockValue_c
         const char* stringValue;
         void* pointerValue;
         const void* constPointerValue;
-        void (*functionPointerValue)();
+        void (*functionPointerValue)(void);
         const unsigned char* memoryBufferValue;
         const void* objectValue;
     } value;
@@ -77,7 +77,7 @@ struct SMockActualCall_c
     MockActualCall_c* (*withStringParameters)(const char* name, const char* value);
     MockActualCall_c* (*withPointerParameters)(const char* name, void* value);
     MockActualCall_c* (*withConstPointerParameters)(const char* name, const void* value);
-    MockActualCall_c* (*withFunctionPointerParameters)(const char* name, void (*value)());
+    MockActualCall_c* (*withFunctionPointerParameters)(const char* name, void (*value)(void));
     MockActualCall_c* (*withMemoryBufferParameter)(const char* name, const unsigned char* value, size_t size);
     MockActualCall_c* (*withParameterOfType)(const char* type, const char* name, const void* value);
     MockActualCall_c* (*withOutputParameter)(const char* name, void* value);
@@ -96,7 +96,7 @@ struct SMockExpectedCall_c
     MockExpectedCall_c* (*withStringParameters)(const char* name, const char* value);
     MockExpectedCall_c* (*withPointerParameters)(const char* name, void* value);
     MockExpectedCall_c* (*withConstPointerParameters)(const char* name, const void* value);
-    MockExpectedCall_c* (*withFunctionPointerParameters)(const char* name, void (*value)());
+    MockExpectedCall_c* (*withFunctionPointerParameters)(const char* name, void (*value)(void));
     MockExpectedCall_c* (*withMemoryBufferParameter)(const char* name, const unsigned char* value, size_t size);
     MockExpectedCall_c* (*withParameterOfType)(const char* type, const char* name, const void* value);
     MockExpectedCall_c* (*withOutputParameterReturning)(const char* name, const void* value, size_t size);
@@ -109,7 +109,7 @@ struct SMockExpectedCall_c
     MockExpectedCall_c* (*andReturnStringValue)(const char* value);
     MockExpectedCall_c* (*andReturnPointerValue)(void* value);
     MockExpectedCall_c* (*andReturnConstPointerValue)(const void* value);
-    MockExpectedCall_c* (*andReturnFunctionPointerValue)(void (*value)());
+    MockExpectedCall_c* (*andReturnFunctionPointerValue)(void (*value)(void));
 };
 
 typedef int (*MockTypeEqualFunction_c)(const void* object1, const void* object2);
@@ -131,7 +131,7 @@ struct SMockSupport_c
     void (*setStringData) (const char* name, const char* value);
     void (*setPointerData) (const char* name, void* value);
     void (*setConstPointerData) (const char* name, const void* value);
-    void (*setFunctionPointerData) (const char* name, void (*value)());
+    void (*setFunctionPointerData) (const char* name, void (*value)(void));
     void (*setDataObject) (const char* name, const char* type, void* value);
     MockValue_c (*getData)(const char* name);
 

--- a/src/CppUTest/SimpleString.cpp
+++ b/src/CppUTest/SimpleString.cpp
@@ -463,6 +463,11 @@ SimpleString StringFrom(const void* value)
     return SimpleString("0x") + HexStringFrom(value);
 }
 
+SimpleString StringFrom(void (*value)())
+{
+    return SimpleString("0x") + HexStringFrom(value);
+}
+
 SimpleString HexStringFrom(long value)
 {
     return StringFromFormat("%lx", value);
@@ -484,9 +489,25 @@ static long convertPointerToLongValue(const void* value)
     return *long_value;
 }
 
+static long convertFunctionPointerToLongValue(void (*value)())
+{
+    /*
+     * This way of converting also can convert a 64bit pointer in a 32bit integer by truncating.
+     * This isn't the right way to convert pointers values and need to change by implementing a
+     * proper portable way to convert pointers to strings.
+     */
+    long* long_value = (long*) &value;
+    return *long_value;
+}
+
 SimpleString HexStringFrom(const void* value)
 {
     return StringFromFormat("%lx", convertPointerToLongValue(value));
+}
+
+SimpleString HexStringFrom(void (*value)())
+{
+    return StringFromFormat("%lx", convertFunctionPointerToLongValue(value));
 }
 
 SimpleString StringFrom(double value, int precision)

--- a/src/CppUTest/Utest.cpp
+++ b/src/CppUTest/Utest.cpp
@@ -425,6 +425,13 @@ void UtestShell::assertPointersEqual(const void* expected, const void* actual, c
         failWith(EqualsFailure(this, fileName, lineNumber, StringFrom(expected), StringFrom(actual), text));
 }
 
+void UtestShell::assertFunctionPointersEqual(void (*expected)(), void (*actual)(), const char* text, const char* fileName, int lineNumber)
+{
+    getTestResult()->countCheck();
+    if (expected != actual)
+        failWith(EqualsFailure(this, fileName, lineNumber, StringFrom(expected), StringFrom(actual), text));
+}
+
 void UtestShell::assertDoublesEqual(double expected, double actual, double threshold, const char* text, const char* fileName, int lineNumber, const TestTerminator& testTerminator)
 {
     getTestResult()->countCheck();

--- a/src/CppUTestExt/MockActualCall.cpp
+++ b/src/CppUTestExt/MockActualCall.cpp
@@ -261,6 +261,14 @@ MockActualCall& MockCheckedActualCall::withConstPointerParameter(const SimpleStr
     return *this;
 }
 
+MockActualCall& MockCheckedActualCall::withFunctionPointerParameter(const SimpleString& name, void (*value)())
+{
+    MockNamedValue actualParameter(name);
+    actualParameter.setValue(value);
+    checkInputParameter(actualParameter);
+    return *this;
+}
+
 MockActualCall& MockCheckedActualCall::withMemoryBufferParameter(const SimpleString& name, const unsigned char* value, size_t size)
 {
     MockNamedValue actualParameter(name);
@@ -447,6 +455,19 @@ const void * MockCheckedActualCall::returnConstPointerValueOrDefault(const void 
     return returnConstPointerValue();
 }
 
+void (*MockCheckedActualCall::returnFunctionPointerValue())()
+{
+    return returnValue().getFunctionPointerValue();
+}
+
+void (*MockCheckedActualCall::returnFunctionPointerValueOrDefault(void (*default_value)()))()
+{
+    if (!hasReturnValue()) {
+        return default_value;
+    }
+    return returnFunctionPointerValue();
+}
+
 const char * MockCheckedActualCall::returnStringValueOrDefault(const char * default_value)
 {
     if (!hasReturnValue()) {
@@ -594,6 +615,13 @@ MockActualCall& MockActualCallTrace::withConstPointerParameter(const SimpleStrin
     return *this;
 }
 
+MockActualCall& MockActualCallTrace::withFunctionPointerParameter(const SimpleString& name, void (*value)())
+{
+    addParameterName(name);
+    traceBuffer_ += StringFrom(value);
+    return *this;
+}
+
 MockActualCall& MockActualCallTrace::withMemoryBufferParameter(const SimpleString& name, const unsigned char* value, size_t size)
 {
     addParameterName(name);
@@ -686,6 +714,11 @@ const void * MockActualCallTrace::returnConstPointerValue()
     return NULL;
 }
 
+void (*MockActualCallTrace::returnFunctionPointerValue())()
+{
+    return NULL;
+}
+
 const void * MockActualCallTrace::returnConstPointerValueOrDefault(const void *)
 {
     return returnConstPointerValue();
@@ -694,6 +727,11 @@ const void * MockActualCallTrace::returnConstPointerValueOrDefault(const void *)
 void * MockActualCallTrace::returnPointerValueOrDefault(void *)
 {
     return returnPointerValue();
+}
+
+void (*MockActualCallTrace::returnFunctionPointerValueOrDefault(void (*)()))()
+{
+    return returnFunctionPointerValue();
 }
 
 const char * MockActualCallTrace::returnStringValue()

--- a/src/CppUTestExt/MockExpectedCall.cpp
+++ b/src/CppUTestExt/MockExpectedCall.cpp
@@ -137,6 +137,14 @@ MockExpectedCall& MockCheckedExpectedCall::withConstPointerParameter(const Simpl
     return *this;
 }
 
+MockExpectedCall& MockCheckedExpectedCall::withFunctionPointerParameter(const SimpleString& name, void (*value)())
+{
+    MockNamedValue* newParameter = new MockExpectedFunctionParameter(name);
+    inputParameters_->add(newParameter);
+    newParameter->setValue(value);
+    return *this;
+}
+
 MockExpectedCall& MockCheckedExpectedCall::withMemoryBufferParameter(const SimpleString& name, const unsigned char* value, size_t size)
 {
     MockNamedValue* newParameter = new MockExpectedFunctionParameter(name);
@@ -449,6 +457,13 @@ MockExpectedCall& MockCheckedExpectedCall::andReturnValue(const void* value)
     return *this;
 }
 
+MockExpectedCall& MockCheckedExpectedCall::andReturnValue(void (*value)())
+{
+    returnValue_.setName("returnValue");
+    returnValue_.setValue(value);
+    return *this;
+}
+
 MockExpectedCall& MockCheckedExpectedCall::onObject(void* objectPtr)
 {
     wasPassedToObject_ = false;
@@ -578,6 +593,13 @@ MockExpectedCall& MockExpectedCallComposite::withConstPointerParameter(const Sim
     return *this;
 }
 
+MockExpectedCall& MockExpectedCallComposite::withFunctionPointerParameter(const SimpleString& name, void (*value)())
+{
+    for (MockExpectedCallCompositeNode* node = head_; node != NULL; node = node->next_)
+        node->call_.withParameter(name, value);
+    return *this;
+}
+
 MockExpectedCall& MockExpectedCallComposite::withMemoryBufferParameter(const SimpleString& name, const unsigned char* value, size_t size)
 {
     for (MockExpectedCallCompositeNode* node = head_; node != NULL; node = node->next_)
@@ -663,6 +685,13 @@ MockExpectedCall& MockExpectedCallComposite::andReturnValue(void* value)
 }
 
 MockExpectedCall& MockExpectedCallComposite::andReturnValue(const void* value)
+{
+    for (MockExpectedCallCompositeNode* node = head_; node != NULL; node = node->next_)
+        node->call_.andReturnValue(value);
+    return *this;
+}
+
+MockExpectedCall& MockExpectedCallComposite::andReturnValue(void (*value)())
 {
     for (MockExpectedCallCompositeNode* node = head_; node != NULL; node = node->next_)
         node->call_.andReturnValue(value);

--- a/src/CppUTestExt/MockNamedValue.cpp
+++ b/src/CppUTestExt/MockNamedValue.cpp
@@ -88,6 +88,12 @@ void MockNamedValue::setValue(const void* value)
     value_.constPointerValue_ = value;
 }
 
+void MockNamedValue::setValue(void (*value)())
+{
+    type_ = "void (*)()";
+    value_.functionPointerValue_ = value;
+}
+
 void MockNamedValue::setValue(const char* value)
 {
     type_ = "const char*";
@@ -201,6 +207,12 @@ const void* MockNamedValue::getConstPointerValue() const
     return value_.pointerValue_;
 }
 
+void (*MockNamedValue::getFunctionPointerValue() const)()
+{
+    STRCMP_EQUAL("void (*)()", type_.asCharString());
+    return value_.functionPointerValue_;
+}
+
 const unsigned char* MockNamedValue::getMemoryBuffer() const
 {
     STRCMP_EQUAL("const unsigned char*", type_.asCharString());
@@ -270,6 +282,8 @@ bool MockNamedValue::equals(const MockNamedValue& p) const
         return value_.pointerValue_ == p.value_.pointerValue_;
     else if (type_ == "const void*")
         return value_.constPointerValue_ == p.value_.constPointerValue_;
+    else if (type_ == "void (*)()")
+        return value_.functionPointerValue_ == p.value_.functionPointerValue_;
     else if (type_ == "double")
         return (doubles_equal(value_.doubleValue_, p.value_.doubleValue_, 0.005));
     else if (type_ == "const unsigned char*")
@@ -310,6 +324,8 @@ SimpleString MockNamedValue::toString() const
         return value_.stringValue_;
     else if (type_ == "void*")
         return StringFrom(value_.pointerValue_);
+    else if (type_ == "void (*)()")
+        return StringFrom(value_.functionPointerValue_);
     else if (type_ == "const void*")
         return StringFrom(value_.constPointerValue_);
     else if (type_ == "double")

--- a/src/CppUTestExt/MockSupport.cpp
+++ b/src/CppUTestExt/MockSupport.cpp
@@ -360,6 +360,12 @@ void MockSupport::setData(const SimpleString& name, const void* value)
     newData->setValue(value);
 }
 
+void MockSupport::setData(const SimpleString& name, void (*value)())
+{
+    MockNamedValue* newData = retrieveDataFromStore(name);
+    newData->setValue(value);
+}
+
 void MockSupport::setDataObject(const SimpleString& name, const SimpleString& type, void* value)
 {
     MockNamedValue* newData = retrieveDataFromStore(name);
@@ -512,6 +518,14 @@ const void* MockSupport::returnConstPointerValueOrDefault(const void * defaultVa
     return defaultValue;
 }
 
+void (*MockSupport::returnFunctionPointerValueOrDefault(void (*defaultValue)()))()
+{
+    if (hasReturnValue()) {
+        return functionPointerReturnValue();
+    }
+    return defaultValue;
+}
+
 void* MockSupport::pointerReturnValue()
 {
     return returnValue().getPointerValue();
@@ -520,6 +534,11 @@ void* MockSupport::pointerReturnValue()
 const void* MockSupport::constPointerReturnValue()
 {
     return returnValue().getConstPointerValue();
+}
+
+void (*MockSupport::functionPointerReturnValue())()
+{
+    return returnValue().getFunctionPointerValue();
 }
 
 bool MockSupport::hasReturnValue()

--- a/tests/CppUTestExt/MockActualCallTest.cpp
+++ b/tests/CppUTestExt/MockActualCallTest.cpp
@@ -144,6 +144,8 @@ TEST(MockCheckedActualCall, MockIgnoredActualCallWorksAsItShould)
     CHECK(0 == actual.returnPointerValueOrDefault((void*) 0x0));
     CHECK(0 == actual.returnConstPointerValue());
     CHECK(0 == actual.returnConstPointerValueOrDefault((const void*) 0x0));
+    CHECK(0 == actual.returnFunctionPointerValue());
+    CHECK(0 == actual.returnFunctionPointerValueOrDefault((void(*)()) 0x0));
     CHECK_FALSE(actual.hasReturnValue());
     CHECK(actual.returnValue().equals(MockNamedValue("")));
 }
@@ -153,6 +155,7 @@ TEST(MockCheckedActualCall, remainderOfMockActualCallTraceWorksAsItShould)
     int value;
     const int const_value = 1;
     const unsigned char mem_buffer[] = { 0xFE, 0x15 };
+    void (*function_value)() = (void (*)())0xDEAD;
     MockActualCallTrace actual;
     actual.withName("func");
     actual.withCallOrder(1);
@@ -163,9 +166,10 @@ TEST(MockCheckedActualCall, remainderOfMockActualCallTraceWorksAsItShould)
     actual.withLongIntParameter("long_int", (long int) 1);
     actual.withPointerParameter("pointer", &value);
     actual.withConstPointerParameter("const_pointer", &const_value);
+    actual.withFunctionPointerParameter("function_pointer", function_value);
     actual.withMemoryBufferParameter("mem_buffer", mem_buffer, sizeof(mem_buffer));
     actual.withParameterOfType("int", "named_type", &const_value);
-    
+
     SimpleString expectedString("\nFunction name:func");
     expectedString += " withCallOrder:1";
     expectedString += " onObject:0x";
@@ -177,6 +181,8 @@ TEST(MockCheckedActualCall, remainderOfMockActualCallTraceWorksAsItShould)
     expectedString += HexStringFrom(&value);
     expectedString += " const_pointer:0x";
     expectedString += HexStringFrom(&const_value);
+    expectedString += " function_pointer:0x";
+    expectedString += HexStringFrom(function_value);
     expectedString += " mem_buffer:Size = 2 | HexContents = FE 15";
     expectedString += " int named_type:0x";
     expectedString += HexStringFrom(&const_value);
@@ -201,5 +207,7 @@ TEST(MockCheckedActualCall, remainderOfMockActualCallTraceWorksAsItShould)
     CHECK(0 == actual.returnPointerValueOrDefault((void*) 0x0));
     CHECK(0 == actual.returnConstPointerValue());
     CHECK(0 == actual.returnConstPointerValueOrDefault((const void*) 0x0));
+    CHECK(0 == actual.returnFunctionPointerValue());
+    CHECK(0 == actual.returnFunctionPointerValueOrDefault((void (*)()) 0x0));
 }
 

--- a/tests/CppUTestExt/MockExpectedCallTest.cpp
+++ b/tests/CppUTestExt/MockExpectedCallTest.cpp
@@ -239,6 +239,14 @@ TEST(MockExpectedCall, callWithConstPointerParameter)
     POINTERS_EQUAL(ptr, call->getInputParameter("constPointer").getConstPointerValue());
 }
 
+TEST(MockExpectedCall, callWithFunctionPointerParameter)
+{
+    void (*ptr)() = (void (*)()) 0x123;
+    call->withParameter("functionPointer", ptr);
+    STRCMP_EQUAL("void (*)()", call->getInputParameterType("functionPointer").asCharString());
+    FUNCTIONPOINTERS_EQUAL(ptr, call->getInputParameter("functionPointer").getFunctionPointerValue());
+}
+
 TEST(MockExpectedCall, callWithMemoryBuffer)
 {
     const unsigned char mem_buffer[] = { 0x12, 0xFE, 0xA1 };
@@ -580,6 +588,12 @@ TEST(MockExpectedCallComposite, hasConstPointerParameter)
     STRCMP_EQUAL("name -> const void* param: <0x0>", call.callToString().asCharString());
 }
 
+TEST(MockExpectedCallComposite, hasFunctionPointerParameter)
+{
+    composite.withParameter("param", (void (*)()) 0);
+    STRCMP_EQUAL("name -> void (*)() param: <0x0>", call.callToString().asCharString());
+}
+
 TEST(MockExpectedCallComposite, hasMemoryBufferParameter)
 {
     const unsigned char mem_buffer[] = { 0x89, 0xFE, 0x15 };
@@ -655,6 +669,13 @@ TEST(MockExpectedCallComposite, hasConstPointerReturnValue)
     POINTERS_EQUAL((const void*) 0, call.returnValue().getConstPointerValue());
 }
 
+TEST(MockExpectedCallComposite, hasFunctionPointerReturnValue)
+{
+    composite.andReturnValue((void(*)()) 0);
+    STRCMP_EQUAL("void (*)()", call.returnValue().getType().asCharString());
+    FUNCTIONPOINTERS_EQUAL((void(*)()) 0, call.returnValue().getFunctionPointerValue());
+}
+
 TEST(MockExpectedCallComposite, isOnObject)
 {
     composite.onObject(&composite);
@@ -697,6 +718,7 @@ TEST(MockIgnoredExpectedCall, worksAsItShould)
     ignored.withStringParameter("goo", "hello");
     ignored.withPointerParameter("pie", (void*) 0);
     ignored.withConstPointerParameter("woo", (const void*) 0);
+    ignored.withFunctionPointerParameter("fop", (void(*)()) 0);
     ignored.withMemoryBufferParameter("waa", (const unsigned char*) 0, 0);
     ignored.withParameterOfType("top", "mytype", (const void*) 0);
     ignored.withOutputParameterReturning("bar", (const void*) 0, 1);
@@ -709,4 +731,5 @@ TEST(MockIgnoredExpectedCall, worksAsItShould)
     ignored.andReturnValue("boo");
     ignored.andReturnValue((void*) 0);
     ignored.andReturnValue((const void*) 0);
+    ignored.andReturnValue((void(*)()) 0);
 }

--- a/tests/CppUTestExt/MockParameterTest.cpp
+++ b/tests/CppUTestExt/MockParameterTest.cpp
@@ -184,6 +184,14 @@ TEST(MockParameterTest, expectOneConstPointerParameterAndValue)
     mock().checkExpectations();
 }
 
+TEST(MockParameterTest, expectOneFunctionPointerParameterAndValue)
+{
+    mock().expectOneCall("foo").withParameter("parameter", (void(*)()) 0x01);
+    mock().actualCall("foo").withParameter("parameter", (void(*)()) 0x01);
+
+    mock().checkExpectations();
+}
+
 TEST(MockParameterTest, expectOneMemBufferParameterAndValue)
 {
     unsigned char memBuffer1[] = { 0x12, 0x15, 0xFF };

--- a/tests/CppUTestExt/MockReturnValueTest.cpp
+++ b/tests/CppUTestExt/MockReturnValueTest.cpp
@@ -425,6 +425,23 @@ TEST(MockReturnValueTest, WhenNoPointerReturnValueIsExpectedButThereIsADefaultSh
     POINTERS_EQUAL(default_return_value, mock().returnPointerValueOrDefault(default_return_value));
 }
 
+TEST(MockReturnValueTest, WhenAFunctionPointerReturnValueIsExpectedAndAlsoThereIsADefaultShouldlIgnoreTheDefault)
+{
+    void (*default_return_value)() = (void(*)()) 0x777;
+    void (*expected_return_value)() = (void(*)()) 0x144000;
+    mock().expectOneCall("foo").andReturnValue(expected_return_value);
+    FUNCTIONPOINTERS_EQUAL(expected_return_value, mock().actualCall("foo").returnFunctionPointerValueOrDefault(default_return_value));
+    FUNCTIONPOINTERS_EQUAL(expected_return_value, mock().returnFunctionPointerValueOrDefault(default_return_value));
+}
+
+TEST(MockReturnValueTest, WhenNoFunctionPointerReturnValueIsExpectedButThereIsADefaultShouldlUseTheDefaultValue)
+{
+    void (*default_return_value)() = (void(*)()) 0x10;
+    mock().expectOneCall("foo");
+    FUNCTIONPOINTERS_EQUAL(default_return_value, mock().actualCall("foo").returnFunctionPointerValueOrDefault(default_return_value));
+    FUNCTIONPOINTERS_EQUAL(default_return_value, mock().returnFunctionPointerValueOrDefault(default_return_value));
+}
+
 TEST(MockReturnValueTest, PointerReturnValue)
 {
     void* ptr = (void*) 0x00107;
@@ -444,6 +461,17 @@ TEST(MockReturnValueTest, ConstPointerReturnValue)
     POINTERS_EQUAL(ptr, actual_call.returnValue().getConstPointerValue());
     POINTERS_EQUAL(ptr, actual_call.returnConstPointerValue());
     POINTERS_EQUAL(ptr, mock().constPointerReturnValue());
+}
+
+TEST(MockReturnValueTest, FunctionPointerReturnValue)
+{
+    void (*ptr)() = (void(*)()) 0x00107;
+    mock().expectOneCall("foo").andReturnValue(ptr);
+    MockActualCall& actual_call = mock().actualCall("foo");
+
+    FUNCTIONPOINTERS_EQUAL(ptr, actual_call.returnValue().getFunctionPointerValue());
+    FUNCTIONPOINTERS_EQUAL(ptr, actual_call.returnFunctionPointerValue());
+    FUNCTIONPOINTERS_EQUAL(ptr, mock().functionPointerReturnValue());
 }
 
 TEST(MockReturnValueTest, whenCallingDisabledOrIgnoredActualCallsThenTheyDontReturnPreviousCallsValues)

--- a/tests/CppUTestExt/MockSupportTest.cpp
+++ b/tests/CppUTestExt/MockSupportTest.cpp
@@ -112,6 +112,13 @@ TEST(MockSupportTest, setConstDataPointer)
     POINTERS_EQUAL(ptr, mock().getData("data").getConstPointerValue());
 }
 
+TEST(MockSupportTest, setDataFunctionPointer)
+{
+    void (*ptr)() = (void(*)()) 0x001;
+    mock().setData("data", ptr);
+    FUNCTIONPOINTERS_EQUAL(ptr, mock().getData("data").getFunctionPointerValue());
+}
+
 TEST(MockSupportTest, setDataObject)
 {
     void * ptr = (void*) 0x001;

--- a/tests/CppUTestExt/MockSupport_cTest.cpp
+++ b/tests/CppUTestExt/MockSupport_cTest.cpp
@@ -46,9 +46,11 @@ TEST(MockSupport_c, expectAndActualOneCall)
 TEST(MockSupport_c, expectAndActualParameters)
 {
     mock_c()->expectOneCall("boo")->withIntParameters("integer", 1)->withDoubleParameters("double", 1.0)->
-            withStringParameters("string", "string")->withPointerParameters("pointer", (void*) 1);
+            withStringParameters("string", "string")->withPointerParameters("pointer", (void*) 1)->
+            withFunctionPointerParameters("functionPointer", (void(*)()) 1);
     mock_c()->actualCall("boo")->withIntParameters("integer", 1)->withDoubleParameters("double", 1.0)->
-            withStringParameters("string", "string")->withPointerParameters("pointer", (void*) 1);
+            withStringParameters("string", "string")->withPointerParameters("pointer", (void*) 1)->
+            withFunctionPointerParameters("functionPointer", (void(*)()) 1);
 }
 
 extern "C"{
@@ -174,6 +176,13 @@ TEST(MockSupport_c, returnConstPointerValue)
     LONGS_EQUAL(MOCKVALUETYPE_CONST_POINTER, mock_c()->returnValue().type);
 }
 
+TEST(MockSupport_c, returnFunctionPointerValue)
+{
+    mock_c()->expectOneCall("boo")->andReturnFunctionPointerValue((void(*)()) 10);
+    FUNCTIONPOINTERS_EQUAL((void(*)()) 10, mock_c()->actualCall("boo")->returnValue().value.functionPointerValue);
+    LONGS_EQUAL(MOCKVALUETYPE_FUNCTIONPOINTER, mock_c()->returnValue().type);
+}
+
 TEST(MockSupport_c, MockSupportWithScope)
 {
     mock_scope_c("scope")->expectOneCall("boo");
@@ -210,6 +219,12 @@ TEST(MockSupport_c, MockSupportSetConstPointerData)
 {
     mock_c()->setConstPointerData("constPointer", (const void*) 1);
     POINTERS_EQUAL((const void*) 1, mock_c()->getData("constPointer").value.constPointerValue);
+}
+
+TEST(MockSupport_c, MockSupportSetFunctionPointerData)
+{
+    mock_c()->setFunctionPointerData("functionPointer", (void(*)()) 1);
+    FUNCTIONPOINTERS_EQUAL((void(*)()) 1, mock_c()->getData("functionPointer").value.functionPointerValue);
 }
 
 TEST(MockSupport_c, MockSupportSetDataObject)
@@ -265,11 +280,11 @@ TEST_ORDERED(MockSupport_c, shouldCrashOnFailure, 21)
     UtestShell::setCrashMethod(crashMethod);
     mock_c()->crashOnFailure(true);
     fixture.setTestFunction(failedCallToMockC);
-    
+
     fixture.runAllTests();
 
     CHECK(cpputestHasCrashed);
-    
+
     UtestShell::resetCrashMethod();
     mock_c()->crashOnFailure(false);
 }
@@ -280,7 +295,7 @@ TEST_ORDERED(MockSupport_c, nextTestShouldNotCrashOnFailure, 22)
     TestTestingFixture fixture;
     UtestShell::setCrashMethod(crashMethod);
     fixture.setTestFunction(failedCallToMockC);
-    
+
     fixture.runAllTests();
 
     CHECK_FALSE(cpputestHasCrashed);

--- a/tests/CppUTestExt/MockSupport_cTestCFile.c
+++ b/tests/CppUTestExt/MockSupport_cTestCFile.c
@@ -46,10 +46,12 @@ void all_mock_support_c_calls(void)
 
     mock_c()->expectOneCall("boo")->withIntParameters("integer", 1)->withDoubleParameters("double", 1.0)->
             withStringParameters("string", "string")->withPointerParameters("pointer", (void*) 1)->
-            withConstPointerParameters("constpointer", (const void*) 1);
+            withConstPointerParameters("constpointer", (const void*) 1)->
+            withFunctionPointerParameters("functionpointer", (void(*)()) 1);
     mock_c()->actualCall("boo")->withIntParameters("integer", 1)->withDoubleParameters("double", 1.0)->
             withStringParameters("string", "string")->withPointerParameters("pointer", (void*) 1)->
-            withConstPointerParameters("constpointer", (const void*) 1);
+            withConstPointerParameters("constpointer", (const void*) 1)->
+            withFunctionPointerParameters("functionpointer", (void(*)()) 1);
 
     mock_c()->expectOneCall("boo")->withMemoryBufferParameter("name", (void*) 1, 0);
     mock_c()->actualCall("boo")->withMemoryBufferParameter("name", (void*) 1, 0);
@@ -74,6 +76,10 @@ void all_mock_support_c_calls(void)
 
     mock_c()->expectOneCall("boo4")->andReturnPointerValue((void*) 10);
     mock_c()->actualCall("boo4")->returnValue();
+    mock_c()->returnValue();
+
+    mock_c()->expectOneCall("boo5")->andReturnFunctionPointerValue((void(*)()) 10);
+    mock_c()->actualCall("boo5")->returnValue();
     mock_c()->returnValue();
 
     mock_c()->disable();

--- a/tests/SimpleStringTest.cpp
+++ b/tests/SimpleStringTest.cpp
@@ -461,6 +461,18 @@ TEST(SimpleString, Booleans)
     CHECK(s2 == "false");
 }
 
+TEST(SimpleString, Pointers)
+{
+    SimpleString s(StringFrom((void *)0x1234));
+    STRCMP_EQUAL("0x1234", s.asCharString());
+}
+
+TEST(SimpleString, FunctionPointers)
+{
+    SimpleString s(StringFrom((void (*)())0x1234));
+    STRCMP_EQUAL("0x1234", s.asCharString());
+}
+
 TEST(SimpleString, Characters)
 {
     SimpleString s(StringFrom('a'));
@@ -521,6 +533,12 @@ TEST(SimpleString, HexStrings)
 {
     SimpleString h1 = HexStringFrom(0xffffL);
     STRCMP_EQUAL("ffff", h1.asCharString());
+
+    SimpleString h2 = HexStringFrom((void *)0xfffeL);
+    STRCMP_EQUAL("fffe", h2.asCharString());
+
+    SimpleString h3 = HexStringFrom((void (*)())0xfffdL);
+    STRCMP_EQUAL("fffd", h3.asCharString());
 }
 
 TEST(SimpleString, StringFromFormat)

--- a/tests/TestUTestMacro.cpp
+++ b/tests/TestUTestMacro.cpp
@@ -885,6 +885,59 @@ IGNORE_TEST(UnitTestMacros, POINTERS_EQUAL_TEXTWorksInAnIgnoredTest)
     POINTERS_EQUAL_TEXT((void*) 0xbeef, (void*) 0xdead, "Failed because it failed") // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
+
+static void _failingTestMethodWithFUNCTIONPOINTERS_EQUAL()
+{
+    FUNCTIONPOINTERS_EQUAL((void (*)())0xa5a5, (void (*)())0xf0f0);
+    lineOfCodeExecutedAfterCheck = true; // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
+TEST(UnitTestMacros, FailureWithFUNCTIONPOINTERS_EQUAL)
+{
+    runTestWithMethod(_failingTestMethodWithFUNCTIONPOINTERS_EQUAL);
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <0xa5a5>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <0xf0f0>");
+}
+
+TEST(UnitTestMacros, FUNCTIONPOINTERS_EQUALBehavesAsProperMacro)
+{
+    if (false) FUNCTIONPOINTERS_EQUAL(0, (void (*)())0xbeefbeef)
+    else FUNCTIONPOINTERS_EQUAL((void (*)())0xdeadbeef, (void (*)())0xdeadbeef)
+}
+
+IGNORE_TEST(UnitTestMacros, FUNCTIONPOINTERS_EQUALWorksInAnIgnoredTest)
+{
+    FUNCTIONPOINTERS_EQUAL((void (*)())0xbeef, (void (*)())0xdead) // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
+static void _failingTestMethodWithFUNCTIONPOINTERS_EQUAL_TEXT()
+{
+    FUNCTIONPOINTERS_EQUAL_TEXT((void (*)())0xa5a5, (void (*)())0xf0f0, "Failed because it failed");
+    lineOfCodeExecutedAfterCheck = true; // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
+TEST(UnitTestMacros, FailureWithFUNCTIONPOINTERS_EQUAL_TEXT)
+{
+    runTestWithMethod(_failingTestMethodWithFUNCTIONPOINTERS_EQUAL_TEXT);
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <0xa5a5>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <0xf0f0>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("Failed because it failed");
+}
+
+TEST(UnitTestMacros, FUNCTIONPOINTERS_EQUAL_TEXTBehavesAsProperMacro)
+{
+    if (false) FUNCTIONPOINTERS_EQUAL_TEXT(0, (void (*)())0xbeefbeef, "Failed because it failed")
+    else FUNCTIONPOINTERS_EQUAL_TEXT((void (*)())0xdeadbeef, (void (*)())0xdeadbeef, "Failed because it failed")
+}
+
+IGNORE_TEST(UnitTestMacros, FUNCTIONPOINTERS_EQUAL_TEXTWorksInAnIgnoredTest)
+{
+    FUNCTIONPOINTERS_EQUAL_TEXT((void (*)())0xbeef, (void (*)())0xdead, "Failed because it failed") // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
+
+
+
 static void _failingTestMethodWithDOUBLES_EQUAL()
 {
     DOUBLES_EQUAL(0.12, 44.1, 0.3);


### PR DESCRIPTION
Mixing function and data pointers isn't allowed when compiling in pedantic mode. Attempting to use the CppUTest pointer assertions or mock support causes the following compiler errors:
clang: "error: cast between pointer-to-function and pointer-to-object is an extension [-Werror,-Wpedantic]"
gcc: "error: ISO C++ forbids casting between pointer-to-function and pointer-to-object [-Werror=pedantic]"

This patch adds explicit function pointer support. Sorry it's huge. It touches quite a few files.