### PR TITLE
ignoreAdditionalCalls (ignoreMultipleCalls?)

### DIFF
--- a/include/CppUTestExt/MockSupport.h
+++ b/include/CppUTestExt/MockSupport.h
@@ -97,6 +97,7 @@ public:
     virtual void enable();
     virtual void tracing(bool enabled);
     virtual void ignoreOtherCalls();
+    virtual void ignoreAdditionalCalls();
 
     virtual void checkExpectations();
     virtual bool expectedCallsLeft();
@@ -133,6 +134,7 @@ private:
     MockExpectedCallsList expectations_;
     MockExpectedCallsList unExpectations_;
     bool ignoreOtherCalls_;
+    bool ignoreAdditionalCalls_;
     bool enabled_;
     MockCheckedActualCall *lastActualFunctionCall_;
     MockExpectedCallComposite compositeCalls_;
@@ -153,6 +155,7 @@ private:
 
     bool hasntExpectationWithName(const SimpleString& functionName);
     bool hasntUnexpectationWithName(const SimpleString& functionName);
+    bool hasntUnFulfilledWithName(const SimpleString& functionName);
     bool hasCallsOutOfOrder();
 
     SimpleString appendScopeToName(const SimpleString& functionName);

--- a/include/CppUTestExt/MockSupport_c.h
+++ b/include/CppUTestExt/MockSupport_c.h
@@ -189,6 +189,7 @@ struct SMockSupport_c
     void (*disable)(void);
     void (*enable)(void);
     void (*ignoreOtherCalls)(void);
+    void (*ignoreAdditionalCalls)(void);	
 
     void (*checkExpectations)(void);
     int (*expectedCallsLeft)(void);

--- a/src/CppUTestExt/MockSupport_c.cpp
+++ b/src/CppUTestExt/MockSupport_c.cpp
@@ -125,6 +125,7 @@ MockActualCall_c* actualCall_c(const char* name);
 void disable_c();
 void enable_c();
 void ignoreOtherCalls_c();
+void ignoreAdditionalCalls_c();
 void setBoolData_c(const char* name, int value);
 void setIntData_c(const char* name, int value);
 void setUnsignedIntData_c(const char* name, unsigned int value);
@@ -339,6 +340,7 @@ static MockSupport_c gMockSupport = {
         disable_c,
         enable_c,
         ignoreOtherCalls_c,
+        ignoreAdditionalCalls_c,
         checkExpectations_c,
         expectedCallsLeft_c,
         clear_c,
@@ -812,6 +814,11 @@ void enable_c()
 void ignoreOtherCalls_c()
 {
     currentMockSupport->ignoreOtherCalls();
+}
+
+void ignoreAdditionalCalls_c()
+{
+    currentMockSupport->ignoreAdditionalCalls();
 }
 
 void setBoolData_c(const char* name, int value)

--- a/tests/CppUTestExt/MockCallTest.cpp
+++ b/tests/CppUTestExt/MockCallTest.cpp
@@ -277,8 +277,19 @@ TEST(MockCallTest, ignoreOtherCallsExceptForTheExpectedOne)
 {
     mock().expectOneCall("foo");
     mock().ignoreOtherCalls();
-    mock().actualCall("bar").withParameter("foo", 1);;
+    mock().actualCall("bar").withParameter("foo", 1);
 
+    mock().clear();
+}
+
+TEST(MockCallTest, ignoreAdditionalCallsExceptForTheExpectedOne)
+{
+    mock().expectOneCall("foo");
+    mock().ignoreAdditionalCalls();
+    mock().actualCall("foo");
+    mock().actualCall("foo");
+    mock().actualCall("foo").withParameter("foo", 1);
+	
     mock().clear();
 }
 
@@ -299,6 +310,23 @@ TEST(MockCallTest, ignoreOtherCallsDoesntIgnoreMultipleCallsOfTheSameFunction)
     CHECK_EXPECTED_MOCK_FAILURE(expectedFailure);
 }
 
+TEST(MockCallTest, ignoreAdditionalCallsOfTheSameFunctionDoesntIgnoreOtherCalls)
+{
+    MockFailureReporterInstaller failureReporterInstaller;
+
+    MockExpectedCallsListForTest expectations;
+    expectations.addFunction("foo")->callWasMade(1);
+    MockUnexpectedCallHappenedFailure expectedFailure(mockFailureTest(), "bar", expectations);
+
+    mock().expectOneCall("foo");
+    mock().ignoreAdditionalCalls();
+    mock().actualCall("foo");
+    mock().actualCall("foo");
+    mock().actualCall("bar");
+
+    CHECK_EXPECTED_MOCK_FAILURE(expectedFailure);
+}
+
 TEST(MockCallTest, ignoreOtherStillFailsIfExpectedOneDidntHappen)
 {
     MockFailureReporterInstaller failureReporterInstaller;
@@ -309,6 +337,21 @@ TEST(MockCallTest, ignoreOtherStillFailsIfExpectedOneDidntHappen)
 
     mock().expectOneCall("foo");
     mock().ignoreOtherCalls();
+    mock().checkExpectations();
+
+    CHECK_EXPECTED_MOCK_FAILURE(expectedFailure);
+}
+
+TEST(MockCallTest, ignoreAdditionalStillFailsIfExpectedOneDidntHappen)
+{
+    MockFailureReporterInstaller failureReporterInstaller;
+
+    MockExpectedCallsListForTest expectations;
+    expectations.addFunction("foo");
+    MockExpectedCallsDidntHappenFailure expectedFailure(mockFailureTest(), expectations);
+
+    mock().expectOneCall("foo");
+    mock().ignoreAdditionalCalls();
     mock().checkExpectations();
 
     CHECK_EXPECTED_MOCK_FAILURE(expectedFailure);

--- a/tests/CppUTestExt/MockHierarchyTest.cpp
+++ b/tests/CppUTestExt/MockHierarchyTest.cpp
@@ -122,6 +122,27 @@ TEST(MockHierarchyTest, ignoreOtherCallsWorksHierarchicallyWhenDynamicallyCreate
     mock().checkExpectations();
 }
 
+TEST(MockHierarchyTest, ignoreAdditionalCallsWorksHierarchically)
+{
+    mock("first").expectOneCall("boo");
+    mock().ignoreAdditionalCalls();
+    mock("first").actualCall("boo");
+    mock("first").actualCall("boo");
+
+    mock().checkExpectations();
+}
+
+TEST(MockHierarchyTest, ignoreAdditionalCallsWorksHierarchicallyWhenDynamicallyCreated)
+{
+    mock().ignoreAdditionalCalls();
+    mock("first").expectOneCall("boo");
+    mock("first").actualCall("boo");
+    mock("first").actualCall("boo");
+
+    mock().checkExpectations();
+}
+
+
 TEST(MockHierarchyTest, checkExpectationsWorksHierarchicallyForLastCallNotFinished)
 {
     MockFailureReporterInstaller failureReporterInstaller;

--- a/tests/CppUTestExt/MockSupport_cTest.cpp
+++ b/tests/CppUTestExt/MockSupport_cTest.cpp
@@ -650,3 +650,13 @@ TEST(MockSupport_c, ignoreOtherCalls)
     mock_c()->actualCall("bar");
     mock_c()->checkExpectations();
 }
+
+TEST(MockSupport_c, ignoreAdditionalCalls)
+{
+    mock_c()->expectOneCall("foo");
+    mock_c()->ignoreAdditionalCalls();
+    mock_c()->actualCall("foo");
+    mock_c()->actualCall("foo");
+    mock_c()->checkExpectations();
+}
+


### PR DESCRIPTION
Hi, basvodde and arstrube
    My colleagues raised an requirements for "ignore additional (multiple, extra) calls".
    Here, we have ignoreOtherCalls which does not ignore the expected one.
    Then, we add a feature ignoreAdditionalCalls which behaviors like below. What I concern is the name "ignoreAdditionalCalls". Is this name a good one?
    Thanks!
    
TEST(MockCallTest, ignoreAdditionalCallsExceptForTheExpectedOne)
{
    mock().expectOneCall("foo");
    mock().ignoreAdditionalCalls();
    mock().actualCall("foo");

    /* The following calls will not fail, because the additional calls for expected is ignored. */
    mock().actualCall("foo");    
    mock().actualCall("foo").withParameter("foo", 1);
	
    mock().clear();
}