### PR TITLE
Force GCC 4.8.5 on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ environment:
   - PlatformToolset: v100
 
 install:
-- ps: if ($env:PlatformToolset -eq 'MinGW') { choco install mingw $( if ($env:Platform -eq 'Win32') { Write-Output -forcex86 } ) }
+- ps: if ($env:PlatformToolset -eq 'MinGW') { choco install mingw --version 4.8.5 $( if ($env:Platform -eq 'Win32') { Write-Output -forcex86 } ) }
 - ps: if ($env:PlatformToolset -eq 'Cygwin') { (New-Object System.Net.WebClient).DownloadFile('https://cygwin.com/setup-x86.exe', "${env:TEMP}\cygwin-setup.exe") ; . "${env:TEMP}\cygwin-setup.exe" --quiet-mode --packages autoconf automake make gcc-core libtool gcc-g++ }
 
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,13 +8,21 @@ environment:
   - PlatformToolset: Cygwin
   - PlatformToolset: MinGW
     Platform: Win32
+    Version: 4.8.5
   - PlatformToolset: MinGW
     Platform: x64
+    Version: 4.8.5
+  - PlatformToolset: MinGW
+    Platform: Win32
+    Version: 5.3.0
+  - PlatformToolset: MinGW
+    Platform: x64
+    Version: 5.3.0
   - PlatformToolset: v90
   - PlatformToolset: v100
 
 install:
-- ps: if ($env:PlatformToolset -eq 'MinGW') { choco install mingw --version 4.8.5 $( if ($env:Platform -eq 'Win32') { Write-Output -forcex86 } ) }
+- ps: if ($env:PlatformToolset -eq 'MinGW') { choco install mingw --version $env:Version $( if ($env:Platform -eq 'Win32') { Write-Output -forcex86 } ) }
 - ps: if ($env:PlatformToolset -eq 'Cygwin') { (New-Object System.Net.WebClient).DownloadFile('https://cygwin.com/setup-x86.exe', "${env:TEMP}\cygwin-setup.exe") ; . "${env:TEMP}\cygwin-setup.exe" --quiet-mode --packages autoconf automake make gcc-core libtool gcc-g++ }
 
 build_script:


### PR DESCRIPTION
This is one solution to #869. It forces GCC to install version 4.8.5 which doesn't have any errors during the build.

@arstrube Your choice as to if you want this solution or to come up with a code change that works properly.