### PR TITLE
Added ignores for VS2015 files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,8 @@ Release
 *.tlog
 *.cache
 *.user
+*.VC.db
+*.VC.opendb
 _build_
 _build
 builds/*gcc*


### PR DESCRIPTION
When using Visual Studio 2015 I noticed that there's a couple new files generated by the IDE containing local information.  I added the extensions for these files to the .gitignore file.