### PR TITLE
Add CHECK_EQUAL_C_POINTER

### DIFF
--- a/include/CppUTest/TestHarness_c.h
+++ b/include/CppUTest/TestHarness_c.h
@@ -48,6 +48,9 @@
 #define CHECK_EQUAL_C_STRING(expected,actual) \
   CHECK_EQUAL_C_STRING_LOCATION(expected,actual,__FILE__,__LINE__)
 
+#define CHECK_EQUAL_C_POINTER(expected,actual) \
+  CHECK_EQUAL_C_POINTER_LOCATION(expected,actual,__FILE__,__LINE__)
+
 #define FAIL_TEXT_C(text) \
   FAIL_TEXT_C_LOCATION(text,__FILE__,__LINE__)
 
@@ -116,6 +119,8 @@ extern void CHECK_EQUAL_C_CHAR_LOCATION(char expected, char actual,
         const char* fileName, int lineNumber);
 extern void CHECK_EQUAL_C_STRING_LOCATION(const char* expected,
         const char* actual, const char* fileName, int lineNumber);
+extern void CHECK_EQUAL_C_POINTER_LOCATION(const void* expected,
+        const void* actual, const char* fileName, int lineNumber);
 extern void FAIL_TEXT_C_LOCATION(const char* text, const char* fileName,
         int lineNumber);
 extern void FAIL_C_LOCATION(const char* fileName, int lineNumber);

--- a/include/CppUTest/Utest.h
+++ b/include/CppUTest/Utest.h
@@ -113,7 +113,7 @@ public:
     virtual void assertCstrNoCaseContains(const char *expected, const char *actual, const char* text, const char *fileName, int lineNumber);
     virtual void assertLongsEqual(long expected, long actual, const char* text, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
     virtual void assertUnsignedLongsEqual(unsigned long expected, unsigned long actual, const char* text, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
-    virtual void assertPointersEqual(const void *expected, const void *actual, const char* text, const char *fileName, int lineNumber);
+    virtual void assertPointersEqual(const void *expected, const void *actual, const char* text, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
     virtual void assertFunctionPointersEqual(void (*expected)(), void (*actual)(), const char* text, const char* fileName, int lineNumber);
     virtual void assertDoublesEqual(double expected, double actual, double threshold, const char* text, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
     virtual void assertEquals(bool failed, const char* expected, const char* actual, const char* text, const char* file, int line, const TestTerminator& testTerminator = NormalTestTerminator());

--- a/src/CppUTest/TestHarness_c.cpp
+++ b/src/CppUTest/TestHarness_c.cpp
@@ -55,6 +55,11 @@ void CHECK_EQUAL_C_STRING_LOCATION(const char* expected, const char* actual, con
     UtestShell::getCurrent()->assertCstrEqual(expected, actual, NULL, fileName, lineNumber, TestTerminatorWithoutExceptions());
 }
 
+void CHECK_EQUAL_C_POINTER_LOCATION(const void* expected, const void* actual, const char* fileName, int lineNumber)
+{
+    UtestShell::getCurrent()->assertPointersEqual(expected, actual, NULL, fileName, lineNumber, TestTerminatorWithoutExceptions());
+}
+
 void FAIL_TEXT_C_LOCATION(const char* text, const char* fileName, int lineNumber)
 {
     UtestShell::getCurrent()->fail(text,  fileName, lineNumber, TestTerminatorWithoutExceptions());

--- a/src/CppUTest/Utest.cpp
+++ b/src/CppUTest/Utest.cpp
@@ -418,11 +418,11 @@ void UtestShell::assertUnsignedLongsEqual(unsigned long expected, unsigned long 
         failWith(UnsignedLongsEqualFailure (this, fileName, lineNumber, expected, actual, text), testTerminator);
 }
 
-void UtestShell::assertPointersEqual(const void* expected, const void* actual, const char* text, const char* fileName, int lineNumber)
+void UtestShell::assertPointersEqual(const void* expected, const void* actual, const char* text, const char* fileName, int lineNumber, const TestTerminator& testTerminator)
 {
     getTestResult()->countCheck();
     if (expected != actual)
-        failWith(EqualsFailure(this, fileName, lineNumber, StringFrom(expected), StringFrom(actual), text));
+        failWith(EqualsFailure(this, fileName, lineNumber, StringFrom(expected), StringFrom(actual), text), testTerminator);
 }
 
 void UtestShell::assertFunctionPointersEqual(void (*expected)(), void (*actual)(), const char* text, const char* fileName, int lineNumber)

--- a/tests/TestHarness_cTest.cpp
+++ b/tests/TestHarness_cTest.cpp
@@ -149,6 +149,22 @@ TEST(TestHarness_c, checkString)
     CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
 }
 
+static void _failPointerMethod()
+{
+    HasTheDestructorBeenCalledChecker checker;
+    CHECK_EQUAL_C_POINTER(NULL, (void *)0x1);
+}
+
+TEST(TestHarness_c, checkPointer)
+{
+    CHECK_EQUAL_C_POINTER(NULL, NULL);
+    fixture->setTestFunction(_failPointerMethod);
+    fixture->runAllTests();
+    fixture->assertPrintContains("expected <0x0>\n	but was  <0x1>");
+    fixture->assertPrintContains("arness_c");
+    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
+}
+
 static void _failTextMethod()
 {
     HasTheDestructorBeenCalledChecker checker;


### PR DESCRIPTION
This allows users of the C interface to compare pointers and get proper feedback based on the failure state.