### PR TITLE
Fixed a failed test on clang++3.7.

### DIFF
--- a/include/CppUTest/TestTestingFixture.h
+++ b/include/CppUTest/TestTestingFixture.h
@@ -100,16 +100,19 @@ public:
         return genTest_->hasFailed();
     }
 
-
     void assertPrintContains(const SimpleString& contains)
     {
-        assertPrintContains(output_, contains);
+        assertPrintContains(getOutput(), contains);
     }
 
-    static void assertPrintContains(StringBufferTestOutput* output,
-            const SimpleString& contains)
+    const SimpleString& getOutput()
     {
-        STRCMP_CONTAINS(contains.asCharString(), output->getOutput().asCharString());
+        return output_->getOutput();
+    }
+
+    static void assertPrintContains(const SimpleString& output, const SimpleString& contains)
+    {
+        STRCMP_CONTAINS(contains.asCharString(), output.asCharString());
 
     }
 

--- a/tests/UtestTest.cpp
+++ b/tests/UtestTest.cpp
@@ -191,7 +191,7 @@ TEST(UtestShell, TestDefaultCrashMethodInSeparateProcessTest)
     fixture.runAllTests();
     fixture.assertPrintContains("Failed in separate process - killed by signal");
 
-    /* Signal 11 usually happens, but with clang4.7 on Linux, it produced signal 4 */
+    /* Signal 11 usually happens, but with clang3.7 on Linux, it produced signal 4 */
     CHECK(fixture.getOutput().contains("signal 11") || fixture.getOutput().contains("signal 4"));
 }
 

--- a/tests/UtestTest.cpp
+++ b/tests/UtestTest.cpp
@@ -189,7 +189,10 @@ TEST(UtestShell, TestDefaultCrashMethodInSeparateProcessTest)
     fixture.setTestFunction(UtestShell::crash);
     fixture.registry_->setRunTestsInSeperateProcess();
     fixture.runAllTests();
-    fixture.assertPrintContains("Failed in separate process - killed by signal 11");
+    fixture.assertPrintContains("Failed in separate process - killed by signal");
+
+    /* Signal 11 usually happens, but with clang4.7 on Linux, it produced signal 4 */
+    CHECK(fixture.getOutput().contains("signal 11") || fixture.getOutput().contains("signal 4"));
 }
 
 #endif


### PR DESCRIPTION
The separate process test returned a different signal. Looking into it, it seems that signal is also valid and thus it shouldn't fail the test. For now, created a test that has an 'or' in it which checks both signals. Not the best choice, but I guess it will do for now?

@arstrube: Might want to check this one. You think this fix is ok? 