### PR TITLE
Get rid of C++11 requirement for IEEE754Plugin

### DIFF
--- a/examples/AllTests/AllTests.cpp
+++ b/examples/AllTests/AllTests.cpp
@@ -28,6 +28,7 @@
 #include "CppUTest/CommandLineTestRunner.h"
 #include "CppUTest/TestPlugin.h"
 #include "CppUTest/TestRegistry.h"
+#include "CppUTestExt/IEEE754ExceptionsPlugin.h"
 #include "CppUTestExt/MockSupportPlugin.h"
 
 class MyDummyComparator : public MockNamedValueComparator
@@ -48,9 +49,11 @@ int main(int ac, char** av)
 {
     MyDummyComparator dummyComparator;
     MockSupportPlugin mockPlugin;
-
+    IEEE754ExceptionsPlugin ieee754Plugin;
+    
     mockPlugin.installComparator("MyDummyType", dummyComparator);
     TestRegistry::getCurrentRegistry()->installPlugin(&mockPlugin);
+    TestRegistry::getCurrentRegistry()->installPlugin(&ieee754Plugin);
     return CommandLineTestRunner::RunAllTests(ac, av);
 }
 

--- a/examples/AllTests/FEDemoTest.cpp
+++ b/examples/AllTests/FEDemoTest.cpp
@@ -1,50 +1,88 @@
+/*
+ * Copyright (c) 2016, Michael Feathers, James Grenning, Bas Vodde
+ * and Arnd Strube. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the <organization> nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE EARLIER MENTIONED AUTHORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL <copyright holder> BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 #include "CppUTest/CommandLineTestRunner.h"
 #include "CppUTest/TestHarness.h"
 #include "CppUTest/TestRegistry.h"
 #include "CppUTestExt/IEEE754ExceptionsPlugin.h"
 
-#ifdef COMPILER_FULLY_SUPPORTS_CXX11
+#ifdef CPPUTEST_HAVE_FENV
 
-#include <cfenv>
+/*
+ * Un-comment the following line to see a demonstration of failing and
+ * crashing tests
+ */
+// #define RUN_FAILING_TESTS
+
+extern "C" {
+    #include <fenv.h>
+}
+
 #include <limits>
 
 static volatile float f;
 
 TEST_GROUP(FE_Demo) {
+    void setup() {
+        IEEE754ExceptionsPlugin::disableInexact();
+    }
 };
 
-TEST(FE_Demo, should_fail_when__FE_DIVBYZERO__is_set) {
+#ifdef RUN_FAILING_TESTS
+#define FAILING_TEST TEST
+#else
+#define FAILING_TEST IGNORE_TEST
+#endif
+
+FAILING_TEST(FE_Demo, should_fail_when__FE_DIVBYZERO__is_set) {
     f = 1.0f;
-    CHECK(f /= 0.0f == std::numeric_limits<float>::infinity() );
+    CHECK((f /= 0.0f) >= std::numeric_limits<float>::infinity() );
 }
 
-TEST(FE_Demo, should_fail_when__FE_UNDERFLOW__is_set) {
+FAILING_TEST(FE_Demo, should_fail_when__FE_UNDERFLOW__is_set) {
     f = 0.01f;
     while (f > 0.0f) f *= f;
     CHECK(f == 0.0f);
 }
 
-TEST(FE_Demo, should_fail_when__FE_OVERFLOW__is_set) {
+FAILING_TEST(FE_Demo, should_fail_when__FE_OVERFLOW__is_set) {
     f = 1000.0f;
     while (f < std::numeric_limits<float>::infinity()) f *= f;
-    CHECK(f == std::numeric_limits<float>::infinity());
+    CHECK(f >= std::numeric_limits<float>::infinity());
 }
 
-TEST(FE_Demo, should_fail_when__FE_INEXACT____is_set) {
+FAILING_TEST(FE_Demo, should_fail_when__FE_INEXACT____is_set) {
+    IEEE754ExceptionsPlugin::enableInexact();
     f = 10.0f;
     DOUBLES_EQUAL(f / 3.0f, 3.333f, 0.001f);
 }
 
 TEST(FE_Demo, should_succeed_when_no_flags_are_set) {
     CHECK(5.0f == 15.0f / 3.0f);
-}
-
-static IEEE754ExceptionFlagsPlugin ieee754Plugin{"IEEE754"};
-
-int main(int ac, char** av) {
-    TestRegistry::getCurrentRegistry()->installPlugin(&ieee754Plugin);
-    ieee754Plugin.enableInexact();
-    return RUN_ALL_TESTS(ac, av);
 }
 
 #endif

--- a/include/CppUTest/CppUTestConfig.h
+++ b/include/CppUTest/CppUTestConfig.h
@@ -166,6 +166,19 @@
 #endif
 
 /*
+ * Handling of IEEE754 floating point exceptions via fenv.h
+ */
+
+#if CPPUTEST_USE_STD_C_LIB
+#define CPPUTEST_HAVE_FENV
+#if defined(__WATCOMC__)
+#define CPPUTEST_FENV_IS_WORKING_PROPERLY 0
+#else
+#define CPPUTEST_FENV_IS_WORKING_PROPERLY 1
+#endif
+#endif
+
+/*
  * Detection of different 64 bit environments
  */
 

--- a/include/CppUTestExt/IEEE754ExceptionsPlugin.h
+++ b/include/CppUTestExt/IEEE754ExceptionsPlugin.h
@@ -38,12 +38,12 @@ public:
     virtual void preTestAction(UtestShell& test, TestResult& result) _override;
     virtual void postTestAction(UtestShell& test, TestResult& result) _override;
 
-    void disableInexact(void);
-    void enableInexact(void);
+    static void disableInexact(void);
+    static void enableInexact(void);
 
 private:
     void ieee754Check(UtestShell& test, TestResult& result, int flag, const char* text);
-    bool inexactEnabled_;
+    static bool inexactDisabled_;
 };
 
 #endif

--- a/src/CppUTestExt/IEEE754ExceptionsPlugin.cpp
+++ b/src/CppUTestExt/IEEE754ExceptionsPlugin.cpp
@@ -36,8 +36,10 @@ extern "C" {
 
 #define IEEE754_CHECK_CLEAR(test, result, flag) ieee754Check(test, result, flag, #flag)
 
+bool IEEE754ExceptionsPlugin::inexactDisabled_ = true;
+
 IEEE754ExceptionsPlugin::IEEE754ExceptionsPlugin(const SimpleString& name)
-    : TestPlugin(name), inexactEnabled_(false)
+    : TestPlugin(name)
 {
 }
 
@@ -53,25 +55,24 @@ void IEEE754ExceptionsPlugin::postTestAction(UtestShell& test, TestResult& resul
         IEEE754_CHECK_CLEAR(test, result, FE_OVERFLOW);
         IEEE754_CHECK_CLEAR(test, result, FE_UNDERFLOW);
         IEEE754_CHECK_CLEAR(test, result, FE_INVALID);
-        if (inexactEnabled_) {
-            IEEE754_CHECK_CLEAR(test, result, FE_INEXACT);
-        }
+        IEEE754_CHECK_CLEAR(test, result, FE_INEXACT);
     }
 }
 
 void IEEE754ExceptionsPlugin::disableInexact()
 {
-    inexactEnabled_ = false;
+    inexactDisabled_ = true;
 }
 
 void IEEE754ExceptionsPlugin::enableInexact()
 {
-    inexactEnabled_ = true;
+    inexactDisabled_ = false;
 }
 
 void IEEE754ExceptionsPlugin::ieee754Check(UtestShell& test, TestResult& result, int flag, const char* text)
 {
     result.countCheck();
+    if(inexactDisabled_) feclearexcept(FE_INEXACT);
     if(fetestexcept(flag)) {
         CHECK(!feclearexcept(FE_ALL_EXCEPT));
         CheckFailure failure(&test, __FILE__, __LINE__, "IEEE754_CHECK_CLEAR", text);

--- a/src/CppUTestExt/IEEE754ExceptionsPlugin.cpp
+++ b/src/CppUTestExt/IEEE754ExceptionsPlugin.cpp
@@ -28,7 +28,7 @@
 #include "CppUTest/TestHarness.h"
 #include "CppUTestExt/IEEE754ExceptionsPlugin.h"
 
-#if CPPUTEST_USE_STD_C_LIB
+#ifdef CPPUTEST_HAVE_FENV
 
 extern "C" {
     #include <fenv.h>

--- a/src/CppUTestExt/IEEE754ExceptionsPlugin.cpp
+++ b/src/CppUTestExt/IEEE754ExceptionsPlugin.cpp
@@ -25,12 +25,14 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifdef CPPUTEST_COMPILER_FULLY_SUPPORTS_CXX11
-
 #include "CppUTest/TestHarness.h"
 #include "CppUTestExt/IEEE754ExceptionsPlugin.h"
 
-#include <fenv.h>
+#if CPPUTEST_USE_STD_C_LIB
+
+extern "C" {
+    #include <fenv.h>
+}
 
 #define IEEE754_CHECK_CLEAR(test, result, flag) ieee754Check(test, result, flag, #flag)
 
@@ -41,7 +43,7 @@ IEEE754ExceptionsPlugin::IEEE754ExceptionsPlugin(const SimpleString& name)
 
 void IEEE754ExceptionsPlugin::preTestAction(UtestShell&, TestResult&)
 {
-    feclearexcept(FE_ALL_EXCEPT);
+    CHECK(!feclearexcept(FE_ALL_EXCEPT));
 }
 
 void IEEE754ExceptionsPlugin::postTestAction(UtestShell& test, TestResult& result)
@@ -71,7 +73,7 @@ void IEEE754ExceptionsPlugin::ieee754Check(UtestShell& test, TestResult& result,
 {
     result.countCheck();
     if(fetestexcept(flag)) {
-        feclearexcept(FE_ALL_EXCEPT);
+        CHECK(!feclearexcept(FE_ALL_EXCEPT));
         CheckFailure failure(&test, __FILE__, __LINE__, "IEEE754_CHECK_CLEAR", text);
         result.addFailure(failure);
     }

--- a/tests/CppUTestExt/IEEE754PluginTest.cpp
+++ b/tests/CppUTestExt/IEEE754PluginTest.cpp
@@ -27,14 +27,13 @@
 
 /* The IEEE754ExceptionFlags plugin by definition requires C++11 */
 
-#ifdef CPPUTEST_COMPILER_FULLY_SUPPORTS_CXX11
-
 #include "CppUTest/CommandLineTestRunner.h"
 #include "CppUTest/TestHarness.h"
 #include "CppUTest/TestRegistry.h"
 #include "CppUTest/TestTestingFixture.h"
 #include "CppUTestExt/IEEE754ExceptionsPlugin.h"
-#include <fenv.h>
+
+#if CPPUTEST_USE_STD_C_LIB
 
 extern "C" { 
     #include "IEEE754PluginTest_c.h"

--- a/tests/CppUTestExt/IEEE754PluginTest.cpp
+++ b/tests/CppUTestExt/IEEE754PluginTest.cpp
@@ -25,15 +25,13 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-/* The IEEE754ExceptionFlags plugin by definition requires C++11 */
-
 #include "CppUTest/CommandLineTestRunner.h"
 #include "CppUTest/TestHarness.h"
 #include "CppUTest/TestRegistry.h"
 #include "CppUTest/TestTestingFixture.h"
 #include "CppUTestExt/IEEE754ExceptionsPlugin.h"
 
-#if CPPUTEST_USE_STD_C_LIB
+#if CPPUTEST_FENV_IS_WORKING_PROPERLY
 
 extern "C" { 
     #include "IEEE754PluginTest_c.h"
@@ -65,13 +63,19 @@ TEST(FE__with_Plugin, should_fail____when__FE_UNDERFLOW__is_set) {
     fixture.assertPrintContains("IEEE754_CHECK_CLEAR(FE_UNDERFLOW) failed");
 }
 
-TEST(FE__with_Plugin, should_fail____when__FE_INVALID____is_set) {
+#ifndef __MINGW64__
+#define NOT_MINGW64_TEST TEST
+#else
+#define NOT_MINGW64_TEST IGNORE_TEST
+#endif
+
+NOT_MINGW64_TEST(FE__with_Plugin, should_fail____when__FE_INVALID____is_set) {
     fixture.setTestFunction(set_invalid_c);
     fixture.runAllTests();
     fixture.assertPrintContains("IEEE754_CHECK_CLEAR(FE_INVALID) failed");
 }
 
-TEST(FE__with_Plugin, should_fail____when__FE_INEXACT____is_set_and_enabled) {
+NOT_MINGW64_TEST(FE__with_Plugin, should_fail____when__FE_INEXACT____is_set_and_enabled) {
     ieee754Plugin.enableInexact();
     fixture.setTestFunction(set_inexact_c);
     fixture.runAllTests();

--- a/tests/CppUTestExt/IEEE754PluginTest.cpp
+++ b/tests/CppUTestExt/IEEE754PluginTest.cpp
@@ -75,7 +75,7 @@ NOT_MINGW64_TEST(FE__with_Plugin, should_fail____when__FE_INVALID____is_set) {
     fixture.assertPrintContains("IEEE754_CHECK_CLEAR(FE_INVALID) failed");
 }
 
-NOT_MINGW64_TEST(FE__with_Plugin, should_fail____when__FE_INEXACT____is_set_and_enabled) {
+TEST(FE__with_Plugin, should_fail____when__FE_INEXACT____is_set_and_enabled) {
     ieee754Plugin.enableInexact();
     fixture.setTestFunction(set_inexact_c);
     fixture.runAllTests();
@@ -98,10 +98,10 @@ TEST(FE__with_Plugin, should_succeed_with_5_checks_when_no_flags_are_set) {
     ieee754Plugin.disableInexact();
 }
 
-TEST(FE__with_Plugin, should_check_four_times_when_all_flags_are_set) {
+TEST(FE__with_Plugin, should_check_five_times_when_all_flags_are_set) {
     fixture.setTestFunction(set_everything_c);
     fixture.runAllTests();
-    LONGS_EQUAL(4, fixture.getCheckCount());
+    LONGS_EQUAL(5, fixture.getCheckCount());
 }
 
 TEST(FE__with_Plugin, should_fail_only_once_when_all_flags_are_set) {

--- a/tests/CppUTestExt/IEEE754PluginTest_c.c
+++ b/tests/CppUTestExt/IEEE754PluginTest_c.c
@@ -27,7 +27,6 @@
 
 #include "IEEE754PluginTest_c.h"
 #include <math.h>
-#include <fenv.h>
 
 static volatile float f;
 


### PR DESCRIPTION
This one still faces at least two challenges:

1. Building without Standard C libraries fails (naturally) -- @basvodde what would be the cleanest way to deal with that? PlatformSpecifics function, perhaps?

2. Open Watcom does support `fenv.h`. However, I couldn't convince it to link the fe... functions... yet.