### PR TITLE
argument line option to enable OPTRUN_TEST

### DIFF
--- a/include/CppUTest/CommandLineArguments.h
+++ b/include/CppUTest/CommandLineArguments.h
@@ -45,6 +45,7 @@ public:
     bool isColor() const;
     bool isListingTestGroupNames() const;
     bool isListingTestGroupAndCaseNames() const;
+	bool isOptRun() const;
     int getRepeatCount() const;
     const TestFilter* getGroupFilters() const;
     const TestFilter* getNameFilters() const;
@@ -69,6 +70,7 @@ private:
     bool runTestsAsSeperateProcess_;
     bool listTestGroupNames_;
     bool listTestGroupAndCaseNames_;
+	bool isOptRun_;
     int repeat_;
     TestFilter* groupFilters_;
     TestFilter* nameFilters_;

--- a/include/CppUTest/TestRegistry.h
+++ b/include/CppUTest/TestRegistry.h
@@ -54,7 +54,6 @@ public:
     virtual void listTestGroupAndCaseNames(TestResult& result);
     virtual void setNameFilters(const TestFilter* filters);
     virtual void setGroupFilters(const TestFilter* filters);
-
     virtual void installPlugin(TestPlugin* plugin);
     virtual void resetPlugins();
     virtual TestPlugin* getFirstPlugin();
@@ -73,7 +72,7 @@ public:
 
     virtual void setRunTestsInSeperateProcess();
     int getCurrentRepetition();
-
+	void setOptRun();
 private:
 
     bool testShouldRun(UtestShell* test, TestResult& result);
@@ -86,7 +85,7 @@ private:
     static TestRegistry* currentRegistry_;
     bool runInSeperateProcess_;
     int currentRepetition_;
-
+	bool isOptRun_;
 };
 
 #endif

--- a/include/CppUTest/TestTestingFixture.h
+++ b/include/CppUTest/TestTestingFixture.h
@@ -116,6 +116,12 @@ public:
 
     }
 
+	int getRunCount()
+	{
+		return result_->getRunCount();
+	}
+
+
     TestRegistry* registry_;
     ExecFunctionTestShell* genTest_;
     StringBufferTestOutput* output_;

--- a/include/CppUTest/Utest.h
+++ b/include/CppUTest/Utest.h
@@ -103,6 +103,7 @@ public:
     int getLineNumber() const;
     virtual bool willRun() const;
     virtual bool hasFailed() const;
+	bool isOptRun() const;
     void countCheck();
 
     virtual void assertTrue(bool condition, const char *checkString, const char *conditionString, const char* text, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
@@ -137,6 +138,8 @@ public:
     virtual bool isRunInSeperateProcess() const;
     virtual void setRunInSeperateProcess();
 
+	void setOptRun();
+
     virtual Utest* createTest();
     virtual void destroyTest(Utest* test);
 
@@ -160,6 +163,7 @@ private:
     UtestShell *next_;
     bool isRunAsSeperateProcess_;
     bool hasFailed_;
+	bool isOptRun_;
 
     void setTestResult(TestResult* result);
     void setCurrentTest(UtestShell* test);
@@ -169,6 +173,8 @@ private:
     static TestResult* testResult_;
 
 };
+
+
 
 //////////////////// ExecFunctionTest
 
@@ -229,6 +235,20 @@ private:
     IgnoredUtestShell(const IgnoredUtestShell&);
     IgnoredUtestShell& operator=(const IgnoredUtestShell&);
 
+};
+
+////////////////////optRunTest
+class OptRunUtestShell : public IgnoredUtestShell
+{
+public:
+	OptRunUtestShell();
+	virtual ~OptRunUtestShell();
+    explicit OptRunUtestShell(const char* groupName, const char* testName,
+            const char* fileName, int lineNumber);
+    virtual bool willRun() const _override;
+	virtual void runOneTest(TestPlugin* plugin, TestResult& result) _override;
+protected:
+	virtual SimpleString getMacroName() const _override;
 };
 
 //////////////////// TestInstaller

--- a/include/CppUTest/UtestMacros.h
+++ b/include/CppUTest/UtestMacros.h
@@ -83,6 +83,21 @@
    static TestInstaller TEST_##testGroup##testName##_Installer(IGNORE##testGroup##_##testName##_TestShell_instance, #testGroup, #testName, __FILE__,__LINE__); \
     void IGNORE##testGroup##_##testName##_Test::testBodyThatNeverRuns ()
 
+#define OPTRUN_TEST(testGroup, testName)\
+  /* External declarations for strict compilers */ \
+  class OPTRUN##testGroup##_##testName##_TestShell; \
+  extern OPTRUN##testGroup##_##testName##_TestShell OPTRUN##testGroup##_##testName##_TestShell_instance; \
+  \
+  class OPTRUN##testGroup##_##testName##_Test : public TEST_GROUP_##CppUTestGroup##testGroup \
+{ public: OPTRUN##testGroup##_##testName##_Test () : TEST_GROUP_##CppUTestGroup##testGroup () {} \
+  public: void testBody (); }; \
+  class OPTRUN##testGroup##_##testName##_TestShell : public OptRunUtestShell { \
+      virtual Utest* createTest() _override { return new OPTRUN##testGroup##_##testName##_Test; } \
+  } OPTRUN##testGroup##_##testName##_TestShell_instance; \
+   static TestInstaller TEST_##testGroup##testName##_Installer(OPTRUN##testGroup##_##testName##_TestShell_instance, #testGroup, #testName, __FILE__,__LINE__); \
+    void OPTRUN##testGroup##_##testName##_Test::testBody ()
+
+
 #define IMPORT_TEST_GROUP(testGroup) \
   extern int externTestGroup##testGroup;\
   extern int* p##testGroup; \

--- a/src/CppUTest/CommandLineArguments.cpp
+++ b/src/CppUTest/CommandLineArguments.cpp
@@ -30,7 +30,7 @@
 #include "CppUTest/PlatformSpecificFunctions.h"
 
 CommandLineArguments::CommandLineArguments(int ac, const char** av) :
-    ac_(ac), av_(av), verbose_(false), color_(false), runTestsAsSeperateProcess_(false), listTestGroupNames_(false), listTestGroupAndCaseNames_(false), repeat_(1), groupFilters_(NULL), nameFilters_(NULL), outputType_(OUTPUT_ECLIPSE)
+    ac_(ac), av_(av), verbose_(false), color_(false), runTestsAsSeperateProcess_(false), listTestGroupNames_(false), listTestGroupAndCaseNames_(false), isOptRun_(false), repeat_(1), groupFilters_(NULL), nameFilters_(NULL), outputType_(OUTPUT_ECLIPSE)
 {
 }
 
@@ -59,6 +59,7 @@ bool CommandLineArguments::parse(TestPlugin* plugin)
         else if (argument == "-p") runTestsAsSeperateProcess_ = true;
         else if (argument == "-lg") listTestGroupNames_ = true;
         else if (argument == "-ln") listTestGroupAndCaseNames_ = true;
+		else if (argument == "-optRun") isOptRun_ = true;
         else if (argument.startsWith("-r")) SetRepeatCount(ac_, av_, i);
         else if (argument.startsWith("-g")) AddGroupFilter(ac_, av_, i);
         else if (argument.startsWith("-sg")) AddStrictGroupFilter(ac_, av_, i);
@@ -70,6 +71,7 @@ bool CommandLineArguments::parse(TestPlugin* plugin)
         else if (argument.startsWith("-xsn")) AddExcludeStrictNameFilter(ac_, av_, i);
         else if (argument.startsWith("TEST(")) AddTestToRunBasedOnVerboseOutput(ac_, av_, i, "TEST(");
         else if (argument.startsWith("IGNORE_TEST(")) AddTestToRunBasedOnVerboseOutput(ac_, av_, i, "IGNORE_TEST(");
+		else if (argument.startsWith("OPTRUN_TEST(")) AddTestToRunBasedOnVerboseOutput(ac_, av_, i, "OPTRUN_TEST(");
         else if (argument.startsWith("-o")) correctParameters = SetOutputType(ac_, av_, i);
         else if (argument.startsWith("-p")) correctParameters = plugin->parseAllArguments(ac_, av_, i);
         else if (argument.startsWith("-k")) SetPackageName(ac_, av_, i);
@@ -84,7 +86,7 @@ bool CommandLineArguments::parse(TestPlugin* plugin)
 
 const char* CommandLineArguments::usage() const
 {
-    return "usage [-v] [-c] [-p] [-lg] [-ln] [-r#] [-g|sg|xg|xsg groupName]... [-n|sn|xn|xsn testName]... [\"TEST(groupName, testName)\"]... [-o{normal, junit, teamcity}] [-k packageName]\n";
+    return "usage [-v] [-c] [-p] [-lg] [-ln] [-optRun] [-r#] [-g|sg|xg|xsg groupName]... [-n|sn|xn|xsn testName]... [\"TEST(groupName, testName)\"]... [-o{normal, junit, teamcity}] [-k packageName]\n";
 }
 
 bool CommandLineArguments::isVerbose() const
@@ -105,6 +107,11 @@ bool CommandLineArguments::isListingTestGroupNames() const
 bool CommandLineArguments::isListingTestGroupAndCaseNames() const
 {
     return listTestGroupAndCaseNames_;
+}
+
+bool CommandLineArguments::isOptRun() const
+{
+	return isOptRun_;
 }
 
 bool CommandLineArguments::runTestsInSeperateProcess() const

--- a/src/CppUTest/CommandLineTestRunner.cpp
+++ b/src/CppUTest/CommandLineTestRunner.cpp
@@ -88,9 +88,11 @@ void CommandLineTestRunner::initializeTestRun()
 {
     registry_->setGroupFilters(arguments_->getGroupFilters());
     registry_->setNameFilters(arguments_->getNameFilters());
+	
     if (arguments_->isVerbose()) output_->verbose();
     if (arguments_->isColor()) output_->color();
     if (arguments_->runTestsInSeperateProcess()) registry_->setRunTestsInSeperateProcess();
+	if (arguments_->isOptRun()) registry_->setOptRun();
 }
 
 int CommandLineTestRunner::runAllTests()

--- a/src/CppUTest/TestRegistry.cpp
+++ b/src/CppUTest/TestRegistry.cpp
@@ -29,7 +29,7 @@
 #include "CppUTest/TestRegistry.h"
 
 TestRegistry::TestRegistry() :
-    tests_(NULL), nameFilters_(NULL), groupFilters_(NULL), firstPlugin_(NullTestPlugin::instance()), runInSeperateProcess_(false), currentRepetition_(0)
+    tests_(NULL), nameFilters_(NULL), groupFilters_(NULL), firstPlugin_(NullTestPlugin::instance()), runInSeperateProcess_(false), currentRepetition_(0), isOptRun_(false)
 
 {
 }
@@ -50,6 +50,7 @@ void TestRegistry::runAllTests(TestResult& result)
     result.testsStarted();
     for (UtestShell *test = tests_; test != NULL; test = test->getNext()) {
         if (runInSeperateProcess_) test->setRunInSeperateProcess();
+		if (isOptRun_) test->setOptRun();
 
         if (groupStart) {
             result.currentGroupStarted(test);
@@ -159,6 +160,11 @@ void TestRegistry::setNameFilters(const TestFilter* filters)
 void TestRegistry::setGroupFilters(const TestFilter* filters)
 {
     groupFilters_ = filters;
+}
+
+void TestRegistry::setOptRun()
+{
+	isOptRun_ = true;
 }
 
 void TestRegistry::setRunTestsInSeperateProcess()

--- a/src/CppUTest/Utest.cpp
+++ b/src/CppUTest/Utest.cpp
@@ -132,17 +132,17 @@ extern "C" {
 /******************************** */
 
 UtestShell::UtestShell() :
-    group_("UndefinedTestGroup"), name_("UndefinedTest"), file_("UndefinedFile"), lineNumber_(0), next_(NULL), isRunAsSeperateProcess_(false), hasFailed_(false)
+    group_("UndefinedTestGroup"), name_("UndefinedTest"), file_("UndefinedFile"), lineNumber_(0), next_(NULL), isRunAsSeperateProcess_(false), hasFailed_(false), isOptRun_(false)
 {
 }
 
 UtestShell::UtestShell(const char* groupName, const char* testName, const char* fileName, int lineNumber) :
-        group_(groupName), name_(testName), file_(fileName), lineNumber_(lineNumber), next_(NULL), isRunAsSeperateProcess_(false), hasFailed_(false)
+        group_(groupName), name_(testName), file_(fileName), lineNumber_(lineNumber), next_(NULL), isRunAsSeperateProcess_(false), hasFailed_(false), isOptRun_(false)
 {
 }
 
 UtestShell::UtestShell(const char* groupName, const char* testName, const char* fileName, int lineNumber, UtestShell* nextTest) :
-    group_(groupName), name_(testName), file_(fileName), lineNumber_(lineNumber), next_(nextTest), isRunAsSeperateProcess_(false), hasFailed_(false)
+    group_(groupName), name_(testName), file_(fileName), lineNumber_(lineNumber), next_(nextTest), isRunAsSeperateProcess_(false), hasFailed_(false), isOptRun_(false)
 {
 }
 
@@ -264,6 +264,11 @@ bool UtestShell::hasFailed() const
     return hasFailed_;
 }
 
+bool UtestShell::isOptRun() const
+{
+	return isOptRun_; 
+}
+
 void UtestShell::countCheck()
 {
     getTestResult()->countCheck();
@@ -284,6 +289,11 @@ void UtestShell::setRunInSeperateProcess()
     isRunAsSeperateProcess_ = true;
 }
 
+
+void UtestShell::setOptRun()
+{
+	isOptRun_ = true;
+}
 
 void UtestShell::setFileName(const char* fileName)
 {
@@ -674,4 +684,39 @@ TestInstaller::~TestInstaller()
 void TestInstaller::unDo()
 {
     TestRegistry::getCurrentRegistry()->unDoLastAddTest();
+}
+
+OptRunUtestShell::OptRunUtestShell()
+{
+
+}
+OptRunUtestShell::OptRunUtestShell(const char* groupName, const char* testName, const char* fileName, int lineNumber) :
+   IgnoredUtestShell(groupName, testName, fileName, lineNumber)
+{
+}
+
+OptRunUtestShell::~OptRunUtestShell()
+{
+
+}
+bool OptRunUtestShell::willRun() const
+{
+	if (isOptRun()) return UtestShell::willRun();
+
+	return IgnoredUtestShell::willRun();
+}
+
+void OptRunUtestShell::runOneTest(TestPlugin* plugin, TestResult& result)
+{
+	if (isOptRun()) 
+	{		
+		UtestShell::runOneTest(plugin, result);
+		return;
+	}
+	IgnoredUtestShell::runOneTest(plugin, result);
+}
+
+SimpleString OptRunUtestShell::getMacroName() const
+{
+	return "OPTRUN_TEST";
 }

--- a/tests/CommandLineArgumentsTest.cpp
+++ b/tests/CommandLineArgumentsTest.cpp
@@ -302,6 +302,20 @@ TEST(CommandLineArguments, setTestToRunUsingVerboseOutputOfIgnoreTest)
     CHECK_EQUAL(groupFilter, *args->getGroupFilters());
 }
 
+TEST(CommandLineArguments, setTestToRunUsingVerboseOutputOfOptRunTest)
+{
+	int argc = 2;
+	const char* argv[] = { "tests.exe", "OPTRUN_TEST(testgroup, testname) - stuff" };
+	CHECK(newArgumentParser(argc, argv));
+
+	TestFilter nameFilter("testname");
+	TestFilter groupFilter("testgroup");
+	nameFilter.strictMatching();
+	groupFilter.strictMatching();
+	CHECK_EQUAL(nameFilter, *args->getNameFilters());
+	CHECK_EQUAL(groupFilter, *args->getGroupFilters());
+}
+
 TEST(CommandLineArguments, setNormalOutput)
 {
     int argc = 2;
@@ -370,7 +384,7 @@ TEST(CommandLineArguments, weirdParamatersPrintsUsageAndReturnsFalse)
     int argc = 2;
     const char* argv[] = { "tests.exe", "-SomethingWeird" };
     CHECK(!newArgumentParser(argc, argv));
-    STRCMP_EQUAL("usage [-v] [-c] [-p] [-lg] [-ln] [-r#] [-g|sg|xg|xsg groupName]... [-n|sn|xn|xsn testName]... [\"TEST(groupName, testName)\"]... [-o{normal, junit, teamcity}] [-k packageName]\n",
+    STRCMP_EQUAL("usage [-v] [-c] [-p] [-lg] [-ln] [-optRun] [-r#] [-g|sg|xg|xsg groupName]... [-n|sn|xn|xsn testName]... [\"TEST(groupName, testName)\"]... [-o{normal, junit, teamcity}] [-k packageName]\n",
             args->usage());
 }
 
@@ -424,3 +438,12 @@ TEST(CommandLineArguments, lastParameterFieldMissing)
     CHECK(newArgumentParser(argc, argv));
     CHECK_EQUAL(SimpleString(""), args->getPackageName());
 }
+
+TEST(CommandLineArguments, setOptRun)
+{
+    int argc = 2;
+    const char* argv[] = { "tests.exe", "-optRun"};
+    CHECK(newArgumentParser(argc, argv));
+    CHECK(args->isOptRun());
+}
+

--- a/tests/TestUTestMacro.cpp
+++ b/tests/TestUTestMacro.cpp
@@ -1362,4 +1362,37 @@ TEST(IgnoreTest, printsIGNORE_TESTwhenVerbose)
     fixture.assertPrintContains("IGNORE_TEST");
 }
 
+TEST_GROUP(OptRunTest)
+{
+    TestTestingFixture fixture;
+    OptRunUtestShell optRunTest;
+
+    void setup() _override
+    {
+        fixture.addTest(&optRunTest);
+    }
+};
+
+TEST(OptRunTest, optRunOptionSpecifiedThenIncreaseRunCount)
+{
+    optRunTest.setOptRun();
+    fixture.runAllTests();
+    LONGS_EQUAL(2, fixture.getRunCount());
+    LONGS_EQUAL(0, fixture.getIgnoreCount());
+};
+
+TEST(OptRunTest, optRunOptionNotSpecifiedThenIncreaseIgnoredCount)
+{
+    fixture.runAllTests();
+    LONGS_EQUAL(1, fixture.getRunCount());
+    LONGS_EQUAL(1, fixture.getIgnoreCount());
+};
+
+TEST(OptRunTest, printsOPTRUN_TESTwhenVerbose)
+{
+	fixture.output_->verbose();
+	fixture.runAllTests();
+	fixture.assertPrintContains("OPTRUN_TEST");
+}
+
 


### PR DESCRIPTION
this idea is originated from @PaulBussmann, I have this try since Paul seem busy. 

After discuss, it is more reasonable to add one command line to let the `OPTRUN_TEST` get run.

I  currently prefer `OPTRUN_TEST` rather than `OPTIN_TEST` because I think there should only be two possibility, get run then run counted, or get ignored then ignore counted. so, optional run by specifying the command line option `-optRun`

