### PR TITLE
Make LONGS_EQUAL(_TEXT)() and UNSIGNED_LONGS_EQUAL(_TEXT)() expression safe

### DIFF
--- a/include/CppUTest/UtestMacros.h
+++ b/include/CppUTest/UtestMacros.h
@@ -183,16 +183,16 @@
 
 //Check two long integers for equality
 #define LONGS_EQUAL(expected, actual)\
-  LONGS_EQUAL_LOCATION(expected, actual, NULL, __FILE__, __LINE__)
+  LONGS_EQUAL_LOCATION((expected), (actual), NULL, __FILE__, __LINE__)
 
 #define LONGS_EQUAL_TEXT(expected, actual, text)\
-  LONGS_EQUAL_LOCATION(expected, actual, text, __FILE__, __LINE__)
+  LONGS_EQUAL_LOCATION((expected), (actual), text, __FILE__, __LINE__)
 
 #define UNSIGNED_LONGS_EQUAL(expected, actual)\
-  UNSIGNED_LONGS_EQUAL_LOCATION(expected, actual, NULL, __FILE__, __LINE__)
+  UNSIGNED_LONGS_EQUAL_LOCATION((expected), (actual), NULL, __FILE__, __LINE__)
 
 #define UNSIGNED_LONGS_EQUAL_TEXT(expected, actual, text)\
-  UNSIGNED_LONGS_EQUAL_LOCATION(expected, actual, text, __FILE__, __LINE__)
+  UNSIGNED_LONGS_EQUAL_LOCATION((expected), (actual), text, __FILE__, __LINE__)
 
 #define LONGS_EQUAL_LOCATION(expected, actual, text, file, line)\
   { UtestShell::getCurrent()->assertLongsEqual((long)expected, (long)actual, text, file, line); }

--- a/tests/TestUTestMacro.cpp
+++ b/tests/TestUTestMacro.cpp
@@ -421,6 +421,22 @@ static int _countingMethod()
     return countInCountingMethod++;
 }
 
+TEST(UnitTestMacros, LONGS_EQUAL_macroExpressionSafety)
+{
+    LONGS_EQUAL(1, 0.4 + 0.7);
+    LONGS_EQUAL(0.4 + 0.7, 1);
+    LONGS_EQUAL_TEXT(1, 0.4 + 0.7, "-Wconversion=great");
+    LONGS_EQUAL_TEXT(0.4 + 0.7, 1, "-Wconversion=great");
+}
+
+TEST(UnitTestMacros, UNSIGNED_LONGS_EQUAL_macroExpressionSafety)
+{
+    UNSIGNED_LONGS_EQUAL(1, 0.4 + 0.7);
+    UNSIGNED_LONGS_EQUAL(0.4 + 0.7, 1);
+    UNSIGNED_LONGS_EQUAL_TEXT(1, 0.4 + 0.7, "-Wconversion=great");
+    UNSIGNED_LONGS_EQUAL_TEXT(0.4 + 0.7, 1, "-Wconversion=great");
+}
+
 TEST(UnitTestMacros, passingCheckEqualWillNotBeEvaluatedMultipleTimesWithCHECK_EQUAL)
 {
     countInCountingMethod = 0;


### PR DESCRIPTION
This change ensures expected/actual are put in parenthesis before calling (UNSIGNED_)LONGS_EQUAL_LOCATION().  This makes these macros expression-safe, equivalent to their counterparts (CHECK et al, POINTERS_EQUAL, etc.)

This prevents unwanted truncation and silences PC-Lint if the user writes a check like:
LONGS_EQUAL(c, a + b);

FWIW if the user uses the GCC flag -Wconversion=error, the above would cause a compilation error if a would lose precision when cast to (long) per the expansion:

assertLongsEqual(c, (long)a + b, ...)