### PR TITLE
Refactor IEEE754 debugging functions

### DIFF
--- a/include/CppUTestExt/IEEE754ExceptionsPlugin.h
+++ b/include/CppUTestExt/IEEE754ExceptionsPlugin.h
@@ -40,7 +40,10 @@ public:
 
     static void disableInexact(void);
     static void enableInexact(void);
-    static bool checkIeee754ExeptionFlag(int flag);
+    static bool checkIeee754OverflowExceptionFlag();
+    static bool checkIeee754UnderflowExceptionFlag();
+    static bool checkIeee754InexactExceptionFlag();
+    static bool checkIeee754DivByZeroExceptionFlag();
 
 private:
     void ieee754Check(UtestShell& test, TestResult& result, int flag, const char* text);

--- a/src/CppUTestExt/IEEE754ExceptionsPlugin.cpp
+++ b/src/CppUTestExt/IEEE754ExceptionsPlugin.cpp
@@ -69,9 +69,24 @@ void IEEE754ExceptionsPlugin::enableInexact()
     inexactDisabled_ = false;
 }
 
-bool IEEE754ExceptionsPlugin::checkIeee754ExeptionFlag(int flag)
+bool IEEE754ExceptionsPlugin::checkIeee754OverflowExceptionFlag()
 {
-    return fetestexcept(flag) != 0;
+    return fetestexcept(FE_OVERFLOW) != 0;
+}
+
+bool IEEE754ExceptionsPlugin::checkIeee754UnderflowExceptionFlag()
+{
+    return fetestexcept(FE_UNDERFLOW) != 0;
+}
+
+bool IEEE754ExceptionsPlugin::checkIeee754InexactExceptionFlag()
+{
+    return fetestexcept(FE_INEXACT) != 0;
+}
+
+bool IEEE754ExceptionsPlugin::checkIeee754DivByZeroExceptionFlag()
+{
+    return fetestexcept(FE_DIVBYZERO) != 0;
 }
 
 void IEEE754ExceptionsPlugin::ieee754Check(UtestShell& test, TestResult& result, int flag, const char* text)

--- a/tests/CppUTestExt/IEEE754PluginTest.cpp
+++ b/tests/CppUTestExt/IEEE754PluginTest.cpp
@@ -119,11 +119,10 @@ TEST(FE__with_Plugin, should_not_fail_again_when_test_has_already_failed)
 {
     fixture.setTestFunction(set_everything_but_already_failed);
     fixture.runAllTests();
-    CHECK(
-        IEEE754ExceptionsPlugin::checkIeee754ExeptionFlag(1 << 2) ||
-        IEEE754ExceptionsPlugin::checkIeee754ExeptionFlag(1 << 3) ||
-        IEEE754ExceptionsPlugin::checkIeee754ExeptionFlag(1 << 4)
-    );
+    CHECK(IEEE754ExceptionsPlugin::checkIeee754OverflowExceptionFlag());
+    CHECK(IEEE754ExceptionsPlugin::checkIeee754UnderflowExceptionFlag());
+    CHECK(IEEE754ExceptionsPlugin::checkIeee754InexactExceptionFlag());
+    CHECK(IEEE754ExceptionsPlugin::checkIeee754DivByZeroExceptionFlag());
     LONGS_EQUAL(1, fixture.getCheckCount());
     LONGS_EQUAL(1, fixture.getFailureCount());
 }


### PR DESCRIPTION
As discussed in #954, I split the checkIeee754ExeptionFlag(int flag) function into specific functions for each flag.
This allows keeping the specifics of how the flags are defined in the class and avoid anything else depending on fenv.