### PR TITLE
Improve performance of MockExpectedCallsList

### DIFF
--- a/include/CppUTestExt/MockExpectedCallsList.h
+++ b/include/CppUTestExt/MockExpectedCallsList.h
@@ -78,7 +78,6 @@ public:
     virtual SimpleString missingParametersToString() const;
 
 protected:
-    virtual void pruneEmptyNodeFromList();
 
     class MockExpectedCallsListNode
     {
@@ -91,8 +90,12 @@ protected:
     };
 
     virtual MockExpectedCallsListNode* findNodeWithCallOrderOf(int callOrder) const;
+    virtual void pruneEmptyNodeFromList(MockExpectedCallsListNode*& parent,
+                                        MockExpectedCallsListNode*& p);
 private:
     MockExpectedCallsListNode* head_;
+    // we maintain a pointer to the last element in order to provide O(1) insertion
+    MockExpectedCallsListNode* tail_;
 
     MockExpectedCallsList(const MockExpectedCallsList&);
 };


### PR DESCRIPTION
For large number (e.g. 10000) of mocked calls, the simple linked list
was a performance bottleneck.
This patch brings two improvements:
- tracking the last element of the linked list (for O(1) insertion)
- deleting NULL elements as they are marked, as opposed to rescanning
  the list from scratch after marking.
Profiling with callgrind shows that the linked list structure is no
longer the performance bottleneck.

I know that having a huge number of mocked/expected calls is debatable, but it did happen to matter in my use case. Basically, I'm doing checks of the type: perform an operation, and assert that a certain log message is displayed. This means that MockExpectedCallsList has to scale to the number of logs printed by the operation.

As you see from the Callgrind results for this particular test case, addExpectedCall was spending most of its time in self(). Where the vast majority of this time went was into looping through the linked list in order to find the tail, so that it can insert the new element.

Profiling overview before patch:
<img width="1165" alt="callgrind results before patch" src="https://cloud.githubusercontent.com/assets/6031818/9428879/0eeab80a-49be-11e5-8ef6-2d554956efc5.png">
Profiling before patch, zoom in on addExpectedCall:
<img width="1165" alt="callgrind zoom in on addexpectedcall" src="https://cloud.githubusercontent.com/assets/6031818/9428880/0eebcdc6-49be-11e5-8fd2-833bd89b9571.png">
Profiling overview after patch:
<img width="1165" alt="callgrind results after patch" src="https://cloud.githubusercontent.com/assets/6031818/9428881/0eecc69a-49be-11e5-9ec8-5ad7ed65bcd8.png">