### PR TITLE
Fix overwriting xml files if groups are mixed in their order #168

### DIFF
--- a/include/CppUTest/JUnitTestOutput.h
+++ b/include/CppUTest/JUnitTestOutput.h
@@ -28,7 +28,8 @@
 #ifndef D_JUnitTestOutput_h
 #define D_JUnitTestOutput_h
 
-#include <map>
+#include <string>
+#include <list>
 #include "TestOutput.h"
 #include "SimpleString.h"
 #include "PlatformSpecificFunctions_c.h"
@@ -77,7 +78,7 @@ protected:
     virtual void writeFileEnding();
 
 private:
-    std::map<std::string, PlatformSpecificFile> fileMap_;
+    std::list<std::string> fileList_;
 };
 
 #endif

--- a/include/CppUTest/JUnitTestOutput.h
+++ b/include/CppUTest/JUnitTestOutput.h
@@ -28,8 +28,10 @@
 #ifndef D_JUnitTestOutput_h
 #define D_JUnitTestOutput_h
 
+#include <map>
 #include "TestOutput.h"
 #include "SimpleString.h"
+#include "PlatformSpecificFunctions_c.h"
 
 struct JUnitTestOutputImpl;
 struct JUnitTestCaseResultNode;
@@ -74,6 +76,8 @@ protected:
     virtual void writeFailure(JUnitTestCaseResultNode* node);
     virtual void writeFileEnding();
 
+private:
+    std::map<std::string, PlatformSpecificFile> fileMap_;
 };
 
 #endif

--- a/src/CppUTest/JUnitTestOutput.cpp
+++ b/src/CppUTest/JUnitTestOutput.cpp
@@ -25,7 +25,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <iostream>
+#include <algorithm>
 #include "CppUTest/TestHarness.h"
 #include "CppUTest/JUnitTestOutput.h"
 #include "CppUTest/TestResult.h"
@@ -271,17 +271,21 @@ void JUnitTestOutput::printFailure(const TestFailure& failure)
 void JUnitTestOutput::openFileForWrite(const SimpleString& fileName)
 {
     std::string fileName_string(fileName.asCharString());
-    if (fileMap_.count(fileName_string)==0)
+
+    if (find(fileList_.begin(), fileList_.end(), fileName_string)==
+        fileList_.end())
     {
+      // not found -> create new
       impl_->file_ = PlatformSpecificFOpen(fileName.asCharString(), "w");
+      if (impl_->file_ != NULL)
+      {
+        fileList_.push_back(fileName_string);
+      }
     }
     else
     {
+      // found -> append
       impl_->file_ = PlatformSpecificFOpen(fileName.asCharString(), "a");
-    }
-    if (impl_->file_ != NULL)
-    {
-      fileMap_[fileName_string] = impl_->file_;
     }
 }
 

--- a/src/CppUTest/JUnitTestOutput.cpp
+++ b/src/CppUTest/JUnitTestOutput.cpp
@@ -25,6 +25,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <iostream>
 #include "CppUTest/TestHarness.h"
 #include "CppUTest/JUnitTestOutput.h"
 #include "CppUTest/TestResult.h"
@@ -269,7 +270,19 @@ void JUnitTestOutput::printFailure(const TestFailure& failure)
 
 void JUnitTestOutput::openFileForWrite(const SimpleString& fileName)
 {
-    impl_->file_ = PlatformSpecificFOpen(fileName.asCharString(), "w");
+    std::string fileName_string(fileName.asCharString());
+    if (fileMap_.count(fileName_string)==0)
+    {
+      impl_->file_ = PlatformSpecificFOpen(fileName.asCharString(), "w");
+    }
+    else
+    {
+      impl_->file_ = PlatformSpecificFOpen(fileName.asCharString(), "a");
+    }
+    if (impl_->file_ != NULL)
+    {
+      fileMap_[fileName_string] = impl_->file_;
+    }
 }
 
 void JUnitTestOutput::writeToFile(const SimpleString& buffer)


### PR DESCRIPTION
This is a simple fix for ticket #168. 

The JunitTestOutput instance keeps book about files already written to and will append instead of cut if a file is about to reopened again.