### PR TITLE
Add CHECK_EQUAL_C_LONGLONG to C TestHarness

### DIFF
--- a/include/CppUTest/CppUTestConfig.h
+++ b/include/CppUTest/CppUTestConfig.h
@@ -256,6 +256,11 @@ struct cpputest_ulonglong
   char dummy[CPPUTEST_SIZE_OF_FAKE_LONG_LONG_TYPE];
 };
 
+#if !defined(__cplusplus)
+typedef struct cpputest_longlong cpputest_longlong;
+typedef struct cpputest_ulonglong cpputest_ulonglong;
+#endif
+
 #endif
 
 /* Visual C++ 10.0+ (2010+) supports the override keyword, but doesn't define the C++ version as C++11 */

--- a/include/CppUTest/TestHarness_c.h
+++ b/include/CppUTest/TestHarness_c.h
@@ -39,6 +39,21 @@
 #define CHECK_EQUAL_C_INT(expected,actual) \
   CHECK_EQUAL_C_INT_LOCATION(expected,actual,__FILE__,__LINE__)
 
+#define CHECK_EQUAL_C_UINT(expected,actual) \
+  CHECK_EQUAL_C_UINT_LOCATION(expected,actual,__FILE__,__LINE__)
+
+#define CHECK_EQUAL_C_LONG(expected,actual) \
+  CHECK_EQUAL_C_LONG_LOCATION(expected,actual,__FILE__,__LINE__)
+
+#define CHECK_EQUAL_C_ULONG(expected,actual) \
+  CHECK_EQUAL_C_ULONG_LOCATION(expected,actual,__FILE__,__LINE__)
+
+#define CHECK_EQUAL_C_LONGLONG(expected,actual) \
+  CHECK_EQUAL_C_LONGLONG_LOCATION(expected,actual,__FILE__,__LINE__)
+
+#define CHECK_EQUAL_C_ULONGLONG(expected,actual) \
+  CHECK_EQUAL_C_ULONGLONG_LOCATION(expected,actual,__FILE__,__LINE__)
+
 #define CHECK_EQUAL_C_REAL(expected,actual,threshold) \
   CHECK_EQUAL_C_REAL_LOCATION(expected,actual,threshold,__FILE__,__LINE__)
 
@@ -121,6 +136,16 @@ extern "C"
 
 /* CHECKS that can be used from C code */
 extern void CHECK_EQUAL_C_INT_LOCATION(int expected, int actual,
+        const char* fileName, int lineNumber);
+extern void CHECK_EQUAL_C_UINT_LOCATION(unsigned int expected, unsigned int actual,
+        const char* fileName, int lineNumber);
+extern void CHECK_EQUAL_C_LONG_LOCATION(long expected, long actual,
+        const char* fileName, int lineNumber);
+extern void CHECK_EQUAL_C_ULONG_LOCATION(unsigned long expected, unsigned long actual,
+        const char* fileName, int lineNumber);
+extern void CHECK_EQUAL_C_LONGLONG_LOCATION(cpputest_longlong expected, cpputest_longlong actual,
+        const char* fileName, int lineNumber);
+extern void CHECK_EQUAL_C_ULONGLONG_LOCATION(cpputest_ulonglong expected, cpputest_ulonglong actual,
         const char* fileName, int lineNumber);
 extern void CHECK_EQUAL_C_REAL_LOCATION(double expected, double actual,
         double threshold, const char* fileName, int lineNumber);

--- a/src/CppUTest/SimpleString.cpp
+++ b/src/CppUTest/SimpleString.cpp
@@ -632,13 +632,13 @@ SimpleString HexStringFrom(void (*value)())
     return StringFromFormat("%lx", convertFunctionPointerToLongValue(value));
 }
 
-SimpleString BracketsFormattedHexStringFrom(cpputest_longlong value)
+SimpleString BracketsFormattedHexStringFrom(cpputest_longlong)
 {
     return "";
 }
 
 
-SimpleString BracketsFormattedHexStringFrom(cpputest_ulonglong value)
+SimpleString BracketsFormattedHexStringFrom(cpputest_ulonglong)
 {
     return "";
 }

--- a/src/CppUTest/TestHarness_c.cpp
+++ b/src/CppUTest/TestHarness_c.cpp
@@ -40,6 +40,31 @@ void CHECK_EQUAL_C_INT_LOCATION(int expected, int actual, const char* fileName, 
     UtestShell::getCurrent()->assertLongsEqual((long)expected, (long)actual, NULL, fileName, lineNumber, TestTerminatorWithoutExceptions());
 }
 
+void CHECK_EQUAL_C_UINT_LOCATION(unsigned int expected, unsigned int actual, const char* fileName, int lineNumber)
+{
+    UtestShell::getCurrent()->assertUnsignedLongsEqual((unsigned long)expected, (unsigned long)actual, NULL, fileName, lineNumber, TestTerminatorWithoutExceptions());
+}
+
+void CHECK_EQUAL_C_LONG_LOCATION(long expected, long actual, const char* fileName, int lineNumber)
+{
+    UtestShell::getCurrent()->assertLongsEqual(expected, actual, NULL, fileName, lineNumber, TestTerminatorWithoutExceptions());
+}
+
+void CHECK_EQUAL_C_ULONG_LOCATION(unsigned long expected, unsigned long actual, const char* fileName, int lineNumber)
+{
+    UtestShell::getCurrent()->assertUnsignedLongsEqual(expected, actual, NULL, fileName, lineNumber, TestTerminatorWithoutExceptions());
+}
+
+void CHECK_EQUAL_C_LONGLONG_LOCATION(cpputest_longlong expected, cpputest_longlong actual, const char* fileName, int lineNumber)
+{
+    UtestShell::getCurrent()->assertLongLongsEqual(expected, actual, NULL, fileName, lineNumber, TestTerminatorWithoutExceptions());
+}
+
+void CHECK_EQUAL_C_ULONGLONG_LOCATION(cpputest_ulonglong expected, cpputest_ulonglong actual, const char* fileName, int lineNumber)
+{
+    UtestShell::getCurrent()->assertUnsignedLongLongsEqual(expected, actual, NULL, fileName, lineNumber, TestTerminatorWithoutExceptions());
+}
+
 void CHECK_EQUAL_C_REAL_LOCATION(double expected, double actual, double threshold, const char* fileName, int lineNumber)
 {
     UtestShell::getCurrent()->assertDoublesEqual(expected, actual, threshold, NULL, fileName, lineNumber, TestTerminatorWithoutExceptions());

--- a/tests/TestFailureTest.cpp
+++ b/tests/TestFailureTest.cpp
@@ -147,7 +147,7 @@ TEST(TestFailure, LongLongsEqualFailure)
 #else
     cpputest_longlong dummy_longlong;
     LongLongsEqualFailure f(test, failFileName, failLineNumber, dummy_longlong, dummy_longlong, "");
-    FAILURE_EQUAL("expected <<longlong_unsupported> 0x<longlong_unsupported>>\n\tbut was  <<longlong_unsupported> 0x<longlong_unsupported>>", f);
+    FAILURE_EQUAL("expected <<longlong_unsupported> >\n\tbut was  <<longlong_unsupported> >", f);
 #endif
 }
 
@@ -159,7 +159,7 @@ TEST(TestFailure, UnsignedLongLongsEqualFailure)
 #else
     cpputest_ulonglong dummy_ulonglong;
     UnsignedLongLongsEqualFailure f(test, failFileName, failLineNumber, dummy_ulonglong, dummy_ulonglong, "");
-    FAILURE_EQUAL("expected <<ulonglong_unsupported> 0x<ulonglong_unsupported>>\n\tbut was  <<ulonglong_unsupported> 0x<ulonglong_unsupported>>", f);
+    FAILURE_EQUAL("expected <<ulonglong_unsupported> >\n\tbut was  <<ulonglong_unsupported> >", f);
 #endif
 }
 

--- a/tests/TestHarness_cTest.cpp
+++ b/tests/TestHarness_cTest.cpp
@@ -99,6 +99,120 @@ TEST(TestHarness_c, checkInt)
     CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
 }
 
+static void _failUnsignedIntMethod()
+{
+    HasTheDestructorBeenCalledChecker checker;
+    CHECK_EQUAL_C_UINT(1, 2);
+} // LCOV_EXCL_LINE
+
+TEST(TestHarness_c, checkUnsignedInt)
+{
+    CHECK_EQUAL_C_UINT(2, 2);
+    fixture->setTestFunction(_failUnsignedIntMethod);
+    fixture->runAllTests();
+    fixture->assertPrintContains("expected <1 (0x1)>\n	but was  <2 (0x2)>");
+    fixture->assertPrintContains("arness_c");
+    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
+}
+
+static void _failLongIntMethod()
+{
+    HasTheDestructorBeenCalledChecker checker;
+    CHECK_EQUAL_C_LONG(1, 2);
+} // LCOV_EXCL_LINE
+
+TEST(TestHarness_c, checkLongInt)
+{
+    CHECK_EQUAL_C_LONG(2, 2);
+    fixture->setTestFunction(_failLongIntMethod);
+    fixture->runAllTests();
+    fixture->assertPrintContains("expected <1 (0x1)>\n	but was  <2 (0x2)>");
+    fixture->assertPrintContains("arness_c");
+    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
+}
+
+static void _failUnsignedLongIntMethod()
+{
+    HasTheDestructorBeenCalledChecker checker;
+    CHECK_EQUAL_C_ULONG(1, 2);
+} // LCOV_EXCL_LINE
+
+TEST(TestHarness_c, checkUnsignedLongInt)
+{
+    CHECK_EQUAL_C_ULONG(2, 2);
+    fixture->setTestFunction(_failUnsignedLongIntMethod);
+    fixture->runAllTests();
+    fixture->assertPrintContains("expected <1 (0x1)>\n	but was  <2 (0x2)>");
+    fixture->assertPrintContains("arness_c");
+    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
+}
+
+#ifdef CPPUTEST_USE_LONG_LONG
+
+static void _failLongLongIntMethod()
+{
+    HasTheDestructorBeenCalledChecker checker;
+    CHECK_EQUAL_C_LONGLONG(1, 2);
+} // LCOV_EXCL_LINE
+
+TEST(TestHarness_c, checkLongLongInt)
+{
+    CHECK_EQUAL_C_LONGLONG(2, 2);
+    fixture->setTestFunction(_failLongLongIntMethod);
+    fixture->runAllTests();
+    fixture->assertPrintContains("expected <1 (0x1)>\n	but was  <2 (0x2)>");
+    fixture->assertPrintContains("arness_c");
+    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
+}
+
+static void _failUnsignedLongLongIntMethod()
+{
+    HasTheDestructorBeenCalledChecker checker;
+    CHECK_EQUAL_C_ULONGLONG(1, 2);
+} // LCOV_EXCL_LINE
+
+TEST(TestHarness_c, checkUnsignedLongLongInt)
+{
+    CHECK_EQUAL_C_ULONGLONG(2, 2);
+    fixture->setTestFunction(_failUnsignedLongLongIntMethod);
+    fixture->runAllTests();
+    fixture->assertPrintContains("expected <1 (0x1)>\n	but was  <2 (0x2)>");
+    fixture->assertPrintContains("arness_c");
+    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
+}
+
+#else
+
+static void _failLongLongIntMethod()
+{
+    cpputest_longlong dummy_longlong;
+    CHECK_EQUAL_C_LONGLONG(dummy_longlong, dummy_longlong);
+} // LCOV_EXCL_LINE
+
+TEST(TestHarness_c, checkLongLongInt)
+{
+    fixture->setTestFunction(_failLongLongIntMethod);
+    fixture->runAllTests();
+    fixture->assertPrintContains("is not supported");
+    fixture->assertPrintContains("arness_c");
+}
+
+static void _failUnsignedLongLongIntMethod()
+{
+    cpputest_ulonglong dummy_ulonglong;
+    CHECK_EQUAL_C_ULONGLONG(dummy_ulonglong, dummy_ulonglong);
+} // LCOV_EXCL_LINE
+
+TEST(TestHarness_c, checkUnsignedLongLongInt)
+{
+    fixture->setTestFunction(_failUnsignedLongLongIntMethod);
+    fixture->runAllTests();
+    fixture->assertPrintContains("is not supported");
+    fixture->assertPrintContains("arness_c");
+}
+
+#endif
+
 static void _failRealMethod()
 {
     HasTheDestructorBeenCalledChecker checker;


### PR DESCRIPTION
And the other int flavours for good measure.

This will have a trivial conflict with #998 if that's merged first but any good merge tool will resolve it automatically.  (Or remind me after merging that and I'll rebase this.)