### PR TITLE
Additional filters to exclude tests based on group and/or name

### DIFF
--- a/include/CppUTest/CommandLineArguments.h
+++ b/include/CppUTest/CommandLineArguments.h
@@ -79,8 +79,10 @@ private:
     void SetRepeatCount(int ac, const char** av, int& index);
     void AddGroupFilter(int ac, const char** av, int& index);
     void AddStrictGroupFilter(int ac, const char** av, int& index);
+    void AddExcludeGroupFilter(int ac, const char** av, int& index);
     void AddNameFilter(int ac, const char** av, int& index);
     void AddStrictNameFilter(int ac, const char** av, int& index);
+    void AddExcludeNameFilter(int ac, const char** av, int& index);
     void AddTestToRunBasedOnVerboseOutput(int ac, const char** av, int& index, const char* parameterName);
     bool SetOutputType(int ac, const char** av, int& index);
     void SetPackageName(int ac, const char** av, int& index);

--- a/include/CppUTest/CommandLineArguments.h
+++ b/include/CppUTest/CommandLineArguments.h
@@ -80,9 +80,11 @@ private:
     void AddGroupFilter(int ac, const char** av, int& index);
     void AddStrictGroupFilter(int ac, const char** av, int& index);
     void AddExcludeGroupFilter(int ac, const char** av, int& index);
+    void AddExcludeStrictGroupFilter(int ac, const char** av, int& index);
     void AddNameFilter(int ac, const char** av, int& index);
     void AddStrictNameFilter(int ac, const char** av, int& index);
     void AddExcludeNameFilter(int ac, const char** av, int& index);
+    void AddExcludeStrictNameFilter(int ac, const char** av, int& index);
     void AddTestToRunBasedOnVerboseOutput(int ac, const char** av, int& index, const char* parameterName);
     bool SetOutputType(int ac, const char** av, int& index);
     void SetPackageName(int ac, const char** av, int& index);

--- a/include/CppUTest/TestFilter.h
+++ b/include/CppUTest/TestFilter.h
@@ -37,13 +37,14 @@ public:
     TestFilter();
     TestFilter(const char* filter);
     TestFilter(const SimpleString& filter);
-    
+
     TestFilter* add(TestFilter* filter);
     TestFilter* getNext() const;
 
     bool match(const SimpleString& name) const;
 
     void strictMatching();
+    void invertMatching();
 
     bool operator==(const TestFilter& filter) const;
     bool operator!=(const TestFilter& filter) const;
@@ -52,6 +53,7 @@ public:
 private:
     SimpleString filter_;
     bool strictMatching_;
+    bool invertMatching_;
     TestFilter* next_;
 };
 

--- a/src/CppUTest/CommandLineArguments.cpp
+++ b/src/CppUTest/CommandLineArguments.cpp
@@ -63,9 +63,11 @@ bool CommandLineArguments::parse(TestPlugin* plugin)
         else if (argument.startsWith("-g")) AddGroupFilter(ac_, av_, i);
         else if (argument.startsWith("-sg")) AddStrictGroupFilter(ac_, av_, i);
         else if (argument.startsWith("-xg")) AddExcludeGroupFilter(ac_, av_, i);
+        else if (argument.startsWith("-xsg")) AddExcludeStrictGroupFilter(ac_, av_, i);
         else if (argument.startsWith("-n")) AddNameFilter(ac_, av_, i);
         else if (argument.startsWith("-sn")) AddStrictNameFilter(ac_, av_, i);
         else if (argument.startsWith("-xn")) AddExcludeNameFilter(ac_, av_, i);
+        else if (argument.startsWith("-xsn")) AddExcludeStrictNameFilter(ac_, av_, i);
         else if (argument.startsWith("TEST(")) AddTestToRunBasedOnVerboseOutput(ac_, av_, i, "TEST(");
         else if (argument.startsWith("IGNORE_TEST(")) AddTestToRunBasedOnVerboseOutput(ac_, av_, i, "IGNORE_TEST(");
         else if (argument.startsWith("-o")) correctParameters = SetOutputType(ac_, av_, i);
@@ -82,7 +84,7 @@ bool CommandLineArguments::parse(TestPlugin* plugin)
 
 const char* CommandLineArguments::usage() const
 {
-    return "usage [-v] [-c] [-p] [-lg] [-ln] [-r#] [-g|sg|xg groupName]... [-n|sn|xn testName]... [\"TEST(groupName, testName)\"]... [-o{normal, junit, teamcity}] [-k packageName]\n";
+    return "usage [-v] [-c] [-p] [-lg] [-ln] [-r#] [-g|sg|xg|xsg groupName]... [-n|sn|xn|xsn testName]... [\"TEST(groupName, testName)\"]... [-o{normal, junit, teamcity}] [-k packageName]\n";
 }
 
 bool CommandLineArguments::isVerbose() const
@@ -170,6 +172,14 @@ void CommandLineArguments::AddExcludeGroupFilter(int ac, const char** av, int& i
     groupFilters_ = groupFilter->add(groupFilters_);
 }
 
+void CommandLineArguments::AddExcludeStrictGroupFilter(int ac, const char** av, int& i)
+{
+    TestFilter* groupFilter = new TestFilter(getParameterField(ac, av, i, "-xsg"));
+    groupFilter->strictMatching();
+    groupFilter->invertMatching();
+    groupFilters_ = groupFilter->add(groupFilters_);
+}
+
 void CommandLineArguments::AddNameFilter(int ac, const char** av, int& i)
 {
     TestFilter* nameFilter = new TestFilter(getParameterField(ac, av, i, "-n"));
@@ -187,6 +197,14 @@ void CommandLineArguments::AddExcludeNameFilter(int ac, const char** av, int& in
 {
     TestFilter* nameFilter = new TestFilter(getParameterField(ac, av, index, "-xn"));
     nameFilter->invertMatching();
+    nameFilters_= nameFilter->add(nameFilters_);
+}
+
+void CommandLineArguments::AddExcludeStrictNameFilter(int ac, const char** av, int& index)
+{
+    TestFilter* nameFilter = new TestFilter(getParameterField(ac, av, index, "-xsn"));
+    nameFilter->invertMatching();
+    nameFilter->strictMatching();
     nameFilters_= nameFilter->add(nameFilters_);
 }
 

--- a/src/CppUTest/CommandLineArguments.cpp
+++ b/src/CppUTest/CommandLineArguments.cpp
@@ -53,7 +53,7 @@ bool CommandLineArguments::parse(TestPlugin* plugin)
     bool correctParameters = true;
     for (int i = 1; i < ac_; i++) {
         SimpleString argument = av_[i];
-        
+
         if      (argument == "-v") verbose_ = true;
         else if (argument == "-c") color_ = true;
         else if (argument == "-p") runTestsAsSeperateProcess_ = true;
@@ -62,8 +62,10 @@ bool CommandLineArguments::parse(TestPlugin* plugin)
         else if (argument.startsWith("-r")) SetRepeatCount(ac_, av_, i);
         else if (argument.startsWith("-g")) AddGroupFilter(ac_, av_, i);
         else if (argument.startsWith("-sg")) AddStrictGroupFilter(ac_, av_, i);
+        else if (argument.startsWith("-xg")) AddExcludeGroupFilter(ac_, av_, i);
         else if (argument.startsWith("-n")) AddNameFilter(ac_, av_, i);
         else if (argument.startsWith("-sn")) AddStrictNameFilter(ac_, av_, i);
+        else if (argument.startsWith("-xn")) AddExcludeNameFilter(ac_, av_, i);
         else if (argument.startsWith("TEST(")) AddTestToRunBasedOnVerboseOutput(ac_, av_, i, "TEST(");
         else if (argument.startsWith("IGNORE_TEST(")) AddTestToRunBasedOnVerboseOutput(ac_, av_, i, "IGNORE_TEST(");
         else if (argument.startsWith("-o")) correctParameters = SetOutputType(ac_, av_, i);
@@ -80,7 +82,7 @@ bool CommandLineArguments::parse(TestPlugin* plugin)
 
 const char* CommandLineArguments::usage() const
 {
-    return "usage [-v] [-c] [-p] [-lg] [-ln] [-r#] [-g|sg groupName]... [-n|sn testName]... [\"TEST(groupName, testName)\"]... [-o{normal, junit, teamcity}] [-k packageName]\n";
+    return "usage [-v] [-c] [-p] [-lg] [-ln] [-r#] [-g|sg|xg groupName]... [-n|sn|xn testName]... [\"TEST(groupName, testName)\"]... [-o{normal, junit, teamcity}] [-k packageName]\n";
 }
 
 bool CommandLineArguments::isVerbose() const
@@ -161,6 +163,13 @@ void CommandLineArguments::AddStrictGroupFilter(int ac, const char** av, int& i)
     groupFilters_ = groupFilter->add(groupFilters_);
 }
 
+void CommandLineArguments::AddExcludeGroupFilter(int ac, const char** av, int& i)
+{
+    TestFilter* groupFilter = new TestFilter(getParameterField(ac, av, i, "-xg"));
+    groupFilter->invertMatching();
+    groupFilters_ = groupFilter->add(groupFilters_);
+}
+
 void CommandLineArguments::AddNameFilter(int ac, const char** av, int& i)
 {
     TestFilter* nameFilter = new TestFilter(getParameterField(ac, av, i, "-n"));
@@ -171,6 +180,13 @@ void CommandLineArguments::AddStrictNameFilter(int ac, const char** av, int& ind
 {
     TestFilter* nameFilter = new TestFilter(getParameterField(ac, av, index, "-sn"));
     nameFilter->strictMatching();
+    nameFilters_= nameFilter->add(nameFilters_);
+}
+
+void CommandLineArguments::AddExcludeNameFilter(int ac, const char** av, int& index)
+{
+    TestFilter* nameFilter = new TestFilter(getParameterField(ac, av, index, "-xn"));
+    nameFilter->invertMatching();
     nameFilters_= nameFilter->add(nameFilters_);
 }
 

--- a/src/CppUTest/TestFilter.cpp
+++ b/src/CppUTest/TestFilter.cpp
@@ -28,16 +28,16 @@
 #include "CppUTest/CppUTestConfig.h"
 #include "CppUTest/TestFilter.h"
 
-TestFilter::TestFilter() : strictMatching_(false), next_(NULL)
+TestFilter::TestFilter() : strictMatching_(false), invertMatching_(false), next_(NULL)
 {
 }
 
-TestFilter::TestFilter(const SimpleString& filter) : strictMatching_(false), next_(NULL)
+TestFilter::TestFilter(const SimpleString& filter) : strictMatching_(false), invertMatching_(false), next_(NULL)
 {
     filter_ = filter;
 }
 
-TestFilter::TestFilter(const char* filter) : strictMatching_(false), next_(NULL)
+TestFilter::TestFilter(const char* filter) : strictMatching_(false), invertMatching_(false), next_(NULL)
 {
     filter_ = filter;
 }
@@ -58,16 +58,28 @@ void TestFilter::strictMatching()
     strictMatching_ = true;
 }
 
+void TestFilter::invertMatching()
+{
+    invertMatching_ = true;
+}
+
 bool TestFilter::match(const SimpleString& name) const
 {
+    bool matches = false;
+
     if(strictMatching_)
-        return name == filter_;
-    return name.contains(filter_);
+        matches = name == filter_;
+    else
+        matches = name.contains(filter_);
+
+    return invertMatching_ ? !matches : matches;
 }
 
 bool TestFilter::operator==(const TestFilter& filter) const
 {
-    return (filter_ == filter.filter_ && strictMatching_ == filter.strictMatching_);
+    return (filter_ == filter.filter_ &&
+            strictMatching_ == filter.strictMatching_ &&
+            invertMatching_ == filter.invertMatching_);
 }
 
 bool TestFilter::operator!=(const TestFilter& filter) const
@@ -78,8 +90,13 @@ bool TestFilter::operator!=(const TestFilter& filter) const
 SimpleString TestFilter::asString() const
 {
     SimpleString textFilter =  StringFromFormat("TestFilter: \"%s\"", filter_.asCharString());
-    if (strictMatching_)
+    if (strictMatching_ && invertMatching_)
+        textFilter += " with strict, invert matching";
+    else if (strictMatching_)
         textFilter += " with strict matching";
+    else if (invertMatching_)
+        textFilter += " with invert matching";
+
     return textFilter;
 }
 

--- a/tests/CommandLineArgumentsTest.cpp
+++ b/tests/CommandLineArgumentsTest.cpp
@@ -163,6 +163,14 @@ TEST(CommandLineArguments, setNameFilter)
     CHECK_EQUAL(TestFilter("name"), *args->getNameFilters());
 }
 
+TEST(CommandLineArguments, setNameFilterSameParameter)
+{
+    int argc = 2;
+    const char* argv[] = { "tests.exe", "-nname" };
+    CHECK(newArgumentParser(argc, argv));
+    CHECK_EQUAL(TestFilter("name"), *args->getNameFilters());
+}
+
 TEST(CommandLineArguments, setStrictNameFilter)
 {
     int argc = 3;
@@ -173,12 +181,14 @@ TEST(CommandLineArguments, setStrictNameFilter)
     CHECK_EQUAL(nameFilter, *args->getNameFilters());
 }
 
-TEST(CommandLineArguments, setNameFilterSameParameter)
+TEST(CommandLineArguments, setStrictNameFilterSameParameter)
 {
     int argc = 2;
-    const char* argv[] = { "tests.exe", "-nname" };
+    const char* argv[] = { "tests.exe", "-snname" };
     CHECK(newArgumentParser(argc, argv));
-    CHECK_EQUAL(TestFilter("name"), *args->getNameFilters());
+    TestFilter nameFilter("name");
+    nameFilter.strictMatching();
+    CHECK_EQUAL(nameFilter, *args->getNameFilters());
 }
 
 TEST(CommandLineArguments, setTestToRunUsingVerboseOutput)

--- a/tests/CommandLineArgumentsTest.cpp
+++ b/tests/CommandLineArgumentsTest.cpp
@@ -174,6 +174,28 @@ TEST(CommandLineArguments, setExcludeGroupFilterSameParameter)
     CHECK_EQUAL(groupFilter, *args->getGroupFilters());
 }
 
+TEST(CommandLineArguments, setExcludeStrictGroupFilter)
+{
+    int argc = 3;
+    const char* argv[] = { "tests.exe", "-xsg", "group" };
+    CHECK(newArgumentParser(argc, argv));
+    TestFilter groupFilter("group");
+    groupFilter.invertMatching();
+    groupFilter.strictMatching();
+    CHECK_EQUAL(groupFilter, *args->getGroupFilters());
+}
+
+TEST(CommandLineArguments, setExcludeStrictGroupFilterSameParameter)
+{
+    int argc = 2;
+    const char* argv[] = { "tests.exe", "-xsggroup" };
+    CHECK(newArgumentParser(argc, argv));
+    TestFilter groupFilter("group");
+    groupFilter.invertMatching();
+    groupFilter.strictMatching();
+    CHECK_EQUAL(groupFilter, *args->getGroupFilters());
+}
+
 TEST(CommandLineArguments, setNameFilter)
 {
     int argc = 3;
@@ -227,6 +249,28 @@ TEST(CommandLineArguments, setExcludeNameFilterSameParameter)
     CHECK(newArgumentParser(argc, argv));
     TestFilter nameFilter("name");
     nameFilter.invertMatching();
+    CHECK_EQUAL(nameFilter, *args->getNameFilters());
+}
+
+TEST(CommandLineArguments, setExcludeStrictNameFilter)
+{
+    int argc = 3;
+    const char* argv[] = { "tests.exe", "-xsn", "name" };
+    CHECK(newArgumentParser(argc, argv));
+    TestFilter nameFilter("name");
+    nameFilter.invertMatching();
+    nameFilter.strictMatching();
+    CHECK_EQUAL(nameFilter, *args->getNameFilters());
+}
+
+TEST(CommandLineArguments, setExcludeStrictNameFilterSameParameter)
+{
+    int argc = 2;
+    const char* argv[] = { "tests.exe", "-xsnname" };
+    CHECK(newArgumentParser(argc, argv));
+    TestFilter nameFilter("name");
+    nameFilter.invertMatching();
+    nameFilter.strictMatching();
     CHECK_EQUAL(nameFilter, *args->getNameFilters());
 }
 
@@ -326,7 +370,7 @@ TEST(CommandLineArguments, weirdParamatersPrintsUsageAndReturnsFalse)
     int argc = 2;
     const char* argv[] = { "tests.exe", "-SomethingWeird" };
     CHECK(!newArgumentParser(argc, argv));
-    STRCMP_EQUAL("usage [-v] [-c] [-p] [-lg] [-ln] [-r#] [-g|sg|xg groupName]... [-n|sn|xn testName]... [\"TEST(groupName, testName)\"]... [-o{normal, junit, teamcity}] [-k packageName]\n",
+    STRCMP_EQUAL("usage [-v] [-c] [-p] [-lg] [-ln] [-r#] [-g|sg|xg|xsg groupName]... [-n|sn|xn|xsn testName]... [\"TEST(groupName, testName)\"]... [-o{normal, junit, teamcity}] [-k packageName]\n",
             args->usage());
 }
 

--- a/tests/CommandLineArgumentsTest.cpp
+++ b/tests/CommandLineArgumentsTest.cpp
@@ -154,6 +154,25 @@ TEST(CommandLineArguments, setStrictGroupFilterSameParameter)
     CHECK_EQUAL(groupFilter, *args->getGroupFilters());
 }
 
+TEST(CommandLineArguments, setExcludeGroupFilter)
+{
+    int argc = 3;
+    const char* argv[] = { "tests.exe", "-xg", "group" };
+    CHECK(newArgumentParser(argc, argv));
+    TestFilter groupFilter("group");
+    groupFilter.invertMatching();
+    CHECK_EQUAL(groupFilter, *args->getGroupFilters());
+}
+
+TEST(CommandLineArguments, setExcludeGroupFilterSameParameter)
+{
+    int argc = 2;
+    const char* argv[] = { "tests.exe", "-xggroup" };
+    CHECK(newArgumentParser(argc, argv));
+    TestFilter groupFilter("group");
+    groupFilter.invertMatching();
+    CHECK_EQUAL(groupFilter, *args->getGroupFilters());
+}
 
 TEST(CommandLineArguments, setNameFilter)
 {
@@ -188,6 +207,26 @@ TEST(CommandLineArguments, setStrictNameFilterSameParameter)
     CHECK(newArgumentParser(argc, argv));
     TestFilter nameFilter("name");
     nameFilter.strictMatching();
+    CHECK_EQUAL(nameFilter, *args->getNameFilters());
+}
+
+TEST(CommandLineArguments, setExcludeNameFilter)
+{
+    int argc = 3;
+    const char* argv[] = { "tests.exe", "-xn", "name" };
+    CHECK(newArgumentParser(argc, argv));
+    TestFilter nameFilter("name");
+    nameFilter.invertMatching();
+    CHECK_EQUAL(nameFilter, *args->getNameFilters());
+}
+
+TEST(CommandLineArguments, setExcludeNameFilterSameParameter)
+{
+    int argc = 2;
+    const char* argv[] = { "tests.exe", "-xnname" };
+    CHECK(newArgumentParser(argc, argv));
+    TestFilter nameFilter("name");
+    nameFilter.invertMatching();
     CHECK_EQUAL(nameFilter, *args->getNameFilters());
 }
 
@@ -287,7 +326,7 @@ TEST(CommandLineArguments, weirdParamatersPrintsUsageAndReturnsFalse)
     int argc = 2;
     const char* argv[] = { "tests.exe", "-SomethingWeird" };
     CHECK(!newArgumentParser(argc, argv));
-    STRCMP_EQUAL("usage [-v] [-c] [-p] [-lg] [-ln] [-r#] [-g|sg groupName]... [-n|sn testName]... [\"TEST(groupName, testName)\"]... [-o{normal, junit, teamcity}] [-k packageName]\n",
+    STRCMP_EQUAL("usage [-v] [-c] [-p] [-lg] [-ln] [-r#] [-g|sg|xg groupName]... [-n|sn|xn testName]... [\"TEST(groupName, testName)\"]... [-o{normal, junit, teamcity}] [-k packageName]\n",
             args->usage());
 }
 
@@ -324,10 +363,10 @@ TEST(CommandLineArguments, setPackageName)
 TEST(CommandLineArguments, lotsOfGroupsAndTests)
 {
     int argc = 10;
-    const char* argv[] = { "tests.exe", "-sggroup1", "-sntest1", "-sggroup2", "-sntest2", "-sntest3", "-sggroup3", "-sntest4", "-sggroup4", "-sntest5" };
+    const char* argv[] = { "tests.exe", "-sggroup1", "-xntest1", "-sggroup2", "-sntest2", "-sntest3", "-sggroup3", "-sntest4", "-sggroup4", "-sntest5" };
     CHECK(newArgumentParser(argc, argv));
     TestFilter nameFilter("test1");
-    nameFilter.strictMatching();
+    nameFilter.invertMatching();
     TestFilter groupFilter("group1");
     groupFilter.strictMatching();
     CHECK_EQUAL(nameFilter, *args->getNameFilters()->getNext()->getNext()->getNext()->getNext());

--- a/tests/TestFilterTest.cpp
+++ b/tests/TestFilterTest.cpp
@@ -57,6 +57,26 @@ TEST(TestFilter, strictMatching)
     CHECK(!filter.match(" filter"));
 }
 
+TEST(TestFilter, invertMatching)
+{
+    TestFilter filter("filter");
+    filter.invertMatching();
+    CHECK(!filter.match("filter"));
+    CHECK(!filter.match("filterr"));
+    CHECK(filter.match("notevenclose"));
+    CHECK(filter.match(""));
+}
+
+TEST(TestFilter, invertStrictMatching)
+{
+    TestFilter filter("filter");
+    filter.invertMatching();
+    filter.strictMatching();
+    CHECK(!filter.match("filter"));
+    CHECK(filter.match("filterr"));
+    CHECK(filter.match(" filter"));
+}
+
 TEST(TestFilter, equality)
 {
     TestFilter filter1("filter");
@@ -71,6 +91,14 @@ TEST(TestFilter, equalityWithStrictness)
     TestFilter filter1("filter");
     TestFilter filter2("filter");
     filter2.strictMatching();
+    CHECK(! (filter1 == filter2));
+}
+
+TEST(TestFilter, equalityWithInvertion)
+{
+    TestFilter filter1("filter");
+    TestFilter filter2("filter");
+    filter2.invertMatching();
     CHECK(! (filter1 == filter2));
 }
 
@@ -94,6 +122,21 @@ TEST(TestFilter, stringFromWithStrictMatching)
     TestFilter filter("filter");
     filter.strictMatching();
     STRCMP_EQUAL("TestFilter: \"filter\" with strict matching", StringFrom(filter).asCharString());
+}
+
+TEST(TestFilter, stringFromWithInvertMatching)
+{
+    TestFilter filter("filter");
+    filter.invertMatching();
+    STRCMP_EQUAL("TestFilter: \"filter\" with invert matching", StringFrom(filter).asCharString());
+}
+
+TEST(TestFilter, stringFromWithStrictInvertMatching)
+{
+    TestFilter filter("filter");
+    filter.strictMatching();
+    filter.invertMatching();
+    STRCMP_EQUAL("TestFilter: \"filter\" with strict, invert matching", StringFrom(filter).asCharString());
 }
 
 TEST(TestFilter, listOfFilters)


### PR DESCRIPTION
Implementation for issue #107.

New command line options:

`-xg <group>`: exclude test groups matching `group` string. 
`-xn <name>`: exclude test names matching `name` string.
`-xsg <group>`: exclude test group strictly matching `group` string.
`-xsn <name>`: exclude test names strictly matching `name` string.

Working use cases are:

* Exclude one test group.
* Exclude one test name.
* Exclude one test name within a group.
* Filter one test name in all but one excluded group.
* Exclude one test name in all but one excluded group.

Since test filter combination is implemented as a set union rather than intersection, combining two or more non-overlapping exclude group options, i.e. `-xg group1 -xg group2` turns out to run the full list of tests including all groups. Same thing happens when combining multiple exclude name options.

In order to have excluding combinations working differently, it'd be required a new command line option to specify whether filtering options should be combined with logical AND or OR operations. IMHO, that'd be too much convoluted. 

