### PR TITLE
Cmake auto set include path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: cpp
 sudo: false
+addons:
+  apt:
+    sources: ['kubuntu-backports']
+    packages: ['cmake']
 matrix:
     include:
     - compiler: clang
@@ -38,10 +42,6 @@ matrix:
           - dosbox
 global:
 - os: linux
-  addons:
-    apt:
-      sources: ['kalakris-cmake']
-      packages: ['cmake']
 - rvm: '1.9.3'
 - secure: |-
     P05xUfJVw5YM4hF7hzQLjyMzDD4Q1/fyWP9Uk5aK5VrSWNY99EuxldXI5QK/

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ matrix:
           - valgrind
     - compiler: clang
       env: BUILD=cmake
+      addons:
+        apt:
+          packages:
+          - cmake
     - compiler: clang
       env: BUILD=autotools_gtest
     - compiler: clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,6 @@ matrix:
           - valgrind
     - compiler: clang
       env: BUILD=cmake
-      addons:
-        apt:
-          packages:
-          - cmake
     - compiler: clang
       env: BUILD=autotools_gtest
     - compiler: clang
@@ -42,6 +38,10 @@ matrix:
           - dosbox
 global:
 - os: linux
+  addons:
+    apt:
+      sources: ['kalakris-cmake']
+      packages: ['cmake']
 - rvm: '1.9.3'
 - secure: |-
     P05xUfJVw5YM4hF7hzQLjyMzDD4Q1/fyWP9Uk5aK5VrSWNY99EuxldXI5QK/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ set(CppUTest_version_major 3)
 set(CppUTest_version_minor 7.2)
 
 # 2.6.3 is needed for ctest support
-cmake_minimum_required(VERSION 2.8.7)
+cmake_minimum_required(VERSION 2.8.11)
 
 # Check for functions before setting a lot of stuff
 include(CheckFunctionExists)

--- a/src/CppUTest/CMakeLists.txt
+++ b/src/CppUTest/CMakeLists.txt
@@ -19,39 +19,17 @@ set(CppUTest_src
         ../Platforms/${CPP_PLATFORM}/UtestPlatform.cpp
 )
 
-set(CppUTest_headers
-        ${CppUTestRootDirectory}/include/CppUTest/CommandLineArguments.h
-        ${CppUTestRootDirectory}/include/CppUTest/PlatformSpecificFunctions.h
-        ${CppUTestRootDirectory}/include/CppUTest/TestMemoryAllocator.h
-        ${CppUTestRootDirectory}/include/CppUTest/CommandLineTestRunner.h
-        ${CppUTestRootDirectory}/include/CppUTest/PlatformSpecificFunctions_c.h
-        ${CppUTestRootDirectory}/include/CppUTest/TestOutput.h
-        ${CppUTestRootDirectory}/include/CppUTest/CppUTestConfig.h
-        ${CppUTestRootDirectory}/include/CppUTest/SimpleString.h
-        ${CppUTestRootDirectory}/include/CppUTest/TestPlugin.h
-        ${CppUTestRootDirectory}/include/CppUTest/JUnitTestOutput.h
-        ${CppUTestRootDirectory}/include/CppUTest/TeamCityTestOutput.h
-        ${CppUTestRootDirectory}/include/CppUTest/StandardCLibrary.h
-        ${CppUTestRootDirectory}/include/CppUTest/TestRegistry.h
-        ${CppUTestRootDirectory}/include/CppUTest/MemoryLeakDetector.h
-        ${CppUTestRootDirectory}/include/CppUTest/TestFailure.h
-        ${CppUTestRootDirectory}/include/CppUTest/TestResult.h
-        ${CppUTestRootDirectory}/include/CppUTest/MemoryLeakDetectorMallocMacros.h
-        ${CppUTestRootDirectory}/include/CppUTest/TestFilter.h
-        ${CppUTestRootDirectory}/include/CppUTest/TestTestingFixture.h
-        ${CppUTestRootDirectory}/include/CppUTest/MemoryLeakDetectorNewMacros.h
-        ${CppUTestRootDirectory}/include/CppUTest/TestHarness.h
-        ${CppUTestRootDirectory}/include/CppUTest/Utest.h
-        ${CppUTestRootDirectory}/include/CppUTest/MemoryLeakWarningPlugin.h
-        ${CppUTestRootDirectory}/include/CppUTest/TestHarness_c.h
-        ${CppUTestRootDirectory}/include/CppUTest/UtestMacros.h
-)
-
-add_library(CppUTest STATIC ${CppUTest_src} ${CppUTest_headers})
+add_library(CppUTest STATIC ${CppUTest_src})
 if (WIN32)
     target_link_libraries(CppUTest winmm.lib)
 endif (WIN32)
-install(FILES ${CppUTest_headers} DESTINATION include/CppUTest)
+
+target_include_directories(CppUTest PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include/CppUTest>
+    $<INSTALL_INTERFACE:include>
+    )
+
+install(DIRECTORY ${CppUTestRootDirectory}/include/CppUTest DESTINATION include)
 install(TARGETS CppUTest
     EXPORT CppUTestTargets
     RUNTIME DESTINATION bin

--- a/src/CppUTestExt/CMakeLists.txt
+++ b/src/CppUTestExt/CMakeLists.txt
@@ -15,32 +15,15 @@ set(CppUTestExt_src
         MockSupport.cpp
 )
 
-set(CppUTestExt_headers
-        ${CppUTestRootDirectory}/include/CppUTestExt/CodeMemoryReportFormatter.h
-        ${CppUTestRootDirectory}/include/CppUTestExt/IEEE754ExceptionsPlugin.h
-        ${CppUTestRootDirectory}/include/CppUTestExt/MemoryReportAllocator.h
-        ${CppUTestRootDirectory}/include/CppUTestExt/MockExpectedCall.h
-        ${CppUTestRootDirectory}/include/CppUTestExt/MockCheckedExpectedCall.h
-        ${CppUTestRootDirectory}/include/CppUTestExt/MockExpectedCallsList.h
-        ${CppUTestRootDirectory}/include/CppUTestExt/MockSupportPlugin.h
-        ${CppUTestRootDirectory}/include/CppUTestExt/MemoryReportFormatter.h
-        ${CppUTestRootDirectory}/include/CppUTestExt/MockFailure.h
-        ${CppUTestRootDirectory}/include/CppUTestExt/MockSupport.h
-        ${CppUTestRootDirectory}/include/CppUTestExt/MockSupport_c.h
-        ${CppUTestRootDirectory}/include/CppUTestExt/GMock.h
-        ${CppUTestRootDirectory}/include/CppUTestExt/GTest.h
-        ${CppUTestRootDirectory}/include/CppUTestExt/MemoryReporterPlugin.h
-        ${CppUTestRootDirectory}/include/CppUTestExt/OrderedTest.h
-        ${CppUTestRootDirectory}/include/CppUTestExt/GTestConvertor.h
-        ${CppUTestRootDirectory}/include/CppUTestExt/MockActualCall.h
-        ${CppUTestRootDirectory}/include/CppUTestExt/MockCheckedActualCall.h
-        ${CppUTestRootDirectory}/include/CppUTestExt/MockNamedValue.h
-        ${CppUTestRootDirectory}/include/CppUTestExt/MockSupport.h
-)
-
-add_library(CppUTestExt STATIC ${CppUTestExt_src} ${CppUTestExt_headers})
+add_library(CppUTestExt STATIC ${CppUTestExt_src})
 target_link_libraries(CppUTestExt ${CPPUNIT_EXTERNAL_LIBRARIES})
-install(FILES ${CppUTestExt_headers} DESTINATION include/CppUTestExt)
+
+target_include_directories(CppUTestExt PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include/CppUTestExt>
+    $<INSTALL_INTERFACE:include>
+    )
+
+install(DIRECTORY ${CppUTestRootDirectory}/include/CppUTestExt DESTINATION include)
 install(TARGETS CppUTestExt
     EXPORT CppUTestTargets
     RUNTIME DESTINATION bin


### PR DESCRIPTION
Provide automatic includes for lib clients that link with the CppUTest libs.

Below is a minimal `CMakeLists.txt`

``` .cmake
cmake_minimum_required(VERSION 2.8.11)
project(mytest)

include(CTest)
enable_testing()

# Provide access to installed CppUTest
# if installed in non-standard place add "HINTS <path-to-installed-cpputest-lib>"
FIND_PACKAGE(CppUTest)

add_executable(mytest mytest.cpp)
target_link_libraries(mytest CppUTest)
```
