### PR TITLE
Fix CMake absolute paths when CppUTest is nested.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ include("${CppUTestRootDirectory}/cmake/Modules/CppUTestConfigurationOptions.cma
 include(CTest)
 #include("${CppUTestRootDirectory}/cmake/Modules/CheckFunctionExists.cmake")
 include("${CppUTestRootDirectory}/cmake/Modules/CppUTestBuildTimeDiscoverTests.cmake")
-include("${CppUTestRootDirectory}/cmake/Modules/CppUTestSetTestOutputLocation.cmake")
+include("${CppUTestRootDirectory}/cmake/Modules/CppUTestNormalizeTestOutputLocation.cmake")
 
 configure_file (
     "${PROJECT_SOURCE_DIR}/config.h.cmake"

--- a/cmake/Modules/CppUTestNormalizeTestOutputLocation.cmake
+++ b/cmake/Modules/CppUTestNormalizeTestOutputLocation.cmake
@@ -1,10 +1,10 @@
 # Override output properties to put test executable at specificied location
-function (cpputest_set_test_output_location TEST_TARGET OUTPUT_LOCATION)
-    set_target_properties(${TEST_TARGET} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${OUTPUT_LOCATION})
+function (cpputest_normalize_test_output_location TEST_TARGET)
+    set_target_properties(${TEST_TARGET} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
     foreach(OUTPUT_CONFIG ${CMAKE_CONFIGURATION_TYPES})
         string(TOUPPER ${OUTPUT_CONFIG} OUTPUT_CONFIG)
         set_target_properties(${TEST_TARGET} PROPERTIES
-                              RUNTIME_OUTPUT_DIRECTORY_${OUTPUT_CONFIG} ${OUTPUT_LOCATION})
+                              RUNTIME_OUTPUT_DIRECTORY_${OUTPUT_CONFIG} ${CMAKE_CURRENT_BINARY_DIR})
     endforeach(OUTPUT_CONFIG)
 endfunction ()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -51,7 +51,7 @@ if (${CMAKE_HOST_SYSTEM_NAME} MATCHES "OpenBSD")
 endif ()
 
 add_executable(CppUTestTests ${CppUTestTests_src})
-cpputest_set_test_output_location(CppUTestTests "${CMAKE_BINARY_DIR}/tests")
+cpputest_normalize_test_output_location(CppUTestTests)
 target_link_libraries(CppUTestTests CppUTest ${THREAD_LIB})
 
 add_subdirectory(CppUTestExt)

--- a/tests/CppUTestExt/CMakeLists.txt
+++ b/tests/CppUTestExt/CMakeLists.txt
@@ -34,6 +34,6 @@ if (MINGW)
 endif (MINGW)
 
 add_executable(CppUTestExtTests ${CppUTestExtTests_src})
-cpputest_set_test_output_location(CppUTestExtTests "${CMAKE_BINARY_DIR}/tests/CppUTestExt")
+cpputest_normalize_test_output_location(CppUTestExtTests)
 target_link_libraries(CppUTestExtTests CppUTest CppUTestExt ${THREAD_LIB} ${CPPUNIT_EXTERNAL_LIBRARIES})
 cpputest_buildtime_discover_tests(CppUTestExtTests)


### PR DESCRIPTION
A previous 'fix' of mine has CMake hard-coding CppUTest test executables to "${CMAKE_BINARY_DIR}/tests". That's ok when CppUTest is built as the CMake root, but when CppUTest is a component in a more complex project, that path is no longer correct.

This PR changes `cpputest_set_test_output_location` to `cpputest_normalize_test_output_location`, and no longer takes an output path. Instead, the new function simply pushes ${CMAKE_CURRENT_BINARY_DIR} as the build target for all configuration variants, which was the intent of my original clumsy PR.

This is still a WIP so that @jerryryle can see it, please don't merge yet!