### PR TITLE
Fix for #817 one balanced implementation for expecting no call functionality

### DIFF
--- a/include/CppUTestExt/MockSupport.h
+++ b/include/CppUTestExt/MockSupport.h
@@ -47,6 +47,7 @@ public:
 
     virtual void strictOrder();
     virtual MockExpectedCall& expectOneCall(const SimpleString& functionName);
+    virtual void expectNoCall(const SimpleString& functionName);
     virtual MockExpectedCall& expectNCalls(int amount, const SimpleString& functionName);
     virtual MockActualCall& actualCall(const SimpleString& functionName);
     virtual bool hasReturnValue();
@@ -127,6 +128,7 @@ private:
     MockFailureReporter *standardReporter_;
     MockFailureReporter defaultReporter_;
     MockExpectedCallsList expectations_;
+    MockExpectedCallsList unExpectations_;
     bool ignoreOtherCalls_;
     bool enabled_;
     MockCheckedActualCall *lastActualFunctionCall_;
@@ -144,6 +146,9 @@ private:
     MockNamedValue* retrieveDataFromStore(const SimpleString& name);
 
     MockSupport* getMockSupport(MockNamedValueListNode* node);
+    
+    bool hasntExpectationWithName(const SimpleString& functionName);
+    bool hasntUnexpectationWithName(const SimpleString& functionName);
 };
 
 #endif


### PR DESCRIPTION
after several implementations try, I chose this as my solution to for the expecting no call functionality. It's the more balanced one, for satisfying the simplicity , sufficient and compliant with existed system design requirement .
Let's see if it's worth to be added.

#Solution Description
add one unexpected list in MockSupport, and add one expectNoCall in MockSupport. When expectNoCall() is invoked, One unexpected call will be appended to the unexpected list.
then in actualCall(), current existed expectation empty judge will changed to judge if both expectation list and unexpectation list are empty. If expectation list is empty and unexpectation list is not empty, actualCall() will go ahead to trigger the unexpected call failure.