### PR TITLE
change getOneFulfilledExpectationWithIgnoredParameters to right name

### DIFF
--- a/include/CppUTestExt/MockExpectedCallsList.h
+++ b/include/CppUTestExt/MockExpectedCallsList.h
@@ -67,7 +67,7 @@ public:
 
     virtual MockCheckedExpectedCall* removeOneFulfilledExpectation();
     virtual MockCheckedExpectedCall* removeOneFulfilledExpectationWithIgnoredParameters();
-    virtual MockCheckedExpectedCall* getOneFulfilledExpectationWithIgnoredParameters();
+    virtual MockCheckedExpectedCall* getOneFulfilledExpectationWithoutIgnoredParameters();
 
     virtual void resetExpectations();
     virtual void callWasMade(int callOrder);

--- a/src/CppUTestExt/MockActualCall.cpp
+++ b/src/CppUTestExt/MockActualCall.cpp
@@ -106,7 +106,7 @@ void MockCheckedActualCall::finalizeOutputParameters(MockCheckedExpectedCall* ex
 void MockCheckedActualCall::finalizeCallWhenFulfilled()
 {
     if (unfulfilledExpectations_.hasFulfilledExpectationsWithoutIgnoredParameters()) {
-        finalizeOutputParameters(unfulfilledExpectations_.getOneFulfilledExpectationWithIgnoredParameters());
+        finalizeOutputParameters(unfulfilledExpectations_.getOneFulfilledExpectationWithoutIgnoredParameters());
     }
 
     if (unfulfilledExpectations_.hasFulfilledExpectations()) {

--- a/src/CppUTestExt/MockExpectedCallsList.cpp
+++ b/src/CppUTestExt/MockExpectedCallsList.cpp
@@ -222,7 +222,7 @@ MockCheckedExpectedCall* MockExpectedCallsList::removeOneFulfilledExpectation()
     return NULL;
 }
 
-MockCheckedExpectedCall* MockExpectedCallsList::getOneFulfilledExpectationWithIgnoredParameters()
+MockCheckedExpectedCall* MockExpectedCallsList::getOneFulfilledExpectationWithoutIgnoredParameters()
 {
     for (MockExpectedCallsListNode* p = head_; p; p = p->next_) {
         if (p->expectedCall_->isFulfilledWithoutIgnoredParameters()) {

--- a/tests/CppUTestExt/ExpectedFunctionsListTest.cpp
+++ b/tests/CppUTestExt/ExpectedFunctionsListTest.cpp
@@ -271,9 +271,9 @@ TEST(MockExpectedCallsList, removeOneFulfilledExpectationFromEmptyList)
     POINTERS_EQUAL(NULL, list->removeOneFulfilledExpectation());
 }
 
-TEST(MockExpectedCallsList, getOneFulfilledExpectationWithIgnoredParametersFromEmptyList)
+TEST(MockExpectedCallsList, getOneFulfilledExpectationWithoutIgnoredParametersFromEmptyList)
 {
-    POINTERS_EQUAL(NULL, list->getOneFulfilledExpectationWithIgnoredParameters());
+    POINTERS_EQUAL(NULL, list->getOneFulfilledExpectationWithoutIgnoredParameters());
 }
 
 TEST(MockExpectedCallsList, toStringOnEmptyList)


### PR DESCRIPTION
change getOneFulfilledExpectationWithIgnoredParameters to right name which compliant with it's behavior