### PR TITLE
Appveyor cleanup

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ environment:
     PlatformToolset: v140
 
 install:
-- ps: if ($env:PlatformToolset -like 'MinGW*') { choco install mingw --version $env:PlatformToolset $( if ($env:Platform -eq 'MinGW32') { Write-Output -forcex86 } ) | Out-Null }
+- ps: if ($env:Platform -like 'MinGW*') { choco install mingw --version $env:PlatformToolset $( if ($env:Platform -like '*32') { Write-Output -forcex86 } ) | Out-Null }
 
 build_script:
 - ps: scripts\appveyor_ci_build.ps1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,6 @@
 version: 3.7.0-ci{build}
 
-os:
-- Windows Server 2012 R2
+image: Visual Studio 2013
 
 environment:
   Configuration: Release

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: 3.7.0-ci{build}
 
-image: Visual Studio 2013
+image: Visual Studio 2015
 
 environment:
   Configuration: Release
@@ -18,6 +18,8 @@ environment:
     PlatformToolset: v90
   - Platform: Win32
     PlatformToolset: v100
+  - Platform: Win32
+    PlatformToolset: v140
 
 install:
 - ps: if ($env:Platform -like 'MinGW*') { choco install mingw --version $env:PlatformToolset $( if ($env:Platform -like '*32') { Write-Output -forcex86 } ) | Out-Null }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ os:
 environment:
   matrix:
   - PlatformToolset: Cygwin
+    Platform: x86
   - PlatformToolset: MinGW
     Platform: Win32
     Version: 4.8.5
@@ -19,8 +20,14 @@ environment:
     Platform: x64
     Version: 5.3.0
   - PlatformToolset: v90
+    Platform: Win32
+    Configuration: Release
   - PlatformToolset: v100
+    Platform: Win32
+    Configuration: Release
   - PlatformToolset: v140
+    Platform: Win32
+    Configuration: Release
 
 install:
 - ps: if ($env:PlatformToolset -eq 'MinGW') { choco install mingw --version $env:Version $( if ($env:Platform -eq 'Win32') { Write-Output -forcex86 } ) | Out-Null }
@@ -36,6 +43,3 @@ artifacts:
 - path: lib\CppUTest.lib
   name: CppUTest
 
-# Other configuration options
-platform: Win32
-configuration: Release

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,7 @@ os:
 - Windows Server 2012 R2
 
 environment:
+  Configuration: Release
   matrix:
   - Platform: Cygwin32
   - Platform: MinGW32

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,6 +20,7 @@ environment:
     Version: 5.3.0
   - PlatformToolset: v90
   - PlatformToolset: v100
+  - PlatformToolset: v140
 
 install:
 - ps: if ($env:PlatformToolset -eq 'MinGW') { choco install mingw --version $env:Version $( if ($env:Platform -eq 'Win32') { Write-Output -forcex86 } ) | Out-Null }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,8 +18,6 @@ environment:
     PlatformToolset: v90
   - Platform: Win32
     PlatformToolset: v100
-  - Platform: Win32
-    PlatformToolset: v140
 
 install:
 - ps: if ($env:Platform -like 'MinGW*') { choco install mingw --version $env:PlatformToolset $( if ($env:Platform -like '*32') { Write-Output -forcex86 } ) | Out-Null }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,33 +5,24 @@ os:
 
 environment:
   matrix:
-  - PlatformToolset: Cygwin
-    Platform: x86
-  - PlatformToolset: MinGW
-    Platform: Win32
-    Version: 4.8.5
-  - PlatformToolset: MinGW
-    Platform: x64
-    Version: 4.8.5
-  - PlatformToolset: MinGW
-    Platform: Win32
-    Version: 5.3.0
-  - PlatformToolset: MinGW
-    Platform: x64
-    Version: 5.3.0
-  - PlatformToolset: v90
-    Platform: Win32
-    Configuration: Release
-  - PlatformToolset: v100
-    Platform: Win32
-    Configuration: Release
-  - PlatformToolset: v140
-    Platform: Win32
-    Configuration: Release
+  - Platform: Cygwin32
+  - Platform: MinGW32
+    PlatformToolset: 4.8.5
+  - Platform: MinGW64
+    PlatformToolset: 4.8.5
+  - Platform: MinGW32
+    PlatformToolset: 5.3.0
+  - Platform: MinGW64
+    PlatformToolset: 5.3.0
+  - Platform: Win32
+    PlatformToolset: v90
+  - Platform: Win32
+    PlatformToolset: v100
+  - Platform: Win32
+    PlatformToolset: v140
 
 install:
-- ps: if ($env:PlatformToolset -eq 'MinGW') { choco install mingw --version $env:Version $( if ($env:Platform -eq 'Win32') { Write-Output -forcex86 } ) | Out-Null }
-- ps: if ($env:PlatformToolset -eq 'Cygwin') { (New-Object System.Net.WebClient).DownloadFile('https://cygwin.com/setup-x86.exe', "${env:TEMP}\cygwin-setup.exe") ; . "${env:TEMP}\cygwin-setup.exe" --quiet-mode --packages autoconf automake make gcc-core libtool gcc-g++ }
+- ps: if ($env:PlatformToolset -like 'MinGW*') { choco install mingw --version $env:PlatformToolset $( if ($env:Platform -eq 'MinGW32') { Write-Output -forcex86 } ) | Out-Null }
 
 build_script:
 - ps: scripts\appveyor_ci_build.ps1
@@ -42,4 +33,3 @@ test_script:
 artifacts:
 - path: lib\CppUTest.lib
   name: CppUTest
-

--- a/scripts/appveyor_ci_build.ps1
+++ b/scripts/appveyor_ci_build.ps1
@@ -145,6 +145,7 @@ if ($env:PlatformToolset -eq 'MinGW')
     Remove-PathFolder "C:\Program Files\Git\usr\bin"
     Remove-PathFolder "C:\Program Files (x86)\Git\bin"
     Remove-PathFolder "C:\Program Files (x86)\Git\cmd"
+    Remove-PathFolder "C:\Program Files (x86)\Git\usr\bin"
 
     # Add mingw to the path
     Add-PathFolder $mingw_path

--- a/scripts/appveyor_ci_build.ps1
+++ b/scripts/appveyor_ci_build.ps1
@@ -101,7 +101,7 @@ switch -Wildcard ($env:Platform)
         else
         {
             $VS2010ProjectFiles | foreach {
-                Invoke-BuildCommand "msbuild /ToolsVersion:14.0 $logger_arg $_"
+                Invoke-BuildCommand "msbuild /ToolsVersion:12.0 $logger_arg $_"
             }
         }
     }

--- a/scripts/appveyor_ci_build.ps1
+++ b/scripts/appveyor_ci_build.ps1
@@ -26,9 +26,9 @@ function Invoke-CygwinCommand($command, $directory = '.')
     $cygwin_bin = Get-CygwinBin
 
     $cygwin_directory = (. "${cygwin_bin}\cygpath.exe" (Resolve-Path $directory))
-    $command_wrapped = "${cygwin_bin}\bash.exe --login -c 'cd $cygwin_directory ; $command' ; `$err = `$?"
+    $command_wrapped = "${cygwin_bin}\bash.exe --login -c 'cd $cygwin_directory ; $command'"
     
-    Write-Host $command
+    Write-Host "Executing <$command> in <$cygwin_directory>"
     Invoke-Expression $command_wrapped
 
     if ($LASTEXITCODE -ne 0)
@@ -64,7 +64,9 @@ switch -Wildcard ($env:Platform)
 {
     'Cygwin*'
     {
-        Invoke-CygwinCommand "autoreconf -i .. ; ../configure ; make CppUTestTests.exe CppUTestExtTests.exe" "cpputest_build"
+        Invoke-CygwinCommand "autoreconf -i .." "cpputest_build"
+        Invoke-CygwinCommand "../configure" "cpputest_build"
+        Invoke-CygwinCommand "make CppUTestTests.exe CppUTestExtTests.exe" "cpputest_build"
     }
 
     'MinGW*'

--- a/scripts/appveyor_ci_build.ps1
+++ b/scripts/appveyor_ci_build.ps1
@@ -22,8 +22,9 @@ function Invoke-BuildCommand($command, $directory = '.')
 
 function Invoke-CygwinCommand($command, $directory = '.')
 {
-    # Assume cygwin is located at C:\cygwin for now
-    $cygwin_bin = "C:\cygwin\bin"
+    # Assume cygwin is located at C:\cygwin on x86 and C:\cygwin64 on x64 for now
+    $cygwin_bin = Get-CygwinBin
+
     $cygwin_directory = (. "${cygwin_bin}\cygpath.exe" (Resolve-Path $directory))
     $command_wrapped = "${cygwin_bin}\bash.exe --login -c 'cd $cygwin_directory ; $command' ; `$err = `$?"
     
@@ -68,11 +69,7 @@ switch ($env:PlatformToolset)
 
     'MinGW'
     {
-        $mingw_path = 'C:\Tools\mingw32\bin'
-        if ($env:Platform -eq 'x64')
-        {
-            $mingw_path = 'C:\Tools\mingw64\bin'
-        }
+        $mingw_path = Get-MinGWBin
 
         # Add mingw to the path
         Add-PathFolder $mingw_path

--- a/scripts/appveyor_ci_build.ps1
+++ b/scripts/appveyor_ci_build.ps1
@@ -101,7 +101,7 @@ switch -Wildcard ($env:Platform)
         else
         {
             $VS2010ProjectFiles | foreach {
-                Invoke-BuildCommand "msbuild /ToolsVersion:12.0 $logger_arg $_"
+                Invoke-BuildCommand "msbuild /ToolsVersion:14.0 $logger_arg $_"
             }
         }
     }

--- a/scripts/appveyor_ci_build.ps1
+++ b/scripts/appveyor_ci_build.ps1
@@ -100,7 +100,7 @@ switch ($env:PlatformToolset)
     default   # Mainly for v100, should also support anything newer I think
     {
         $VS2010ProjectFiles | foreach {
-            Invoke-BuildCommand "msbuild $logger_arg $_"
+            Invoke-BuildCommand "msbuild /ToolsVersion:14.0 $logger_arg $_"
         }
     }
 }

--- a/scripts/appveyor_ci_build.ps1
+++ b/scripts/appveyor_ci_build.ps1
@@ -1,12 +1,6 @@
 ﻿
-# Helper function to extract vars out of the vsvars batch file
-function Get-Batchfile ($file) {
-    $cmd = "`"$file`" & set"
-    cmd /c $cmd | Foreach-Object {
-        $p, $v = $_.split('=')
-        Set-Item -path env:$p -value $v
-    }
-}
+# Load functions from the helper file
+. (Join-Path (Split-Path $MyInvocation.MyCommand.Path) 'appveyor_helpers.ps1')
 
 function Invoke-BuildCommand($command, $directory = '.')
 {
@@ -40,52 +34,6 @@ function Invoke-CygwinCommand($command, $directory = '.')
     {
         Write-Host "Command Returned error: $LASTEXITCODE"
         Exit $LASTEXITCODE
-    }
-}
-
-function Remove-PathFolder($folder)
-{
-    [System.Collections.ArrayList]$pathFolders = New-Object System.Collections.ArrayList
-    $env:Path -split ";" | foreach { $pathFolders.Add($_) | Out-Null }
-
-    for ([int]$i = 0; $i -lt $pathFolders.Count; $i++)
-    {
-        if ([string]::Compare($pathFolders[$i], $folder, $true) -eq 0)
-        {
-            Write-Host "Removing $folder from the PATH"
-            $pathFolders.RemoveAt($i)
-            $i--
-        }
-    }
-
-    $env:Path = $pathFolders -join ";"
-}
-
-function Add-PathFolder($folder)
-{
-    if (-not (Test-Path $folder))
-    {
-        Write-Host "Not adding $folder to the PATH, it does not exist"
-    }
-
-    [bool]$alreadyInPath = $false
-    [System.Collections.ArrayList]$pathFolders = New-Object System.Collections.ArrayList
-    $env:Path -split ";" | foreach { $pathFolders.Add($_) | Out-Null }
-
-    for ([int]$i = 0; $i -lt $pathFolders.Count; $i++)
-    {
-        if ([string]::Compare($pathFolders[$i], $folder, $true) -eq 0)
-        {
-            $alreadyInPath = $true
-            break
-        }
-    }
-
-    if (-not $alreadyInPath)
-    {
-        Write-Host "Adding $folder to the PATH"
-        $pathFolders.Insert(0, $folder)
-        $env:Path = $pathFolders -join ";"
     }
 }
 

--- a/scripts/appveyor_ci_test.ps1
+++ b/scripts/appveyor_ci_test.ps1
@@ -58,6 +58,30 @@ function Invoke-CygwinTests($executable)
     Invoke-Expression $cygwin_command
 }
 
+$TestCount = 0
+
+if (-not $env:APPVEYOR)
+{
+    function Add-AppVeyorTest()
+    {
+        # Wacky way to access a script variable, but it works
+        $count = Get-Variable -Name TestCount -Scope script
+        Set-Variable -Name TestCount -Scope script -Value ($count.Value + 1)
+    }
+
+    function Add-AppVeyorMessage($Message, $Category)
+    {
+        if ($Category -eq 'Error')
+        {
+            Write-Error $Message
+        }
+        else
+        {
+            Write-Host $Message
+        }
+    }
+}
+
 switch ($env:PlatformToolset)
 {
     'Cygwin'
@@ -87,3 +111,8 @@ switch ($env:PlatformToolset)
 }
 
 Publish-TestResults (Get-ChildItem 'cpputest_*.xml')
+
+if (-not $env:APPVEYOR)
+{
+    Write-Host "Tests Ran: $TestCount"
+}

--- a/scripts/appveyor_ci_test.ps1
+++ b/scripts/appveyor_ci_test.ps1
@@ -82,15 +82,15 @@ if (-not $env:APPVEYOR)
     }
 }
 
-switch ($env:PlatformToolset)
+switch -Wildcard ($env:Platform)
 {
-    'Cygwin'
+    'Cygwin*'
     {
         Invoke-CygwinTests 'cpputest_build\CppUTestTests.exe'
         Invoke-CygwinTests 'cpputest_build\CppUTestExtTests.exe'
     }
 
-    'MinGW'
+    'MinGW*'
     {
         $mingw_path = Get-MinGWBin
 

--- a/scripts/appveyor_ci_test.ps1
+++ b/scripts/appveyor_ci_test.ps1
@@ -1,4 +1,6 @@
 ﻿
+# Load functions from the helper file
+. (Join-Path (Split-Path $MyInvocation.MyCommand.Path) 'appveyor_helpers.ps1')
 
 function Publish-TestResults($files)
 {
@@ -54,52 +56,6 @@ function Invoke-CygwinTests($executable)
 
     Write-Host $test_command
     Invoke-Expression $cygwin_command
-}
-
-function Remove-PathFolder($folder)
-{
-    [System.Collections.ArrayList]$pathFolders = New-Object System.Collections.ArrayList
-    $env:Path -split ";" | foreach { $pathFolders.Add($_) | Out-Null }
-
-    for ([int]$i = 0; $i -lt $pathFolders.Count; $i++)
-    {
-        if ([string]::Compare($pathFolders[$i], $folder, $true) -eq 0)
-        {
-            Write-Host "Removing $folder from the PATH"
-            $pathFolders.RemoveAt($i)
-            $i--
-        }
-    }
-
-    $env:Path = $pathFolders -join ";"
-}
-
-function Add-PathFolder($folder)
-{
-    if (-not (Test-Path $folder))
-    {
-        Write-Host "Not adding $folder to the PATH, it does not exist"
-    }
-
-    [bool]$alreadyInPath = $false
-    [System.Collections.ArrayList]$pathFolders = New-Object System.Collections.ArrayList
-    $env:Path -split ";" | foreach { $pathFolders.Add($_) | Out-Null }
-
-    for ([int]$i = 0; $i -lt $pathFolders.Count; $i++)
-    {
-        if ([string]::Compare($pathFolders[$i], $folder, $true) -eq 0)
-        {
-            $alreadyInPath = $true
-            break
-        }
-    }
-
-    if (-not $alreadyInPath)
-    {
-        Write-Host "Adding $folder to the PATH"
-        $pathFolders.Insert(0, $folder)
-        $env:Path = $pathFolders -join ";"
-    }
 }
 
 switch ($env:PlatformToolset)

--- a/scripts/appveyor_ci_test.ps1
+++ b/scripts/appveyor_ci_test.ps1
@@ -44,7 +44,7 @@ function Invoke-Tests($executable)
 function Invoke-CygwinTests($executable)
 {
     # Assume cygwin is located at C:\cygwin for now
-    $cygwin_bin = "C:\cygwin\bin"
+    $cygwin_bin = Get-CygwinBin
 
     # Get the full path to the executable
     $cygwin_folder = . "${cygwin_bin}\cygpath.exe" (Resolve-Path ".")
@@ -92,11 +92,7 @@ switch ($env:PlatformToolset)
 
     'MinGW'
     {
-        $mingw_path = 'C:\Tools\mingw32\bin'
-        if ($env:Platform -eq 'x64')
-        {
-            $mingw_path = 'C:\Tools\mingw64\bin'
-        }
+        $mingw_path = Get-MinGWBin
 
         Add-PathFolder $mingw_path
         Invoke-Tests '.\cpputest_build\tests\CppUTestTests.exe'

--- a/scripts/appveyor_helpers.ps1
+++ b/scripts/appveyor_helpers.ps1
@@ -8,6 +8,26 @@ function Get-Batchfile ($file) {
     }
 }
 
+# Helper function to provide the bin-folder path to mingw
+function Get-MinGWBin() {
+    if ($env:Platform -eq 'x64') {
+        Write-Output 'C:\Tools\mingw64\bin'
+    }
+    else {
+        Write-Output 'C:\Tools\mingw32\bin'
+    }
+}
+
+# Helper function to provide the bin-folder path to cygwin
+function Get-CygwinBin() {
+    if ($env:Platform -eq 'x64') {
+        Write-Output 'C:\cygwin64\bin'
+    }
+    else {
+        Write-Output 'C:\cygwin\bin'
+    }
+}
+
 function Add-PathFolder($folder)
 {
     if (-not (Test-Path $folder))

--- a/scripts/appveyor_helpers.ps1
+++ b/scripts/appveyor_helpers.ps1
@@ -10,7 +10,7 @@ function Get-Batchfile ($file) {
 
 # Helper function to provide the bin-folder path to mingw
 function Get-MinGWBin() {
-    if ($env:Platform -eq 'x64') {
+    if ($env:Platform -like '*64') {
         Write-Output 'C:\Tools\mingw64\bin'
     }
     else {
@@ -20,7 +20,7 @@ function Get-MinGWBin() {
 
 # Helper function to provide the bin-folder path to cygwin
 function Get-CygwinBin() {
-    if ($env:Platform -eq 'x64') {
+    if ($env:Platform -like '*64') {
         Write-Output 'C:\cygwin64\bin'
     }
     else {

--- a/scripts/appveyor_helpers.ps1
+++ b/scripts/appveyor_helpers.ps1
@@ -1,0 +1,56 @@
+﻿
+# Helper function to extract vars out of the vsvars batch file
+function Get-Batchfile ($file) {
+    $cmd = "`"$file`" & set"
+    cmd /c $cmd | Foreach-Object {
+        $p, $v = $_.split('=')
+        Set-Item -path env:$p -value $v
+    }
+}
+
+function Add-PathFolder($folder)
+{
+    if (-not (Test-Path $folder))
+    {
+        Write-Host "Not adding $folder to the PATH, it does not exist"
+    }
+
+    [bool]$alreadyInPath = $false
+    [System.Collections.ArrayList]$pathFolders = New-Object System.Collections.ArrayList
+    $env:Path -split ";" | foreach { $pathFolders.Add($_) | Out-Null }
+
+    for ([int]$i = 0; $i -lt $pathFolders.Count; $i++)
+    {
+        if ([string]::Compare($pathFolders[$i], $folder, $true) -eq 0)
+        {
+            $alreadyInPath = $true
+            break
+        }
+    }
+
+    if (-not $alreadyInPath)
+    {
+        Write-Host "Adding $folder to the PATH"
+        $pathFolders.Insert(0, $folder)
+        $env:Path = $pathFolders -join ";"
+    }
+}
+
+function Remove-PathFolder($folder)
+{
+    [System.Collections.ArrayList]$pathFolders = New-Object System.Collections.ArrayList
+    $env:Path -split ";" | foreach { $pathFolders.Add($_) | Out-Null }
+
+    for ([int]$i = 0; $i -lt $pathFolders.Count; $i++)
+    {
+        if ([string]::Compare($pathFolders[$i], $folder, $true) -eq 0)
+        {
+            Write-Host "Removing $folder from the PATH"
+            $pathFolders.RemoveAt($i)
+            $i--
+        }
+    }
+
+    $env:Path = $pathFolders -join ";"
+}
+


### PR DESCRIPTION
Includes a fix to keep Cygwin working for now.  For some reason it doesn't work on the VS2015 image correctly so can't build with the latest version of visual studio (not that such a configuration was in use anyways).

Also includes a fair amount of cleanup and restructuring of the appveyor scripts to try and reduce the amount of duplication in them and have the variables be more consistent across the different configurations.  Basically, MinGW and Cygwin are now seen as platforms the same as Win32 or x64 is.  PlatformToolset is only to determine the version of the compiler to use.