### PR TITLE
Get rid of some more overridden empty destructors

### DIFF
--- a/include/CppUTest/TestMemoryAllocator.h
+++ b/include/CppUTest/TestMemoryAllocator.h
@@ -111,7 +111,6 @@ class FailableMemoryAllocator: public TestMemoryAllocator
 public:
     enum {MAX_NUMBER_OF_FAILED_ALLOCS = 10};
     FailableMemoryAllocator(const char* name_str = "failable alloc", const char* alloc_name_str = "alloc", const char* free_name_str = "free");
-    virtual ~FailableMemoryAllocator() {}
     virtual char* alloc_memory(size_t size, const char* file, int line);
     virtual char* allocMemoryLeakNode(size_t size);
     virtual void failAllocNumber(int number);

--- a/include/CppUTestExt/MockFailure.h
+++ b/include/CppUTestExt/MockFailure.h
@@ -64,70 +64,60 @@ class MockExpectedCallsDidntHappenFailure : public MockFailure
 {
 public:
     MockExpectedCallsDidntHappenFailure(UtestShell* test, const MockExpectedCallsList& expectations);
-    virtual ~MockExpectedCallsDidntHappenFailure(){}
 };
 
 class MockUnexpectedCallHappenedFailure : public MockFailure
 {
 public:
     MockUnexpectedCallHappenedFailure(UtestShell* test, const SimpleString& name, const MockExpectedCallsList& expectations);
-    virtual ~MockUnexpectedCallHappenedFailure(){}
 };
 
 class MockCallOrderFailure : public MockFailure
 {
 public:
     MockCallOrderFailure(UtestShell* test, const MockExpectedCallsList& expectations);
-    virtual ~MockCallOrderFailure(){}
 };
 
 class MockUnexpectedInputParameterFailure : public MockFailure
 {
 public:
     MockUnexpectedInputParameterFailure(UtestShell* test, const SimpleString& functionName, const MockNamedValue& parameter, const MockExpectedCallsList& expectations);
-    virtual ~MockUnexpectedInputParameterFailure(){}
 };
 
 class MockUnexpectedOutputParameterFailure : public MockFailure
 {
 public:
     MockUnexpectedOutputParameterFailure(UtestShell* test, const SimpleString& functionName, const MockNamedValue& parameter, const MockExpectedCallsList& expectations);
-    virtual ~MockUnexpectedOutputParameterFailure(){}
 };
 
 class MockExpectedParameterDidntHappenFailure : public MockFailure
 {
 public:
     MockExpectedParameterDidntHappenFailure(UtestShell* test, const SimpleString& functionName, const MockExpectedCallsList& expectations);
-    virtual ~MockExpectedParameterDidntHappenFailure(){}
 };
 
 class MockNoWayToCompareCustomTypeFailure : public MockFailure
 {
 public:
     MockNoWayToCompareCustomTypeFailure(UtestShell* test, const SimpleString& typeName);
-    virtual ~MockNoWayToCompareCustomTypeFailure(){}
 };
 
 class MockNoWayToCopyCustomTypeFailure : public MockFailure
 {
 public:
     MockNoWayToCopyCustomTypeFailure(UtestShell* test, const SimpleString& typeName);
-    virtual ~MockNoWayToCopyCustomTypeFailure(){}
 };
 
 class MockUnexpectedObjectFailure : public MockFailure
 {
 public:
     MockUnexpectedObjectFailure(UtestShell* test, const SimpleString& functionName, void* expected, const MockExpectedCallsList& expectations);
-    virtual ~MockUnexpectedObjectFailure(){}
 };
 
 class MockExpectedObjectDidntHappenFailure : public MockFailure
 {
 public:
     MockExpectedObjectDidntHappenFailure(UtestShell* test, const SimpleString& functionName, const MockExpectedCallsList& expectations);
-    virtual ~MockExpectedObjectDidntHappenFailure(){}
 };
 
 #endif

--- a/include/CppUTestExt/MockNamedValue.h
+++ b/include/CppUTestExt/MockNamedValue.h
@@ -65,7 +65,6 @@ public:
 
     MockFunctionComparator(isEqualFunction equal, valueToStringFunction valToString)
         : equal_(equal), valueToString_(valToString) {}
-    virtual ~MockFunctionComparator(){}
 
     virtual bool isEqual(const void* object1, const void* object2) _override { return equal_(object1, object2); }
     virtual SimpleString valueToString(const void* object) _override { return valueToString_(object); }
@@ -80,7 +79,6 @@ public:
     typedef void (*copyFunction)(void*, const void*);
 
     MockFunctionCopier(copyFunction copier) : copier_(copier) {}
-    virtual ~MockFunctionCopier(){}
 
     virtual void copy(void* dst, const void* src) _override { copier_(dst, src); }
 


### PR DESCRIPTION
Found some more unneeded empty overridden destructors while checking Coveralls report.