### PR TITLE
add description to numerical check failure

### DIFF
--- a/include/CppUTest/TestFailure.h
+++ b/include/CppUTest/TestFailure.h
@@ -72,6 +72,7 @@ protected:
     SimpleString createButWasString(const SimpleString& expected, const SimpleString& actual);
     SimpleString createDifferenceAtPosString(const SimpleString& actual, size_t position, DifferenceFormat format = DIFFERENCE_STRING);
     SimpleString createUserText(const SimpleString& text);
+    SimpleString createNumericalCheckDescription(const SimpleString& longsEqualString, const SimpleString& expected, const SimpleString& actual);
 
     SimpleString testName_;
     SimpleString testNameOnly_;
@@ -127,6 +128,7 @@ class LongsEqualFailure : public TestFailure
 {
 public:
     LongsEqualFailure(UtestShell* test, const char* fileName, int lineNumber, long expected, long actual, const SimpleString& text);
+    LongsEqualFailure(UtestShell* test, const char* fileName, int lineNumber, long expected, long actual, const SimpleString& longsEqualString, const SimpleString& expectedString, const SimpleString& actualString, const SimpleString& text);
 };
 
 class UnsignedLongsEqualFailure : public TestFailure

--- a/include/CppUTest/Utest.h
+++ b/include/CppUTest/Utest.h
@@ -111,6 +111,7 @@ public:
     virtual void assertCstrNoCaseEqual(const char *expected, const char *actual, const char* text, const char *fileName, int lineNumber);
     virtual void assertCstrContains(const char *expected, const char *actual, const char* text, const char *fileName, int lineNumber);
     virtual void assertCstrNoCaseContains(const char *expected, const char *actual, const char* text, const char *fileName, int lineNumber);
+    virtual void assertLongsEqual(long expected, long actual, const char* longsEqualString, const char* expectedString, const char* actualString, const char* text, const char* fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
     virtual void assertLongsEqual(long expected, long actual, const char* text, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
     virtual void assertUnsignedLongsEqual(unsigned long expected, unsigned long actual, const char* text, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
     virtual void assertLongLongsEqual(cpputest_longlong expected, cpputest_longlong actual, const char* text, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());

--- a/include/CppUTest/UtestMacros.h
+++ b/include/CppUTest/UtestMacros.h
@@ -191,7 +191,7 @@
 
 //Check two long integers for equality
 #define LONGS_EQUAL(expected, actual)\
-  LONGS_EQUAL_LOCATION((expected), (actual), NULL, __FILE__, __LINE__)
+  LONGS_EQUAL_LOCATION_WITH_DESCRIPTION((expected), (actual), "LONGS_EQUAL", #expected, #actual, NULL, __FILE__, __LINE__)
 
 #define LONGS_EQUAL_TEXT(expected, actual, text)\
   LONGS_EQUAL_LOCATION((expected), (actual), text, __FILE__, __LINE__)
@@ -201,6 +201,10 @@
 
 #define UNSIGNED_LONGS_EQUAL_TEXT(expected, actual, text)\
   UNSIGNED_LONGS_EQUAL_LOCATION((expected), (actual), text, __FILE__, __LINE__)
+
+#define LONGS_EQUAL_LOCATION_WITH_DESCRIPTION(expected, actual, longsEqualString, expectedString, actualString, text, file, line)\
+  { UtestShell::getCurrent()->assertLongsEqual((long)expected, (long)actual, longsEqualString, expectedString, actualString, text, file, line); }
+
 
 #define LONGS_EQUAL_LOCATION(expected, actual, text, file, line)\
   { UtestShell::getCurrent()->assertLongsEqual((long)expected, (long)actual, text, file, line); }
@@ -227,7 +231,7 @@
         { UtestShell::getCurrent()->assertUnsignedLongLongsEqual(expected, actual, text, file, line); }
 
 #define BYTES_EQUAL(expected, actual)\
-    LONGS_EQUAL((expected) & 0xff,(actual) & 0xff)
+    LONGS_EQUAL_LOCATION_WITH_DESCRIPTION(((expected) & 0xff), ((actual) & 0xff), "BYTES_EQUAL", #expected, #actual, NULL, __FILE__, __LINE__)
 
 #define BYTES_EQUAL_TEXT(expected, actual, text)\
     LONGS_EQUAL_TEXT((expected) & 0xff, (actual) & 0xff, text)

--- a/src/CppUTest/TestFailure.cpp
+++ b/src/CppUTest/TestFailure.cpp
@@ -129,6 +129,20 @@ bool TestFailure::isInHelperFunction() const
 {
     return lineNumber_ < testLineNumber_;
 }
+SimpleString TestFailure::createNumericalCheckDescription(const SimpleString& longsEqualString, const SimpleString& expected, const SimpleString& actual)
+{
+    SimpleString result;
+    
+    result += longsEqualString;
+    result += "(";
+    result += expected;
+    result += ", ";
+    result += actual;
+    result += ")";
+    result += " failed!\n";
+
+    return result;
+}
 
 SimpleString TestFailure::createButWasString(const SimpleString& expected, const SimpleString& actual)
 {
@@ -235,12 +249,31 @@ FailFailure::FailFailure(UtestShell* test, const char* fileName, int lineNumber,
 {
     message_ = message;
 }
+LongsEqualFailure::LongsEqualFailure(UtestShell* test, const char* fileName, int lineNumber, long expected, long actual, const SimpleString& longsEqualString, const SimpleString& expectedString, const SimpleString& actualString, const SimpleString& text)
+: TestFailure(test, fileName, lineNumber)
+{
+    message_ = createUserText(text);
+
+    message_ += createNumericalCheckDescription(longsEqualString, expectedString, actualString);
+
+    SimpleString aDecimal = StringFrom(actual);
+    SimpleString aHex = HexStringFrom(actual);
+    SimpleString eDecimal = StringFrom(expected);
+    SimpleString eHex = HexStringFrom(expected);
+
+    SimpleString::padStringsToSameLength(aDecimal, eDecimal, ' ');
+    SimpleString::padStringsToSameLength(aHex, eHex, '0');
+
+    SimpleString actualReported = aDecimal + " 0x" + aHex;
+    SimpleString expectedReported = eDecimal + " 0x" + eHex;
+    message_ += createButWasString(expectedReported, actualReported);
+}
 
 LongsEqualFailure::LongsEqualFailure(UtestShell* test, const char* fileName, int lineNumber, long expected, long actual, const SimpleString& text)
 : TestFailure(test, fileName, lineNumber)
 {
     message_ = createUserText(text);
-
+    
     SimpleString aDecimal = StringFrom(actual);
     SimpleString aHex = HexStringFrom(actual);
     SimpleString eDecimal = StringFrom(expected);

--- a/src/CppUTest/TestResult.cpp
+++ b/src/CppUTest/TestResult.cpp
@@ -30,7 +30,7 @@
 #include "CppUTest/TestFailure.h"
 #include "CppUTest/TestOutput.h"
 #include "CppUTest/PlatformSpecificFunctions.h"
-
+  
 TestResult::TestResult(TestOutput& p) :
     output_(p), testCount_(0), runCount_(0), checkCount_(0), failureCount_(0), filteredOutCount_(0), ignoredCount_(0), totalExecutionTime_(0), timeStarted_(0), currentTestTimeStarted_(0),
             currentTestTotalExecutionTime_(0), currentGroupTimeStarted_(0), currentGroupTotalExecutionTime_(0)

--- a/src/CppUTest/Utest.cpp
+++ b/src/CppUTest/Utest.cpp
@@ -415,6 +415,14 @@ void UtestShell::assertCstrNoCaseContains(const char* expected, const char* actu
         failWith(ContainsFailure(this, fileName, lineNumber, expected, actual, text));
 }
 
+void UtestShell::assertLongsEqual(long expected, long actual, const char* longsEqualString, const char* expectedString, const char* actualString, const char* text, const char* fileName, int lineNumber, const TestTerminator& testTerminator)
+{
+    getTestResult()->countCheck();
+    if (expected != actual)
+        failWith(LongsEqualFailure (this, fileName, lineNumber, expected, actual, longsEqualString, expectedString, actualString, text), testTerminator);
+}
+
+
 void UtestShell::assertLongsEqual(long expected, long actual, const char* text, const char* fileName, int lineNumber, const TestTerminator& testTerminator)
 {
     getTestResult()->countCheck();

--- a/tests/TestUTestMacro.cpp
+++ b/tests/TestUTestMacro.cpp
@@ -883,6 +883,47 @@ static void _failingTestMethodWithLONGS_EQUAL()
     LONGS_EQUAL(1, 0xff);
     lineOfCodeExecutedAfterCheck = true; // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
+class globalConfigureFactory
+{
+public:
+    static int getUserHighestPriority()
+    {
+        return 4;
+    }
+};
+
+class usersPriorityGenerator
+{
+public:
+    usersPriorityGenerator()
+    {
+        usersPriority[0] = 4;
+        usersPriority[1] = 2;
+    }
+    int(&getUsersPriority())[2]
+    {
+        return usersPriority;
+    }
+private:
+    int usersPriority[2];
+};
+static void _failingTestMethodWithLONGS_EQUALUsedForNonMagicValue()
+{
+    usersPriorityGenerator uPG;
+        
+    LONGS_EQUAL(globalConfigureFactory::getUserHighestPriority(), uPG.getUsersPriority()[0]);
+    LONGS_EQUAL(globalConfigureFactory::getUserHighestPriority() - 1, uPG.getUsersPriority()[1]);
+
+    lineOfCodeExecutedAfterCheck = true; // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
+TEST(UnitTestMacros, FailureWithLONGS_EQUALSUsedForNonMagicValue)
+{
+    runTestWithMethod(_failingTestMethodWithLONGS_EQUALUsedForNonMagicValue);
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("LONGS_EQUAL(globalConfigureFactory::getUserHighestPriority() - 1, uPG.getUsersPriority()[1]) failed!");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <3 0x3>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <2 0x2>");
+}
 
 TEST(UnitTestMacros, FailureWithLONGS_EQUALS)
 {


### PR DESCRIPTION
example:
```.cpp
class globalConfigureFactory
{
public:
    static int getUserHighestPriority()
    {
        return 4;
    }
};

class usersPriorityGenerator
{
public:
    usersPriorityGenerator()
    {
        usersPriority[0] = 4;
        usersPriority[1] = 2;
    }
    int(&getUsersPriority())[2]
    {
        return usersPriority;
    }
private:
    int usersPriority[2];
};

TEST(testGroup, testUserPriorityCalculation)
{
    usersPriorityGenerator uPG;
        
    ...//some code here to calculate users priority using class usersPriorityGenerator
    LONGS_EQUAL(globalConfigureFactory::getUserHighestPriority(), uPG.getUsersPriority()[0]);
    LONGS_EQUAL(globalConfigureFactory::getUserHighestPriority() - 1, uPG.getUsersPriority()[1]);
}
```
in this example, I have more than one numeric check in TEST, and none use the simple and readable magic number as in the cppUTest framework's TEST such as `LONGS_EQUAL(1, 0xff);`, so if one of my check fail, I will get something like `expected <3 0x3>, but was  <2 0x2>`, this will not let me locate exactly and quickly which check really fail, because in my LONGS_EQUAL there isn't 0x3 or 0x2 there, I need to debug dynamically to find which function's result mapping to 0x3 and which mapping to 0x2.

I think a description to those numerical check will be efficient to take me to the exact failure CHECK, such as `LONGS_EQUAL(globalConfigureFactory::getUserHighestPriority() - 1, uPG.getUsersPriority()[1]) failed!   expected <3 0x3>, but was  <2 0x2>`

LONGS_EQUAL_TEXT is not my choice because I don't want to send any special message to the failure, I just want to know which numerical check fail.

This PR only add description to LONGS_EQUAL, and let's see if extend to other numerical check too.
This TEST `TEST(UnitTestMacros, FailureWithLONGS_EQUALSUsedForNonMagicValue)` tell what this PR has done.

