### PR TITLE
Put the Vc6 fix where it belongs

### DIFF
--- a/tests/AllTests.dsp
+++ b/tests/AllTests.dsp
@@ -42,7 +42,7 @@ RSC=rc.exe
 # PROP Ignore_Export_Lib 0
 # PROP Target_Dir ""
 # ADD BASE CPP /nologo /W3 /GX /O2 /D "WIN32" /D "NDEBUG" /D "_CONSOLE" /D "_MBCS" /YX /FD /c
-# ADD CPP /nologo /W3 /GX /O2 /I "..\include" /I "..\include\Platforms\VisualCpp" /D "WIN32" /D "NDEBUG" /D "_CONSOLE" /D "_MBCS" /D "CPPUTEST_MEM_LEAK_DETECTION_DISABLED" /YX /FD /c
+# ADD CPP /nologo /W3 /GX /O2 /Ob0 /I "..\include" /I "..\include\Platforms\VisualCpp" /D "WIN32" /D "NDEBUG" /D "_CONSOLE" /D "_MBCS" /D "CPPUTEST_MEM_LEAK_DETECTION_DISABLED" /YX /FD /c
 # ADD BASE RSC /l 0x409 /d "NDEBUG"
 # ADD RSC /l 0x409 /d "NDEBUG"
 BSC32=bscmake.exe

--- a/tests/CppUTestExt/MockFailureTest.h
+++ b/tests/CppUTestExt/MockFailureTest.h
@@ -72,8 +72,10 @@ inline UtestShell* mockFailureTest()
     return MockFailureReporterForTest::getReporter()->getTestToFail();
 }
 
-#define mockFailureString() /* inline function will not work in VC6 */ \
-    MockFailureReporterForTest::getReporter()->mockFailureString
+inline SimpleString mockFailureString()
+{
+    return MockFailureReporterForTest::getReporter()->mockFailureString;
+}
 
 inline void CLEAR_MOCK_FAILURE()
 {


### PR DESCRIPTION
(actually, it is the method `MockFailureReporterForTest::getReporter()` that must not be inlined)