### PR TITLE
Correct use of ordinal numbers in MockUnexpectedCallHappenedFailure

### DIFF
--- a/CppUTest.vcxproj
+++ b/CppUTest.vcxproj
@@ -150,12 +150,15 @@
   <ItemGroup>
     <ClInclude Include="include\CppUTestExt\CodeMemoryReportFormatter.h" />
     <ClInclude Include="include\CppUTestExt\GMock.h" />
+    <ClInclude Include="include\CppUTestExt\GTest.h" />
     <ClInclude Include="include\CppUTestExt\GTestConvertor.h" />
     <ClInclude Include="include\CppUTestExt\MemoryReportAllocator.h" />
     <ClInclude Include="include\CppUTestExt\MemoryReporterPlugin.h" />
     <ClInclude Include="include\CppUTestExt\MemoryReportFormatter.h" />
+    <ClInclude Include="include\CppUTestExt\MockActualCall.h" />
     <ClInclude Include="include\CppUTestExt\MockCheckedActualCall.h" />
     <ClInclude Include="include\CppUTestExt\MockCheckedExpectedCall.h" />
+    <ClInclude Include="include\CppUTestExt\MockExpectedCall.h" />
     <ClInclude Include="include\CppUTestExt\MockExpectedCallsList.h" />
     <ClInclude Include="include\CppUTestExt\MockFailure.h" />
     <ClInclude Include="include\CppUTestExt\MockNamedValue.h" />

--- a/include/CppUTest/SimpleString.h
+++ b/include/CppUTest/SimpleString.h
@@ -154,6 +154,7 @@ SimpleString StringFromBinaryOrNull(const unsigned char* value, size_t size);
 SimpleString StringFromBinaryWithSize(const unsigned char* value, size_t size);
 SimpleString StringFromBinaryWithSizeOrNull(const unsigned char* value, size_t size);
 SimpleString StringFromMaskedBits(unsigned long value, unsigned long mask, size_t byteCount);
+SimpleString StringFromOrdinalNumber(unsigned int number);
 
 #if CPPUTEST_USE_STD_CPP_LIB
 

--- a/src/CppUTest/SimpleString.cpp
+++ b/src/CppUTest/SimpleString.cpp
@@ -653,6 +653,26 @@ SimpleString StringFromMaskedBits(unsigned long value, unsigned long mask, size_
     return result;
 }
 
+SimpleString StringFromOrdinalNumber(unsigned int number)
+{
+    unsigned int onesDigit = number % 10;
+
+    const char* suffix;
+    if (number >= 11 && number <= 13) {
+        suffix = "th";
+    } else if (3 == onesDigit) {
+        suffix = "rd";
+    } else if (2 == onesDigit) {
+        suffix = "nd";
+    } else if (1 == onesDigit) {
+        suffix = "st";
+    } else {
+        suffix = "th";
+    }
+
+    return StringFromFormat("%u%s", number, suffix);
+}
+
 SimpleStringCollection::SimpleStringCollection()
 {
     collection_ = 0;

--- a/src/CppUTestExt/MockFailure.cpp
+++ b/src/CppUTestExt/MockFailure.cpp
@@ -103,11 +103,12 @@ MockExpectedCallsDidntHappenFailure::MockExpectedCallsDidntHappenFailure(UtestSh
 
 MockUnexpectedCallHappenedFailure::MockUnexpectedCallHappenedFailure(UtestShell* test, const SimpleString& name, const MockExpectedCallsList& expectations) : MockFailure(test)
 {
-    int amountOfExpectations = expectations.amountOfExpectationsFor(name);
-    if (amountOfExpectations)
-        message_ = StringFromFormat("Mock Failure: Unexpected additional (%dth) call to function: ", amountOfExpectations+1);
-    else
+    if (expectations.amountOfExpectationsFor(name)) {
+        SimpleString ordinalNumber = StringFromOrdinalNumber((unsigned)(expectations.amountOfExpectationsFor(name) + 1));
+        message_ = StringFromFormat("Mock Failure: Unexpected additional (%s) call to function: ", ordinalNumber.asCharString());
+    } else {
         message_ = "Mock Failure: Unexpected call to function: ";
+    }
     message_ += name;
     message_ += "\n";
     addExpectationsAndCallHistory(expectations);

--- a/tests/CppUTestExt/MockFailureTest.cpp
+++ b/tests/CppUTestExt/MockFailureTest.cpp
@@ -61,6 +61,23 @@ TEST_GROUP(MockFailureTest)
         list->addExpectedCall(call2);
         list->addExpectedCall(call3);
     }
+
+    void checkUnexpectedNthCallMessage(unsigned int count, const char* expectedOrdinal)
+    {
+        MockExpectedCallsList callList;
+        MockCheckedExpectedCall expCall;
+
+        expCall.withName("bar");
+        for (unsigned int i = 0; i < (count - 1); i++) {
+            expCall.callWasMade(1);
+            callList.addExpectedCall(&expCall);
+        }
+
+        MockUnexpectedCallHappenedFailure failure(UtestShell::getCurrent(), "bar", callList);
+
+        SimpleString expectedMessage = StringFromFormat("Mock Failure: Unexpected additional (%s) call to function: bar\n\tEXPECTED", expectedOrdinal);
+        STRCMP_CONTAINS(expectedMessage.asCharString(), failure.getMessage().asCharString());
+    }
 };
 
 TEST(MockFailureTest, noErrorFailureSomethingGoneWrong)
@@ -96,14 +113,18 @@ TEST(MockFailureTest, expectedCallDidNotHappen)
                  "\t\thaphaphap -> no parameters", failure.getMessage().asCharString());
 }
 
-TEST(MockFailureTest, MockUnexpectedAdditionalCallFailure)
+TEST(MockFailureTest, MockUnexpectedNthAdditionalCallFailure)
 {
-    call1->withName("bar");
-    call1->callWasMade(1);
-    list->addExpectedCall(call1);
-
-    MockUnexpectedCallHappenedFailure failure(UtestShell::getCurrent(), "bar", *list);
-    STRCMP_CONTAINS("Mock Failure: Unexpected additional (2th) call to function: bar\n\tEXPECTED", failure.getMessage().asCharString());
+    checkUnexpectedNthCallMessage(2, "2nd");
+    checkUnexpectedNthCallMessage(3, "3rd");
+    checkUnexpectedNthCallMessage(4, "4th");
+    checkUnexpectedNthCallMessage(11, "11th");
+    checkUnexpectedNthCallMessage(12, "12th");
+    checkUnexpectedNthCallMessage(13, "13th");
+    checkUnexpectedNthCallMessage(14, "14th");
+    checkUnexpectedNthCallMessage(21, "21st");
+    checkUnexpectedNthCallMessage(22, "22nd");
+    checkUnexpectedNthCallMessage(23, "23rd");
 }
 
 TEST(MockFailureTest, MockUnexpectedInputParameterFailure)

--- a/tests/SimpleStringTest.cpp
+++ b/tests/SimpleStringTest.cpp
@@ -957,3 +957,34 @@ TEST(SimpleString, MaskedBits4bytes)
         STRCMP_EQUAL("11xx11xx 11xx11xx 11xx11xx 11xx11xx", StringFromMaskedBits(0xFFFFFFFF, 0xCCCCCCCC, 4).asCharString());
     }
 }
+
+TEST(SimpleString, StringFromOrdinalNumberOnes)
+{
+    STRCMP_EQUAL("2nd", StringFromOrdinalNumber(2).asCharString());
+    STRCMP_EQUAL("3rd", StringFromOrdinalNumber(3).asCharString());
+    STRCMP_EQUAL("4th", StringFromOrdinalNumber(4).asCharString());
+    STRCMP_EQUAL("5th", StringFromOrdinalNumber(5).asCharString());
+    STRCMP_EQUAL("6th", StringFromOrdinalNumber(6).asCharString());
+    STRCMP_EQUAL("7th", StringFromOrdinalNumber(7).asCharString());
+}
+
+TEST(SimpleString, StringFromOrdinalNumberTens)
+{
+    STRCMP_EQUAL("10th", StringFromOrdinalNumber(10).asCharString());
+    STRCMP_EQUAL("11th", StringFromOrdinalNumber(11).asCharString());
+    STRCMP_EQUAL("12th", StringFromOrdinalNumber(12).asCharString());
+    STRCMP_EQUAL("13th", StringFromOrdinalNumber(13).asCharString());
+    STRCMP_EQUAL("14th", StringFromOrdinalNumber(14).asCharString());
+    STRCMP_EQUAL("18th", StringFromOrdinalNumber(18).asCharString());
+}
+
+TEST(SimpleString, StringFromOrdinalNumberOthers)
+{
+    STRCMP_EQUAL("21st", StringFromOrdinalNumber(21).asCharString());
+    STRCMP_EQUAL("22nd", StringFromOrdinalNumber(22).asCharString());
+    STRCMP_EQUAL("23rd", StringFromOrdinalNumber(23).asCharString());
+    STRCMP_EQUAL("24th", StringFromOrdinalNumber(24).asCharString());
+    STRCMP_EQUAL("32nd", StringFromOrdinalNumber(32).asCharString());
+    STRCMP_EQUAL("100th", StringFromOrdinalNumber(100).asCharString());
+    STRCMP_EQUAL("101st", StringFromOrdinalNumber(101).asCharString());
+}


### PR DESCRIPTION
Previously, all such failures displayed a failure message containing "Unexpected additional (Nth) call", even for values such as 2, 3, etc.

This patch correctly differentiates based on English ordinal numbering rules, adding tests for all the special cases I could think of.  If I should break it into multiple tests, let me know!

(sorry, this must be the most nit-picky pull request of all time...)