### PR TITLE
Portability fixes

### DIFF
--- a/include/CppUTest/CppUTestConfig.h
+++ b/include/CppUTest/CppUTestConfig.h
@@ -174,7 +174,7 @@
 
 #if CPPUTEST_USE_STD_C_LIB && (!defined(_MSC_VER) || (_MSC_VER >= 1800))
 #define CPPUTEST_HAVE_FENV
-#if defined(__WATCOMC__)
+#if defined(__WATCOMC__) || defined(__ARMEL__) || defined(__m68k__)
 #define CPPUTEST_FENV_IS_WORKING_PROPERLY 0
 #else
 #define CPPUTEST_FENV_IS_WORKING_PROPERLY 1

--- a/tests/CppUTestExt/MockSupport_cTest.cpp
+++ b/tests/CppUTestExt/MockSupport_cTest.cpp
@@ -186,8 +186,8 @@ TEST(MockSupport_c, outputParameters_differentType)
 
 TEST(MockSupport_c, outputParametersOfType)
 {
-    long param = 1;
-    const long retval = 2;
+    int param = 1;
+    const int retval = 2;
     mock_c()->installCopier("typeName", typeCopy);
     mock_c()->expectOneCall("foo")->withOutputParameterOfTypeReturning("typeName", "out", &retval);
     mock_c()->actualCall("foo")->withOutputParameterOfType("typeName", "out", &param);


### PR DESCRIPTION
This patches fixes build failures on armel and m68k that do not seem
to have working FENV support (changes to CppUTestConfig.h).

It also fixes build failures on s390x, ppc64 and sparc64 which
were failing a test due to them being big-endian architectures
(changes to tests/CppUTestExt/MockSupport_cTest.cpp, typeCopy copies
an "int" but the variables param and retval were defined as "long").

Fixes #1004