### PR TITLE
Add IEEE754 files to Visual Studio

### DIFF
--- a/CppUTest.vcproj
+++ b/CppUTest.vcproj
@@ -227,29 +227,11 @@
 				</FileConfiguration>
 			</File>
 			<File
-				RelativePath="SRC\CPPUTEST\JUnitTestOutput.cpp"
+				RelativePath=".\src\CppUTestExt\IEEE754ExceptionsPlugin.cpp"
 				>
-				<FileConfiguration
-					Name="Debug|Win32"
-					>
-					<Tool
-						Name="VCCLCompilerTool"
-						AdditionalIncludeDirectories=""
-						PreprocessorDefinitions=""
-					/>
-				</FileConfiguration>
-				<FileConfiguration
-					Name="Release|Win32"
-					>
-					<Tool
-						Name="VCCLCompilerTool"
-						AdditionalIncludeDirectories=""
-						PreprocessorDefinitions=""
-					/>
-				</FileConfiguration>
 			</File>
 			<File
-				RelativePath="SRC\CPPUTEST\TeamCityTestOutput.cpp"
+				RelativePath="SRC\CPPUTEST\JUnitTestOutput.cpp"
 				>
 				<FileConfiguration
 					Name="Debug|Win32"
@@ -623,6 +605,28 @@
 				</FileConfiguration>
 			</File>
 			<File
+				RelativePath="SRC\CPPUTEST\TeamCityTestOutput.cpp"
+				>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+			</File>
+			<File
 				RelativePath="SRC\CPPUTEST\TestFailure.cpp"
 				>
 				<FileConfiguration
@@ -852,7 +856,15 @@
 				>
 			</File>
 			<File
+				RelativePath=".\include\CppUTest\CommandLineArguments.h"
+				>
+			</File>
+			<File
 				RelativePath="include\CppUTest\CommandLineTestRunner.h"
+				>
+			</File>
+			<File
+				RelativePath=".\include\CppUTest\CppUTestConfig.h"
 				>
 			</File>
 			<File
@@ -872,7 +884,23 @@
 				>
 			</File>
 			<File
+				RelativePath=".\include\CppUTestExt\IEEE754ExceptionsPlugin.h"
+				>
+			</File>
+			<File
 				RelativePath="include\CppUTest\JunitTestOutput.h"
+				>
+			</File>
+			<File
+				RelativePath=".\include\CppUTest\MemoryLeakDetector.h"
+				>
+			</File>
+			<File
+				RelativePath=".\include\CppUTest\MemoryLeakDetectorMallocMacros.h"
+				>
+			</File>
+			<File
+				RelativePath=".\include\CppUTest\MemoryLeakDetectorNewMacros.h"
 				>
 			</File>
 			<File
@@ -896,11 +924,19 @@
 				>
 			</File>
 			<File
+				RelativePath=".\include\CppUTestExt\MockActualCall.h"
+				>
+			</File>
+			<File
 				RelativePath="include\CppUTestExt\MockCheckedActualCall.h"
 				>
 			</File>
 			<File
 				RelativePath="include\CppUTestExt\MockCheckedExpectedCall.h"
+				>
+			</File>
+			<File
+				RelativePath=".\include\CppUTestExt\MockExpectedCall.h"
 				>
 			</File>
 			<File
@@ -944,7 +980,19 @@
 				>
 			</File>
 			<File
+				RelativePath=".\include\CppUTest\PlatformSpecificFunctions.h"
+				>
+			</File>
+			<File
+				RelativePath=".\include\CppUTest\PlatformSpecificFunctions_c.h"
+				>
+			</File>
+			<File
 				RelativePath="include\CppUTest\RealTestOutput.h"
+				>
+			</File>
+			<File
+				RelativePath=".\include\CppUTest\SimpleMutex.h"
 				>
 			</File>
 			<File
@@ -953,6 +1001,22 @@
 			</File>
 			<File
 				RelativePath="include\CppUTest\SimpleStringExtensions.h"
+				>
+			</File>
+			<File
+				RelativePath=".\include\CppUTest\StandardCLibrary.h"
+				>
+			</File>
+			<File
+				RelativePath=".\include\CppUTest\TeamCityTestOutput.h"
+				>
+			</File>
+			<File
+				RelativePath=".\include\CppUTest\TestFailure.h"
+				>
+			</File>
+			<File
+				RelativePath=".\include\CppUTest\TestFilter.h"
 				>
 			</File>
 			<File
@@ -965,6 +1029,10 @@
 			</File>
 			<File
 				RelativePath="include\CppUTest\TestInstaller.h"
+				>
+			</File>
+			<File
+				RelativePath=".\include\CppUTest\TestMemoryAllocator.h"
 				>
 			</File>
 			<File
@@ -984,7 +1052,15 @@
 				>
 			</File>
 			<File
+				RelativePath=".\include\CppUTest\TestTestingFixture.h"
+				>
+			</File>
+			<File
 				RelativePath="include\CppUTest\Utest.h"
+				>
+			</File>
+			<File
+				RelativePath=".\include\CppUTest\UtestMacros.h"
 				>
 			</File>
 			<File

--- a/CppUTest.vcxproj
+++ b/CppUTest.vcxproj
@@ -112,6 +112,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="src\CppUTestExt\CodeMemoryReportFormatter.cpp" />
+    <ClCompile Include="src\CppUTestExt\IEEE754ExceptionsPlugin.cpp" />
     <ClCompile Include="src\CppUTestExt\MemoryReportAllocator.cpp" />
     <ClCompile Include="src\CppUTestExt\MemoryReporterPlugin.cpp" />
     <ClCompile Include="src\CppUTestExt\MemoryReportFormatter.cpp" />
@@ -152,6 +153,7 @@
     <ClInclude Include="include\CppUTestExt\GMock.h" />
     <ClInclude Include="include\CppUTestExt\GTest.h" />
     <ClInclude Include="include\CppUTestExt\GTestConvertor.h" />
+    <ClInclude Include="include\cpputestext\ieee754exceptionsplugin.h" />
     <ClInclude Include="include\CppUTestExt\MemoryReportAllocator.h" />
     <ClInclude Include="include\CppUTestExt\MemoryReporterPlugin.h" />
     <ClInclude Include="include\CppUTestExt\MemoryReportFormatter.h" />
@@ -168,7 +170,9 @@
     <ClInclude Include="include\CppUTestExt\OrderedTest.h" />
     <ClInclude Include="include\CppUTest\CommandLineArguments.h" />
     <ClInclude Include="include\CppUTest\CommandLineTestRunner.h" />
+    <ClInclude Include="include\cpputest\cpputestconfig.h" />
     <ClInclude Include="include\CppUTest\JUnitTestOutput.h" />
+    <ClInclude Include="include\cpputest\platformspecificfunctions_c.h" />
     <ClInclude Include="include\CppUTest\TeamCityTestOutput.h" />
     <ClInclude Include="include\CppUTest\MemoryLeakDetector.h" />
     <ClInclude Include="include\CppUTest\MemoryLeakDetectorMallocMacros.h" />

--- a/include/CppUTest/CppUTestConfig.h
+++ b/include/CppUTest/CppUTestConfig.h
@@ -167,9 +167,10 @@
 
 /*
  * Handling of IEEE754 floating point exceptions via fenv.h
+ * Works on non-Visual C++ compilers and Visual C++ 2008 and newer
  */
 
-#if CPPUTEST_USE_STD_C_LIB
+#if CPPUTEST_USE_STD_C_LIB && (!defined(_MSC_VER) || (_MSC_VER >= 1500))
 #define CPPUTEST_HAVE_FENV
 #if defined(__WATCOMC__)
 #define CPPUTEST_FENV_IS_WORKING_PROPERLY 0

--- a/include/CppUTest/CppUTestConfig.h
+++ b/include/CppUTest/CppUTestConfig.h
@@ -170,7 +170,7 @@
  * Works on non-Visual C++ compilers and Visual C++ 2008 and newer
  */
 
-#if CPPUTEST_USE_STD_C_LIB && (!defined(_MSC_VER) || (_MSC_VER >= 1500))
+#if CPPUTEST_USE_STD_C_LIB && (!defined(_MSC_VER) || (_MSC_VER >= 1800))
 #define CPPUTEST_HAVE_FENV
 #if defined(__WATCOMC__)
 #define CPPUTEST_FENV_IS_WORKING_PROPERLY 0

--- a/tests/AllTests.vcproj
+++ b/tests/AllTests.vcproj
@@ -493,6 +493,14 @@
 				</FileConfiguration>
 			</File>
 			<File
+				RelativePath=".\CppUTestExt\IEEE754PluginTest.cpp"
+				>
+			</File>
+			<File
+				RelativePath=".\CppUTestExt\IEEE754PluginTest_c.c"
+				>
+			</File>
+			<File
 				RelativePath="JUnitOutputTest.cpp"
 				>
 				<FileConfiguration
@@ -731,6 +739,14 @@
 				</FileConfiguration>
 			</File>
 			<File
+				RelativePath="CppUTestExt\MockFailureReporterForTest.cpp"
+				>
+			</File>
+			<File
+				RelativePath="CppUTestExt\MockFailureReporterForTest.h"
+				>
+			</File>
+			<File
 				RelativePath="CppUTestExt\MockFailureTest.cpp"
 				>
 				<FileConfiguration
@@ -752,14 +768,6 @@
 						ForcedIncludeFiles=""
 					/>
 				</FileConfiguration>
-			</File>
-			<File
-				RelativePath="CppUTestExt\MockFailureReporterForTest.cpp"
-				>
-			</File>
-			<File
-				RelativePath="CppUTestExt\MockFailureReporterForTest.h"
-				>
 			</File>
 			<File
 				RelativePath=".\CppUTestExt\MockHierarchyTest.cpp"
@@ -1364,6 +1372,10 @@
 			</File>
 			<File
 				RelativePath="..\include\CppUTest\CppUTestConfig.h"
+				>
+			</File>
+			<File
+				RelativePath=".\CppUTestExt\IEEE754PluginTest_c.h"
 				>
 			</File>
 			<File

--- a/tests/AllTests.vcxproj
+++ b/tests/AllTests.vcxproj
@@ -145,6 +145,8 @@
     <ClCompile Include="CppUTestExt\GMockTest.cpp" />
     <ClCompile Include="CppUTestExt\GTest1Test.cpp" />
     <ClCompile Include="CppUTestExt\GTest2ConvertorTest.cpp" />
+    <ClCompile Include="CppUTestExt\IEEE754PluginTest.cpp" />
+    <ClCompile Include="CppUTestExt\IEEE754PluginTest_c.c" />
     <ClCompile Include="CppUTestExt\MemoryReportAllocatorTest.cpp" />
     <ClCompile Include="CppUTestExt\MemoryReporterPluginTest.cpp" />
     <ClCompile Include="CppUTestExt\MemoryReportFormatterTest.cpp" />
@@ -195,6 +197,8 @@
     <ClInclude Include="AllocationInCppFile.h" />
     <ClInclude Include="AllocLetTestFree.h" />
     <ClInclude Include="AllTests.h" />
+    <ClInclude Include="CppUTestExt\IEEE754PluginTest_c.h" />
+    <ClInclude Include="cpputestext\mockfailurereporterfortest.h" />
     <ClInclude Include="CppUTestExt\MockFailureTest.h" />
     <ClInclude Include="CppUTestExt\MockSupport_cTestCFile.h" />
   </ItemGroup>

--- a/tests/CppUTestExt/IEEE754PluginTest_c.c
+++ b/tests/CppUTestExt/IEEE754PluginTest_c.c
@@ -76,4 +76,4 @@ void set_everything_c()
     set_inexact_c();
 }
 
-#endif // CPPUTEST_HAVE_FENV
+#endif /* CPPUTEST_HAVE_FENV */

--- a/tests/CppUTestExt/IEEE754PluginTest_c.c
+++ b/tests/CppUTestExt/IEEE754PluginTest_c.c
@@ -25,8 +25,6 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <CppUTest/CppUTestConfig.h>
-
 #include "IEEE754PluginTest_c.h"
 #include <math.h>
 

--- a/tests/CppUTestExt/IEEE754PluginTest_c.c
+++ b/tests/CppUTestExt/IEEE754PluginTest_c.c
@@ -27,8 +27,6 @@
 
 #include <CppUTest/CppUTestConfig.h>
 
-#ifdef CPPUTEST_HAVE_FENV
-
 #include "IEEE754PluginTest_c.h"
 #include <math.h>
 
@@ -42,14 +40,14 @@ void set_divisionbyzero_c(void)
 
 void set_overflow_c(void)
 {
-    f = 1000.0f;
-    while (f < INFINITY) f *= f;
+   f = 1e38f;
+   f *= f;
 }
 
 void set_underflow_c(void)
 {
-    f = 0.01f;
-    while (f > 0.0f) f *= f;
+   f = 1e-38f;
+   f *= f;
 }
 
 void set_invalid_c(void)
@@ -75,5 +73,3 @@ void set_everything_c()
     set_invalid_c();
     set_inexact_c();
 }
-
-#endif /* CPPUTEST_HAVE_FENV */

--- a/tests/CppUTestExt/IEEE754PluginTest_c.c
+++ b/tests/CppUTestExt/IEEE754PluginTest_c.c
@@ -25,6 +25,10 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <CppUTest/CppUTestConfig.h>
+
+#ifdef CPPUTEST_HAVE_FENV
+
 #include "IEEE754PluginTest_c.h"
 #include <math.h>
 
@@ -71,3 +75,5 @@ void set_everything_c()
     set_invalid_c();
     set_inexact_c();
 }
+
+#endif // CPPUTEST_HAVE_FENV


### PR DESCRIPTION
Also adds a check for _MSC_VER to disable the FENV logic for versions prior to 2013.  Older versions don't have the fenv.h header file that is required for this to work properly.

This should fix the issue seen in #946.