### PR TITLE
Three improvements to IEEE754Plugin

### DIFF
--- a/include/CppUTestExt/IEEE754ExceptionsPlugin.h
+++ b/include/CppUTestExt/IEEE754ExceptionsPlugin.h
@@ -33,8 +33,7 @@
 class IEEE754ExceptionsPlugin: public TestPlugin
 {
 public:
-    IEEE754ExceptionsPlugin(const SimpleString& name) : TestPlugin(name),
-        inexactEnabled_(false) {}
+    IEEE754ExceptionsPlugin(const SimpleString& name = "IEEE754ExceptionsPlugin");
 
     virtual void preTestAction(UtestShell& test, TestResult& result) _override;
     virtual void postTestAction(UtestShell& test, TestResult& result) _override;

--- a/src/CppUTestExt/IEEE754ExceptionsPlugin.cpp
+++ b/src/CppUTestExt/IEEE754ExceptionsPlugin.cpp
@@ -30,13 +30,18 @@
 #include "CppUTest/TestHarness.h"
 #include "CppUTestExt/IEEE754ExceptionsPlugin.h"
 
-#include <cfenv>
+#include <fenv.h>
 
 #define IEEE754_CHECK_CLEAR(test, result, flag) ieee754Check(test, result, flag, #flag)
 
+IEEE754ExceptionsPlugin::IEEE754ExceptionsPlugin(const SimpleString& name)
+    : TestPlugin(name), inexactEnabled_(false)
+{
+}
+
 void IEEE754ExceptionsPlugin::preTestAction(UtestShell&, TestResult&)
 {
-    std::feclearexcept(FE_ALL_EXCEPT);
+    feclearexcept(FE_ALL_EXCEPT);
 }
 
 void IEEE754ExceptionsPlugin::postTestAction(UtestShell& test, TestResult& result)
@@ -65,8 +70,8 @@ void IEEE754ExceptionsPlugin::enableInexact()
 void IEEE754ExceptionsPlugin::ieee754Check(UtestShell& test, TestResult& result, int flag, const char* text)
 {
     result.countCheck();
-    if(std::fetestexcept(flag)) {
-        std::feclearexcept(FE_ALL_EXCEPT);
+    if(fetestexcept(flag)) {
+        feclearexcept(FE_ALL_EXCEPT);
         CheckFailure failure(&test, __FILE__, __LINE__, "IEEE754_CHECK_CLEAR", text);
         result.addFailure(failure);
     }

--- a/tests/CppUTestExt/IEEE754PluginTest.cpp
+++ b/tests/CppUTestExt/IEEE754PluginTest.cpp
@@ -34,7 +34,7 @@
 #include "CppUTest/TestRegistry.h"
 #include "CppUTest/TestTestingFixture.h"
 #include "CppUTestExt/IEEE754ExceptionsPlugin.h"
-#include <cfenv>
+#include <fenv.h>
 
 extern "C" { 
     #include "IEEE754PluginTest_c.h"
@@ -42,8 +42,8 @@ extern "C" {
 
 TEST_GROUP(FE__with_Plugin) {
     TestTestingFixture fixture;
-    IEEE754ExceptionsPlugin ieee754Plugin{"IEEE754"};
-    void setup(void) override {
+    IEEE754ExceptionsPlugin ieee754Plugin;
+    void setup(void) _override {
         fixture.registry_->installPlugin(&ieee754Plugin);
     }
 };
@@ -119,13 +119,11 @@ TEST(FE__with_Plugin, should_not_fail_again_when_test_has_already_failed) {
     LONGS_EQUAL(1, fixture.getFailureCount());
 }
 
-static IEEE754ExceptionsPlugin ip{"IEEE754"};
+static IEEE754ExceptionsPlugin ip;
 
 TEST_GROUP(IEEE754ExceptionsPlugin2) {
-    
-    TestRegistry* registry = TestRegistry::getCurrentRegistry();
-    void setup(void) override {
-        registry->installPlugin(&ip);
+    void setup(void) _override {
+        TestRegistry::getCurrentRegistry()->installPlugin(&ip);
     }
 };
 


### PR DESCRIPTION
1. Default argument for name (important for non-C++11 compilers)

2. Make declaration / implementation like in existing plugins

3. Minimum requirement for this to work is actually C99, not C++11.
   Hence, use \<fenv.h\> rather than \<cfenv\>.