### PR TITLE
Fix CppUTest for OSX / Xcode7 / clang-700.x

### DIFF
--- a/build/MakefileWorker.mk
+++ b/build/MakefileWorker.mk
@@ -189,10 +189,16 @@ ifeq ($(COMPILER_NAME),$(CLANG_STR))
 # -Wno-global-constructors Wno-exit-time-destructors -> Great warnings, but in CppUTest it is impossible to avoid as the automatic test registration depends on the global ctor and dtor
 # -Wno-weak-vtables -> The TEST_GROUP macro declares a class and will automatically inline its methods. Thats ok as they are only in one translation unit. Unfortunately, the warning can't detect that, so it must be disabled.
 # -Wno-old-style-casts -> We only use old style casts by decision
+	CPPUTEST_CXX_WARNINGFLAGS += -Weverything -Wno-disabled-macro-expansion -Wno-padded -Wno-global-constructors -Wno-exit-time-destructors -Wno-weak-vtables -Wno-old-style-cast
+	CPPUTEST_C_WARNINGFLAGS += -Weverything -Wno-padded
+
+# Clang "7" (Xcode 7 command-line tools) introduced new warnings by default that don't exist on previous versions of clang and cause errors when present.
+ifeq ($(findstring clang-7,$(CC_VERSION_OUTPUT)),clang-7)
 # -Wno-reserved-id-macro -> Many CppUTest macros start with __, which is a reserved namespace
 # -Wno-keyword-macro -> CppUTest redefines the 'new' keyword for memory leak tracking
-	CPPUTEST_CXX_WARNINGFLAGS += -Weverything -Wno-disabled-macro-expansion -Wno-padded -Wno-global-constructors -Wno-exit-time-destructors -Wno-weak-vtables -Wno-old-style-cast -Wno-reserved-id-macro -Wno-keyword-macro
-	CPPUTEST_C_WARNINGFLAGS += -Weverything -Wno-padded -Wno-reserved-id-macro -Wno-keyword-macro
+	CPPUTEST_CXX_WARNINGFLAGS += -Wno-reserved-id-macro -Wno-keyword-macro
+	CPPUTEST_C_WARNINGFLAGS += -Wno-reserved-id-macro -Wno-keyword-macro
+endif
 endif
 
 # Uhm. Maybe put some warning flags for SunStudio here?

--- a/build/MakefileWorker.mk
+++ b/build/MakefileWorker.mk
@@ -189,8 +189,10 @@ ifeq ($(COMPILER_NAME),$(CLANG_STR))
 # -Wno-global-constructors Wno-exit-time-destructors -> Great warnings, but in CppUTest it is impossible to avoid as the automatic test registration depends on the global ctor and dtor
 # -Wno-weak-vtables -> The TEST_GROUP macro declares a class and will automatically inline its methods. Thats ok as they are only in one translation unit. Unfortunately, the warning can't detect that, so it must be disabled.
 # -Wno-old-style-casts -> We only use old style casts by decision
-	CPPUTEST_CXX_WARNINGFLAGS += -Weverything -Wno-disabled-macro-expansion -Wno-padded -Wno-global-constructors -Wno-exit-time-destructors -Wno-weak-vtables -Wno-old-style-cast
-	CPPUTEST_C_WARNINGFLAGS += -Weverything -Wno-padded
+# -Wno-reserved-id-macro -> Many CppUTest macros start with __, which is a reserved namespace
+# -Wno-keyword-macro -> CppUTest redefines the 'new' keyword for memory leak tracking
+	CPPUTEST_CXX_WARNINGFLAGS += -Weverything -Wno-disabled-macro-expansion -Wno-padded -Wno-global-constructors -Wno-exit-time-destructors -Wno-weak-vtables -Wno-old-style-cast -Wno-reserved-id-macro -Wno-keyword-macro
+	CPPUTEST_C_WARNINGFLAGS += -Weverything -Wno-padded -Wno-reserved-id-macro -Wno-keyword-macro
 endif
 
 # Uhm. Maybe put some warning flags for SunStudio here?

--- a/cmake/Modules/CppUTestConfigurationOptions.cmake
+++ b/cmake/Modules/CppUTestConfigurationOptions.cmake
@@ -12,6 +12,11 @@ else (MSVC)
     set(CPP_PLATFORM GccNoStdC)
 endif (MSVC)
 
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    set(CPPUTEST_CXX_FLAGS "${CPPUTEST_CXX_FLAGS} -Wno-reserved-id-macro -Wno-keyword-macro")
+    set(CPPUTEST_C_FLAGS "${CPPUTEST_C_FLAGS} -Wno-reserved-id-macro -Wno-keyword-macro")
+endif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+
 include("${CppUTestRootDirectory}/cmake/Modules/CppUTestWarningFlags.cmake")
 
 if (NOT STD_CPP)

--- a/cmake/Modules/CppUTestConfigurationOptions.cmake
+++ b/cmake/Modules/CppUTestConfigurationOptions.cmake
@@ -12,11 +12,6 @@ else (MSVC)
     set(CPP_PLATFORM GccNoStdC)
 endif (MSVC)
 
-if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    set(CPPUTEST_CXX_FLAGS "${CPPUTEST_CXX_FLAGS} -Wno-reserved-id-macro -Wno-keyword-macro")
-    set(CPPUTEST_C_FLAGS "${CPPUTEST_C_FLAGS} -Wno-reserved-id-macro -Wno-keyword-macro")
-endif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-
 include("${CppUTestRootDirectory}/cmake/Modules/CppUTestWarningFlags.cmake")
 
 if (NOT STD_CPP)

--- a/cmake/Modules/CppUTestWarningFlags.cmake
+++ b/cmake/Modules/CppUTestWarningFlags.cmake
@@ -34,6 +34,8 @@ else (MSVC)
         Wsign-conversion
         Wno-padded
         Wno-disabled-macro-expansion
+        Wno-reserved-id-macro
+        Wno-keyword-macro
         )
 
     if (NOT GMOCK AND NOT REAL_GTEST)

--- a/configure.ac
+++ b/configure.ac
@@ -176,6 +176,18 @@ AC_MSG_CHECKING([whether CC and CXX supports -Wno-padded])
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([])], [AC_MSG_RESULT([yes]); CPPUTEST_CWARNINGFLAGS="${CPPUTEST_CWARNINGFLAGS} -Wno-padded"; CPPUTEST_CXXWARNINGFLAGS="${CPPUTEST_CXXWARNINGFLAGS} -Wno-padded" ], [AC_MSG_RESULT([no])])
 CFLAGS="$saved_cflags"
 
+# FLag -Wno-reserved-id-macro.
+CXXFLAGS="-Werror -Wno-reserved-id-macro"
+AC_MSG_CHECKING([whether CC and CXX supports -Wno-reserved-id-macro])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([])], [AC_MSG_RESULT([yes]); CPPUTEST_CWARNINGFLAGS="${CPPUTEST_CWARNINGFLAGS} -Wno-reserved-id-macro"; CPPUTEST_CXXWARNINGFLAGS="${CPPUTEST_CXXWARNINGFLAGS} -Wno-reserved-id-macro" ], [AC_MSG_RESULT([no])])
+CFLAGS="$saved_cflags"
+
+# FLag -Wno-keyword-macro.
+CXXFLAGS="-Werror -Wno-keyword-macro"
+AC_MSG_CHECKING([whether CC and CXX supports -Wno-keyword-macro])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([])], [AC_MSG_RESULT([yes]); CPPUTEST_CWARNINGFLAGS="${CPPUTEST_CWARNINGFLAGS} -Wno-keyword-macro"; CPPUTEST_CXXWARNINGFLAGS="${CPPUTEST_CXXWARNINGFLAGS} -Wno-keyword-macro" ], [AC_MSG_RESULT([no])])
+CFLAGS="$saved_cflags"
+
 # FLag -Wno-global-constructors.
 AC_LANG_PUSH([C++])
 CXXFLAGS="-Werror -Wno-global-constructors"


### PR DESCRIPTION
Add -Wno-reserved-id-macro and -Wno-keyword-macro to clang builds. Fixes CppUTest on Xcode 7+, with clang-700+, where warnings were added about using reserved namespaces like __, and for macros that shadow keywords.