### PR TITLE
Add missing sources to visual studio

### DIFF
--- a/CppUTest.vcproj
+++ b/CppUTest.vcproj
@@ -803,6 +803,10 @@
 				</FileConfiguration>
 			</File>
 			<File
+				RelativePath=".\src\CppUTest\TestTestingFixture.cpp"
+				>
+			</File>
+			<File
 				RelativePath="SRC\CPPUTEST\Utest.cpp"
 				>
 				<FileConfiguration

--- a/CppUTest.vcproj
+++ b/CppUTest.vcproj
@@ -872,15 +872,15 @@
 				>
 			</File>
 			<File
-				RelativePath="include\CppUTest\EqualsFailure.h"
-				>
-			</File>
-			<File
-				RelativePath="include\CppUTest\Failure.h"
+				RelativePath=".\include\CppUTest\CppUTestGeneratedConfig.h"
 				>
 			</File>
 			<File
 				RelativePath="include\CppUTestExt\GMock.h"
+				>
+			</File>
+			<File
+				RelativePath=".\include\CppUTestExt\GTest.h"
 				>
 			</File>
 			<File
@@ -905,10 +905,6 @@
 			</File>
 			<File
 				RelativePath=".\include\CppUTest\MemoryLeakDetectorNewMacros.h"
-				>
-			</File>
-			<File
-				RelativePath="include\CppUTest\MemoryLeakWarning.h"
 				>
 			</File>
 			<File
@@ -968,19 +964,7 @@
 				>
 			</File>
 			<File
-				RelativePath="include\CppUTest\MockTestOutput.h"
-				>
-			</File>
-			<File
-				RelativePath="include\CppUTest\NullTest.h"
-				>
-			</File>
-			<File
 				RelativePath="include\CppUTestExt\OrderedTest.h"
-				>
-			</File>
-			<File
-				RelativePath="src\Platforms\VisualCpp\Platform.h"
 				>
 			</File>
 			<File
@@ -992,19 +976,11 @@
 				>
 			</File>
 			<File
-				RelativePath="include\CppUTest\RealTestOutput.h"
-				>
-			</File>
-			<File
 				RelativePath=".\include\CppUTest\SimpleMutex.h"
 				>
 			</File>
 			<File
 				RelativePath="include\CppUTest\SimpleString.h"
-				>
-			</File>
-			<File
-				RelativePath="include\CppUTest\SimpleStringExtensions.h"
 				>
 			</File>
 			<File
@@ -1029,10 +1005,6 @@
 			</File>
 			<File
 				RelativePath="include\CppUTest\TestHarness_c.h"
-				>
-			</File>
-			<File
-				RelativePath="include\CppUTest\TestInstaller.h"
 				>
 			</File>
 			<File
@@ -1065,10 +1037,6 @@
 			</File>
 			<File
 				RelativePath=".\include\CppUTest\UtestMacros.h"
-				>
-			</File>
-			<File
-				RelativePath="include\CppUTest\VirtualCall.h"
 				>
 			</File>
 		</Filter>

--- a/CppUTest.vcxproj
+++ b/CppUTest.vcxproj
@@ -172,6 +172,7 @@
     <ClInclude Include="include\CppUTest\CommandLineArguments.h" />
     <ClInclude Include="include\CppUTest\CommandLineTestRunner.h" />
     <ClInclude Include="include\cpputest\cpputestconfig.h" />
+    <ClInclude Include="include\CppUTest\CppUTestGeneratedConfig.h" />
     <ClInclude Include="include\CppUTest\JUnitTestOutput.h" />
     <ClInclude Include="include\cpputest\platformspecificfunctions_c.h" />
     <ClInclude Include="include\CppUTest\TeamCityTestOutput.h" />

--- a/CppUTest.vcxproj
+++ b/CppUTest.vcxproj
@@ -141,6 +141,7 @@
     <ClCompile Include="src\CppUTest\TestPlugin.cpp" />
     <ClCompile Include="src\CppUTest\TestRegistry.cpp" />
     <ClCompile Include="src\CppUTest\TestResult.cpp" />
+    <ClCompile Include="src\CppUTest\TestTestingFixture.cpp" />
     <ClCompile Include="src\CppUTest\Utest.cpp" />
     <ClCompile Include="src\Platforms\VisualCpp\UtestPlatform.cpp">
       <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>

--- a/tests/AllTests.vcproj
+++ b/tests/AllTests.vcproj
@@ -1300,6 +1300,10 @@
 				</FileConfiguration>
 			</File>
 			<File
+				RelativePath=".\TestUTestStringMacro.cpp"
+				>
+			</File>
+			<File
 				RelativePath="UtestPlatformTest.cpp"
 				>
 				<FileConfiguration

--- a/tests/AllTests.vcproj
+++ b/tests/AllTests.vcproj
@@ -1371,63 +1371,7 @@
 				>
 			</File>
 			<File
-				RelativePath="..\include\CppUTest\CommandLineArguments.h"
-				>
-			</File>
-			<File
-				RelativePath="..\include\CppUTest\CppUTestConfig.h"
-				>
-			</File>
-			<File
 				RelativePath=".\CppUTestExt\IEEE754PluginTest_c.h"
-				>
-			</File>
-			<File
-				RelativePath="..\include\CppUTest\MemoryLeakDetector.h"
-				>
-			</File>
-			<File
-				RelativePath="..\include\CppUTest\MemoryLeakDetectorMallocMacros.h"
-				>
-			</File>
-			<File
-				RelativePath="..\include\CppUTest\MemoryLeakDetectorNewMacros.h"
-				>
-			</File>
-			<File
-				RelativePath="..\include\CppUTest\PlatformSpecificFunctions.h"
-				>
-			</File>
-			<File
-				RelativePath="..\include\CppUTest\PlatformSpecificFunctions_c.h"
-				>
-			</File>
-			<File
-				RelativePath="..\include\CppUTest\SimpleMutex.h"
-				>
-			</File>
-			<File
-				RelativePath="..\include\CppUTest\StandardCLibrary.h"
-				>
-			</File>
-			<File
-				RelativePath="..\include\CppUTest\TestFailure.h"
-				>
-			</File>
-			<File
-				RelativePath="..\include\CppUTest\TestFilter.h"
-				>
-			</File>
-			<File
-				RelativePath="..\include\CppUTest\TestMemoryAllocator.h"
-				>
-			</File>
-			<File
-				RelativePath="..\include\CppUTest\TestTestingFixture.h"
-				>
-			</File>
-			<File
-				RelativePath="..\include\CppUTest\UtestMacros.h"
 				>
 			</File>
 		</Filter>

--- a/tests/AllTests.vcxproj
+++ b/tests/AllTests.vcxproj
@@ -189,6 +189,7 @@
     <ClCompile Include="TestRegistryTest.cpp" />
     <ClCompile Include="TestResultTest.cpp" />
     <ClCompile Include="TestUTestMacro.cpp" />
+    <ClCompile Include="TestUTestStringMacro.cpp" />
     <ClCompile Include="UtestPlatformTest.cpp" />
     <ClCompile Include="UtestTest.cpp" />
   </ItemGroup>


### PR DESCRIPTION
I've added the new source file to the VS201x and VS2005 projects.  I also cleaned up the header files in the VS2005 projects - has no effect on compiling but makes the project cleaner.

VS2013 and VS2015 still fail due to one of the floating point tests.