### PR TITLE
Support for 64/128 bit integer comparison

### DIFF
--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,0 +1,2 @@
+build/
+dist/

--- a/examples/NBMakefile
+++ b/examples/NBMakefile
@@ -1,0 +1,128 @@
+#
+#  There exist several targets which are by default empty and which can be 
+#  used for execution of your targets. These targets are usually executed 
+#  before and after some main targets. They are: 
+#
+#     .build-pre:              called before 'build' target
+#     .build-post:             called after 'build' target
+#     .clean-pre:              called before 'clean' target
+#     .clean-post:             called after 'clean' target
+#     .clobber-pre:            called before 'clobber' target
+#     .clobber-post:           called after 'clobber' target
+#     .all-pre:                called before 'all' target
+#     .all-post:               called after 'all' target
+#     .help-pre:               called before 'help' target
+#     .help-post:              called after 'help' target
+#
+#  Targets beginning with '.' are not intended to be called on their own.
+#
+#  Main targets can be executed directly, and they are:
+#  
+#     build                    build a specific configuration
+#     clean                    remove built files from a configuration
+#     clobber                  remove all built files
+#     all                      build all configurations
+#     help                     print help mesage
+#  
+#  Targets .build-impl, .clean-impl, .clobber-impl, .all-impl, and
+#  .help-impl are implemented in nbproject/makefile-impl.mk.
+#
+#  Available make variables:
+#
+#     CND_BASEDIR                base directory for relative paths
+#     CND_DISTDIR                default top distribution directory (build artifacts)
+#     CND_BUILDDIR               default top build directory (object files, ...)
+#     CONF                       name of current configuration
+#     CND_PLATFORM_${CONF}       platform name (current configuration)
+#     CND_ARTIFACT_DIR_${CONF}   directory of build artifact (current configuration)
+#     CND_ARTIFACT_NAME_${CONF}  name of build artifact (current configuration)
+#     CND_ARTIFACT_PATH_${CONF}  path to build artifact (current configuration)
+#     CND_PACKAGE_DIR_${CONF}    directory of package (current configuration)
+#     CND_PACKAGE_NAME_${CONF}   name of package (current configuration)
+#     CND_PACKAGE_PATH_${CONF}   path to package (current configuration)
+#
+# NOCDDL
+
+
+# Environment 
+MKDIR=mkdir
+CP=cp
+CCADMIN=CCadmin
+
+
+# build
+build: .build-post
+
+.build-pre:
+# Add your pre 'build' code here...
+
+.build-post: .build-impl
+# Add your post 'build' code here...
+
+
+# clean
+clean: .clean-post
+
+.clean-pre:
+# Add your pre 'clean' code here...
+
+.clean-post: .clean-impl
+# Add your post 'clean' code here...
+
+
+# clobber
+clobber: .clobber-post
+
+.clobber-pre:
+# Add your pre 'clobber' code here...
+
+.clobber-post: .clobber-impl
+# Add your post 'clobber' code here...
+
+
+# all
+all: .all-post
+
+.all-pre:
+# Add your pre 'all' code here...
+
+.all-post: .all-impl
+# Add your post 'all' code here...
+
+
+# build tests
+build-tests: .build-tests-post
+
+.build-tests-pre:
+# Add your pre 'build-tests' code here...
+
+.build-tests-post: .build-tests-impl
+# Add your post 'build-tests' code here...
+
+
+# run tests
+test: .test-post
+
+.test-pre: build-tests
+# Add your pre 'test' code here...
+
+.test-post: .test-impl
+# Add your post 'test' code here...
+
+
+# help
+help: .help-post
+
+.help-pre:
+# Add your pre 'help' code here...
+
+.help-post: .help-impl
+# Add your post 'help' code here...
+
+
+
+# include project implementation makefile
+include nbproject/Makefile-impl.mk
+
+# include project make variables
+include nbproject/Makefile-variables.mk

--- a/examples/nbproject/.gitignore
+++ b/examples/nbproject/.gitignore
@@ -1,0 +1,3 @@
+private/
+*.mk
+*.bash

--- a/examples/nbproject/configurations.xml
+++ b/examples/nbproject/configurations.xml
@@ -103,7 +103,7 @@
           <itemPath>../src/Platforms/Gcc/UtestPlatform.cpp</itemPath>
         </logicalFolder>
       </logicalFolder>
-      <logicalFolder name="tests" displayName="tests" projectFiles="true">
+      <logicalFolder name="tests" displayName="Tests" projectFiles="true">
         <itemPath>../tests/AllTests.cpp</itemPath>
         <itemPath>../tests/AllocLetTestFree.c</itemPath>
         <itemPath>../tests/AllocLetTestFreeTest.cpp</itemPath>

--- a/examples/nbproject/configurations.xml
+++ b/examples/nbproject/configurations.xml
@@ -178,12 +178,13 @@
           <incDir>
             <pElem>../include</pElem>
           </incDir>
+          <commandLine>-Wall -Wextra -Wshadow -Wswitch-default -Wswitch-enum -Wconversion -Wsign-conversion -Wno-padded -Werror -pedantic-errors -Wstrict-prototypes</commandLine>
         </cTool>
         <ccTool>
           <incDir>
             <pElem>../include</pElem>
           </incDir>
-          <warningLevel>2</warningLevel>
+          <commandLine>-Wall -Wextra -Wshadow -Wswitch-default -Wswitch-enum -Wconversion -pedantic -Wsign-conversion -Woverloaded-virtual -Wno-disabled-macro-expansion -Wno-padded -Wno-reserved-id-macro -Wno-keyword-macro -Wno-global-constructors -Wno-exit-time-destructors -Wno-weak-vtables -Wno-old-style-cast</commandLine>
         </ccTool>
         <fortranCompilerTool>
           <commandLine>-Werror=float-conversion</commandLine>

--- a/examples/nbproject/configurations.xml
+++ b/examples/nbproject/configurations.xml
@@ -1,0 +1,578 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configurationDescriptor version="97">
+  <logicalFolder name="root" displayName="root" projectFiles="true" kind="ROOT">
+    <logicalFolder name="HeaderFiles"
+                   displayName="Header Files"
+                   projectFiles="true">
+      <logicalFolder name="CppUTest" displayName="CppUTest" projectFiles="true">
+        <itemPath>../include/CppUTest/CommandLineArguments.h</itemPath>
+        <itemPath>../include/CppUTest/CommandLineTestRunner.h</itemPath>
+        <itemPath>../include/CppUTest/CppUTestConfig.h</itemPath>
+        <itemPath>../include/CppUTest/JUnitTestOutput.h</itemPath>
+        <itemPath>../include/CppUTest/MemoryLeakDetector.h</itemPath>
+        <itemPath>../include/CppUTest/MemoryLeakDetectorMallocMacros.h</itemPath>
+        <itemPath>../include/CppUTest/MemoryLeakDetectorNewMacros.h</itemPath>
+        <itemPath>../include/CppUTest/MemoryLeakWarningPlugin.h</itemPath>
+        <itemPath>../include/CppUTest/PlatformSpecificFunctions.h</itemPath>
+        <itemPath>../include/CppUTest/PlatformSpecificFunctions_c.h</itemPath>
+        <itemPath>../include/CppUTest/SimpleMutex.h</itemPath>
+        <itemPath>../include/CppUTest/SimpleString.h</itemPath>
+        <itemPath>../include/CppUTest/StandardCLibrary.h</itemPath>
+        <itemPath>../include/CppUTest/TeamCityTestOutput.h</itemPath>
+        <itemPath>../include/CppUTest/TestFailure.h</itemPath>
+        <itemPath>../include/CppUTest/TestFilter.h</itemPath>
+        <itemPath>../include/CppUTest/TestHarness.h</itemPath>
+        <itemPath>../include/CppUTest/TestHarness_c.h</itemPath>
+        <itemPath>../include/CppUTest/TestMemoryAllocator.h</itemPath>
+        <itemPath>../include/CppUTest/TestOutput.h</itemPath>
+        <itemPath>../include/CppUTest/TestPlugin.h</itemPath>
+        <itemPath>../include/CppUTest/TestRegistry.h</itemPath>
+        <itemPath>../include/CppUTest/TestResult.h</itemPath>
+        <itemPath>../include/CppUTest/TestTestingFixture.h</itemPath>
+        <itemPath>../include/CppUTest/Utest.h</itemPath>
+        <itemPath>../include/CppUTest/UtestMacros.h</itemPath>
+      </logicalFolder>
+      <logicalFolder name="CppUTestExt" displayName="CppUTestExt" projectFiles="true">
+        <itemPath>../include/CppUTestExt/CodeMemoryReportFormatter.h</itemPath>
+        <itemPath>../include/CppUTestExt/GMock.h</itemPath>
+        <itemPath>../include/CppUTestExt/GTest.h</itemPath>
+        <itemPath>../include/CppUTestExt/GTestConvertor.h</itemPath>
+        <itemPath>../include/CppUTestExt/IEEE754ExceptionsPlugin.h</itemPath>
+        <itemPath>../include/CppUTestExt/MemoryReportAllocator.h</itemPath>
+        <itemPath>../include/CppUTestExt/MemoryReportFormatter.h</itemPath>
+        <itemPath>../include/CppUTestExt/MemoryReporterPlugin.h</itemPath>
+        <itemPath>../include/CppUTestExt/MockActualCall.h</itemPath>
+        <itemPath>../include/CppUTestExt/MockCheckedActualCall.h</itemPath>
+        <itemPath>../include/CppUTestExt/MockCheckedExpectedCall.h</itemPath>
+        <itemPath>../include/CppUTestExt/MockExpectedCall.h</itemPath>
+        <itemPath>../include/CppUTestExt/MockExpectedCallsList.h</itemPath>
+        <itemPath>../include/CppUTestExt/MockFailure.h</itemPath>
+        <itemPath>../include/CppUTestExt/MockNamedValue.h</itemPath>
+        <itemPath>../include/CppUTestExt/MockSupport.h</itemPath>
+        <itemPath>../include/CppUTestExt/MockSupportPlugin.h</itemPath>
+        <itemPath>../include/CppUTestExt/MockSupport_c.h</itemPath>
+        <itemPath>../include/CppUTestExt/OrderedTest.h</itemPath>
+      </logicalFolder>
+      <logicalFolder name="Platforms" displayName="Platforms" projectFiles="true">
+      </logicalFolder>
+    </logicalFolder>
+    <logicalFolder name="ResourceFiles"
+                   displayName="Resource Files"
+                   projectFiles="true">
+    </logicalFolder>
+    <logicalFolder name="SourceFiles"
+                   displayName="Source Files"
+                   projectFiles="true">
+      <logicalFolder name="CppUTest" displayName="CppUTest" projectFiles="true">
+        <itemPath>../src/CppUTest/CommandLineArguments.cpp</itemPath>
+        <itemPath>../src/CppUTest/CommandLineTestRunner.cpp</itemPath>
+        <itemPath>../src/CppUTest/JUnitTestOutput.cpp</itemPath>
+        <itemPath>../src/CppUTest/MemoryLeakDetector.cpp</itemPath>
+        <itemPath>../src/CppUTest/MemoryLeakWarningPlugin.cpp</itemPath>
+        <itemPath>../src/CppUTest/SimpleMutex.cpp</itemPath>
+        <itemPath>../src/CppUTest/SimpleString.cpp</itemPath>
+        <itemPath>../src/CppUTest/TeamCityTestOutput.cpp</itemPath>
+        <itemPath>../src/CppUTest/TestFailure.cpp</itemPath>
+        <itemPath>../src/CppUTest/TestFilter.cpp</itemPath>
+        <itemPath>../src/CppUTest/TestHarness_c.cpp</itemPath>
+        <itemPath>../src/CppUTest/TestMemoryAllocator.cpp</itemPath>
+        <itemPath>../src/CppUTest/TestOutput.cpp</itemPath>
+        <itemPath>../src/CppUTest/TestPlugin.cpp</itemPath>
+        <itemPath>../src/CppUTest/TestRegistry.cpp</itemPath>
+        <itemPath>../src/CppUTest/TestResult.cpp</itemPath>
+        <itemPath>../src/CppUTest/Utest.cpp</itemPath>
+      </logicalFolder>
+      <logicalFolder name="CppUTestExt" displayName="CppUTestExt" projectFiles="true">
+        <itemPath>../src/CppUTestExt/CodeMemoryReportFormatter.cpp</itemPath>
+        <itemPath>../src/CppUTestExt/IEEE754ExceptionsPlugin.cpp</itemPath>
+        <itemPath>../src/CppUTestExt/MemoryReportAllocator.cpp</itemPath>
+        <itemPath>../src/CppUTestExt/MemoryReportFormatter.cpp</itemPath>
+        <itemPath>../src/CppUTestExt/MemoryReporterPlugin.cpp</itemPath>
+        <itemPath>../src/CppUTestExt/MockActualCall.cpp</itemPath>
+        <itemPath>../src/CppUTestExt/MockExpectedCall.cpp</itemPath>
+        <itemPath>../src/CppUTestExt/MockExpectedCallsList.cpp</itemPath>
+        <itemPath>../src/CppUTestExt/MockFailure.cpp</itemPath>
+        <itemPath>../src/CppUTestExt/MockNamedValue.cpp</itemPath>
+        <itemPath>../src/CppUTestExt/MockSupport.cpp</itemPath>
+        <itemPath>../src/CppUTestExt/MockSupportPlugin.cpp</itemPath>
+        <itemPath>../src/CppUTestExt/MockSupport_c.cpp</itemPath>
+        <itemPath>../src/CppUTestExt/OrderedTest.cpp</itemPath>
+      </logicalFolder>
+      <logicalFolder name="Platforms" displayName="Platforms" projectFiles="true">
+        <logicalFolder name="Gcc" displayName="Gcc" projectFiles="true">
+          <itemPath>../src/Platforms/Gcc/UtestPlatform.cpp</itemPath>
+        </logicalFolder>
+      </logicalFolder>
+      <logicalFolder name="tests" displayName="tests" projectFiles="true">
+        <itemPath>../tests/AllTests.cpp</itemPath>
+        <itemPath>../tests/AllocLetTestFree.c</itemPath>
+        <itemPath>../tests/AllocLetTestFreeTest.cpp</itemPath>
+        <itemPath>../tests/AllocationInCFile.c</itemPath>
+        <itemPath>../tests/AllocationInCppFile.cpp</itemPath>
+        <itemPath>../tests/CheatSheetTest.cpp</itemPath>
+        <itemPath>../tests/CommandLineArgumentsTest.cpp</itemPath>
+        <itemPath>../tests/CommandLineTestRunnerTest.cpp</itemPath>
+        <itemPath>../tests/JUnitOutputTest.cpp</itemPath>
+        <itemPath>../tests/MemoryLeakDetectorTest.cpp</itemPath>
+        <itemPath>../tests/MemoryLeakWarningTest.cpp</itemPath>
+        <itemPath>../tests/MemoryOperatorOverloadTest.cpp</itemPath>
+        <itemPath>../tests/PluginTest.cpp</itemPath>
+        <itemPath>../tests/PreprocessorTest.cpp</itemPath>
+        <itemPath>../tests/SetPluginTest.cpp</itemPath>
+        <itemPath>../tests/SimpleMutexTest.cpp</itemPath>
+        <itemPath>../tests/SimpleStringTest.cpp</itemPath>
+        <itemPath>../tests/TeamCityOutputTest.cpp</itemPath>
+        <itemPath>../tests/TestFailureNaNTest.cpp</itemPath>
+        <itemPath>../tests/TestFailureTest.cpp</itemPath>
+        <itemPath>../tests/TestFilterTest.cpp</itemPath>
+        <itemPath>../tests/TestHarness_cTest.cpp</itemPath>
+        <itemPath>../tests/TestHarness_cTestCFile.c</itemPath>
+        <itemPath>../tests/TestInstallerTest.cpp</itemPath>
+        <itemPath>../tests/TestMemoryAllocatorTest.cpp</itemPath>
+        <itemPath>../tests/TestOutputTest.cpp</itemPath>
+        <itemPath>../tests/TestRegistryTest.cpp</itemPath>
+        <itemPath>../tests/TestResultTest.cpp</itemPath>
+        <itemPath>../tests/TestUTestMacro.cpp</itemPath>
+        <itemPath>../tests/UtestPlatformTest.cpp</itemPath>
+        <itemPath>../tests/UtestTest.cpp</itemPath>
+      </logicalFolder>
+    </logicalFolder>
+    <logicalFolder name="TestFiles"
+                   displayName="Test Files"
+                   projectFiles="false"
+                   kind="TEST_LOGICAL_FOLDER">
+    </logicalFolder>
+    <logicalFolder name="ExternalFiles"
+                   displayName="Important Files"
+                   projectFiles="false"
+                   kind="IMPORTANT_FILES_FOLDER">
+      <itemPath>NBMakefile</itemPath>
+    </logicalFolder>
+  </logicalFolder>
+  <sourceRootList>
+    <Elem>src/CppUTest</Elem>
+    <Elem>src/CppUTestExt</Elem>
+    <Elem>src/Platforms</Elem>
+    <Elem>include</Elem>
+    <Elem>examples/AllTests</Elem>
+    <Elem>../include/CppUTest</Elem>
+    <Elem>../include/CppUTestExt</Elem>
+    <Elem>../include/Platforms</Elem>
+    <Elem>AllTests</Elem>
+    <Elem>ApplicationLib</Elem>
+    <Elem>../src/CppUTest</Elem>
+    <Elem>../src/CppUTestExt</Elem>
+    <Elem>../src/Platforms</Elem>
+    <Elem>../tests</Elem>
+  </sourceRootList>
+  <projectmakefile>NBMakefile</projectmakefile>
+  <confs>
+    <conf name="Debug" type="1">
+      <toolsSet>
+        <compilerSet>Cygwin|Cygwin</compilerSet>
+        <dependencyChecking>true</dependencyChecking>
+        <rebuildPropChanged>false</rebuildPropChanged>
+      </toolsSet>
+      <compileType>
+        <cTool>
+          <incDir>
+            <pElem>../include</pElem>
+          </incDir>
+        </cTool>
+        <ccTool>
+          <incDir>
+            <pElem>../include</pElem>
+          </incDir>
+          <warningLevel>2</warningLevel>
+        </ccTool>
+        <fortranCompilerTool>
+          <commandLine>-Werror=float-conversion</commandLine>
+        </fortranCompilerTool>
+      </compileType>
+      <item path="../include/CppUTest/CommandLineArguments.h"
+            ex="false"
+            tool="3"
+            flavor2="0">
+      </item>
+      <item path="../include/CppUTest/CommandLineTestRunner.h"
+            ex="false"
+            tool="3"
+            flavor2="0">
+      </item>
+      <item path="../include/CppUTest/CppUTestConfig.h"
+            ex="false"
+            tool="3"
+            flavor2="0">
+      </item>
+      <item path="../include/CppUTest/JUnitTestOutput.h"
+            ex="false"
+            tool="3"
+            flavor2="0">
+      </item>
+      <item path="../include/CppUTest/MemoryLeakDetector.h"
+            ex="false"
+            tool="3"
+            flavor2="0">
+      </item>
+      <item path="../include/CppUTest/MemoryLeakDetectorMallocMacros.h"
+            ex="false"
+            tool="3"
+            flavor2="0">
+      </item>
+      <item path="../include/CppUTest/MemoryLeakDetectorNewMacros.h"
+            ex="false"
+            tool="3"
+            flavor2="0">
+      </item>
+      <item path="../include/CppUTest/MemoryLeakWarningPlugin.h"
+            ex="false"
+            tool="3"
+            flavor2="0">
+      </item>
+      <item path="../include/CppUTest/PlatformSpecificFunctions.h"
+            ex="false"
+            tool="3"
+            flavor2="0">
+      </item>
+      <item path="../include/CppUTest/PlatformSpecificFunctions_c.h"
+            ex="false"
+            tool="3"
+            flavor2="0">
+      </item>
+      <item path="../include/CppUTest/SimpleMutex.h" ex="false" tool="3" flavor2="0">
+      </item>
+      <item path="../include/CppUTest/SimpleString.h" ex="false" tool="3" flavor2="0">
+      </item>
+      <item path="../include/CppUTest/StandardCLibrary.h"
+            ex="false"
+            tool="3"
+            flavor2="0">
+      </item>
+      <item path="../include/CppUTest/TeamCityTestOutput.h"
+            ex="false"
+            tool="3"
+            flavor2="0">
+      </item>
+      <item path="../include/CppUTest/TestFailure.h" ex="false" tool="3" flavor2="0">
+      </item>
+      <item path="../include/CppUTest/TestFilter.h" ex="false" tool="3" flavor2="0">
+      </item>
+      <item path="../include/CppUTest/TestHarness.h" ex="false" tool="3" flavor2="0">
+      </item>
+      <item path="../include/CppUTest/TestHarness_c.h"
+            ex="false"
+            tool="3"
+            flavor2="0">
+      </item>
+      <item path="../include/CppUTest/TestMemoryAllocator.h"
+            ex="false"
+            tool="3"
+            flavor2="0">
+      </item>
+      <item path="../include/CppUTest/TestOutput.h" ex="false" tool="3" flavor2="0">
+      </item>
+      <item path="../include/CppUTest/TestPlugin.h" ex="false" tool="3" flavor2="0">
+      </item>
+      <item path="../include/CppUTest/TestRegistry.h" ex="false" tool="3" flavor2="0">
+      </item>
+      <item path="../include/CppUTest/TestResult.h" ex="false" tool="3" flavor2="0">
+      </item>
+      <item path="../include/CppUTest/TestTestingFixture.h"
+            ex="false"
+            tool="3"
+            flavor2="0">
+      </item>
+      <item path="../include/CppUTest/Utest.h" ex="false" tool="3" flavor2="0">
+      </item>
+      <item path="../include/CppUTest/UtestMacros.h" ex="false" tool="3" flavor2="0">
+      </item>
+      <item path="../include/CppUTestExt/CodeMemoryReportFormatter.h"
+            ex="false"
+            tool="3"
+            flavor2="0">
+      </item>
+      <item path="../include/CppUTestExt/GMock.h" ex="false" tool="3" flavor2="0">
+      </item>
+      <item path="../include/CppUTestExt/GTest.h" ex="false" tool="3" flavor2="0">
+      </item>
+      <item path="../include/CppUTestExt/GTestConvertor.h"
+            ex="false"
+            tool="3"
+            flavor2="0">
+      </item>
+      <item path="../include/CppUTestExt/IEEE754ExceptionsPlugin.h"
+            ex="false"
+            tool="3"
+            flavor2="0">
+      </item>
+      <item path="../include/CppUTestExt/MemoryReportAllocator.h"
+            ex="false"
+            tool="3"
+            flavor2="0">
+      </item>
+      <item path="../include/CppUTestExt/MemoryReportFormatter.h"
+            ex="false"
+            tool="3"
+            flavor2="0">
+      </item>
+      <item path="../include/CppUTestExt/MemoryReporterPlugin.h"
+            ex="false"
+            tool="3"
+            flavor2="0">
+      </item>
+      <item path="../include/CppUTestExt/MockActualCall.h"
+            ex="false"
+            tool="3"
+            flavor2="0">
+      </item>
+      <item path="../include/CppUTestExt/MockCheckedActualCall.h"
+            ex="false"
+            tool="3"
+            flavor2="0">
+      </item>
+      <item path="../include/CppUTestExt/MockCheckedExpectedCall.h"
+            ex="false"
+            tool="3"
+            flavor2="0">
+      </item>
+      <item path="../include/CppUTestExt/MockExpectedCall.h"
+            ex="false"
+            tool="3"
+            flavor2="0">
+      </item>
+      <item path="../include/CppUTestExt/MockExpectedCallsList.h"
+            ex="false"
+            tool="3"
+            flavor2="0">
+      </item>
+      <item path="../include/CppUTestExt/MockFailure.h"
+            ex="false"
+            tool="3"
+            flavor2="0">
+      </item>
+      <item path="../include/CppUTestExt/MockNamedValue.h"
+            ex="false"
+            tool="3"
+            flavor2="0">
+      </item>
+      <item path="../include/CppUTestExt/MockSupport.h"
+            ex="false"
+            tool="3"
+            flavor2="0">
+      </item>
+      <item path="../include/CppUTestExt/MockSupportPlugin.h"
+            ex="false"
+            tool="3"
+            flavor2="0">
+      </item>
+      <item path="../include/CppUTestExt/MockSupport_c.h"
+            ex="false"
+            tool="3"
+            flavor2="0">
+      </item>
+      <item path="../include/CppUTestExt/OrderedTest.h"
+            ex="false"
+            tool="3"
+            flavor2="0">
+      </item>
+      <item path="../src/CppUTest/CommandLineArguments.cpp"
+            ex="false"
+            tool="1"
+            flavor2="0">
+      </item>
+      <item path="../src/CppUTest/CommandLineTestRunner.cpp"
+            ex="false"
+            tool="1"
+            flavor2="0">
+      </item>
+      <item path="../src/CppUTest/JUnitTestOutput.cpp"
+            ex="false"
+            tool="1"
+            flavor2="0">
+      </item>
+      <item path="../src/CppUTest/MemoryLeakDetector.cpp"
+            ex="false"
+            tool="1"
+            flavor2="0">
+      </item>
+      <item path="../src/CppUTest/MemoryLeakWarningPlugin.cpp"
+            ex="false"
+            tool="1"
+            flavor2="0">
+      </item>
+      <item path="../src/CppUTest/SimpleMutex.cpp" ex="false" tool="1" flavor2="0">
+      </item>
+      <item path="../src/CppUTest/SimpleString.cpp" ex="false" tool="1" flavor2="0">
+      </item>
+      <item path="../src/CppUTest/TeamCityTestOutput.cpp"
+            ex="false"
+            tool="1"
+            flavor2="0">
+      </item>
+      <item path="../src/CppUTest/TestFailure.cpp" ex="false" tool="1" flavor2="0">
+      </item>
+      <item path="../src/CppUTest/TestFilter.cpp" ex="false" tool="1" flavor2="0">
+      </item>
+      <item path="../src/CppUTest/TestHarness_c.cpp" ex="false" tool="1" flavor2="0">
+      </item>
+      <item path="../src/CppUTest/TestMemoryAllocator.cpp"
+            ex="false"
+            tool="1"
+            flavor2="0">
+      </item>
+      <item path="../src/CppUTest/TestOutput.cpp" ex="false" tool="1" flavor2="0">
+      </item>
+      <item path="../src/CppUTest/TestPlugin.cpp" ex="false" tool="1" flavor2="0">
+      </item>
+      <item path="../src/CppUTest/TestRegistry.cpp" ex="false" tool="1" flavor2="0">
+      </item>
+      <item path="../src/CppUTest/TestResult.cpp" ex="false" tool="1" flavor2="0">
+      </item>
+      <item path="../src/CppUTest/Utest.cpp" ex="false" tool="1" flavor2="0">
+      </item>
+      <item path="../src/CppUTestExt/CodeMemoryReportFormatter.cpp"
+            ex="false"
+            tool="1"
+            flavor2="0">
+      </item>
+      <item path="../src/CppUTestExt/IEEE754ExceptionsPlugin.cpp"
+            ex="false"
+            tool="1"
+            flavor2="0">
+      </item>
+      <item path="../src/CppUTestExt/MemoryReportAllocator.cpp"
+            ex="false"
+            tool="1"
+            flavor2="0">
+      </item>
+      <item path="../src/CppUTestExt/MemoryReportFormatter.cpp"
+            ex="false"
+            tool="1"
+            flavor2="0">
+      </item>
+      <item path="../src/CppUTestExt/MemoryReporterPlugin.cpp"
+            ex="false"
+            tool="1"
+            flavor2="0">
+      </item>
+      <item path="../src/CppUTestExt/MockActualCall.cpp"
+            ex="false"
+            tool="1"
+            flavor2="0">
+      </item>
+      <item path="../src/CppUTestExt/MockExpectedCall.cpp"
+            ex="false"
+            tool="1"
+            flavor2="0">
+      </item>
+      <item path="../src/CppUTestExt/MockExpectedCallsList.cpp"
+            ex="false"
+            tool="1"
+            flavor2="0">
+      </item>
+      <item path="../src/CppUTestExt/MockFailure.cpp" ex="false" tool="1" flavor2="0">
+      </item>
+      <item path="../src/CppUTestExt/MockNamedValue.cpp"
+            ex="false"
+            tool="1"
+            flavor2="0">
+      </item>
+      <item path="../src/CppUTestExt/MockSupport.cpp" ex="false" tool="1" flavor2="0">
+      </item>
+      <item path="../src/CppUTestExt/MockSupportPlugin.cpp"
+            ex="false"
+            tool="1"
+            flavor2="0">
+      </item>
+      <item path="../src/CppUTestExt/MockSupport_c.cpp"
+            ex="false"
+            tool="1"
+            flavor2="0">
+      </item>
+      <item path="../src/CppUTestExt/OrderedTest.cpp" ex="false" tool="1" flavor2="0">
+      </item>
+      <item path="../src/Platforms/Gcc/UtestPlatform.cpp"
+            ex="false"
+            tool="1"
+            flavor2="0">
+      </item>
+      <item path="../tests/AllTests.cpp" ex="false" tool="1" flavor2="0">
+      </item>
+      <item path="../tests/AllocLetTestFree.c" ex="false" tool="0" flavor2="0">
+      </item>
+      <item path="../tests/AllocLetTestFreeTest.cpp" ex="false" tool="1" flavor2="0">
+      </item>
+      <item path="../tests/AllocationInCFile.c" ex="false" tool="0" flavor2="0">
+      </item>
+      <item path="../tests/AllocationInCppFile.cpp" ex="false" tool="1" flavor2="0">
+      </item>
+      <item path="../tests/CheatSheetTest.cpp" ex="false" tool="1" flavor2="0">
+      </item>
+      <item path="../tests/CommandLineArgumentsTest.cpp"
+            ex="false"
+            tool="1"
+            flavor2="0">
+      </item>
+      <item path="../tests/CommandLineTestRunnerTest.cpp"
+            ex="false"
+            tool="1"
+            flavor2="0">
+      </item>
+      <item path="../tests/JUnitOutputTest.cpp" ex="false" tool="1" flavor2="0">
+      </item>
+      <item path="../tests/MemoryLeakDetectorTest.cpp"
+            ex="false"
+            tool="1"
+            flavor2="0">
+      </item>
+      <item path="../tests/MemoryLeakWarningTest.cpp" ex="false" tool="1" flavor2="0">
+      </item>
+      <item path="../tests/MemoryOperatorOverloadTest.cpp"
+            ex="false"
+            tool="1"
+            flavor2="0">
+      </item>
+      <item path="../tests/PluginTest.cpp" ex="false" tool="1" flavor2="0">
+      </item>
+      <item path="../tests/PreprocessorTest.cpp" ex="false" tool="1" flavor2="0">
+      </item>
+      <item path="../tests/SetPluginTest.cpp" ex="false" tool="1" flavor2="0">
+      </item>
+      <item path="../tests/SimpleMutexTest.cpp" ex="false" tool="1" flavor2="0">
+      </item>
+      <item path="../tests/SimpleStringTest.cpp" ex="false" tool="1" flavor2="0">
+      </item>
+      <item path="../tests/TeamCityOutputTest.cpp" ex="false" tool="1" flavor2="0">
+      </item>
+      <item path="../tests/TestFailureNaNTest.cpp" ex="false" tool="1" flavor2="0">
+      </item>
+      <item path="../tests/TestFailureTest.cpp" ex="false" tool="1" flavor2="0">
+      </item>
+      <item path="../tests/TestFilterTest.cpp" ex="false" tool="1" flavor2="0">
+      </item>
+      <item path="../tests/TestHarness_cTest.cpp" ex="false" tool="1" flavor2="0">
+      </item>
+      <item path="../tests/TestHarness_cTestCFile.c" ex="false" tool="0" flavor2="0">
+      </item>
+      <item path="../tests/TestInstallerTest.cpp" ex="false" tool="1" flavor2="0">
+      </item>
+      <item path="../tests/TestMemoryAllocatorTest.cpp"
+            ex="false"
+            tool="1"
+            flavor2="0">
+      </item>
+      <item path="../tests/TestOutputTest.cpp" ex="false" tool="1" flavor2="0">
+      </item>
+      <item path="../tests/TestRegistryTest.cpp" ex="false" tool="1" flavor2="0">
+      </item>
+      <item path="../tests/TestResultTest.cpp" ex="false" tool="1" flavor2="0">
+      </item>
+      <item path="../tests/TestUTestMacro.cpp" ex="false" tool="1" flavor2="0">
+      </item>
+      <item path="../tests/UtestPlatformTest.cpp" ex="false" tool="1" flavor2="0">
+      </item>
+      <item path="../tests/UtestTest.cpp" ex="false" tool="1" flavor2="0">
+      </item>
+    </conf>
+  </confs>
+</configurationDescriptor>

--- a/examples/nbproject/project.xml
+++ b/examples/nbproject/project.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://www.netbeans.org/ns/project/1">
+    <type>org.netbeans.modules.cnd.makeproject</type>
+    <configuration>
+        <data xmlns="http://www.netbeans.org/ns/make-project/1">
+            <name>CppUTest</name>
+            <c-extensions>c</c-extensions>
+            <cpp-extensions>cpp</cpp-extensions>
+            <header-extensions>h</header-extensions>
+            <sourceEncoding>UTF-8</sourceEncoding>
+            <make-dep-projects/>
+            <sourceRootList>
+                <sourceRootElem>src/CppUTest</sourceRootElem>
+                <sourceRootElem>src/CppUTestExt</sourceRootElem>
+                <sourceRootElem>src/Platforms</sourceRootElem>
+                <sourceRootElem>include</sourceRootElem>
+                <sourceRootElem>examples/AllTests</sourceRootElem>
+                <sourceRootElem>../include/CppUTest</sourceRootElem>
+                <sourceRootElem>../include/CppUTestExt</sourceRootElem>
+                <sourceRootElem>../include/Platforms</sourceRootElem>
+                <sourceRootElem>AllTests</sourceRootElem>
+                <sourceRootElem>ApplicationLib</sourceRootElem>
+                <sourceRootElem>../src/CppUTest</sourceRootElem>
+                <sourceRootElem>../src/CppUTestExt</sourceRootElem>
+                <sourceRootElem>../src/Platforms</sourceRootElem>
+                <sourceRootElem>../tests</sourceRootElem>
+            </sourceRootList>
+            <confList>
+                <confElem>
+                    <name>Debug</name>
+                    <type>1</type>
+                </confElem>
+            </confList>
+            <formatting>
+                <project-formatting-style>false</project-formatting-style>
+            </formatting>
+        </data>
+    </configuration>
+</project>

--- a/include/CppUTest/SimpleString.h
+++ b/include/CppUTest/SimpleString.h
@@ -153,6 +153,8 @@ SimpleString StringFromBinary(const unsigned char* value, size_t size);
 SimpleString StringFromBinaryOrNull(const unsigned char* value, size_t size);
 SimpleString StringFromBinaryWithSize(const unsigned char* value, size_t size);
 SimpleString StringFromBinaryWithSizeOrNull(const unsigned char* value, size_t size);
+SimpleString StringFromAnyInteger(const unsigned char* value, size_t size);
+SimpleString StringFromAnyIntegerOrNull(const unsigned char* value, size_t size);
 SimpleString StringFromMaskedBits(unsigned long value, unsigned long mask, size_t byteCount);
 SimpleString StringFromOrdinalNumber(unsigned int number);
 

--- a/include/CppUTest/TestFailure.h
+++ b/include/CppUTest/TestFailure.h
@@ -153,6 +153,12 @@ public:
 	BinaryEqualFailure(UtestShell* test, const char* fileName, int lineNumber, const unsigned char* expected, const unsigned char* actual, size_t size, const SimpleString& text);
 };
 
+class IntsEqualFailure : public TestFailure
+{
+public:
+	IntsEqualFailure(UtestShell* test, const char* fileName, int lineNumber, const unsigned char* expected, const unsigned char* actual, size_t size, const SimpleString& text);
+};
+
 class BitsEqualFailure : public TestFailure
 {
 public:

--- a/include/CppUTest/TestFailure.h
+++ b/include/CppUTest/TestFailure.h
@@ -153,10 +153,10 @@ public:
 	BinaryEqualFailure(UtestShell* test, const char* fileName, int lineNumber, const unsigned char* expected, const unsigned char* actual, size_t size, const SimpleString& text);
 };
 
-class IntsEqualFailure : public TestFailure
+class AnyIntsEqualFailure : public TestFailure
 {
 public:
-	IntsEqualFailure(UtestShell* test, const char* fileName, int lineNumber, const unsigned char* expected, const unsigned char* actual, size_t size, const SimpleString& text);
+	AnyIntsEqualFailure(UtestShell* test, const char* fileName, int lineNumber, const unsigned char* expected, const unsigned char* actual, size_t size, const SimpleString& text);
 };
 
 class BitsEqualFailure : public TestFailure

--- a/include/CppUTest/Utest.h
+++ b/include/CppUTest/Utest.h
@@ -118,7 +118,7 @@ public:
     virtual void assertDoublesEqual(double expected, double actual, double threshold, const char* text, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
     virtual void assertEquals(bool failed, const char* expected, const char* actual, const char* text, const char* file, int line, const TestTerminator& testTerminator = NormalTestTerminator());
     virtual void assertBinaryEqual(const void *expected, const void *actual, size_t length, const char* text, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
-    virtual void assertIntsEqual(const void *expected, const void *actual, size_t length, const char* text, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
+    virtual void assertAnyIntsEqual(const void *expected, const void *actual, size_t length, const char* text, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
     virtual void assertBitsEqual(unsigned long expected, unsigned long actual, unsigned long mask, size_t byteCount, const char* text, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
     virtual void fail(const char *text, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
     virtual void exitTest(const TestTerminator& testTerminator = NormalTestTerminator());

--- a/include/CppUTest/Utest.h
+++ b/include/CppUTest/Utest.h
@@ -118,6 +118,7 @@ public:
     virtual void assertDoublesEqual(double expected, double actual, double threshold, const char* text, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
     virtual void assertEquals(bool failed, const char* expected, const char* actual, const char* text, const char* file, int line, const TestTerminator& testTerminator = NormalTestTerminator());
     virtual void assertBinaryEqual(const void *expected, const void *actual, size_t length, const char* text, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
+    virtual void assertIntsEqual(const void *expected, const void *actual, size_t length, const char* text, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
     virtual void assertBitsEqual(unsigned long expected, unsigned long actual, unsigned long mask, size_t byteCount, const char* text, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
     virtual void fail(const char *text, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
     virtual void exitTest(const TestTerminator& testTerminator = NormalTestTerminator());

--- a/include/CppUTest/UtestMacros.h
+++ b/include/CppUTest/UtestMacros.h
@@ -197,14 +197,14 @@
 #define LONGS_EQUAL_LOCATION(expected, actual, text, file, line)\
   { if ((sizeof(expected) > sizeof(long)) || (sizeof(actual) > sizeof(long))) \
         UtestShell::getCurrent()->print( \
-            "Size of `expected` or `actual` is bigger than size of `long int`\nConsider use of MEMCMP_EQUAL().\n", \
+            "Size of `expected` or `actual` is bigger than size of `long int`\n\tConsider use of INTS_EQUAL().\n", \
             file, line); \
     UtestShell::getCurrent()->assertLongsEqual((long)expected, (long)actual, text, file, line); }
 
 #define UNSIGNED_LONGS_EQUAL_LOCATION(expected, actual, text, file, line)\
   { if ((sizeof(expected) > sizeof(long)) || (sizeof(actual) > sizeof(long))) \
         UtestShell::getCurrent()->print( \
-            "Size of `expected` or `actual` is bigger than size of `long int`\nConsider use of MEMCMP_EQUAL().\n", \
+            "Size of `expected` or `actual` is bigger than size of `long int`\n\tConsider use of INTS_EQUAL().\n", \
             file, line); \
     UtestShell::getCurrent()->assertUnsignedLongsEqual((unsigned long)expected, (unsigned long)actual, text, file, line); }
 
@@ -250,6 +250,15 @@
 
 #define MEMCMP_EQUAL_LOCATION(expected, actual, size, text, file, line)\
   { UtestShell::getCurrent()->assertBinaryEqual(expected, actual, size, text, file, line); }
+
+#define INTS_EQUAL(expected, actual, size)\
+  INTS_EQUAL_LOCATION(expected, actual, size, NULL, __FILE__, __LINE__)
+
+#define INTS_EQUAL_TEXT(expected, actual, size, text)\
+  INTS_EQUAL_LOCATION(expected, actual, size, text, __FILE__, __LINE__)
+
+#define INTS_EQUAL_LOCATION(expected, actual, size, text, file, line)\
+  { UtestShell::getCurrent()->assertIntsEqual(expected, actual, size, text, file, line); }
 
 #define BITS_EQUAL(expected, actual, mask)\
   BITS_LOCATION(expected, actual, mask, NULL, __FILE__, __LINE__)

--- a/include/CppUTest/UtestMacros.h
+++ b/include/CppUTest/UtestMacros.h
@@ -197,14 +197,14 @@
 #define LONGS_EQUAL_LOCATION(expected, actual, text, file, line)\
   { if ((sizeof(expected) > sizeof(long)) || (sizeof(actual) > sizeof(long))) \
         UtestShell::getCurrent()->print( \
-            "Size of `expected` or `actual` is bigger than size of `long int`\n\tConsider use of INTS_EQUAL().\n", \
+            "WARNING:\n\tSize of `expected` or `actual` is bigger than size of `long int`\n\tConsider use of ANYINTS_EQUAL().\n", \
             file, line); \
     UtestShell::getCurrent()->assertLongsEqual((long)expected, (long)actual, text, file, line); }
 
 #define UNSIGNED_LONGS_EQUAL_LOCATION(expected, actual, text, file, line)\
   { if ((sizeof(expected) > sizeof(long)) || (sizeof(actual) > sizeof(long))) \
         UtestShell::getCurrent()->print( \
-            "Size of `expected` or `actual` is bigger than size of `long int`\n\tConsider use of INTS_EQUAL().\n", \
+            "WARNING:\n\tSize of `expected` or `actual` is bigger than size of `long int`\n\tConsider use of ANYINTS_EQUAL().\n", \
             file, line); \
     UtestShell::getCurrent()->assertUnsignedLongsEqual((unsigned long)expected, (unsigned long)actual, text, file, line); }
 
@@ -251,14 +251,14 @@
 #define MEMCMP_EQUAL_LOCATION(expected, actual, size, text, file, line)\
   { UtestShell::getCurrent()->assertBinaryEqual(expected, actual, size, text, file, line); }
 
-#define INTS_EQUAL(expected, actual, size)\
-  INTS_EQUAL_LOCATION(expected, actual, size, NULL, __FILE__, __LINE__)
+#define ANYINTS_EQUAL(expected, actual, size)\
+  ANYINTS_EQUAL_LOCATION(expected, actual, size, NULL, __FILE__, __LINE__)
 
-#define INTS_EQUAL_TEXT(expected, actual, size, text)\
-  INTS_EQUAL_LOCATION(expected, actual, size, text, __FILE__, __LINE__)
+#define ANYINTS_EQUAL_TEXT(expected, actual, size, text)\
+  ANYINTS_EQUAL_LOCATION(expected, actual, size, text, __FILE__, __LINE__)
 
-#define INTS_EQUAL_LOCATION(expected, actual, size, text, file, line)\
-  { UtestShell::getCurrent()->assertIntsEqual(expected, actual, size, text, file, line); }
+#define ANYINTS_EQUAL_LOCATION(expected, actual, size, text, file, line)\
+  { UtestShell::getCurrent()->assertAnyIntsEqual(expected, actual, size, text, file, line); }
 
 #define BITS_EQUAL(expected, actual, mask)\
   BITS_LOCATION(expected, actual, mask, NULL, __FILE__, __LINE__)

--- a/include/CppUTest/UtestMacros.h
+++ b/include/CppUTest/UtestMacros.h
@@ -195,10 +195,18 @@
   UNSIGNED_LONGS_EQUAL_LOCATION((expected), (actual), text, __FILE__, __LINE__)
 
 #define LONGS_EQUAL_LOCATION(expected, actual, text, file, line)\
-  { UtestShell::getCurrent()->assertLongsEqual((long)expected, (long)actual, text, file, line); }
+  { if ((sizeof(expected) > sizeof(long)) || (sizeof(actual) > sizeof(long))) \
+        UtestShell::getCurrent()->print( \
+            "Size of `expected` or `actual` is bigger than size of `long int`\nConsider use of MEMCMP_EQUAL().\n", \
+            file, line); \
+    UtestShell::getCurrent()->assertLongsEqual((long)expected, (long)actual, text, file, line); }
 
 #define UNSIGNED_LONGS_EQUAL_LOCATION(expected, actual, text, file, line)\
-  { UtestShell::getCurrent()->assertUnsignedLongsEqual((unsigned long)expected, (unsigned long)actual, text, file, line); }
+  { if ((sizeof(expected) > sizeof(long)) || (sizeof(actual) > sizeof(long))) \
+        UtestShell::getCurrent()->print( \
+            "Size of `expected` or `actual` is bigger than size of `long int`\nConsider use of MEMCMP_EQUAL().\n", \
+            file, line); \
+    UtestShell::getCurrent()->assertUnsignedLongsEqual((unsigned long)expected, (unsigned long)actual, text, file, line); }
 
 #define BYTES_EQUAL(expected, actual)\
     LONGS_EQUAL((expected) & 0xff,(actual) & 0xff)

--- a/src/CppUTest/SimpleString.cpp
+++ b/src/CppUTest/SimpleString.cpp
@@ -628,6 +628,23 @@ SimpleString StringFromBinaryWithSizeOrNull(const unsigned char* value, size_t s
     return (value) ? StringFromBinaryWithSize(value, size) : "(null)";
 }
 
+SimpleString StringFromAnyInteger(const unsigned char* value, size_t size)
+{
+    SimpleString result = "0x";
+
+    for (int i = size-1; i >= 0; i--)
+    {
+        result += StringFromFormat("%02X", value[i]);
+    }
+
+    return result;
+}
+
+SimpleString StringFromAnyIntegerOrNull(const unsigned char* value, size_t size)
+{
+    return (value && size) ? StringFromAnyInteger(value, size) : "(null)";
+}
+
 SimpleString StringFromMaskedBits(unsigned long value, unsigned long mask, size_t byteCount)
 {
     SimpleString result;

--- a/src/CppUTest/SimpleString.cpp
+++ b/src/CppUTest/SimpleString.cpp
@@ -632,9 +632,8 @@ SimpleString StringFromAnyInteger(const unsigned char* value, size_t size)
 {
     SimpleString result = "0x";
 
-    for (int i = size-1; i >= 0; i--)
-    {
-        result += StringFromFormat("%02X", value[i]);
+    for (size_t i = 0; i < size; i++) {
+        result += StringFromFormat("%02X", value[size-1-i]);
     }
 
     return result;

--- a/src/CppUTest/TestFailure.cpp
+++ b/src/CppUTest/TestFailure.cpp
@@ -318,6 +318,15 @@ BinaryEqualFailure::BinaryEqualFailure(UtestShell* test, const char* fileName, i
 	}
 }
 
+IntsEqualFailure::IntsEqualFailure(UtestShell* test, const char* fileName, int lineNumber, const unsigned char* expected,
+                                       const unsigned char* actual, size_t size, const SimpleString& text)
+: TestFailure(test, fileName, lineNumber)
+{
+    message_ = createUserText(text);
+
+	message_ += createButWasString(StringFromAnyIntegerOrNull(expected, size), StringFromAnyIntegerOrNull(actual, size));
+}
+
 BitsEqualFailure::BitsEqualFailure(UtestShell* test, const char* fileName, int lineNumber, unsigned long expected, unsigned long actual,
                                    unsigned long mask, size_t byteCount, const SimpleString& text)
 : TestFailure(test, fileName, lineNumber)

--- a/src/CppUTest/TestFailure.cpp
+++ b/src/CppUTest/TestFailure.cpp
@@ -322,6 +322,19 @@ IntsEqualFailure::IntsEqualFailure(UtestShell* test, const char* fileName, int l
                                        const unsigned char* actual, size_t size, const SimpleString& text)
 : TestFailure(test, fileName, lineNumber)
 {
+    if (size <= sizeof(long))
+    {
+        long lexp = 0, lact = 0;
+        for (size_t i = 0; i < size; i++)
+            ((unsigned char*)&lexp)[i] = ((const unsigned char *)expected)[i];
+        for (size_t i = 0; i < size; i++)
+            ((unsigned char*)&lact)[i] = ((const unsigned char *)actual)[i];
+
+        LongsEqualFailure f(test, fileName, lineNumber, lexp, lact, text);
+        message_ = f.getMessage();
+        return;
+    }
+
     message_ = createUserText(text);
 
 	message_ += createButWasString(StringFromAnyIntegerOrNull(expected, size), StringFromAnyIntegerOrNull(actual, size));

--- a/src/CppUTest/TestFailure.cpp
+++ b/src/CppUTest/TestFailure.cpp
@@ -318,7 +318,7 @@ BinaryEqualFailure::BinaryEqualFailure(UtestShell* test, const char* fileName, i
 	}
 }
 
-IntsEqualFailure::IntsEqualFailure(UtestShell* test, const char* fileName, int lineNumber, const unsigned char* expected,
+AnyIntsEqualFailure::AnyIntsEqualFailure(UtestShell* test, const char* fileName, int lineNumber, const unsigned char* expected,
                                        const unsigned char* actual, size_t size, const SimpleString& text)
 : TestFailure(test, fileName, lineNumber)
 {

--- a/src/CppUTest/Utest.cpp
+++ b/src/CppUTest/Utest.cpp
@@ -455,6 +455,16 @@ void UtestShell::assertBinaryEqual(const void *expected, const void *actual, siz
         failWith(BinaryEqualFailure(this, fileName, lineNumber, (const unsigned char *) expected, (const unsigned char *) actual, length, text), testTerminator);
 }
 
+void UtestShell::assertIntsEqual(const void *expected, const void *actual, size_t length, const char* text, const char *fileName, int lineNumber, const TestTerminator& testTerminator)
+{
+    getTestResult()->countCheck();
+    if (actual == 0 && expected == 0) return;
+    if (actual == 0 || expected == 0)
+        failWith(IntsEqualFailure(this, fileName, lineNumber, (const unsigned char *) expected, (const unsigned char *) actual, length, text), testTerminator);
+    if (SimpleString::MemCmp(expected, actual, length) != 0)
+        failWith(IntsEqualFailure(this, fileName, lineNumber, (const unsigned char *) expected, (const unsigned char *) actual, length, text), testTerminator);
+}
+
 void UtestShell::assertBitsEqual(unsigned long expected, unsigned long actual, unsigned long mask, size_t byteCount, const char* text, const char *fileName, int lineNumber, const TestTerminator& testTerminator)
 {
     getTestResult()->countCheck();

--- a/src/CppUTest/Utest.cpp
+++ b/src/CppUTest/Utest.cpp
@@ -455,14 +455,14 @@ void UtestShell::assertBinaryEqual(const void *expected, const void *actual, siz
         failWith(BinaryEqualFailure(this, fileName, lineNumber, (const unsigned char *) expected, (const unsigned char *) actual, length, text), testTerminator);
 }
 
-void UtestShell::assertIntsEqual(const void *expected, const void *actual, size_t length, const char* text, const char *fileName, int lineNumber, const TestTerminator& testTerminator)
+void UtestShell::assertAnyIntsEqual(const void *expected, const void *actual, size_t length, const char* text, const char *fileName, int lineNumber, const TestTerminator& testTerminator)
 {
     getTestResult()->countCheck();
     if (actual == 0 && expected == 0) return;
     if (actual == 0 || expected == 0)
-        failWith(IntsEqualFailure(this, fileName, lineNumber, (const unsigned char *) expected, (const unsigned char *) actual, length, text), testTerminator);
+        failWith(AnyIntsEqualFailure(this, fileName, lineNumber, (const unsigned char *) expected, (const unsigned char *) actual, length, text), testTerminator);
     if (SimpleString::MemCmp(expected, actual, length) != 0)
-        failWith(IntsEqualFailure(this, fileName, lineNumber, (const unsigned char *) expected, (const unsigned char *) actual, length, text), testTerminator);
+        failWith(AnyIntsEqualFailure(this, fileName, lineNumber, (const unsigned char *) expected, (const unsigned char *) actual, length, text), testTerminator);
 }
 
 void UtestShell::assertBitsEqual(unsigned long expected, unsigned long actual, unsigned long mask, size_t byteCount, const char* text, const char *fileName, int lineNumber, const TestTerminator& testTerminator)

--- a/tests/AllTests.cpp
+++ b/tests/AllTests.cpp
@@ -33,6 +33,11 @@ int main(int ac, const char** av)
     CHECK(true);
     LONGS_EQUAL(1, 1);
 
+#ifdef __GNUC__
+//    __int128_t i128 = 1;
+//    LONGS_EQUAL(1, i128);
+#endif
+
     return CommandLineTestRunner::RunAllTests(ac, const_cast<char**>(av)); /* cover alternate method */
 }
 

--- a/tests/AllTests.cpp
+++ b/tests/AllTests.cpp
@@ -42,7 +42,7 @@ int main(int ac, const char** av)
         // expected <0x00000000000000000000000000000001>
         // but was  <0x00000000000000000080000000000000>
         __int128_t c128 = 1;
-        __int128_t d128 = 1LL << 55;
+        __int128_t d128 = 1L << 55;
         INTS_EQUAL(&c128, &d128, sizeof(c128));
 #endif
 

--- a/tests/AllTests.cpp
+++ b/tests/AllTests.cpp
@@ -33,7 +33,7 @@ int main(int ac, const char** av)
     CHECK(true);
     LONGS_EQUAL(1, 1);
 
-#if 0
+#if (defined __GNUG__) && 0
         // print int size warning
         __int128_t a128 = 1;
         __int128_t b128 = 1;
@@ -43,7 +43,7 @@ int main(int ac, const char** av)
         // but was  <0x00000000000000000080000000000000>
         __int128_t c128 = 1;
         __int128_t d128 = 1L << 55;
-        INTS_EQUAL(&c128, &d128, sizeof(c128));
+        ANYINTS_EQUAL(&c128, &d128, sizeof(c128));
 #endif
 
     return CommandLineTestRunner::RunAllTests(ac, const_cast<char**>(av)); /* cover alternate method */

--- a/tests/AllTests.cpp
+++ b/tests/AllTests.cpp
@@ -34,8 +34,16 @@ int main(int ac, const char** av)
     LONGS_EQUAL(1, 1);
 
 #ifdef __GNUC__
-//    __int128_t i128 = 1;
-//    LONGS_EQUAL(1, i128);
+        // print int size warning
+        __int128_t a128 = 1;
+        __int128_t b128 = 1;
+        LONGS_EQUAL(a128, b128);
+
+        // expected <0x00000000000000000000000000000001>
+        // but was  <0x00000000000000000080000000000000>
+        __int128_t c128 = 1;
+        __int128_t d128 = 1LL << 55;
+        INTS_EQUAL(&c128, &d128, sizeof(c128));
 #endif
 
     return CommandLineTestRunner::RunAllTests(ac, const_cast<char**>(av)); /* cover alternate method */

--- a/tests/AllTests.cpp
+++ b/tests/AllTests.cpp
@@ -33,7 +33,7 @@ int main(int ac, const char** av)
     CHECK(true);
     LONGS_EQUAL(1, 1);
 
-#ifdef __GNUC__
+#if 0
         // print int size warning
         __int128_t a128 = 1;
         __int128_t b128 = 1;

--- a/tests/TestFailureTest.cpp
+++ b/tests/TestFailureTest.cpp
@@ -337,7 +337,7 @@ TEST(TestFailure, IntsEqualOneByte)
 {
     const unsigned char expectedData[] = { 0x01 };
     const unsigned char actualData[] = { 0x02 };
-    IntsEqualFailure f(test, failFileName, failLineNumber, expectedData, actualData, sizeof(expectedData), "");
+    AnyIntsEqualFailure f(test, failFileName, failLineNumber, expectedData, actualData, sizeof(expectedData), "");
     FAILURE_EQUAL("expected <1 0x1>\n\tbut was  <2 0x2>", f);
 }
 
@@ -345,7 +345,7 @@ TEST(TestFailure, IntsEqualTwoBytes)
 {
     const unsigned char expectedData[] = {0x00, 0x01};
     const unsigned char actualData[] = {0x00, 0x02};
-    IntsEqualFailure f(test, failFileName, failLineNumber, expectedData, actualData, sizeof(expectedData), "");
+    AnyIntsEqualFailure f(test, failFileName, failLineNumber, expectedData, actualData, sizeof(expectedData), "");
     FAILURE_EQUAL("expected <256 0x100>\n\tbut was  <512 0x200>", f);
 }
 
@@ -353,7 +353,7 @@ TEST(TestFailure, IntsEqualFourBytes)
 {
     const unsigned char expectedData[] = {0x00, 0x01, 0x00, 0x00};
     const unsigned char actualData[] = {0x00, 0x02, 0x00, 0x00};
-    IntsEqualFailure f(test, failFileName, failLineNumber, expectedData, actualData, sizeof(expectedData), "");
+    AnyIntsEqualFailure f(test, failFileName, failLineNumber, expectedData, actualData, sizeof(expectedData), "");
 
     if (sizeof(long) >= 4)
     {

--- a/tests/TestFailureTest.cpp
+++ b/tests/TestFailureTest.cpp
@@ -333,6 +333,38 @@ TEST(TestFailure, BinaryEqualFullWidth)
     			"\t                                               ^", f);
 }
 
+TEST(TestFailure, IntsEqualOneByte)
+{
+    const unsigned char expectedData[] = { 0x01 };
+    const unsigned char actualData[] = { 0x02 };
+    IntsEqualFailure f(test, failFileName, failLineNumber, expectedData, actualData, sizeof(expectedData), "");
+    FAILURE_EQUAL("expected <1 0x1>\n\tbut was  <2 0x2>", f);
+}
+
+TEST(TestFailure, IntsEqualTwoBytes)
+{
+    const unsigned char expectedData[] = {0x00, 0x01};
+    const unsigned char actualData[] = {0x00, 0x02};
+    IntsEqualFailure f(test, failFileName, failLineNumber, expectedData, actualData, sizeof(expectedData), "");
+    FAILURE_EQUAL("expected <256 0x100>\n\tbut was  <512 0x200>", f);
+}
+
+TEST(TestFailure, IntsEqualFourBytes)
+{
+    const unsigned char expectedData[] = {0x00, 0x01, 0x00, 0x00};
+    const unsigned char actualData[] = {0x00, 0x02, 0x00, 0x00};
+    IntsEqualFailure f(test, failFileName, failLineNumber, expectedData, actualData, sizeof(expectedData), "");
+
+    if (sizeof(long) >= 4)
+    {
+        FAILURE_EQUAL("expected <256 0x100>\n\tbut was  <512 0x200>", f);
+    }
+    else
+    {
+        FAILURE_EQUAL("expected <0x00000100>\n\tbut was  <0x00000200>", f);
+    }
+}
+
 TEST(TestFailure, BinaryEqualLast)
 {
     const unsigned char expectedData[] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};


### PR DESCRIPTION
As the default LONGS_EQUAL act different depending on platform,
user should be warned that this macro may not work as expected.
Further on, more universal macro should be provided, like
MEMCMP_EQUAL(), but presenting output as hexadecimal number,
not a hexadecimal memory dump.

I created INTS_EQAL() macro - just a proposal. 
It works like a MEMCMP_EQUAL(), but produces following output:
    expected <0x00000000000000000000000000000001>
    but was  <0x00000000000000000080000000000000>
