### PR TITLE
(#922) MockSupport::expectNoCall does not append scope to function name

### DIFF
--- a/src/CppUTestExt/MockSupport.cpp
+++ b/src/CppUTestExt/MockSupport.cpp
@@ -169,7 +169,7 @@ void MockSupport::expectNoCall(const SimpleString& functionName)
     countCheck();
 
     MockCheckedExpectedCall* call = new MockCheckedExpectedCall;
-    call->withName(functionName);
+    call->withName(appendScopeToName(functionName));
     unExpectations_.addExpectedCall(call);
 }
 

--- a/tests/CppUTestExt/MockCallTest.cpp
+++ b/tests/CppUTestExt/MockCallTest.cpp
@@ -233,6 +233,46 @@ TEST(MockCallTest, ignoreOtherCallsExceptForTheUnExpectedOne)
     CHECK_EXPECTED_MOCK_FAILURE(expectedFailure);
 }
 
+
+TEST(MockCallTest, expectNoCallInScopeThatHappened)
+{
+    MockFailureReporterInstaller failureReporterInstaller;
+
+    MockExpectedCallsListForTest expectations;
+    MockUnexpectedCallHappenedFailure expectedFailure(mockFailureTest(), "scope::lazy", expectations);
+
+    mock("scope").expectNoCall("lazy");
+    mock("scope").actualCall("lazy");
+
+    CHECK_EXPECTED_MOCK_FAILURE(expectedFailure);
+}
+
+TEST(MockCallTest, expectNoCallInScopeButActualCallInAnotherScope)
+{
+    MockFailureReporterInstaller failureReporterInstaller;
+
+    MockExpectedCallsListForTest expectations;
+    MockUnexpectedCallHappenedFailure expectedFailure(mockFailureTest(), "scope2::lazy", expectations);
+
+    mock("scope1").expectNoCall("lazy");
+    mock("scope2").actualCall("lazy");
+
+    CHECK_EXPECTED_MOCK_FAILURE(expectedFailure);
+}
+
+TEST(MockCallTest, expectNoCallInScopeButActualCallInGlobal)
+{
+    MockFailureReporterInstaller failureReporterInstaller;
+
+    MockExpectedCallsListForTest expectations;
+    MockUnexpectedCallHappenedFailure expectedFailure(mockFailureTest(), "lazy", expectations);
+
+    mock("scope1").expectNoCall("lazy");
+    mock().actualCall("lazy");
+
+    CHECK_EXPECTED_MOCK_FAILURE(expectedFailure);
+}
+
 TEST(MockCallTest, ignoreOtherCallsExceptForTheExpectedOne)
 {
     mock().expectOneCall("foo");


### PR DESCRIPTION
Fix this issue.