### PR TITLE
Quieter autoconf

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -50,7 +50,7 @@ lib_libCppUTest_a_SOURCES = \
 	src/CppUTest/TestRegistry.cpp \
 	src/CppUTest/TestResult.cpp \
 	src/CppUTest/Utest.cpp \
-	src/Platforms/$(CPP_PLATFORM)/UtestPlatform.cpp
+	src/Platforms/@CPP_PLATFORM@/UtestPlatform.cpp
 
 include_cpputestdir = $(includedir)/CppUTest
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 
 AC_PREREQ([2.68])
 AC_INIT([CppUTest], [3.7.2], [https://github.com/cpputest/cpputest])
-AM_INIT_AUTOMAKE
+AM_INIT_AUTOMAKE([subdir-objects])
 AC_CONFIG_SRCDIR([src/CppUTest/Utest.cpp])
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_FILES([cpputest.pc])

--- a/configure.ac
+++ b/configure.ac
@@ -22,7 +22,6 @@ case "x$build_os" in
 		;;
 esac
 
-
 AC_PROG_CC
 AC_PROG_CPP
 AC_PROG_CXX
@@ -32,7 +31,6 @@ AM_PROG_CC_C_O
 AM_SILENT_RULES
 
 ACX_PTHREAD([LIBS="$PTHREAD_LIBS $LIBS"])
-
 
 # This additional -lpthread was added due to a bug on gcc for MacOSX: http://gcc.gnu.org/bugzilla/show_bug.cgi?id=42159
 # According to the bug report, a workaround is to link -lpthread. Even the ACX_PTHREAD doesn't do that, so we add an


### PR DESCRIPTION
enable [subdir-objects] in AM_INIT_AUTOMAKE, fix bug in Makefile.am. Subdirectory artifacts like Platforms/Gcc/... now get correct output directories.