### PR TITLE
Dormant test

### DIFF
--- a/include/CppUTest/TestFilter.h
+++ b/include/CppUTest/TestFilter.h
@@ -42,6 +42,7 @@ public:
     TestFilter* getNext() const;
 
     bool match(const SimpleString& name) const;
+	bool isStrictMatching() const;
 
     void strictMatching();
     void invertMatching();

--- a/include/CppUTest/Utest.h
+++ b/include/CppUTest/Utest.h
@@ -95,7 +95,7 @@ public:
     virtual UtestShell *getNext() const;
     virtual int countTests();
 
-    bool shouldRun(const TestFilter* groupFilters, const TestFilter* nameFilters) const;
+	virtual bool shouldRun(const TestFilter* groupFilters, const TestFilter* nameFilters);
     const SimpleString getName() const;
     const SimpleString getGroup() const;
     virtual SimpleString getFormattedName() const;
@@ -152,9 +152,10 @@ protected:
 
     virtual SimpleString getMacroName() const;
     TestResult *getTestResult();
+	bool match(const char* target, const TestFilter* filters) const;
+	const char *group_;
+	const char *name_;
 private:
-    const char *group_;
-    const char *name_;
     const char *file_;
     int lineNumber_;
     UtestShell *next_;
@@ -163,7 +164,6 @@ private:
 
     void setTestResult(TestResult* result);
     void setCurrentTest(UtestShell* test);
-    bool match(const char* target, const TestFilter* filters) const;
 
     static UtestShell* currentTest_;
     static TestResult* testResult_;
@@ -229,6 +229,28 @@ private:
     IgnoredUtestShell(const IgnoredUtestShell&);
     IgnoredUtestShell& operator=(const IgnoredUtestShell&);
 
+};
+
+//////////////////// DormantTest
+
+class DormantUtestShell : public IgnoredUtestShell
+{
+public:
+	DormantUtestShell();
+	virtual ~DormantUtestShell();
+	explicit DormantUtestShell(const char* groupName, const char* testName,
+		const char* fileName, int lineNumber);
+	virtual bool willRun() const _override;
+	bool match(const char* target, const TestFilter* filters, const bool strict) const;
+	virtual bool shouldRun(const TestFilter* groupFilters, const TestFilter* nameFilters) _override;
+protected:  virtual SimpleString getMacroName() const _override;
+			virtual void runOneTest(TestPlugin* plugin, TestResult& result) _override;
+
+private:
+
+	DormantUtestShell(const DormantUtestShell&);
+	DormantUtestShell& operator=(const DormantUtestShell&);
+	bool willRun_;
 };
 
 //////////////////// TestInstaller

--- a/include/CppUTest/UtestMacros.h
+++ b/include/CppUTest/UtestMacros.h
@@ -76,12 +76,26 @@
   \
   class IGNORE##testGroup##_##testName##_Test : public TEST_GROUP_##CppUTestGroup##testGroup \
 { public: IGNORE##testGroup##_##testName##_Test () : TEST_GROUP_##CppUTestGroup##testGroup () {} \
-  public: void testBodyThatNeverRuns (); }; \
+  public: void testBodyThatNeverRuns(); }; \
   class IGNORE##testGroup##_##testName##_TestShell : public IgnoredUtestShell { \
       virtual Utest* createTest() _override { return new IGNORE##testGroup##_##testName##_Test; } \
   } IGNORE##testGroup##_##testName##_TestShell_instance; \
    static TestInstaller TEST_##testGroup##testName##_Installer(IGNORE##testGroup##_##testName##_TestShell_instance, #testGroup, #testName, __FILE__,__LINE__); \
-    void IGNORE##testGroup##_##testName##_Test::testBodyThatNeverRuns ()
+    void IGNORE##testGroup##_##testName##_Test::testBodyThatNeverRuns()
+
+#define DORMANT_TEST(testGroup, testName)\
+  /* External declarations for strict compilers */ \
+  class DORMANT_##testGroup##_##testName##_TestShell; \
+  extern DORMANT_##testGroup##_##testName##_TestShell DORMANT_##testGroup##_##testName##_TestShell_instance; \
+  \
+  class DORMANT_##testGroup##_##testName##_Test : public TEST_GROUP_##CppUTestGroup##testGroup \
+{ public: DORMANT_##testGroup##_##testName##_Test () : TEST_GROUP_##CppUTestGroup##testGroup () {} \
+  public: void testBody(); }; \
+  class DORMANT_##testGroup##_##testName##_TestShell : public DormantUtestShell { \
+      virtual Utest* createTest() _override { return new DORMANT_##testGroup##_##testName##_Test; } \
+  } DORMANT_##testGroup##_##testName##_TestShell_instance; \
+   static TestInstaller TEST_##testGroup##testName##_Installer(DORMANT_##testGroup##_##testName##_TestShell_instance, #testGroup, #testName, __FILE__,__LINE__); \
+	void DORMANT_##testGroup##_##testName##_Test::testBody()
 
 #define IMPORT_TEST_GROUP(testGroup) \
   extern int externTestGroup##testGroup;\

--- a/src/CppUTest/TestFilter.cpp
+++ b/src/CppUTest/TestFilter.cpp
@@ -63,6 +63,11 @@ void TestFilter::invertMatching()
     invertMatching_ = true;
 }
 
+bool TestFilter::isStrictMatching() const
+{
+	return strictMatching_;
+}
+
 bool TestFilter::match(const SimpleString& name) const
 {
     bool matches = false;

--- a/src/CppUTest/Utest.cpp
+++ b/src/CppUTest/Utest.cpp
@@ -324,7 +324,7 @@ bool UtestShell::match(const char* target, const TestFilter* filters) const
     return false;
 }
 
-bool UtestShell::shouldRun(const TestFilter* groupFilters, const TestFilter* nameFilters) const
+bool UtestShell::shouldRun(const TestFilter* groupFilters, const TestFilter* nameFilters)
 {
     return match(group_, groupFilters) && match(name_, nameFilters);
 }
@@ -641,17 +641,66 @@ IgnoredUtestShell::~IgnoredUtestShell()
 
 bool IgnoredUtestShell::willRun() const
 {
-    return false;
+	return false;
 }
 
 SimpleString IgnoredUtestShell::getMacroName() const
 {
-    return "IGNORE_TEST";
+	return "IGNORE_TEST";
 }
 
 void IgnoredUtestShell::runOneTest(TestPlugin* /* plugin */, TestResult& result)
 {
-    result.countIgnored();
+	result.countIgnored();
+}
+
+
+/////////////// DormantUtestShell /////////////
+DormantUtestShell::DormantUtestShell() : willRun_(false)
+{
+}
+
+DormantUtestShell::DormantUtestShell(const char* groupName, const char* testName, const char* fileName, int lineNumber) :
+	IgnoredUtestShell(groupName, testName, fileName, lineNumber)
+{
+}
+
+DormantUtestShell::~DormantUtestShell()
+{
+}
+
+bool DormantUtestShell::match(const char* target, const TestFilter* filters, const bool strict) const
+{
+	if (filters == NULL) return false;
+
+	for (; filters != NULL; filters = filters->getNext())
+		if (filters->match(target) && (!strict || filters->isStrictMatching())) return true;
+
+	return false;
+}
+
+bool DormantUtestShell::shouldRun(const TestFilter* groupFilters, const TestFilter* nameFilters)
+{
+	willRun_ = match(group_, groupFilters, true) && match(name_, nameFilters, true);
+	return match(group_, groupFilters, false) && match(name_, nameFilters, false);
+}
+
+bool DormantUtestShell::willRun() const
+{
+	return willRun_;
+}
+
+SimpleString DormantUtestShell::getMacroName() const
+{
+	return "DORMANT_TEST";
+}
+
+void DormantUtestShell::runOneTest(TestPlugin* plugin, TestResult& result)
+{
+	if (willRun())
+		UtestShell::runOneTest(plugin, result);
+	else
+		IgnoredUtestShell::runOneTest(plugin, result);
 }
 
 

--- a/tests/CommandLineArgumentsTest.cpp
+++ b/tests/CommandLineArgumentsTest.cpp
@@ -302,6 +302,8 @@ TEST(CommandLineArguments, setTestToRunUsingVerboseOutputOfIgnoreTest)
     CHECK_EQUAL(groupFilter, *args->getGroupFilters());
 }
 
+// TODO: test DORMANT_TEST
+
 TEST(CommandLineArguments, setNormalOutput)
 {
     int argc = 2;


### PR DESCRIPTION
Currently the CppUTests are all either "opt-out" (can be filtered to be not run with command line) or they are disabled ("IGNORE_TEST").  

I am looking for a way to have CppUTests "opt-in", means that they are included in the testing executable, but only run if I explicitely chose them.

So I created the macro DORMANT_TEST that declares an "opt-in" test dormant until it is awaked using strict name filtering using e.g. "-sg <group-name> -sn <test-name>" . Like IGNORE_TEST it is not executed by default, so I DORMANT_TEST is an apoption of IGNORE_TEST, with key change of DormantUtestShell::shouldRun and DormantUtestShell::willRun .
**--> Please pull my changes to cpputest master.**

About IGNORE_TEST:
First I thought this could be done using IGNORE_TEST, but it looks like there is no way to run an IGNORE_TEST compiled into a testing executable even not using command line option "IGNORE_TEST" (only sets up filtering for the named test, but cannot execute it -> why sets it up filtering though?) or a custom derived runner class. 

The current behavior of "IGNORE_TEST" is useless to me, I can easily surround a test with "#if 0 ... #endif" if don't like it to be included in the testing executable.
IMHO it would be better to be used for tests that are executed, but not counted as failures if they fail (if all TEST(...)s pass, the IGNORE_TEST()s won't make the test run FAIL, but I can see from the verbose logs if the test was successful or not).
