### PR TITLE
Add -l to gcov options, so inline functions will be analyzed correctly.

### DIFF
--- a/scripts/travis_ci_build.sh
+++ b/scripts/travis_ci_build.sh
@@ -67,7 +67,7 @@ if [ "x$BUILD" = "xcmake-coverage" ]; then
     make
     ctest
 
-    coveralls -b . -r .. -i "src" -i "include" --gcov-options="-bc" || true
+    coveralls -b . -r .. -i "src" -i "include" --gcov-options="-lbc" || true
 fi
 
 if [ "x$BUILD" = "xmake-dos" ]; then


### PR DESCRIPTION
This fixes issue #836.