### PR TITLE
Appveyor support for Cygwin/autotools

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,7 @@ os:
 
 environment:
   matrix:
+  - PlatformToolset: Cygwin
   - PlatformToolset: MinGW
     Platform: Win32
   - PlatformToolset: MinGW
@@ -14,6 +15,7 @@ environment:
 
 install:
 - ps: if ($env:PlatformToolset -eq 'MinGW') { choco install mingw $( if ($env:Platform -eq 'Win32') { Write-Output -forcex86 } ) }
+- ps: if ($env:PlatformToolset -eq 'Cygwin') { (New-Object System.Net.WebClient).DownloadFile('https://cygwin.com/setup-x86.exe', "${env:TEMP}\cygwin-setup.exe") ; . "${env:TEMP}\cygwin-setup.exe" --quiet-mode --packages autoconf automake make gcc-core libtool gcc-g++ }
 
 build_script:
 - ps: scripts\appveyor_ci_build.ps1

--- a/scripts/appveyor_ci_build.ps1
+++ b/scripts/appveyor_ci_build.ps1
@@ -125,7 +125,7 @@ if ($env:PlatformToolset -eq 'v100')
 
 if ($env:PlatformToolset -eq 'Cygwin')
 {
-    Invoke-CygwinCommand "autoreconf -i .. ; ../configure ; make -j ${NUMBER_OF_PROCESSORS} CppUTestTests.exe CppUTestExtTests.exe" "cpputest_build"
+    Invoke-CygwinCommand "autoreconf -i .. ; ../configure ; make CppUTestTests.exe CppUTestExtTests.exe" "cpputest_build"
 }
 
 if ($env:PlatformToolset -eq 'MinGW')

--- a/scripts/appveyor_ci_build.ps1
+++ b/scripts/appveyor_ci_build.ps1
@@ -125,7 +125,7 @@ if ($env:PlatformToolset -eq 'v100')
 
 if ($env:PlatformToolset -eq 'Cygwin')
 {
-    Invoke-CygwinCommand "autoreconf -i .. ; ../configure ; make -j ${NUMBER_OF_PROCESSORS} all" "cpputest_build"
+    Invoke-CygwinCommand "autoreconf -i .. ; ../configure ; make -j ${NUMBER_OF_PROCESSORS} CppUTestTests.exe CppUTestExtTests.exe" "cpputest_build"
 }
 
 if ($env:PlatformToolset -eq 'MinGW')

--- a/scripts/appveyor_ci_test.ps1
+++ b/scripts/appveyor_ci_test.ps1
@@ -106,8 +106,8 @@ switch ($env:PlatformToolset)
 {
     'Cygwin'
     {
-        Invoke-CygwinTests('cpputest_build\CppUTestTests.exe')
-        Invoke-CygwinTests('cpputest_build\CppUTestExtTests.exe')
+        Invoke-CygwinTests 'cpputest_build\CppUTestTests.exe'
+        Invoke-CygwinTests 'cpputest_build\CppUTestExtTests.exe'
     }
 
     'MinGW'
@@ -119,15 +119,15 @@ switch ($env:PlatformToolset)
         }
 
         Add-PathFolder $mingw_path
-        Invoke-Tests('.\cpputest_build\tests\CppUTestTests.exe')
-        Invoke-Tests('.\cpputest_build\tests\CppUTestExt\CppUTestExtTests.exe')
+        Invoke-Tests '.\cpputest_build\tests\CppUTestTests.exe'
+        Invoke-Tests '.\cpputest_build\tests\CppUTestExt\CppUTestExtTests.exe'
         Remove-PathFolder $mingw_path
     }
 
     default
     {
-        Invoke-Tests('.\cpputest_build\AllTests.exe')
+        Invoke-Tests '.\cpputest_build\AllTests.exe'
     }
 }
 
-Publish-TestResults
+Publish-TestResults (Get-ChildItem 'cpputest_*.xml')


### PR DESCRIPTION
I finally got autotools working via cygwin on AppVeyor.  I think there was an open issue for this a while ago that got closed.

Anyways, it runs and shows the test results the same as MinGW or Visual C++.  For some reason, Cygwin results in the most tests being run compared to the other two environments.  I'm not sure everything I added is needed, but I'll look at doing some cleanup later this week and might remove a few things then (mostly around the install logic).