### PR TITLE
[Reopen] change getOneFulfilledExpectationWithIgnoredParameters to right name

### DIFF
--- a/include/CppUTestExt/MockExpectedCallsList.h
+++ b/include/CppUTestExt/MockExpectedCallsList.h
@@ -66,8 +66,8 @@ public:
     virtual void onlyKeepUnfulfilledExpectations();
 
     virtual MockCheckedExpectedCall* removeOneFulfilledExpectation();
-    virtual MockCheckedExpectedCall* removeOneFulfilledExpectationWithIgnoredParameters();
-    virtual MockCheckedExpectedCall* getOneFulfilledExpectationWithIgnoredParameters();
+    virtual MockCheckedExpectedCall* removeOneFulfilledExpectationWithOutIgnoredParameters();
+    virtual MockCheckedExpectedCall* getOneFulfilledExpectationWithOutIgnoredParameters();
 
     virtual void resetExpectations();
     virtual void callWasMade(int callOrder);

--- a/src/CppUTestExt/MockActualCall.cpp
+++ b/src/CppUTestExt/MockActualCall.cpp
@@ -106,7 +106,7 @@ void MockCheckedActualCall::finalizeOutputParameters(MockCheckedExpectedCall* ex
 void MockCheckedActualCall::finalizeCallWhenFulfilled()
 {
     if (unfulfilledExpectations_.hasFulfilledExpectationsWithoutIgnoredParameters()) {
-        finalizeOutputParameters(unfulfilledExpectations_.getOneFulfilledExpectationWithIgnoredParameters());
+        finalizeOutputParameters(unfulfilledExpectations_.getOneFulfilledExpectationWithOutIgnoredParameters());
     }
 
     if (unfulfilledExpectations_.hasFulfilledExpectations()) {
@@ -342,7 +342,7 @@ void MockCheckedActualCall::checkExpectations()
     if (! unfulfilledExpectations_.hasUnfulfilledExpectations())
         FAIL("Actual call is in progress. Checking expectations. But no unfulfilled expectations. Cannot happen.") // LCOV_EXCL_LINE
 
-    fulfilledExpectation_ = unfulfilledExpectations_.removeOneFulfilledExpectationWithIgnoredParameters();
+    fulfilledExpectation_ = unfulfilledExpectations_.removeOneFulfilledExpectationWithOutIgnoredParameters();
     if (fulfilledExpectation_) {
         callHasSucceeded();
         unfulfilledExpectations_.resetExpectations();

--- a/src/CppUTestExt/MockExpectedCallsList.cpp
+++ b/src/CppUTestExt/MockExpectedCallsList.cpp
@@ -222,7 +222,7 @@ MockCheckedExpectedCall* MockExpectedCallsList::removeOneFulfilledExpectation()
     return NULL;
 }
 
-MockCheckedExpectedCall* MockExpectedCallsList::getOneFulfilledExpectationWithIgnoredParameters()
+MockCheckedExpectedCall* MockExpectedCallsList::getOneFulfilledExpectationWithOutIgnoredParameters()
 {
     for (MockExpectedCallsListNode* p = head_; p; p = p->next_) {
         if (p->expectedCall_->isFulfilledWithoutIgnoredParameters()) {
@@ -232,7 +232,7 @@ MockCheckedExpectedCall* MockExpectedCallsList::getOneFulfilledExpectationWithIg
     return NULL;
 }
 
-MockCheckedExpectedCall* MockExpectedCallsList::removeOneFulfilledExpectationWithIgnoredParameters()
+MockCheckedExpectedCall* MockExpectedCallsList::removeOneFulfilledExpectationWithOutIgnoredParameters()
 {
     for (MockExpectedCallsListNode* p = head_; p; p = p->next_) {
         if (p->expectedCall_->isFulfilledWithoutIgnoredParameters()) {

--- a/tests/CppUTestExt/ExpectedFunctionsListTest.cpp
+++ b/tests/CppUTestExt/ExpectedFunctionsListTest.cpp
@@ -271,9 +271,9 @@ TEST(MockExpectedCallsList, removeOneFulfilledExpectationFromEmptyList)
     POINTERS_EQUAL(NULL, list->removeOneFulfilledExpectation());
 }
 
-TEST(MockExpectedCallsList, getOneFulfilledExpectationWithIgnoredParametersFromEmptyList)
+TEST(MockExpectedCallsList, getOneFulfilledExpectationWithOutIgnoredParametersFromEmptyList)
 {
-    POINTERS_EQUAL(NULL, list->getOneFulfilledExpectationWithIgnoredParameters());
+    POINTERS_EQUAL(NULL, list->getOneFulfilledExpectationWithOutIgnoredParameters());
 }
 
 TEST(MockExpectedCallsList, toStringOnEmptyList)


### PR DESCRIPTION
This PR seems closed exceptionally by me, now reopen it
