### PR TITLE
Add mock support for bool (C++ only).

### DIFF
--- a/include/CppUTestExt/MockActualCall.h
+++ b/include/CppUTestExt/MockActualCall.h
@@ -43,6 +43,7 @@ public:
 
     virtual MockActualCall& withName(const SimpleString& name)=0;
     virtual MockActualCall& withCallOrder(int callOrder)=0;
+    MockActualCall& withParameter(const SimpleString& name, bool value) { return withBoolParameter(name, value); }
     MockActualCall& withParameter(const SimpleString& name, int value) { return withIntParameter(name, value); }
     MockActualCall& withParameter(const SimpleString& name, unsigned int value) { return withUnsignedIntParameter(name, value); }
     MockActualCall& withParameter(const SimpleString& name, long int value) { return withLongIntParameter(name, value); }
@@ -57,6 +58,7 @@ public:
     virtual MockActualCall& withOutputParameter(const SimpleString& name, void* output)=0;
     virtual MockActualCall& withOutputParameterOfType(const SimpleString& typeName, const SimpleString& name, void* output)=0;
 
+    virtual MockActualCall& withBoolParameter(const SimpleString& name, bool value)=0;
     virtual MockActualCall& withIntParameter(const SimpleString& name, int value)=0;
     virtual MockActualCall& withUnsignedIntParameter(const SimpleString& name, unsigned int value)=0;
     virtual MockActualCall& withLongIntParameter(const SimpleString& name, long int value)=0;
@@ -70,6 +72,9 @@ public:
 
     virtual bool hasReturnValue()=0;
     virtual MockNamedValue returnValue()=0;
+
+    virtual bool returnBoolValueOrDefault(bool default_value)=0;
+    virtual bool returnBoolValue()=0;
 
     virtual int returnIntValueOrDefault(int default_value)=0;
     virtual int returnIntValue()=0;

--- a/include/CppUTestExt/MockCheckedActualCall.h
+++ b/include/CppUTestExt/MockCheckedActualCall.h
@@ -39,6 +39,7 @@ public:
 
     virtual MockActualCall& withName(const SimpleString& name) _override;
     virtual MockActualCall& withCallOrder(int) _override;
+    virtual MockActualCall& withBoolParameter(const SimpleString& name, bool value) _override;
     virtual MockActualCall& withIntParameter(const SimpleString& name, int value) _override;
     virtual MockActualCall& withUnsignedIntParameter(const SimpleString& name, unsigned int value) _override;
     virtual MockActualCall& withLongIntParameter(const SimpleString& name, long int value) _override;
@@ -55,6 +56,9 @@ public:
 
     virtual bool hasReturnValue() _override;
     virtual MockNamedValue returnValue() _override;
+
+    virtual bool returnBoolValueOrDefault(bool default_value) _override;
+    virtual bool returnBoolValue() _override;
 
     virtual int returnIntValueOrDefault(int default_value) _override;
     virtual int returnIntValue() _override;
@@ -147,6 +151,7 @@ public:
 
     virtual MockActualCall& withName(const SimpleString& name) _override;
     virtual MockActualCall& withCallOrder(int) _override;
+    virtual MockActualCall& withBoolParameter(const SimpleString& name, bool value) _override;
     virtual MockActualCall& withIntParameter(const SimpleString& name, int value) _override;
     virtual MockActualCall& withUnsignedIntParameter(const SimpleString& name, unsigned int value) _override;
     virtual MockActualCall& withLongIntParameter(const SimpleString& name, long int value) _override;
@@ -163,6 +168,9 @@ public:
 
     virtual bool hasReturnValue() _override;
     virtual MockNamedValue returnValue() _override;
+
+    virtual bool returnBoolValueOrDefault(bool default_value) _override;
+    virtual bool returnBoolValue() _override;
 
     virtual int returnIntValueOrDefault(int default_value) _override;
     virtual int returnIntValue() _override;
@@ -208,6 +216,7 @@ class MockIgnoredActualCall: public MockActualCall
 public:
     virtual MockActualCall& withName(const SimpleString&) _override { return *this;}
     virtual MockActualCall& withCallOrder(int) _override { return *this; }
+    virtual MockActualCall& withBoolParameter(const SimpleString&, bool) _override { return *this; }
     virtual MockActualCall& withIntParameter(const SimpleString&, int) _override { return *this; }
     virtual MockActualCall& withUnsignedIntParameter(const SimpleString&, unsigned int) _override { return *this; }
     virtual MockActualCall& withLongIntParameter(const SimpleString&, long int) _override { return *this; }
@@ -224,6 +233,9 @@ public:
 
     virtual bool hasReturnValue() _override { return false; }
     virtual MockNamedValue returnValue() _override { return MockNamedValue(""); }
+
+    virtual bool returnBoolValueOrDefault(bool) _override { return false; }
+    virtual bool returnBoolValue() _override { return false; }
 
     virtual int returnIntValue() _override { return 0; }
     virtual int returnIntValueOrDefault(int value) _override { return value; }

--- a/include/CppUTestExt/MockCheckedExpectedCall.h
+++ b/include/CppUTestExt/MockCheckedExpectedCall.h
@@ -40,6 +40,7 @@ public:
 
     virtual MockExpectedCall& withName(const SimpleString& name) _override;
     virtual MockExpectedCall& withCallOrder(int callOrder) _override;
+    virtual MockExpectedCall& withBoolParameter(const SimpleString& name, bool value) _override;
     virtual MockExpectedCall& withIntParameter(const SimpleString& name, int value) _override;
     virtual MockExpectedCall& withUnsignedIntParameter(const SimpleString& name, unsigned int value) _override;
     virtual MockExpectedCall& withLongIntParameter(const SimpleString& name, long int value) _override;
@@ -55,6 +56,7 @@ public:
     virtual MockExpectedCall& withOutputParameterOfTypeReturning(const SimpleString& typeName, const SimpleString& name, const void* value) _override;
     virtual MockExpectedCall& ignoreOtherParameters() _override;
 
+    virtual MockExpectedCall& andReturnValue(bool value) _override;
     virtual MockExpectedCall& andReturnValue(int value) _override;
     virtual MockExpectedCall& andReturnValue(unsigned int value) _override;
     virtual MockExpectedCall& andReturnValue(long int value) _override;
@@ -141,6 +143,7 @@ public:
 
     virtual MockExpectedCall& withName(const SimpleString& name) _override;
     virtual MockExpectedCall& withCallOrder(int callOrder) _override;
+    virtual MockExpectedCall& withBoolParameter(const SimpleString& name, bool value) _override;
     virtual MockExpectedCall& withIntParameter(const SimpleString& name, int value) _override;
     virtual MockExpectedCall& withUnsignedIntParameter(const SimpleString& name, unsigned int value) _override;
     virtual MockExpectedCall& withLongIntParameter(const SimpleString& name, long int value) _override;
@@ -156,6 +159,7 @@ public:
     virtual MockExpectedCall& withOutputParameterOfTypeReturning(const SimpleString& typeName, const SimpleString& name, const void* value) _override;
     virtual MockExpectedCall& ignoreOtherParameters() _override;
 
+    virtual MockExpectedCall& andReturnValue(bool value) _override;
     virtual MockExpectedCall& andReturnValue(int value) _override;
     virtual MockExpectedCall& andReturnValue(unsigned int value) _override;
     virtual MockExpectedCall& andReturnValue(long int value) _override;
@@ -180,6 +184,7 @@ public:
 
     virtual MockExpectedCall& withName(const SimpleString&) _override { return *this;}
     virtual MockExpectedCall& withCallOrder(int) _override { return *this; }
+    virtual MockExpectedCall& withBoolParameter(const SimpleString&, bool) _override { return *this; }
     virtual MockExpectedCall& withIntParameter(const SimpleString&, int) _override { return *this; }
     virtual MockExpectedCall& withUnsignedIntParameter(const SimpleString&, unsigned int) _override{ return *this; }
     virtual MockExpectedCall& withLongIntParameter(const SimpleString&, long int) _override { return *this; }
@@ -195,6 +200,7 @@ public:
     virtual MockExpectedCall& withOutputParameterOfTypeReturning(const SimpleString&, const SimpleString&, const void*) _override { return *this; }
     virtual MockExpectedCall& ignoreOtherParameters() _override { return *this;}
 
+    virtual MockExpectedCall& andReturnValue(bool) _override { return *this; }
     virtual MockExpectedCall& andReturnValue(int) _override { return *this; }
     virtual MockExpectedCall& andReturnValue(unsigned int) _override { return *this; }
     virtual MockExpectedCall& andReturnValue(long int) _override { return *this; }

--- a/include/CppUTestExt/MockExpectedCall.h
+++ b/include/CppUTestExt/MockExpectedCall.h
@@ -40,6 +40,7 @@ public:
 
     virtual MockExpectedCall& withName(const SimpleString& name)=0;
     virtual MockExpectedCall& withCallOrder(int)=0;
+    MockExpectedCall& withParameter(const SimpleString& name, bool value) { return withBoolParameter(name, value); }
     MockExpectedCall& withParameter(const SimpleString& name, int value) { return withIntParameter(name, value); }
     MockExpectedCall& withParameter(const SimpleString& name, unsigned int value) { return withUnsignedIntParameter(name, value); }
     MockExpectedCall& withParameter(const SimpleString& name, long int value) { return withLongIntParameter(name, value); }
@@ -55,6 +56,7 @@ public:
     virtual MockExpectedCall& withOutputParameterOfTypeReturning(const SimpleString& typeName, const SimpleString& name, const void* value)=0;
     virtual MockExpectedCall& ignoreOtherParameters()=0;
 
+    virtual MockExpectedCall& withBoolParameter(const SimpleString& name, bool value)=0;
     virtual MockExpectedCall& withIntParameter(const SimpleString& name, int value)=0;
     virtual MockExpectedCall& withUnsignedIntParameter(const SimpleString& name, unsigned int value)=0;
     virtual MockExpectedCall& withLongIntParameter(const SimpleString& name, long int value)=0;
@@ -65,6 +67,7 @@ public:
     virtual MockExpectedCall& withFunctionPointerParameter(const SimpleString& name, void (*value)())=0;
     virtual MockExpectedCall& withConstPointerParameter(const SimpleString& name, const void* value)=0;
     virtual MockExpectedCall& withMemoryBufferParameter(const SimpleString& name, const unsigned char* value, size_t size)=0;
+    virtual MockExpectedCall& andReturnValue(bool value)=0;
     virtual MockExpectedCall& andReturnValue(int value)=0;
     virtual MockExpectedCall& andReturnValue(unsigned int value)=0;
     virtual MockExpectedCall& andReturnValue(long int value)=0;

--- a/include/CppUTestExt/MockNamedValue.h
+++ b/include/CppUTestExt/MockNamedValue.h
@@ -101,6 +101,7 @@ public:
     DEFAULT_COPY_CONSTRUCTOR(MockNamedValue)
     virtual ~MockNamedValue();
 
+    virtual void setValue(bool value);
     virtual void setValue(int value);
     virtual void setValue(unsigned int value);
     virtual void setValue(long int value);
@@ -124,6 +125,7 @@ public:
     virtual SimpleString getName() const;
     virtual SimpleString getType() const;
 
+    virtual bool getBoolValue() const;
     virtual int getIntValue() const;
     virtual unsigned int getUnsignedIntValue() const;
     virtual long int getLongIntValue() const;
@@ -145,6 +147,7 @@ private:
     SimpleString name_;
     SimpleString type_;
     union {
+        bool boolValue_;
         int intValue_;
         unsigned int unsignedIntValue_;
         long int longIntValue_;

--- a/include/CppUTestExt/MockSupport.h
+++ b/include/CppUTestExt/MockSupport.h
@@ -52,6 +52,8 @@ public:
     virtual MockActualCall& actualCall(const SimpleString& functionName);
     virtual bool hasReturnValue();
     virtual MockNamedValue returnValue();
+    virtual bool boolReturnValue();
+    virtual bool returnBoolValueOrDefault(bool defaultValue);
     virtual int intReturnValue();
     virtual int returnIntValueOrDefault(int defaultValue);
     virtual unsigned int unsignedIntReturnValue();
@@ -72,6 +74,7 @@ public:
     virtual void (*functionPointerReturnValue())();
 
     bool hasData(const SimpleString& name);
+    void setData(const SimpleString& name, bool value);
     void setData(const SimpleString& name, int value);
     void setData(const SimpleString& name, unsigned int value);
     void setData(const SimpleString& name, const char* value);

--- a/include/CppUTestExt/MockSupport_c.h
+++ b/include/CppUTestExt/MockSupport_c.h
@@ -35,6 +35,7 @@ extern "C" {
 #include "CppUTest/StandardCLibrary.h"
 
 typedef enum {
+    MOCKVALUETYPE_BOOL,
     MOCKVALUETYPE_UNSIGNED_INTEGER,
     MOCKVALUETYPE_INTEGER,
     MOCKVALUETYPE_LONG_INTEGER,
@@ -52,6 +53,7 @@ typedef struct SMockValue_c
 {
     MockValueType_c type;
     union {
+        int boolValue;
         int intValue;
         unsigned int unsignedIntValue;
         long int longIntValue;
@@ -69,6 +71,7 @@ typedef struct SMockValue_c
 typedef struct SMockActualCall_c MockActualCall_c;
 struct SMockActualCall_c
 {
+    MockActualCall_c* (*withBoolParameters)(const char* name, int value);
     MockActualCall_c* (*withIntParameters)(const char* name, int value);
     MockActualCall_c* (*withUnsignedIntParameters)(const char* name, unsigned int value);
     MockActualCall_c* (*withLongIntParameters)(const char* name, long int value);
@@ -84,6 +87,8 @@ struct SMockActualCall_c
     MockActualCall_c* (*withOutputParameterOfType)(const char* type, const char* name, void* value);
     int (*hasReturnValue)(void);
     MockValue_c (*returnValue)(void);
+    int (*boolReturnValue)(void);
+    int (*returnBoolValueOrDefault)(int defaultValue);
     int (*intReturnValue)(void);
     int (*returnIntValueOrDefault)(int defaultValue);
     unsigned int (*unsignedIntReturnValue)(void);
@@ -107,6 +112,7 @@ struct SMockActualCall_c
 typedef struct SMockExpectedCall_c MockExpectedCall_c;
 struct SMockExpectedCall_c
 {
+    MockExpectedCall_c* (*withBoolParameters)(const char* name, int value);
     MockExpectedCall_c* (*withIntParameters)(const char* name, int value);
     MockExpectedCall_c* (*withUnsignedIntParameters)(const char* name, unsigned int value);
     MockExpectedCall_c* (*withLongIntParameters)(const char* name, long int value);
@@ -122,6 +128,7 @@ struct SMockExpectedCall_c
     MockExpectedCall_c* (*withOutputParameterOfTypeReturning)(const char* type, const char* name, const void* value);
     MockExpectedCall_c* (*ignoreOtherParameters)(void);
 
+    MockExpectedCall_c* (*andReturnBoolValue)(int value);
     MockExpectedCall_c* (*andReturnUnsignedIntValue)(unsigned int value);
     MockExpectedCall_c* (*andReturnIntValue)(int value);
     MockExpectedCall_c* (*andReturnLongIntValue)(long int value);
@@ -147,6 +154,8 @@ struct SMockSupport_c
     MockActualCall_c* (*actualCall)(const char* name);
     int (*hasReturnValue)(void);
     MockValue_c (*returnValue)(void);
+    int (*boolReturnValue)(void);
+    int (*returnBoolValueOrDefault)(int defaultValue);
     int (*intReturnValue)(void);
     int (*returnIntValueOrDefault)(int defaultValue);
     unsigned int (*unsignedIntReturnValue)(void);
@@ -166,6 +175,7 @@ struct SMockSupport_c
     void (*(*functionPointerReturnValue)(void))(void);
     void (*(*returnFunctionPointerValueOrDefault) (void(*defaultValue)(void)))(void);
 
+    void (*setBoolData) (const char* name, int value);
     void (*setIntData) (const char* name, int value);
     void (*setUnsignedIntData) (const char* name, unsigned int value);
     void (*setStringData) (const char* name, const char* value);

--- a/src/CppUTestExt/MockActualCall.cpp
+++ b/src/CppUTestExt/MockActualCall.cpp
@@ -197,6 +197,14 @@ void MockCheckedActualCall::checkOutputParameter(const MockNamedValue& outputPar
     finalizeCallWhenFulfilled();
 }
 
+MockActualCall& MockCheckedActualCall::withBoolParameter(const SimpleString& name, bool value)
+{
+    MockNamedValue actualParameter(name);
+    actualParameter.setValue(value);
+    checkInputParameter(actualParameter);
+    return *this;
+}
+
 MockActualCall& MockCheckedActualCall::withUnsignedIntParameter(const SimpleString& name, unsigned int value)
 {
     MockNamedValue actualParameter(name);
@@ -362,6 +370,19 @@ MockNamedValue MockCheckedActualCall::returnValue()
     if (fulfilledExpectation_)
         return fulfilledExpectation_->returnValue();
     return MockNamedValue("no return value");
+}
+
+bool MockCheckedActualCall::returnBoolValueOrDefault(bool default_value)
+{
+    if (!hasReturnValue()) {
+        return default_value;
+    }
+    return returnBoolValue();
+}
+
+bool MockCheckedActualCall::returnBoolValue()
+{
+    return returnValue().getBoolValue();
 }
 
 int MockCheckedActualCall::returnIntValueOrDefault(int default_value)
@@ -559,6 +580,13 @@ void MockActualCallTrace::addParameterName(const SimpleString& name)
     traceBuffer_ += ":";
 }
 
+MockActualCall& MockActualCallTrace::withBoolParameter(const SimpleString& name, bool value)
+{
+    addParameterName(name);
+    traceBuffer_ += StringFrom(value);
+    return *this;
+}
+
 MockActualCall& MockActualCallTrace::withUnsignedIntParameter(const SimpleString& name, unsigned int value)
 {
     addParameterName(name);
@@ -682,6 +710,16 @@ unsigned long int MockActualCallTrace::returnUnsignedLongIntValueOrDefault(unsig
 long int MockActualCallTrace::returnLongIntValueOrDefault(long int)
 {
     return returnLongIntValue();
+}
+
+bool MockActualCallTrace::returnBoolValue()
+{
+    return false;
+}
+
+bool MockActualCallTrace::returnBoolValueOrDefault(bool)
+{
+    return false;
 }
 
 int MockActualCallTrace::returnIntValue()

--- a/src/CppUTestExt/MockExpectedCall.cpp
+++ b/src/CppUTestExt/MockExpectedCall.cpp
@@ -73,6 +73,14 @@ MockExpectedCall& MockCheckedExpectedCall::withName(const SimpleString& name)
     return *this;
 }
 
+MockExpectedCall& MockCheckedExpectedCall::withBoolParameter(const SimpleString& name, bool value)
+{
+    MockNamedValue* newParameter = new MockExpectedFunctionParameter(name);
+    inputParameters_->add(newParameter);
+    newParameter->setValue(value);
+    return *this;
+}
+
 MockExpectedCall& MockCheckedExpectedCall::withUnsignedIntParameter(const SimpleString& name, unsigned int value)
 {
     MockNamedValue* newParameter = new MockExpectedFunctionParameter(name);
@@ -401,6 +409,13 @@ bool MockCheckedExpectedCall::MockExpectedFunctionParameter::isFulfilled() const
     return fulfilled_;
 }
 
+MockExpectedCall& MockCheckedExpectedCall::andReturnValue(bool value)
+{
+    returnValue_.setName("returnValue");
+    returnValue_.setValue(value);
+    return *this;
+}
+
 MockExpectedCall& MockCheckedExpectedCall::andReturnValue(unsigned int value)
 {
     returnValue_.setName("returnValue");
@@ -536,6 +551,13 @@ MockExpectedCall& MockExpectedCallComposite::withCallOrder(int)
     return *this; // LCOV_EXCL_LINE
 }
 
+MockExpectedCall& MockExpectedCallComposite::withBoolParameter(const SimpleString& name, bool value)
+{
+    for (MockExpectedCallCompositeNode* node = head_; node != NULL; node = node->next_)
+        node->call_.withParameter(name, value);
+    return *this;
+}
+
 MockExpectedCall& MockExpectedCallComposite::withUnsignedIntParameter(const SimpleString& name, unsigned int value)
 {
     for (MockExpectedCallCompositeNode* node = head_; node != NULL; node = node->next_)
@@ -632,6 +654,13 @@ MockExpectedCall& MockExpectedCallComposite::ignoreOtherParameters()
 {
     for (MockExpectedCallCompositeNode* node = head_; node != NULL; node = node->next_)
         node->call_.ignoreOtherParameters();
+    return *this;
+}
+
+MockExpectedCall& MockExpectedCallComposite::andReturnValue(bool value)
+{
+    for (MockExpectedCallCompositeNode* node = head_; node != NULL; node = node->next_)
+        node->call_.andReturnValue(value);
     return *this;
 }
 

--- a/src/CppUTestExt/MockNamedValue.cpp
+++ b/src/CppUTestExt/MockNamedValue.cpp
@@ -46,6 +46,12 @@ MockNamedValue::~MockNamedValue()
 {
 }
 
+void MockNamedValue::setValue(bool value)
+{
+    type_ = "bool";
+    value_.boolValue_ = value;
+}
+
 void MockNamedValue::setValue(unsigned int value)
 {
     type_ = "unsigned int";
@@ -136,6 +142,12 @@ SimpleString MockNamedValue::getName() const
 SimpleString MockNamedValue::getType() const
 {
     return type_;
+}
+
+bool MockNamedValue::getBoolValue() const
+{
+    STRCMP_EQUAL("bool", type_.asCharString());
+    return value_.boolValue_;
 }
 
 unsigned int MockNamedValue::getUnsignedIntValue() const
@@ -268,7 +280,9 @@ bool MockNamedValue::equals(const MockNamedValue& p) const
 
     if (type_ != p.type_) return false;
 
-    if (type_ == "int")
+    if (type_ == "bool")
+        return value_.boolValue_ == p.value_.boolValue_;
+    else if (type_ == "int")
         return value_.intValue_ == p.value_.intValue_;
     else if (type_ == "unsigned int")
         return value_.unsignedIntValue_ == p.value_.unsignedIntValue_;
@@ -312,7 +326,9 @@ bool MockNamedValue::compatibleForCopying(const MockNamedValue& p) const
 
 SimpleString MockNamedValue::toString() const
 {
-    if (type_ == "int")
+    if (type_ == "bool")
+        return StringFrom(value_.boolValue_);
+    else if (type_ == "int")
         return StringFrom(value_.intValue_);
     else if (type_ == "unsigned int")
         return StringFrom(value_.unsignedIntValue_);

--- a/src/CppUTestExt/MockSupport.cpp
+++ b/src/CppUTestExt/MockSupport.cpp
@@ -369,6 +369,12 @@ MockNamedValue* MockSupport::retrieveDataFromStore(const SimpleString& name)
     return newData;
 }
 
+void MockSupport::setData(const SimpleString& name, bool value)
+{
+    MockNamedValue* newData = retrieveDataFromStore(name);
+    newData->setValue(value);
+}
+
 void MockSupport::setData(const SimpleString& name, unsigned int value)
 {
     MockNamedValue* newData = retrieveDataFromStore(name);
@@ -469,6 +475,11 @@ MockNamedValue MockSupport::returnValue()
     return MockNamedValue("");
 }
 
+bool MockSupport::boolReturnValue()
+{
+    return returnValue().getBoolValue();
+}
+
 unsigned int MockSupport::unsignedIntReturnValue()
 {
     return returnValue().getUnsignedIntValue();
@@ -499,6 +510,14 @@ long int MockSupport::returnLongIntValueOrDefault(long int defaultValue)
 {
     if (hasReturnValue()) {
         return longIntReturnValue();
+    }
+    return defaultValue;
+}
+
+bool MockSupport::returnBoolValueOrDefault(bool defaultValue)
+{
+    if (hasReturnValue()) {
+        return boolReturnValue();
     }
     return defaultValue;
 }

--- a/tests/CppUTestExt/MockActualCallTest.cpp
+++ b/tests/CppUTestExt/MockActualCallTest.cpp
@@ -137,6 +137,8 @@ TEST(MockCheckedActualCall, MockIgnoredActualCallWorksAsItShould)
     actual.withName("func");
     actual.withCallOrder(1);
 
+    CHECK(false == actual.returnBoolValue());
+    CHECK(false == actual.returnBoolValueOrDefault(true));
     CHECK(0 == actual.returnUnsignedLongIntValue());
     CHECK(0 == actual.returnIntValue());
     CHECK(1ul == actual.returnUnsignedLongIntValueOrDefault(1ul));
@@ -170,6 +172,7 @@ TEST(MockCheckedActualCall, remainderOfMockActualCallTraceWorksAsItShould)
     actual.withCallOrder(1);
     actual.onObject(&value);
 
+    actual.withBoolParameter("bool", true);
     actual.withUnsignedIntParameter("unsigned_int", (unsigned int) 1);
     actual.withUnsignedLongIntParameter("unsigned_long", (unsigned long)1);
     actual.withLongIntParameter("long_int", (long int) 1);
@@ -183,6 +186,7 @@ TEST(MockCheckedActualCall, remainderOfMockActualCallTraceWorksAsItShould)
     expectedString += " withCallOrder:1";
     expectedString += " onObject:0x";
     expectedString += HexStringFrom(&value);
+    expectedString += " bool:true";
     expectedString += " unsigned_int:         1 (0x00000001)";
     expectedString += " unsigned_long:1 (0x1)";
     expectedString += " long_int:1";
@@ -199,6 +203,8 @@ TEST(MockCheckedActualCall, remainderOfMockActualCallTraceWorksAsItShould)
 
     CHECK_FALSE(actual.hasReturnValue());
     CHECK(actual.returnValue().equals(MockNamedValue("")));
+    CHECK(false == actual.returnBoolValue());
+    CHECK(false == actual.returnBoolValueOrDefault(true));
     CHECK(0 == actual.returnLongIntValue());
     CHECK(0 == actual.returnUnsignedLongIntValue());
     CHECK(0 == actual.returnIntValue());

--- a/tests/CppUTestExt/MockExpectedCallTest.cpp
+++ b/tests/CppUTestExt/MockExpectedCallTest.cpp
@@ -189,6 +189,14 @@ TEST(MockExpectedCall, callWithIntegerParameter)
     CHECK(call->hasInputParameterWithName("integer"));
 }
 
+TEST(MockExpectedCall, callWithBooleanParameter)
+{
+    call->withParameter("boolean", true);
+    STRCMP_EQUAL("bool", call->getInputParameterType("boolean").asCharString());
+    CHECK_EQUAL(true, call->getInputParameter("boolean").getBoolValue());
+    CHECK(call->hasInputParameterWithName("boolean"));
+}
+
 TEST(MockExpectedCall, callWithUnsignedLongIntegerParameter)
 {
     const SimpleString name = "unsigned long integer";
@@ -564,6 +572,12 @@ TEST_GROUP(MockExpectedCallComposite)
     }
 };
 
+TEST(MockExpectedCallComposite, hasBoolParameter)
+{
+    composite.withParameter("param", true);
+    STRCMP_EQUAL("name -> bool param: <true>", call.callToString().asCharString());
+}
+
 TEST(MockExpectedCallComposite, hasLongIntParameter)
 {
     composite.withParameter("param", (long int) -1);
@@ -617,6 +631,13 @@ TEST(MockExpectedCallComposite, hasOutputParameterOfTypeReturning)
 {
     composite.withOutputParameterOfTypeReturning("type", "out", (const void*) 0);
     STRCMP_EQUAL("name -> type out: <output>", call.callToString().asCharString());
+}
+
+TEST(MockExpectedCallComposite, hasBoolReturnValue)
+{
+    composite.andReturnValue(true);
+    STRCMP_EQUAL("bool", call.returnValue().getType().asCharString());
+    CHECK_EQUAL(true, call.returnValue().getBoolValue());
 }
 
 TEST(MockExpectedCallComposite, hasUnsignedIntReturnValue)
@@ -716,6 +737,7 @@ TEST(MockIgnoredExpectedCall, worksAsItShould)
     ignored.withName("func");
     ignored.withCallOrder(1);
     ignored.onObject((void*) 0);
+    ignored.withBoolParameter("umm", true);
     ignored.withIntParameter("bla", (int) 1);
     ignored.withUnsignedIntParameter("foo", (unsigned int) 1);
     ignored.withLongIntParameter("hey", (long int) 1);
@@ -730,6 +752,7 @@ TEST(MockIgnoredExpectedCall, worksAsItShould)
     ignored.withOutputParameterReturning("bar", (void*) 0, 1);
     ignored.withOutputParameterOfTypeReturning("mytype", "bar", (const void*) 0);
     ignored.ignoreOtherParameters();
+    ignored.andReturnValue(true);
     ignored.andReturnValue((double) 1.0f);
     ignored.andReturnValue((unsigned int) 1);
     ignored.andReturnValue((int) 1);

--- a/tests/CppUTestExt/MockParameterTest.cpp
+++ b/tests/CppUTestExt/MockParameterTest.cpp
@@ -37,6 +37,14 @@ TEST_GROUP(MockParameterTest)
   }
 };
 
+TEST(MockParameterTest, expectOneBooleanParameterAndValue)
+{
+    mock().expectOneCall("foo").withParameter("parameter", true);
+    mock().actualCall("foo").withParameter("parameter", true);
+
+    mock().checkExpectations();
+}
+
 TEST(MockParameterTest, expectOneUnsignedIntegerParameterAndValue)
 {
     unsigned int value = 14400;
@@ -677,6 +685,7 @@ TEST(MockParameterTest, ignoreOtherCallsIgnoresWithAllKindsOfParameters)
 {
      mock().ignoreOtherCalls();
      mock().actualCall("boo")
+           .withParameter("umm", true)
            .withParameter("bar", 1u)
            .withParameter("foo", 1l)
            .withParameter("hey", 1ul)

--- a/tests/CppUTestExt/MockReturnValueTest.cpp
+++ b/tests/CppUTestExt/MockReturnValueTest.cpp
@@ -202,6 +202,23 @@ TEST(MockReturnValueTest, WhenNoLongIntegerReturnValueIsExpectedButThereIsADefau
     LONGS_EQUAL(default_return_value, mock().returnLongIntValueOrDefault(default_return_value));
 }
 
+TEST(MockReturnValueTest, WhenABooleanReturnValueIsExpectedAndAlsoThereIsADefaultShouldlIgnoreTheDefault)
+{
+    bool default_return_value = true;
+    bool expected_return_value = false;
+    mock().expectOneCall("foo").andReturnValue(expected_return_value);
+    CHECK_EQUAL(expected_return_value, mock().actualCall("foo").returnBoolValueOrDefault(default_return_value));
+    CHECK_EQUAL(expected_return_value, mock().returnBoolValueOrDefault(default_return_value));
+}
+
+TEST(MockReturnValueTest, WhenNoBooleanReturnValueIsExpectedButThereIsADefaultShouldlUseTheDefaultValue)
+{
+    bool default_return_value = true;
+    mock().expectOneCall("foo");
+    CHECK_EQUAL(default_return_value, mock().actualCall("foo").returnBoolValueOrDefault(default_return_value));
+    CHECK_EQUAL(default_return_value, mock().returnBoolValueOrDefault(default_return_value));
+}
+
 TEST(MockReturnValueTest, WhenAIntegerReturnValueIsExpectedAndAlsoThereIsADefaultShouldlIgnoreTheDefault)
 {
     int default_return_value = 777;
@@ -217,6 +234,47 @@ TEST(MockReturnValueTest, WhenNoIntegerReturnValueIsExpectedButThereIsADefaultSh
     mock().expectOneCall("foo");
     LONGS_EQUAL(default_return_value, mock().actualCall("foo").returnIntValueOrDefault(default_return_value));
     LONGS_EQUAL(default_return_value, mock().returnIntValueOrDefault(default_return_value));
+}
+
+TEST(MockReturnValueTest, BooleanReturnValue)
+{
+    bool expected_value = true;
+    mock().expectOneCall("foo").andReturnValue(true);
+    MockActualCall& actual_call = mock().actualCall("foo");
+
+    CHECK_EQUAL(expected_value, actual_call.returnValue().getBoolValue());
+    CHECK_EQUAL(expected_value, actual_call.returnBoolValue());
+
+    CHECK_EQUAL(expected_value, mock().returnValue().getBoolValue());
+    CHECK_EQUAL(expected_value, mock().boolReturnValue());
+}
+
+TEST(MockReturnValueTest, BooleanReturnValueSetsDifferentValues)
+{
+    bool expected_value = true;
+    bool another_expected_value = false;
+
+    mock().expectOneCall("foo").andReturnValue(expected_value);
+    mock().expectOneCall("foo").andReturnValue(another_expected_value);
+
+    CHECK_EQUAL(expected_value, mock().actualCall("foo").returnValue().getBoolValue());
+    CHECK_EQUAL(expected_value, mock().returnValue().getBoolValue());
+    CHECK_EQUAL(another_expected_value, mock().actualCall("foo").returnValue().getBoolValue());
+    CHECK_EQUAL(another_expected_value, mock().returnValue().getBoolValue());
+}
+
+TEST(MockReturnValueTest, BooleanReturnValueSetsDifferentValuesWhileParametersAreIgnored)
+{
+    bool ret_value = true;
+    bool another_ret_value = false;
+
+    mock().expectOneCall("foo").withParameter("p1", 1).ignoreOtherParameters().andReturnValue(ret_value);
+    mock().expectOneCall("foo").withParameter("p1", 1).ignoreOtherParameters().andReturnValue(another_ret_value);
+
+    CHECK_EQUAL(ret_value, mock().actualCall("foo").withParameter("p1", 1).returnValue().getBoolValue());
+    CHECK_EQUAL(ret_value, mock().returnValue().getBoolValue());
+    CHECK_EQUAL(another_ret_value, mock().actualCall("foo").withParameter("p1", 1).returnValue().getBoolValue());
+    CHECK_EQUAL(another_ret_value, mock().returnValue().getBoolValue());
 }
 
 TEST(MockReturnValueTest, IntegerReturnValue)

--- a/tests/CppUTestExt/MockSupportTest.cpp
+++ b/tests/CppUTestExt/MockSupportTest.cpp
@@ -58,6 +58,13 @@ TEST(MockSupportTest, setDataForIntegerValues)
     LONGS_EQUAL(expected_data, mock().getData("data").getIntValue());
 }
 
+TEST(MockSupportTest, setDataForBooleanValues)
+{
+    bool expected_data = true;
+    mock().setData("data", expected_data);
+    CHECK_EQUAL(expected_data, mock().getData("data").getBoolValue());
+}
+
 TEST(MockSupportTest, hasDataBeenSet)
 {
     CHECK(!mock().hasData("data"));

--- a/tests/CppUTestExt/MockSupport_cTest.cpp
+++ b/tests/CppUTestExt/MockSupport_cTest.cpp
@@ -130,6 +130,12 @@ TEST(MockSupport_c, expectAndActualParametersOnObject)
     mock_c()->removeAllComparatorsAndCopiers();
 }
 
+TEST(MockSupport_c, boolParameter)
+{
+    mock_c()->expectOneCall("foo")->withBoolParameters("p", 1);
+    mock_c()->actualCall("foo")->withBoolParameters("p", 1);
+}
+
 TEST(MockSupport_c, unsignedIntParameter)
 {
     mock_c()->expectOneCall("foo")->withUnsignedIntParameters("p", 1);
@@ -196,6 +202,32 @@ TEST(MockSupport_c, ignoreOtherParameters)
     mock_c()->expectOneCall("foo")->withIntParameters("int", 1)->ignoreOtherParameters();
     mock_c()->actualCall("foo")->withIntParameters("int", 1)->withDoubleParameters("double", 0.01);
     mock_c()->checkExpectations();
+}
+
+TEST(MockSupport_c, returnBoolValue)
+{
+    int expected_value = 1;
+    mock_c()->expectOneCall("boo")->andReturnBoolValue(expected_value);
+    CHECK_EQUAL(expected_value, mock_c()->actualCall("boo")->boolReturnValue());
+    CHECK_EQUAL(expected_value, mock_c()->boolReturnValue());
+    LONGS_EQUAL(MOCKVALUETYPE_BOOL, mock_c()->returnValue().type);
+}
+
+TEST(MockSupport_c, whenReturnValueIsGivenReturnBoolValueOrDefaultShouldIgnoreTheDefault)
+{
+    int defaultValue = 1;
+    int expectedValue = 0;
+    mock_c()->expectOneCall("foo")->andReturnBoolValue(expectedValue);
+    LONGS_EQUAL(expectedValue, mock_c()->actualCall("foo")->returnBoolValueOrDefault(defaultValue));
+    LONGS_EQUAL(expectedValue, mock_c()->returnBoolValueOrDefault(defaultValue));
+}
+
+TEST(MockSupport_c, whenNoReturnValueIsGivenReturnBoolValueOrDefaultShouldlUseTheDefaultValue)
+{
+    int defaultValue = 1;
+    mock_c()->expectOneCall("foo");
+    LONGS_EQUAL(defaultValue, mock_c()->actualCall("foo")->returnBoolValueOrDefault(defaultValue));
+    LONGS_EQUAL(defaultValue, mock_c()->returnBoolValueOrDefault(defaultValue));
 }
 
 TEST(MockSupport_c, returnIntValue)
@@ -430,6 +462,12 @@ TEST(MockSupport_c, MockSupportWithScope)
     LONGS_EQUAL(0, mock_scope_c("other")->expectedCallsLeft());
     LONGS_EQUAL(1, mock_scope_c("scope")->expectedCallsLeft());
     mock_scope_c("scope")->actualCall("boo");
+}
+
+TEST(MockSupport_c, MockSupportSetBoolData)
+{
+    mock_c()->setBoolData("boolean", 1);
+    CHECK_EQUAL(1, mock_c()->getData("boolean").value.boolValue);
 }
 
 TEST(MockSupport_c, MockSupportSetIntData)

--- a/tests/CppUTestExt/MockSupport_cTestCFile.c
+++ b/tests/CppUTestExt/MockSupport_cTestCFile.c
@@ -49,6 +49,7 @@ void all_mock_support_c_calls(void)
     mock_c()->checkExpectations();
 
     mock_c()->expectOneCall("boo")->withIntParameters("integer", 1)->
+            withBoolParameters("bool", 1)->
             withUnsignedIntParameters("unsigned", 1)->
             withLongIntParameters("long int", (long int) -1)->
             withUnsignedLongIntParameters("unsigned long int", (unsigned long int) 1)->
@@ -61,6 +62,7 @@ void all_mock_support_c_calls(void)
             ignoreOtherParameters();
 
     mock_c()->actualCall("boo")->withIntParameters("integer", 1)->
+            withBoolParameters("bool", 1)->
             withUnsignedIntParameters("unsigned", 1)->
             withLongIntParameters("long int", (long int) -1)->
             withUnsignedLongIntParameters("unsigned long int", (unsigned long int) 1)->
@@ -89,9 +91,14 @@ void all_mock_support_c_calls(void)
     mock_c()->clear();
     mock_c()->removeAllComparatorsAndCopiers();
 
+    mock_c()->expectOneCall("boo")->andReturnBoolValue(1);
+    mock_c()->actualCall("boo")->boolReturnValue();
+    mock_c()->boolReturnValue();
+
     mock_c()->expectOneCall("boo")->andReturnIntValue(-10);
     mock_c()->actualCall("boo")->intReturnValue();
     mock_c()->intReturnValue();
+    mock_c()->returnValue();
 
     mock_c()->expectOneCall("boo2")->andReturnUnsignedIntValue(1.0);
     mock_c()->actualCall("boo2")->unsignedIntReturnValue();
@@ -125,6 +132,10 @@ void all_mock_support_c_calls(void)
     mock_c()->actualCall("boo8")->functionPointerReturnValue();
     mock_c()->functionPointerReturnValue();
 
+    mock_c()->setBoolData("bool", 1);
+    mock_c()->expectOneCall("bla")->withBoolParameters("bool", 1);
+    mock_c()->actualCall("bla")->withBoolParameters("bool", mock_c()->getData("bool").value.boolValue);
+
     mock_c()->setIntData("int", 5);
     mock_c()->expectOneCall("bla")->withIntParameters("int", 5);
     mock_c()->actualCall("bla")->withIntParameters("int", mock_c()->getData("int").value.intValue);
@@ -152,6 +163,7 @@ void all_mock_support_c_calls(void)
     mock_c()->clear();
 
     mock_c()->hasReturnValue();
+    mock_c()->returnBoolValueOrDefault(1);
     mock_c()->returnIntValueOrDefault(-1);
     mock_c()->returnUnsignedIntValueOrDefault(1);
     mock_c()->returnLongIntValueOrDefault(-1L);


### PR DESCRIPTION
Mock support for bool in C++ only, split from #847.

Note that since the C API does not support bool at all in this version, I have made one additional change: bool parameters and return values are now implicitly convertible to int parameters and return values respectively, and vice versa.  (This only applies to int, not other types such as long or unsigned int.)

This has a consequence that even C++-only tests will pass where the expectation is for a bool and the actual call is an int (or the reverse) -- opinions will probably differ on whether this is a benefit or a drawback, but it was something that I was trying to avoid in the prior PR.

However the main reason this has been done is specifically to allow the case where a C++ test is expecting a bool parameter/return but the actual call is made via the C API, which can only express this as an int.  (There is however no unit test for this as the current tests don't verify compatibility between C and C++ APIs in this fashion.)