### PR TITLE
another proposed fix of #829

### DIFF
--- a/include/CppUTestExt/MockExpectedCallsList.h
+++ b/include/CppUTestExt/MockExpectedCallsList.h
@@ -53,6 +53,8 @@ public:
     virtual void addExpectedCall(MockCheckedExpectedCall* call);
     virtual void addExpectations(const MockExpectedCallsList& list);
     virtual void addExpectationsRelatedTo(const SimpleString& name, const MockExpectedCallsList& list);
+    
+    virtual void onlyKeepOutOfOrderExpectations();
     virtual void addUnfulfilledExpectations(const MockExpectedCallsList& list);
 
     virtual void onlyKeepExpectationsRelatedTo(const SimpleString& name);

--- a/include/CppUTestExt/MockSupport.h
+++ b/include/CppUTestExt/MockSupport.h
@@ -149,6 +149,7 @@ private:
     
     bool hasntExpectationWithName(const SimpleString& functionName);
     bool hasntUnexpectationWithName(const SimpleString& functionName);
+    bool hasCallsOutOfOrder();
 };
 
 #endif

--- a/src/CppUTestExt/MockExpectedCallsList.cpp
+++ b/src/CppUTestExt/MockExpectedCallsList.cpp
@@ -149,6 +149,14 @@ void MockExpectedCallsList::onlyKeepExpectationsRelatedTo(const SimpleString& na
     pruneEmptyNodeFromList();
 }
 
+void MockExpectedCallsList::onlyKeepOutOfOrderExpectations()
+{
+    for (MockExpectedCallsListNode* p = head_; p; p = p->next_)
+        if (!p->expectedCall_->isOutOfOrder())
+            p->expectedCall_ = NULL;
+    pruneEmptyNodeFromList();
+}
+
 void MockExpectedCallsList::onlyKeepUnfulfilledExpectations()
 {
     for (MockExpectedCallsListNode* p = head_; p; p = p->next_)

--- a/src/CppUTestExt/MockFailure.cpp
+++ b/src/CppUTestExt/MockFailure.cpp
@@ -115,9 +115,13 @@ MockUnexpectedCallHappenedFailure::MockUnexpectedCallHappenedFailure(UtestShell*
 
 MockCallOrderFailure::MockCallOrderFailure(UtestShell* test, const MockExpectedCallsList& expectations) : MockFailure(test)
 {
+    MockExpectedCallsList expectationsForOutOfOrder;
+    expectationsForOutOfOrder.addExpectations(expectations);
+    expectationsForOutOfOrder.onlyKeepOutOfOrderExpectations();
+
     message_ = "Mock Failure: Out of order calls";
     message_ += "\n";
-    addExpectationsAndCallHistory(expectations);
+    addExpectationsAndCallHistory(expectationsForOutOfOrder);
 }
 
 MockUnexpectedInputParameterFailure::MockUnexpectedInputParameterFailure(UtestShell* test, const SimpleString& functionName, const MockNamedValue& parameter, const MockExpectedCallsList& expectations)  : MockFailure(test)

--- a/src/CppUTestExt/MockSupport.cpp
+++ b/src/CppUTestExt/MockSupport.cpp
@@ -310,21 +310,41 @@ void MockSupport::countCheck()
     UtestShell::getCurrent()->countCheck();
 }
 
-void MockSupport::checkExpectations()
+void MockSupport::checkExpectationsOfLastCall()
 {
-    for(MockNamedValueListNode *p = data_.begin(); p; p = p->next())
-        if(getMockSupport(p) && getMockSupport(p)->lastActualFunctionCall_)
-            getMockSupport(p)->checkExpectations();
-    
     if(lastActualFunctionCall_)
         lastActualFunctionCall_->checkExpectations();
+
+    for(MockNamedValueListNode *p = data_.begin();p;p = p->next())
+        if(getMockSupport(p) && getMockSupport(p)->lastActualFunctionCall_)
+            getMockSupport(p)->lastActualFunctionCall_->checkExpectations();
+}
+
+bool MockSupport::hasCallsOutOfOrder()
+{
+    if (expectations_.hasCallsOutOfOrder())
+    {
+        return true;
+    }
+    for (MockNamedValueListNode* p = data_.begin(); p; p = p->next())
+        if (getMockSupport(p) && getMockSupport(p)->hasCallsOutOfOrder())
+        {
+            return true;
+        }
+    return false;
+}
+
+void MockSupport::checkExpectations()
+{
+    checkExpectationsOfLastCall();
 
     if (wasLastCallFulfilled() && expectedCallsLeft())
         failTestWithUnexpectedCalls();
 
-    if (expectations_.hasCallsOutOfOrder())
+    if (hasCallsOutOfOrder())
         failTestWithOutOfOrderCalls();
 }
+
 
 bool MockSupport::hasData(const SimpleString& name)
 {

--- a/tests/CppUTestExt/MockStrictOrderTest.cpp
+++ b/tests/CppUTestExt/MockStrictOrderTest.cpp
@@ -105,6 +105,32 @@ TEST(MockStrictOrderTest, orderViolatedWorksHierarchically)
     CHECK_EXPECTED_MOCK_FAILURE(expectedFailure);
 }
 
+TEST(MockStrictOrderTest, orderViolatedWorksWithExtraUnexpectedCall)
+{
+    MockFailureReporterInstaller failureReporterInstaller;
+    mock().strictOrder();
+    mock("bla").strictOrder();
+	mock().ignoreOtherCalls();
+
+    MockExpectedCallsListForTest expectations;
+    expectations.addFunction("foo1", 1)->callWasMade(2);
+    expectations.addFunction("foo2", 2)->callWasMade(1);
+    MockCallOrderFailure expectedFailure(mockFailureTest(), expectations);
+
+    mock("bla").expectOneCall("foo1");
+    mock("foo").expectOneCall("foo1");
+    mock("foo").expectOneCall("foo2"); 
+
+    mock("bla").actualCall("foo1");
+    mock("foo").actualCall("foo2");
+	mock("foo").actualCall("unexpected1");
+    mock("foo").actualCall("foo1");
+	mock("foo").actualCall("unexpected2");
+
+    mock().checkExpectations();
+    CHECK_EXPECTED_MOCK_FAILURE(expectedFailure);
+}
+
 TEST(MockStrictOrderTest, orderViolatedWithinAScope)
 {
     MockFailureReporterInstaller failureReporterInstaller;


### PR DESCRIPTION
For current fix for #829 , I'm afraid if lastActualFunctionCall is null then we lost chance to check other scope out of order.
for example:
```.cpp
    mock().strictOrder();
    mock("bla").strictOrder();
    mock().ignoreOtherCalls();

    MockExpectedCallsListForTest expectations;
    expectations.addFunction("foo1", 1)->callWasMade(2);
    expectations.addFunction("foo2", 2)->callWasMade(1);
    MockCallOrderFailure expectedFailure(mockFailureTest(), expectations);

    mock("bla").expectOneCall("foo1");
    mock("foo").expectOneCall("foo1");
    mock("foo").expectOneCall("foo2"); 

    mock("bla").actualCall("foo1");
    mock("foo").actualCall("foo2");
    mock("foo").actualCall("unexpected1");
    mock("foo").actualCall("foo1");
    mock("foo").actualCall("unexpected2");
```
I admit i'm fastidious about the out of order check :)

I have another proposed fix pull request, hopefully you guys can give some look and comments.