### PR TITLE
Interface for checking an IEEE754 exception flag in the debugger

### DIFF
--- a/include/CppUTestExt/IEEE754ExceptionsPlugin.h
+++ b/include/CppUTestExt/IEEE754ExceptionsPlugin.h
@@ -40,6 +40,7 @@ public:
 
     static void disableInexact(void);
     static void enableInexact(void);
+    static bool checkIeee754ExeptionFlag(int flag);
 
 private:
     void ieee754Check(UtestShell& test, TestResult& result, int flag, const char* text);

--- a/src/CppUTestExt/IEEE754ExceptionsPlugin.cpp
+++ b/src/CppUTestExt/IEEE754ExceptionsPlugin.cpp
@@ -69,6 +69,11 @@ void IEEE754ExceptionsPlugin::enableInexact()
     inexactDisabled_ = false;
 }
 
+bool IEEE754ExceptionsPlugin::checkIeee754ExeptionFlag(int flag)
+{
+    return fetestexcept(flag);
+}
+
 void IEEE754ExceptionsPlugin::ieee754Check(UtestShell& test, TestResult& result, int flag, const char* text)
 {
     result.countCheck();

--- a/tests/CppUTestExt/IEEE754PluginTest.cpp
+++ b/tests/CppUTestExt/IEEE754PluginTest.cpp
@@ -118,6 +118,9 @@ static void set_everything_but_already_failed(void) {
 TEST(FE__with_Plugin, should_not_fail_again_when_test_has_already_failed) {
     fixture.setTestFunction(set_everything_but_already_failed);
     fixture.runAllTests();
+    CHECK(ieee754Plugin.checkIeee754ExeptionFlag(0x04));
+    CHECK(ieee754Plugin.checkIeee754ExeptionFlag(0x08));
+    CHECK(ieee754Plugin.checkIeee754ExeptionFlag(0x10));
     LONGS_EQUAL(1, fixture.getCheckCount());
     LONGS_EQUAL(1, fixture.getFailureCount());
 }


### PR DESCRIPTION
When a test fails due to an an IEEE754 exception flag being set,
it can be hard to find exactly where the error occurred.
By entering the new static method in the debugger as a watch,
e.g. IEEE754ExceptionsPlugin::checkIeee754ExeptionFlag(4), its
value will change to true at the exact point where the problem
occurred.

In most cases, it won't then be necessary to enable floating point
trapping in order to find the offending line (the other PR that
mysteriously fails under Cygwin on Appveyor).