### PR TITLE
Added missing test files to visual studio projects

### DIFF
--- a/tests/AllTests.vcproj
+++ b/tests/AllTests.vcproj
@@ -401,6 +401,29 @@
 				</FileConfiguration>
 			</File>
 			<File
+				RelativePath="CppUTestExt\ExpectedFunctionsListTest.cpp"
+				>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+						ForcedIncludeFiles=""
+					/>
+				</FileConfiguration>
+			</File>
+			<File
 				RelativePath="CppUTestExt\GMockTest.cpp"
 				>
 				<FileConfiguration
@@ -493,29 +516,6 @@
 				</FileConfiguration>
 			</File>
 			<File
-				RelativePath="TeamCityOutputTest.cpp"
-				>
-				<FileConfiguration
-					Name="Release|Win32"
-					>
-					<Tool
-						Name="VCCLCompilerTool"
-						AdditionalIncludeDirectories=""
-						PreprocessorDefinitions=""
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Debug|Win32"
-					>
-					<Tool
-						Name="VCCLCompilerTool"
-						AdditionalIncludeDirectories=""
-						PreprocessorDefinitions=""
-						ForcedIncludeFiles=""
-					/>
-				</FileConfiguration>
-			</File>
-			<File
 				RelativePath="MemoryLeakDetectorTest.cpp"
 				>
 				<FileConfiguration
@@ -539,7 +539,7 @@
 				</FileConfiguration>
 			</File>
 			<File
-				RelativePath="MemoryOperatorOverloadTest.cpp"
+				RelativePath="MemoryLeakWarningTest.cpp"
 				>
 				<FileConfiguration
 					Name="Release|Win32"
@@ -562,7 +562,7 @@
 				</FileConfiguration>
 			</File>
 			<File
-				RelativePath="MemoryLeakWarningTest.cpp"
+				RelativePath="MemoryOperatorOverloadTest.cpp"
 				>
 				<FileConfiguration
 					Name="Release|Win32"
@@ -677,6 +677,10 @@
 				</FileConfiguration>
 			</File>
 			<File
+				RelativePath=".\CppUTestExt\MockCallTest.cpp"
+				>
+			</File>
+			<File
 				RelativePath="CppUTestExt\MockCheatSheetTest.cpp"
 				>
 				<FileConfiguration
@@ -700,30 +704,11 @@
 				</FileConfiguration>
 			</File>
 			<File
-				RelativePath="CppUTestExt\MockExpectedCallTest.cpp"
+				RelativePath=".\CppUTestExt\MockComparatorCopierTest.cpp"
 				>
-				<FileConfiguration
-					Name="Release|Win32"
-					>
-					<Tool
-						Name="VCCLCompilerTool"
-						AdditionalIncludeDirectories=""
-						PreprocessorDefinitions=""
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Debug|Win32"
-					>
-					<Tool
-						Name="VCCLCompilerTool"
-						AdditionalIncludeDirectories=""
-						PreprocessorDefinitions=""
-						ForcedIncludeFiles=""
-					/>
-				</FileConfiguration>
 			</File>
 			<File
-				RelativePath="CppUTestExt\ExpectedFunctionsListTest.cpp"
+				RelativePath="CppUTestExt\MockExpectedCallTest.cpp"
 				>
 				<FileConfiguration
 					Name="Release|Win32"
@@ -773,6 +758,18 @@
 				>
 			</File>
 			<File
+				RelativePath=".\CppUTestExt\MockHierarchyTest.cpp"
+				>
+			</File>
+			<File
+				RelativePath=".\CppUTestExt\MockNamedValueTest.cpp"
+				>
+			</File>
+			<File
+				RelativePath=".\CppUTestExt\MockParameterTest.cpp"
+				>
+			</File>
+			<File
 				RelativePath="CppUTestExt\MockPluginTest.cpp"
 				>
 				<FileConfiguration
@@ -794,6 +791,14 @@
 						ForcedIncludeFiles=""
 					/>
 				</FileConfiguration>
+			</File>
+			<File
+				RelativePath=".\CppUTestExt\MockReturnValueTest.cpp"
+				>
+			</File>
+			<File
+				RelativePath=".\CppUTestExt\MockStrictOrderTest.cpp"
+				>
 			</File>
 			<File
 				RelativePath="CppUTestExt\MockSupport_cTest.cpp"
@@ -985,6 +990,29 @@
 			</File>
 			<File
 				RelativePath="SimpleStringTest.cpp"
+				>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+						ForcedIncludeFiles=""
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath="TeamCityOutputTest.cpp"
 				>
 				<FileConfiguration
 					Name="Release|Win32"

--- a/tests/AllTests.vcxproj
+++ b/tests/AllTests.vcxproj
@@ -149,12 +149,18 @@
     <ClCompile Include="CppUTestExt\MemoryReporterPluginTest.cpp" />
     <ClCompile Include="CppUTestExt\MemoryReportFormatterTest.cpp" />
     <ClCompile Include="CppUTestExt\MockActualCallTest.cpp" />
+    <ClCompile Include="CppUTestExt\MockCallTest.cpp" />
     <ClCompile Include="CppUTestExt\MockCheatSheetTest.cpp" />
+    <ClCompile Include="CppUTestExt\MockComparatorCopierTest.cpp" />
     <ClCompile Include="CppUTestExt\MockExpectedCallTest.cpp" />
     <ClCompile Include="CppUTestExt\ExpectedFunctionsListTest.cpp" />
     <ClCompile Include="CppUTestExt\MockFailureTest.cpp" />
+    <ClCompile Include="CppUTestExt\MockHierarchyTest.cpp" />
     <ClCompile Include="CppUTestExt\MockNamedValueTest.cpp" />
+    <ClCompile Include="CppUTestExt\MockParameterTest.cpp" />
     <ClCompile Include="CppUTestExt\MockPluginTest.cpp" />
+    <ClCompile Include="CppUTestExt\MockReturnValueTest.cpp" />
+    <ClCompile Include="CppUTestExt\MockStrictOrderTest.cpp" />
     <ClCompile Include="CppUTestExt\MockSupportTest.cpp" />
     <ClCompile Include="CppUTestExt\MockSupport_cTest.cpp" />
     <ClCompile Include="CppUTestExt\MockSupport_cTestCFile.c" />
@@ -168,6 +174,7 @@
     <ClCompile Include="SetPluginTest.cpp" />
     <ClCompile Include="SimpleMutexTest.cpp" />
     <ClCompile Include="SimpleStringTest.cpp" />
+    <ClCompile Include="TeamCityOutputTest.cpp" />
     <ClCompile Include="TestFailureNaNTest.cpp" />
     <ClCompile Include="TestFailureTest.cpp" />
     <ClCompile Include="TestFilterTest.cpp" />


### PR DESCRIPTION
This is some cleanup to the visual studio project files to add some missing test files.  I noticed this on appveyor when adding autotools, VS was running a couple hundred fewer tests than autotools or MinGW.

I haven't been able to update/test the VC6 project, I can run builds but don't have the IDE available to regenerate certain files.  Looks like it broke as part of PR #603, so I think it's been broken for a while.  `CppUTest.dep` is looking for `include\Platforms\VisualCpp\stdint.h` which no longer exists and it doesn't know how to create it.