### PR TITLE
Run both MinGW 4.8.5 and MinGW 5.3.0 on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,13 +8,21 @@ environment:
   - PlatformToolset: Cygwin
   - PlatformToolset: MinGW
     Platform: Win32
+    Version: 4.8.5
   - PlatformToolset: MinGW
     Platform: x64
+    Version: 4.8.5
+  - PlatformToolset: MinGW
+    Platform: Win32
+    Version: 5.3.0
+  - PlatformToolset: MinGW
+    Platform: x64
+    Version: 5.3.0
   - PlatformToolset: v90
   - PlatformToolset: v100
 
 install:
-- ps: if ($env:PlatformToolset -eq 'MinGW') { choco install mingw $( if ($env:Platform -eq 'Win32') { Write-Output -forcex86 } ) }
+- ps: if ($env:PlatformToolset -eq 'MinGW') { choco install mingw --version $env:Version $( if ($env:Platform -eq 'Win32') { Write-Output -forcex86 } ) }
 - ps: if ($env:PlatformToolset -eq 'Cygwin') { (New-Object System.Net.WebClient).DownloadFile('https://cygwin.com/setup-x86.exe', "${env:TEMP}\cygwin-setup.exe") ; . "${env:TEMP}\cygwin-setup.exe" --quiet-mode --packages autoconf automake make gcc-core libtool gcc-g++ }
 
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ environment:
   - PlatformToolset: v100
 
 install:
-- ps: if ($env:PlatformToolset -eq 'MinGW') { choco install mingw --version $env:Version $( if ($env:Platform -eq 'Win32') { Write-Output -forcex86 } ) }
+- ps: if ($env:PlatformToolset -eq 'MinGW') { choco install mingw --version $env:Version $( if ($env:Platform -eq 'Win32') { Write-Output -forcex86 } ) | Out-Null }
 - ps: if ($env:PlatformToolset -eq 'Cygwin') { (New-Object System.Net.WebClient).DownloadFile('https://cygwin.com/setup-x86.exe', "${env:TEMP}\cygwin-setup.exe") ; . "${env:TEMP}\cygwin-setup.exe" --quiet-mode --packages autoconf automake make gcc-core libtool gcc-g++ }
 
 build_script:


### PR DESCRIPTION
I've rebased my previous pull request so that it shouldn't fail now.  This version runs both MinGW 4.8.5 and MinGW 5.3.0 on appveyor.  Hopefully this will help us see future failures like `isnan()` one that showed up recently.  Unfortunately, each MinGW configuration seems to take 10-15 minutes to run, so it does add 20-30 minutes to the build time.  Overall it looks like it's 45-70 minutes for appveyor to run, just based on the last couple builds I've seen on this branch.

Also, I've fixed the output from the unzip during the MinGW install command, it gets dumped to null for now.  I'm not the happiest about it since it also dumps the normal install command output, but until chocolatey gets updated to handle this itself, that's how it's going to be.