### PR TITLE
Clang 3.7 fixes

### DIFF
--- a/src/CppUTest/MemoryLeakDetector.cpp
+++ b/src/CppUTest/MemoryLeakDetector.cpp
@@ -168,7 +168,7 @@ void MemoryLeakOutputStringBuffer::reportMemoryLeak(MemoryLeakDetectorNode* leak
 
     total_leaks_++;
     outputBuffer_.add("Alloc num (%u) Leak size: %lu Allocated at: %s and line: %d. Type: \"%s\"\n\tMemory: <%p> Content:\n",
-            leak->number_, (unsigned long) leak->size_, leak->file_, leak->line_, leak->allocator_->alloc_name(), leak->memory_);
+            leak->number_, (unsigned long) leak->size_, leak->file_, leak->line_, leak->allocator_->alloc_name(), (void*) leak->memory_);
     outputBuffer_.addMemoryDump(leak->memory_, leak->size_);
 
     if (SimpleString::StrCmp(leak->allocator_->alloc_name(), (const char*) "malloc") == 0)

--- a/src/CppUTestExt/MemoryReportFormatter.cpp
+++ b/src/CppUTestExt/MemoryReportFormatter.cpp
@@ -49,12 +49,12 @@ void NormalMemoryReportFormatter::report_test_end(TestResult* result, UtestShell
 
 void NormalMemoryReportFormatter::report_alloc_memory(TestResult* result, TestMemoryAllocator* allocator, size_t size, char* memory, const char* file, int line)
 {
-    result->print(StringFromFormat("\tAllocation using %s of size: %lu pointer: %p at %s:%d\n", allocator->alloc_name(), (unsigned long) size, memory, file, line).asCharString());
+    result->print(StringFromFormat("\tAllocation using %s of size: %lu pointer: %p at %s:%d\n", allocator->alloc_name(), (unsigned long) size, (void*) memory, file, line).asCharString());
 }
 
 void NormalMemoryReportFormatter::report_free_memory(TestResult* result, TestMemoryAllocator* allocator, char* memory, const char* file, int line)
 {
-    result->print(StringFromFormat("\tDeallocation using %s of pointer: %p at %s:%d\n", allocator->free_name(),  memory, file, line).asCharString());
+    result->print(StringFromFormat("\tDeallocation using %s of pointer: %p at %s:%d\n", allocator->free_name(), (void*) memory, file, line).asCharString());
 }
 
 void NormalMemoryReportFormatter::report_testgroup_start(TestResult* result, UtestShell& test)

--- a/tests/MemoryLeakDetectorTest.cpp
+++ b/tests/MemoryLeakDetectorTest.cpp
@@ -137,7 +137,7 @@ TEST(MemoryLeakDetectorTest, OneLeak)
     STRCMP_CONTAINS("Memory leak(s) found", output.asCharString());
     STRCMP_CONTAINS("size: 3", output.asCharString());
     STRCMP_CONTAINS("alloc", output.asCharString());
-    STRCMP_CONTAINS(StringFromFormat("%p", mem).asCharString(), output.asCharString());
+    STRCMP_CONTAINS(StringFromFormat("%s", mem).asCharString(), output.asCharString());
     STRCMP_CONTAINS("Total number of leaks", output.asCharString());
     PlatformSpecificFree(mem);
     LONGS_EQUAL(1, testAllocator->alloc_called);


### PR DESCRIPTION
Some fixes for clang (3.7).

**Note:** Tests must be *disabled* to get cpputest compiled with Clang, since they fail to build (#807).