### PR TITLE
Add interface to compare signed byte-sized data

### DIFF
--- a/include/CppUTest/SimpleString.h
+++ b/include/CppUTest/SimpleString.h
@@ -146,6 +146,7 @@ SimpleString StringFrom(long value);
 SimpleString StringFrom(unsigned long value);
 SimpleString StringFrom(cpputest_longlong value);
 SimpleString StringFrom(cpputest_ulonglong value);
+SimpleString HexStringFrom(signed char value);
 SimpleString HexStringFrom(long value);
 SimpleString HexStringFrom(unsigned long value);
 SimpleString HexStringFrom(cpputest_longlong value);

--- a/include/CppUTest/TestFailure.h
+++ b/include/CppUTest/TestFailure.h
@@ -147,6 +147,12 @@ public:
     UnsignedLongLongsEqualFailure(UtestShell* test, const char* fileName, int lineNumber, cpputest_ulonglong expected, cpputest_ulonglong actual, const SimpleString& text);
 };
 
+class SignedBytesEqualFailure : public TestFailure
+{
+public:
+    SignedBytesEqualFailure (UtestShell* test, const char* fileName, int lineNumber, signed char expected, signed char actual, const SimpleString& text);
+};
+
 class StringEqualFailure : public TestFailure
 {
 public:

--- a/include/CppUTest/TestHarness_c.h
+++ b/include/CppUTest/TestHarness_c.h
@@ -45,6 +45,12 @@
 #define CHECK_EQUAL_C_CHAR(expected,actual) \
   CHECK_EQUAL_C_CHAR_LOCATION(expected,actual,__FILE__,__LINE__)
 
+#define CHECK_EQUAL_C_UBYTE(expected,actual) \
+  CHECK_EQUAL_C_UBYTE_LOCATION(expected,actual,__FILE__,__LINE__)
+
+#define CHECK_EQUAL_C_SBYTE(expected,actual) \
+  CHECK_EQUAL_C_SBYTE_LOCATION(expected,actual,__FILE__,__LINE__)
+
 #define CHECK_EQUAL_C_STRING(expected,actual) \
   CHECK_EQUAL_C_STRING_LOCATION(expected,actual,__FILE__,__LINE__)
 
@@ -119,6 +125,10 @@ extern void CHECK_EQUAL_C_INT_LOCATION(int expected, int actual,
 extern void CHECK_EQUAL_C_REAL_LOCATION(double expected, double actual,
         double threshold, const char* fileName, int lineNumber);
 extern void CHECK_EQUAL_C_CHAR_LOCATION(char expected, char actual,
+        const char* fileName, int lineNumber);
+extern void CHECK_EQUAL_C_UBYTE_LOCATION(unsigned char expected, unsigned char actual, 
+        const char* fileName, int lineNumber);
+extern void CHECK_EQUAL_C_SBYTE_LOCATION(signed char expected, signed char actual, 
         const char* fileName, int lineNumber);
 extern void CHECK_EQUAL_C_STRING_LOCATION(const char* expected,
         const char* actual, const char* fileName, int lineNumber);

--- a/include/CppUTest/Utest.h
+++ b/include/CppUTest/Utest.h
@@ -115,6 +115,7 @@ public:
     virtual void assertUnsignedLongsEqual(unsigned long expected, unsigned long actual, const char* text, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
     virtual void assertLongLongsEqual(cpputest_longlong expected, cpputest_longlong actual, const char* text, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
     virtual void assertUnsignedLongLongsEqual(cpputest_ulonglong expected, cpputest_ulonglong actual, const char* text, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
+    virtual void assertSignedBytesEqual(signed char expected, signed char actual, const char* text, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
     virtual void assertPointersEqual(const void *expected, const void *actual, const char* text, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
     virtual void assertFunctionPointersEqual(void (*expected)(), void (*actual)(), const char* text, const char* fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
     virtual void assertDoublesEqual(double expected, double actual, double threshold, const char* text, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());

--- a/include/CppUTest/UtestMacros.h
+++ b/include/CppUTest/UtestMacros.h
@@ -232,6 +232,18 @@
 #define BYTES_EQUAL_TEXT(expected, actual, text)\
     LONGS_EQUAL_TEXT((expected) & 0xff, (actual) & 0xff, text)
 
+#define SIGNED_BYTES_EQUAL(expected, actual)\
+    SIGNED_BYTES_EQUAL_LOCATION(expected, actual, __FILE__, __LINE__)
+
+#define SIGNED_BYTES_EQUAL_LOCATION(expected, actual, file, line) \
+       { UtestShell::getCurrent()->assertSignedBytesEqual(expected, actual, NULL, file, line); }
+
+#define SIGNED_BYTES_EQUAL_TEXT(expected, actual, text)\
+    SIGNED_BYTES_EQUAL_TEXT_LOCATION(expected, actual, text, __FILE__, __LINE__)
+
+#define SIGNED_BYTES_EQUAL_TEXT_LOCATION(expected, actual, text, file, line) \
+        { UtestShell::getCurrent()->assertSignedBytesEqual(expected, actual, text, file, line); }
+
 #define POINTERS_EQUAL(expected, actual)\
     POINTERS_EQUAL_LOCATION((expected), (actual), NULL, __FILE__, __LINE__)
 

--- a/src/CppUTest/SimpleString.cpp
+++ b/src/CppUTest/SimpleString.cpp
@@ -478,6 +478,16 @@ SimpleString HexStringFrom(long value)
     return StringFromFormat("%lx", value);
 }
 
+SimpleString HexStringFrom(signed char value)
+{
+    SimpleString result = StringFromFormat("%x", value);
+    if(value < 0) {
+        size_t size = result.size();
+        result = result.subString(size-(CPPUTEST_CHAR_BIT/4));
+    }
+    return result;
+}
+
 SimpleString HexStringFrom(unsigned long value)
 {
     return StringFromFormat("%lx", value);

--- a/src/CppUTest/TestFailure.cpp
+++ b/src/CppUTest/TestFailure.cpp
@@ -308,6 +308,24 @@ UnsignedLongLongsEqualFailure::UnsignedLongLongsEqualFailure(UtestShell* test, c
     message_ += createButWasString(expectedReported, actualReported);
 }
 
+SignedBytesEqualFailure::SignedBytesEqualFailure (UtestShell* test, const char* fileName, int lineNumber, signed char expected, signed char actual, const SimpleString& text)
+: TestFailure(test, fileName, lineNumber)
+{
+    message_ = createUserText(text);
+
+    SimpleString aDecimal = StringFrom((int)actual);
+    SimpleString aHex = HexStringFrom(actual);
+    SimpleString eDecimal = StringFrom((int)expected);
+    SimpleString eHex = HexStringFrom(expected);
+
+    SimpleString::padStringsToSameLength(aDecimal, eDecimal, ' ');
+    SimpleString::padStringsToSameLength(aHex, eHex, '0');
+
+    SimpleString actualReported = aDecimal + " 0x" + aHex;
+    SimpleString expectedReported = eDecimal + " 0x" + eHex;
+    message_ += createButWasString(expectedReported, actualReported);
+}
+
 StringEqualFailure::StringEqualFailure(UtestShell* test, const char* fileName, int lineNumber, const char* expected, const char* actual, const SimpleString& text)
 : TestFailure(test, fileName, lineNumber)
 {

--- a/src/CppUTest/TestHarness_c.cpp
+++ b/src/CppUTest/TestHarness_c.cpp
@@ -50,6 +50,16 @@ void CHECK_EQUAL_C_CHAR_LOCATION(char expected, char actual, const char* fileNam
     UtestShell::getCurrent()->assertEquals(((expected) != (actual)), StringFrom(expected).asCharString(), StringFrom(actual).asCharString(), NULL, fileName, lineNumber, TestTerminatorWithoutExceptions());
 }
 
+extern void CHECK_EQUAL_C_UBYTE_LOCATION(unsigned char expected, unsigned char actual, const char* fileName, int lineNumber)\
+{
+    UtestShell::getCurrent()->assertEquals(((expected) != (actual)),StringFrom((int)expected).asCharString(), StringFrom((int) actual).asCharString(), NULL, fileName, lineNumber, TestTerminatorWithoutExceptions());
+}
+
+void CHECK_EQUAL_C_SBYTE_LOCATION(char signed expected, signed char actual, const char* fileName, int lineNumber)
+{
+    UtestShell::getCurrent()->assertEquals(((expected) != (actual)),StringFrom((int)expected).asCharString(), StringFrom((int) actual).asCharString(), NULL, fileName, lineNumber, TestTerminatorWithoutExceptions());
+}
+
 void CHECK_EQUAL_C_STRING_LOCATION(const char* expected, const char* actual, const char* fileName, int lineNumber)
 {
     UtestShell::getCurrent()->assertCstrEqual(expected, actual, NULL, fileName, lineNumber, TestTerminatorWithoutExceptions());

--- a/src/CppUTest/Utest.cpp
+++ b/src/CppUTest/Utest.cpp
@@ -455,6 +455,13 @@ void UtestShell::assertUnsignedLongLongsEqual(cpputest_ulonglong expected, cpput
 #endif
 }
 
+void UtestShell::assertSignedBytesEqual(signed char expected, signed char actual, const char* text, const char *fileName, int lineNumber, const TestTerminator& testTerminator)
+{
+    getTestResult()->countCheck();
+    if (expected != actual)
+        failWith(SignedBytesEqualFailure (this, fileName, lineNumber, expected, actual, text), testTerminator);
+}
+
 void UtestShell::assertPointersEqual(const void* expected, const void* actual, const char* text, const char* fileName, int lineNumber, const TestTerminator& testTerminator)
 {
     getTestResult()->countCheck();

--- a/tests/SimpleStringTest.cpp
+++ b/tests/SimpleStringTest.cpp
@@ -482,8 +482,17 @@ TEST(SimpleString, FunctionPointers)
 TEST(SimpleString, Characters)
 {
     SimpleString s(StringFrom('a'));
-    SimpleString s2(StringFrom('a'));
-    CHECK(s == s2);
+    STRCMP_EQUAL("a", s.asCharString());
+}
+
+TEST(SimpleString, NegativeSignedBytes)
+{
+    STRCMP_EQUAL("-15", StringFrom((signed char)-15).asCharString());
+}
+
+TEST(SimpleString, PositiveSignedBytes)
+{
+    STRCMP_EQUAL("4", StringFrom(4).asCharString());
 }
 
 TEST(SimpleString, LongInts)
@@ -554,6 +563,8 @@ TEST(SimpleString, Sizes)
 
 TEST(SimpleString, HexStrings)
 {
+    STRCMP_EQUAL("f3", HexStringFrom((signed char)-13).asCharString());
+
     SimpleString h1 = HexStringFrom(0xffffL);
     STRCMP_EQUAL("ffff", h1.asCharString());
 

--- a/tests/TestHarness_cTest.cpp
+++ b/tests/TestHarness_cTest.cpp
@@ -131,6 +131,38 @@ TEST(TestHarness_c, checkChar)
     CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
 }
 
+static void _failUnsignedByteMethod()
+{
+    HasTheDestructorBeenCalledChecker checker;
+    CHECK_EQUAL_C_UBYTE(254, 253);
+}
+
+TEST(TestHarness_c, checkUnsignedByte)
+{
+    CHECK_EQUAL_C_UBYTE(254, 254);
+    fixture->setTestFunction(_failUnsignedByteMethod);
+    fixture->runAllTests();
+    fixture->assertPrintContains("expected <254>\n	but was  <253>");
+    fixture->assertPrintContains("arness_c");
+    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
+}
+
+static void _failSignedByteMethod()
+{
+    HasTheDestructorBeenCalledChecker checker;
+    CHECK_EQUAL_C_SBYTE(-3, -5);
+}
+
+TEST(TestHarness_c, checkSignedByte)
+{
+    CHECK_EQUAL_C_SBYTE(-3, -3);
+    fixture->setTestFunction(_failSignedByteMethod);
+    fixture->runAllTests();
+    fixture->assertPrintContains("expected <-3>\n	but was  <-5>");
+    fixture->assertPrintContains("arness_c");
+    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
+}
+
 static void _failStringMethod()
 {
     HasTheDestructorBeenCalledChecker checker;

--- a/tests/TestUTestMacro.cpp
+++ b/tests/TestUTestMacro.cpp
@@ -586,6 +586,60 @@ IGNORE_TEST(UnitTestMacros, BYTES_EQUAL_TEXTWorksInAnIgnoredTest)
     BYTES_EQUAL_TEXT('q', 'w', "Failed because it failed") // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
+static void _failingTestMethodWithSIGNED_BYTES_EQUAL()
+{
+    SIGNED_BYTES_EQUAL(-1, -2);
+    TestTestingFixture::lineExecutedAfterCheck(); // LCOV_EXCL_LINE
+}
+
+TEST(UnitTestMacros, FailureWithSIGNED_BYTES_EQUAL)
+{
+    fixture.runTestWithMethod(_failingTestMethodWithSIGNED_BYTES_EQUAL);
+#if CPPUTEST_CHAR_BIT == 16
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <-1 0xffff>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <-2 0xfffe>");
+#else
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <-1 0xff>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <-2 0xfe>");
+#endif
+}
+
+TEST(UnitTestMacros, CHARS_EQUALBehavesAsProperMacro)
+{
+    if (false) SIGNED_BYTES_EQUAL(-1, -2)
+    else SIGNED_BYTES_EQUAL(-3, -3)
+}
+
+IGNORE_TEST(UnitTestMacros, CHARS_EQUALWorksInAnIgnoredTest)
+{
+    SIGNED_BYTES_EQUAL(-7, 19) // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
+static void _failingTestMethodWithSIGNED_BYTES_EQUAL_TEXT()
+{
+    SIGNED_BYTES_EQUAL_TEXT(-127, -126, "Failed because it failed");
+    TestTestingFixture::lineExecutedAfterCheck(); // LCOV_EXCL_LINE
+}
+
+TEST(UnitTestMacros, FailureWithSIGNED_BYTES_EQUAL_TEXT)
+{
+    fixture.runTestWithMethod(_failingTestMethodWithSIGNED_BYTES_EQUAL_TEXT);
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <-127 0x81>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <-126 0x82>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("Failed because it failed");
+}
+
+TEST(UnitTestMacros, CHARS_EQUAL_TEXTBehavesAsProperMacro)
+{
+    if (false) SIGNED_BYTES_EQUAL_TEXT(-1, -2, "Failed because it failed")
+    else SIGNED_BYTES_EQUAL_TEXT(-3, -3, "Failed because it failed")
+}
+
+IGNORE_TEST(UnitTestMacros, SIGNED_BYTES_EQUAL_TEXTWorksInAnIgnoredTest)
+{
+    SIGNED_BYTES_EQUAL_TEXT(-7, 19, "Failed because it failed") // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
 static void _failingTestMethodWithPOINTERS_EQUAL()
 {
     POINTERS_EQUAL((void*)0xa5a5, (void*)0xf0f0);


### PR DESCRIPTION
I noticed that CppUTest currently makes no provision for comparing signed byte-sized values. In my experience, in embedded development, sint8_t is frequently used.

This is an attempt at providing the missing functionality.