### PR TITLE
Fix cmake xcode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ include("${CppUTestRootDirectory}/cmake/Modules/CppUTestConfigurationOptions.cma
 include(CTest)
 #include("${CppUTestRootDirectory}/cmake/Modules/CheckFunctionExists.cmake")
 include("${CppUTestRootDirectory}/cmake/Modules/CppUTestBuildTimeDiscoverTests.cmake")
+include("${CppUTestRootDirectory}/cmake/Modules/CppUTestSetTestOutputLocation.cmake")
 
 configure_file (
     "${PROJECT_SOURCE_DIR}/config.h.cmake"

--- a/cmake/Modules/CppUTestSetTestOutputLocation.cmake
+++ b/cmake/Modules/CppUTestSetTestOutputLocation.cmake
@@ -1,0 +1,10 @@
+# Override output properties to put test executable at specificied location
+function (cpputest_set_test_output_location TEST_TARGET OUTPUT_LOCATION)
+    set_target_properties(${TEST_TARGET} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${OUTPUT_LOCATION})
+    foreach(OUTPUT_CONFIG ${CMAKE_CONFIGURATION_TYPES})
+        string(TOUPPER ${OUTPUT_CONFIG} OUTPUT_CONFIG)
+        set_target_properties(${TEST_TARGET} PROPERTIES
+                              RUNTIME_OUTPUT_DIRECTORY_${OUTPUT_CONFIG} ${OUTPUT_LOCATION})
+    endforeach(OUTPUT_CONFIG)
+endfunction ()
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,6 +46,11 @@ endif (MINGW)
 
 add_executable(CppUTestTests ${CppUTestTests_src})
 target_link_libraries(CppUTestTests CppUTest ${THREAD_LIB})
+set_target_properties(CppUTestTests
+                      PROPERTIES
+                      RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests"
+                      RUNTIME_OUTPUT_DIRECTORY_DEBUG "${CMAKE_BINARY_DIR}/tests"
+                      RUNTIME_OUTPUT_DIRECTORY_RELEASE "${CMAKE_BINARY_DIR}/tests")
 
 add_subdirectory(CppUTestExt)
-cpputest_buildtime_discover_tests (CppUTestTests)
+cpputest_buildtime_discover_tests(CppUTestTests)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -45,12 +45,8 @@ if (MINGW)
 endif (MINGW)
 
 add_executable(CppUTestTests ${CppUTestTests_src})
+cpputest_set_test_output_location(CppUTestTests "${CMAKE_BINARY_DIR}/tests")
 target_link_libraries(CppUTestTests CppUTest ${THREAD_LIB})
-set_target_properties(CppUTestTests
-                      PROPERTIES
-                      RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests"
-                      RUNTIME_OUTPUT_DIRECTORY_DEBUG "${CMAKE_BINARY_DIR}/tests"
-                      RUNTIME_OUTPUT_DIRECTORY_RELEASE "${CMAKE_BINARY_DIR}/tests")
 
 add_subdirectory(CppUTestExt)
 cpputest_buildtime_discover_tests(CppUTestTests)

--- a/tests/CppUTestExt/CMakeLists.txt
+++ b/tests/CppUTestExt/CMakeLists.txt
@@ -34,11 +34,6 @@ if (MINGW)
 endif (MINGW)
 
 add_executable(CppUTestExtTests ${CppUTestExtTests_src})
-set_target_properties(CppUTestExtTests
-                      PROPERTIES
-                      RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests/CppUTestExt"
-                      RUNTIME_OUTPUT_DIRECTORY_DEBUG "${CMAKE_BINARY_DIR}/tests/CppUTestExt"
-                      RUNTIME_OUTPUT_DIRECTORY_RELEASE "${CMAKE_BINARY_DIR}/tests/CppUTestExt")
-
+cpputest_set_test_output_location(CppUTestExtTests "${CMAKE_BINARY_DIR}/tests/CppUTestExt")
 target_link_libraries(CppUTestExtTests CppUTest CppUTestExt ${THREAD_LIB} ${CPPUNIT_EXTERNAL_LIBRARIES})
 cpputest_buildtime_discover_tests(CppUTestExtTests)

--- a/tests/CppUTestExt/CMakeLists.txt
+++ b/tests/CppUTestExt/CMakeLists.txt
@@ -34,5 +34,11 @@ if (MINGW)
 endif (MINGW)
 
 add_executable(CppUTestExtTests ${CppUTestExtTests_src})
+set_target_properties(CppUTestExtTests
+                      PROPERTIES
+                      RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests/CppUTestExt"
+                      RUNTIME_OUTPUT_DIRECTORY_DEBUG "${CMAKE_BINARY_DIR}/tests/CppUTestExt"
+                      RUNTIME_OUTPUT_DIRECTORY_RELEASE "${CMAKE_BINARY_DIR}/tests/CppUTestExt")
+
 target_link_libraries(CppUTestExtTests CppUTest CppUTestExt ${THREAD_LIB} ${CPPUNIT_EXTERNAL_LIBRARIES})
-cpputest_buildtime_discover_tests (CppUTestExtTests)
+cpputest_buildtime_discover_tests(CppUTestExtTests)


### PR DESCRIPTION
By default, Xcode (and VS?) build artifacts to a path that includes the configuration name. In Xcode's case, this was "Debug". CMake was expecting its self-test executables CppUTestTests and CppUTestExtTests to be in specific paths that did not include the configuration paths.

This PR forces Xcode to put the test executables in the same location that the other CMake generators (make / ninja) put them. This is also where the non-cmake autoconf builds put them.

Fixes https://github.com/cpputest/cpputest/issues/877

cc @basvodde 