### PR TITLE
Prune install section in .travis.yml; install Dosbox only for make_dos.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,11 @@ matrix:
     - compiler: gcc
       env: BUILD=cmake_gtest
     - compiler: gcc
-      env: BUILD=cmake-coverage
+      env: BUILD=cmake_coverage
     - compiler: gcc
       env: BUILD=test_report
     - compiler: wcl
-      env: BUILD=make-dos
+      env: BUILD=make_dos
 global:
 - os: linux
 - rvm: '1.9.3'
@@ -34,15 +34,7 @@ global:
 addons:
   apt:
     packages:
-      # - dosbox
       - valgrind
-before_install:
-  #  - sudo pip install cpp-coveralls
-  - sudo apt-get install dosbox
-install:
-  - gem install travis_github_deployer
-  - sudo apt-get update --fix-missing
-    #  - sudo apt-get install valgrind
 before_script:
   - export CPPUTEST_BUILD_DIR=$TRAVIS_BUILD_DIR/cpputest_build
   - mkdir -p $CPPUTEST_BUILD_DIR && cd $CPPUTEST_BUILD_DIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ global:
 addons:
   apt:
     packages:
+#     - dosbox
       - valgrind
 before_script:
   - export CPPUTEST_BUILD_DIR=$TRAVIS_BUILD_DIR/cpputest_build

--- a/scripts/travis_ci_build.sh
+++ b/scripts/travis_ci_build.sh
@@ -13,7 +13,8 @@ if [ "x$BUILD" = "xautotools" ]; then
 
     if [ "x$CXX" = "xg++" ]; then
       echo "Deploy please"
-#        cd .. && travis_github_deployer -v || exit 1
+#      gem install travis_github_deployer
+#      cd .. && travis_github_deployer -v || exit 1
     fi;
 fi
 
@@ -60,8 +61,8 @@ if [ "x$BUILD" = "xtest_report" ]; then
     ant -f generate_junit_report_ant.xml
 fi
 
-if [ "x$BUILD" = "xcmake-coverage" ]; then
-  pip install cpp-coveralls --user `whoami`
+if [ "x$BUILD" = "xcmake_coverage" ]; then
+    pip install cpp-coveralls --user `whoami`
 
     cmake .. -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE -DCOVERAGE=ON
     make
@@ -70,7 +71,8 @@ if [ "x$BUILD" = "xcmake-coverage" ]; then
     coveralls -b . -r .. -i "src" -i "include" --gcov-options="-lbc" || true
 fi
 
-if [ "x$BUILD" = "xmake-dos" ]; then
+if [ "x$BUILD" = "xmake_dos" ]; then
+    sudo apt-get install dosbox
     wget ftp://ftp.openwatcom.org/pub/open-watcom-c-linux-1.9 -O /tmp/watcom.zip
     mkdir -p watcom && unzip -aqd watcom /tmp/watcom.zip && sudo chmod -R 755 watcom/binl
     export PATH=$PATH:$PWD/watcom/binl


### PR DESCRIPTION
This fixes issue #809 - well a related issue which causes all jobs to error when for some reason Dosbox (which is only needed for `make_dos`) cannot be installed.

I tested the github deployer part on my fork and it work (installing correctly, then displaying a message that nothing will be deployed, because it is running on a for - all as expected). After that, I commented out the github deployer part again.