### PR TITLE
CMake provide cpputest_buildtime_discover_tests to clients of the CppUTest libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,10 @@ if(PkgHelpers_AVAILABLE)
     DESTINATION ${LIB_INSTALL_DIR}/CppUTest/cmake )
   install(EXPORT CppUTestTargets
     DESTINATION ${LIB_INSTALL_DIR}/CppUTest/cmake)
+  install(FILES  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Scripts/CppUTestBuildTimeDiscoverTests.cmake
+    DESTINATION ${LIB_INSTALL_DIR}/CppUTest/cmake/Scripts)
+  install(FILES  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/CppUTestBuildTimeDiscoverTests.cmake
+    DESTINATION ${LIB_INSTALL_DIR}/CppUTest/cmake/Modules)
   configure_package_config_file(CppUTestConfig.cmake.build.in
     ${CMAKE_CURRENT_BINARY_DIR}/CppUTestConfig.cmake
     INSTALL_DESTINATION ${CMAKE_CURRENT_BINARY_DIR}

--- a/CppUTestConfig.cmake.install.in
+++ b/CppUTestConfig.cmake.install.in
@@ -3,5 +3,6 @@
 set_and_check(CppUTest_INCLUDE_DIRS "@PACKAGE_INCLUDE_INSTALL_DIR@")
 include("${CMAKE_CURRENT_LIST_DIR}/CppUTestTargets.cmake")
 set(CppUTest_LIBRARIES CppUTest CppUTestExt)
+include("${CMAKE_CURRENT_LIST_DIR}/Modules/CppUTestBuildTimeDiscoverTests.cmake")
 
 check_required_components(CppUTest)

--- a/cmake/Modules/CppUTestBuildTimeDiscoverTests.cmake
+++ b/cmake/Modules/CppUTestBuildTimeDiscoverTests.cmake
@@ -1,9 +1,18 @@
 # Create target to discover tests
 function (cpputest_buildtime_discover_tests EXECUTABLE)
+    # The that to the discover script depends execution mode:
+    # - imported (installed, imported, and executed by a client of the CppUTest lib) or
+    # - internal (building CppUTest it self).
+    if (CppUTest_DIR) # Installed (path is relative to install directory)
+        SET(DISCOVER_SCRIPT ${CppUTest_DIR}/Scripts/CppUTestBuildTimeDiscoverTests.cmake)
+    else (CppUTest_DIR) # internal - (path is relative to source dir)
+        SET(DISCOVER_SCRIPT ${PROJECT_SOURCE_DIR}/cmake/Scripts/CppUTestBuildTimeDiscoverTests.cmake)
+    endif (CppUTest_DIR)
+
     add_custom_command (TARGET ${EXECUTABLE}
-			POST_BUILD
-			COMMAND ${CMAKE_COMMAND} -DTESTS_DETAILED:BOOL=${TESTS_DETAILED} -DEXECUTABLE=${EXECUTABLE} -P ${PROJECT_SOURCE_DIR}/cmake/Scripts/CppUTestBuildTimeDiscoverTests.cmake
-			WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+                        POST_BUILD
+                        COMMAND ${CMAKE_COMMAND} -DTESTS_DETAILED:BOOL=${TESTS_DETAILED} -DEXECUTABLE=${EXECUTABLE} -P ${DISCOVER_SCRIPT}
+                        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 			COMMENT "Discovering Tests in ${EXECUTABLE}"
 			VERBATIM)
 endfunction ()

--- a/src/CppUTest/CMakeLists.txt
+++ b/src/CppUTest/CMakeLists.txt
@@ -19,39 +19,17 @@ set(CppUTest_src
         ../Platforms/${CPP_PLATFORM}/UtestPlatform.cpp
 )
 
-set(CppUTest_headers
-        ${CppUTestRootDirectory}/include/CppUTest/CommandLineArguments.h
-        ${CppUTestRootDirectory}/include/CppUTest/PlatformSpecificFunctions.h
-        ${CppUTestRootDirectory}/include/CppUTest/TestMemoryAllocator.h
-        ${CppUTestRootDirectory}/include/CppUTest/CommandLineTestRunner.h
-        ${CppUTestRootDirectory}/include/CppUTest/PlatformSpecificFunctions_c.h
-        ${CppUTestRootDirectory}/include/CppUTest/TestOutput.h
-        ${CppUTestRootDirectory}/include/CppUTest/CppUTestConfig.h
-        ${CppUTestRootDirectory}/include/CppUTest/SimpleString.h
-        ${CppUTestRootDirectory}/include/CppUTest/TestPlugin.h
-        ${CppUTestRootDirectory}/include/CppUTest/JUnitTestOutput.h
-        ${CppUTestRootDirectory}/include/CppUTest/TeamCityTestOutput.h
-        ${CppUTestRootDirectory}/include/CppUTest/StandardCLibrary.h
-        ${CppUTestRootDirectory}/include/CppUTest/TestRegistry.h
-        ${CppUTestRootDirectory}/include/CppUTest/MemoryLeakDetector.h
-        ${CppUTestRootDirectory}/include/CppUTest/TestFailure.h
-        ${CppUTestRootDirectory}/include/CppUTest/TestResult.h
-        ${CppUTestRootDirectory}/include/CppUTest/MemoryLeakDetectorMallocMacros.h
-        ${CppUTestRootDirectory}/include/CppUTest/TestFilter.h
-        ${CppUTestRootDirectory}/include/CppUTest/TestTestingFixture.h
-        ${CppUTestRootDirectory}/include/CppUTest/MemoryLeakDetectorNewMacros.h
-        ${CppUTestRootDirectory}/include/CppUTest/TestHarness.h
-        ${CppUTestRootDirectory}/include/CppUTest/Utest.h
-        ${CppUTestRootDirectory}/include/CppUTest/MemoryLeakWarningPlugin.h
-        ${CppUTestRootDirectory}/include/CppUTest/TestHarness_c.h
-        ${CppUTestRootDirectory}/include/CppUTest/UtestMacros.h
-)
-
-add_library(CppUTest STATIC ${CppUTest_src} ${CppUTest_headers})
+add_library(CppUTest STATIC ${CppUTest_src})
 if (WIN32)
     target_link_libraries(CppUTest winmm.lib)
 endif (WIN32)
-install(FILES ${CppUTest_headers} DESTINATION include/CppUTest)
+
+target_include_directories(CppUTest PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include/CppUTest>
+    $<INSTALL_INTERFACE:include>
+    )
+
+install(DIRECTORY ${CppUTestRootDirectory}/include/CppUTest DESTINATION include)
 install(TARGETS CppUTest
     EXPORT CppUTestTargets
     RUNTIME DESTINATION bin

--- a/src/CppUTestExt/CMakeLists.txt
+++ b/src/CppUTestExt/CMakeLists.txt
@@ -15,32 +15,15 @@ set(CppUTestExt_src
         MockSupport.cpp
 )
 
-set(CppUTestExt_headers
-        ${CppUTestRootDirectory}/include/CppUTestExt/CodeMemoryReportFormatter.h
-        ${CppUTestRootDirectory}/include/CppUTestExt/IEEE754ExceptionsPlugin.h
-        ${CppUTestRootDirectory}/include/CppUTestExt/MemoryReportAllocator.h
-        ${CppUTestRootDirectory}/include/CppUTestExt/MockExpectedCall.h
-        ${CppUTestRootDirectory}/include/CppUTestExt/MockCheckedExpectedCall.h
-        ${CppUTestRootDirectory}/include/CppUTestExt/MockExpectedCallsList.h
-        ${CppUTestRootDirectory}/include/CppUTestExt/MockSupportPlugin.h
-        ${CppUTestRootDirectory}/include/CppUTestExt/MemoryReportFormatter.h
-        ${CppUTestRootDirectory}/include/CppUTestExt/MockFailure.h
-        ${CppUTestRootDirectory}/include/CppUTestExt/MockSupport.h
-        ${CppUTestRootDirectory}/include/CppUTestExt/MockSupport_c.h
-        ${CppUTestRootDirectory}/include/CppUTestExt/GMock.h
-        ${CppUTestRootDirectory}/include/CppUTestExt/GTest.h
-        ${CppUTestRootDirectory}/include/CppUTestExt/MemoryReporterPlugin.h
-        ${CppUTestRootDirectory}/include/CppUTestExt/OrderedTest.h
-        ${CppUTestRootDirectory}/include/CppUTestExt/GTestConvertor.h
-        ${CppUTestRootDirectory}/include/CppUTestExt/MockActualCall.h
-        ${CppUTestRootDirectory}/include/CppUTestExt/MockCheckedActualCall.h
-        ${CppUTestRootDirectory}/include/CppUTestExt/MockNamedValue.h
-        ${CppUTestRootDirectory}/include/CppUTestExt/MockSupport.h
-)
-
-add_library(CppUTestExt STATIC ${CppUTestExt_src} ${CppUTestExt_headers})
+add_library(CppUTestExt STATIC ${CppUTestExt_src})
 target_link_libraries(CppUTestExt ${CPPUNIT_EXTERNAL_LIBRARIES})
-install(FILES ${CppUTestExt_headers} DESTINATION include/CppUTestExt)
+
+target_include_directories(CppUTestExt PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include/CppUTestExt>
+    $<INSTALL_INTERFACE:include>
+    )
+
+install(DIRECTORY ${CppUTestRootDirectory}/include/CppUTestExt DESTINATION include)
 install(TARGETS CppUTestExt
     EXPORT CppUTestTargets
     RUNTIME DESTINATION bin


### PR DESCRIPTION
There are two part to this pull request

1) Current cmake builds of CppUTest use the function cpputest_buildtime_discover_tests. This pull request makes the  cpputest_buildtime_discover_tests available to projects using CppUTest as an installed lib.

2) Now all include files under include/CppUTest and include/CppUTestExt are installed.
The include paths are also automatically add to the include paths of the lib clients.
Before SimpleMutex.h was not in the install list of include/CppUTest.
Before MockSupport.h was included twice in the install list of include/CppUTestExt.
