### PR TITLE
Compilation fixes for OpenBSD-5.8

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -44,6 +44,12 @@ if (MINGW)
     set(THREAD_LIB "pthread")
 endif (MINGW)
 
+if (${CMAKE_HOST_SYSTEM_NAME} MATCHES "OpenBSD")
+   set (THREADS_HAVE_PTHREAD_ARG 1)
+   find_package (Threads REQUIRED)
+   set (THREAD_LIB "pthread")
+endif ()
+
 add_executable(CppUTestTests ${CppUTestTests_src})
 target_link_libraries(CppUTestTests CppUTest ${THREAD_LIB})
 

--- a/tests/CppUTestExt/MockSupport_cTestCFile.c
+++ b/tests/CppUTestExt/MockSupport_cTestCFile.c
@@ -57,7 +57,7 @@ void all_mock_support_c_calls(void)
             withPointerParameters("pointer", (void*) 1)->
             withConstPointerParameters("constpointer", (const void*) 1)->
             withFunctionPointerParameters("functionpointer", (void(*)()) 1)->
-            withMemoryBufferParameter("name", (void*) 1, 0)->
+            withMemoryBufferParameter("name", (void*) 1, 0UL)->
             ignoreOtherParameters();
 
     mock_c()->actualCall("boo")->withIntParameters("integer", 1)->
@@ -69,12 +69,12 @@ void all_mock_support_c_calls(void)
             withPointerParameters("pointer", (void*) 1)->
             withConstPointerParameters("constpointer", (const void*) 1)->
             withFunctionPointerParameters("functionpointer", (void(*)()) 1)->
-            withMemoryBufferParameter("name", (void*) 1, 0)->
+            withMemoryBufferParameter("name", (void*) 1, 0UL)->
             hasReturnValue();
 
     mock_c()->disable();
     mock_c()->expectOneCall("boo")->withParameterOfType("type", "name", (void*) 1)->
-            withOutputParameterReturning("name", (void*)1, 0)->
+            withOutputParameterReturning("name", (void*)1, 0UL)->
             withOutputParameterOfTypeReturning("type", "name", (void*)1);
     mock_c()->actualCall("boo")->withParameterOfType("type", "name", (void*) 1)->
             withOutputParameter("name", (void*)1)->


### PR DESCRIPTION
Compilation is fixed with the following patches for the system:
$ uname -a
OpenBSD obi_64.abc.lan 5.8 GENERIC.MP#1236 amd64
$ cc -v
Reading specs from /usr/lib/gcc-lib/amd64-unknown-openbsd5.8/4.2.1/specs
Target: amd64-unknown-openbsd5.8
Configured with: OpenBSD/amd64 system compiler
Thread model: posix
gcc version 4.2.1 20070719