### PR TITLE
Bug fix for wrong output parameters being copied

### DIFF
--- a/include/CppUTestExt/MockExpectedCallsList.h
+++ b/include/CppUTestExt/MockExpectedCallsList.h
@@ -43,8 +43,6 @@ public:
     virtual int amountOfExpectationsFor(const SimpleString& name) const;
     virtual int amountOfUnfulfilledExpectations() const;
     virtual bool hasUnfulfilledExpectations() const;
-    virtual bool hasFulfilledExpectations() const;
-    virtual bool hasFulfilledExpectationsWithoutIgnoredParameters() const;
     virtual bool hasUnfulfilledExpectationsBecauseOfMissingParameters() const;
     virtual bool hasExpectationWithName(const SimpleString& name) const;
     virtual bool hasCallsOutOfOrder() const;

--- a/src/CppUTestExt/MockActualCall.cpp
+++ b/src/CppUTestExt/MockActualCall.cpp
@@ -105,13 +105,17 @@ void MockCheckedActualCall::finalizeOutputParameters(MockCheckedExpectedCall* ex
 
 void MockCheckedActualCall::finalizeCallWhenFulfilled()
 {
-    if (unfulfilledExpectations_.hasFulfilledExpectationsWithoutIgnoredParameters()) {
-        finalizeOutputParameters(unfulfilledExpectations_.getOneFulfilledExpectationWithIgnoredParameters());
-    }
+	// Expectations that don't ignore parameters have higher fulfillment preference than those that ignore parameters
 
-    if (unfulfilledExpectations_.hasFulfilledExpectations()) {
-        fulfilledExpectation_ = unfulfilledExpectations_.removeOneFulfilledExpectation();
+    fulfilledExpectation_ = unfulfilledExpectations_.removeOneFulfilledExpectation();
+    if (fulfilledExpectation_) {
+        finalizeOutputParameters(fulfilledExpectation_);
         callHasSucceeded();
+    } else {
+    	MockCheckedExpectedCall* fulfilledExpectationWithIgnoredParameters = unfulfilledExpectations_.getOneFulfilledExpectationWithIgnoredParameters();
+    	if (fulfilledExpectationWithIgnoredParameters) {
+    		finalizeOutputParameters(fulfilledExpectationWithIgnoredParameters);
+    	}
     }
 }
 

--- a/src/CppUTestExt/MockExpectedCallsList.cpp
+++ b/src/CppUTestExt/MockExpectedCallsList.cpp
@@ -81,19 +81,6 @@ int MockExpectedCallsList::amountOfUnfulfilledExpectations() const
     return count;
 }
 
-bool MockExpectedCallsList::hasFulfilledExpectations() const
-{
-    return (size() - amountOfUnfulfilledExpectations()) != 0;
-}
-
-bool MockExpectedCallsList::hasFulfilledExpectationsWithoutIgnoredParameters() const
-{
-    for (MockExpectedCallsListNode* p = head_; p; p = p->next_)
-        if (p->expectedCall_->isFulfilledWithoutIgnoredParameters())
-            return true;
-    return false;
-}
-
 bool MockExpectedCallsList::hasUnfulfilledExpectations() const
 {
     return amountOfUnfulfilledExpectations() != 0;

--- a/tests/CppUTestExt/ExpectedFunctionsListTest.cpp
+++ b/tests/CppUTestExt/ExpectedFunctionsListTest.cpp
@@ -63,7 +63,7 @@ TEST_GROUP(MockExpectedCallsList)
 TEST(MockExpectedCallsList, emptyList)
 {
     CHECK(! list->hasUnfulfilledExpectations());
-    CHECK(! list->hasFulfilledExpectations());
+    CHECK(list->size() == list->amountOfUnfulfilledExpectations());
     LONGS_EQUAL(0, list->size());
 }
 

--- a/tests/CppUTestExt/MockParameterTest.cpp
+++ b/tests/CppUTestExt/MockParameterTest.cpp
@@ -678,6 +678,29 @@ TEST(MockParameterTest, outputParameterWithIgnoredParameters)
     mock().actualCall("foo").withOutputParameter("bar", &retval).withParameter("other", 1);
 
     LONGS_EQUAL(param, retval);
+
+    mock().checkExpectations();
+}
+
+/*
+ * This test checks that the proper output parameters are copied when multiple calls to the same
+ * function are expected.
+ */
+TEST(MockParameterTest, properOutputParametersAreCopied)
+{
+    int expectedValue1 = 1;
+    int expectedValue2 = 2;
+    mock().expectOneCall("foo").withOutputParameterReturning("param", &expectedValue1, sizeof(expectedValue1)).ignoreOtherParameters();
+    mock().expectOneCall("foo").withOutputParameterReturning("param", &expectedValue2, sizeof(expectedValue2));
+
+    int returnedValue1 = 0;
+    int returnedValue2 = 0;
+    mock().actualCall("foo").withOutputParameter("param", &returnedValue1);
+    mock().actualCall("foo").withOutputParameter("param", &returnedValue2).withParameter("optional", 50);
+
+    CHECK_EQUAL_TEXT(expectedValue2, returnedValue1, "Wrong output value in 1st call");
+    CHECK_EQUAL_TEXT(expectedValue1, returnedValue2, "Wrong output value in 2nd call");
+
     mock().checkExpectations();
 }
 


### PR DESCRIPTION
It's been a long time since my last contributions, but I've finally managed to get some free time and I've spend it in finishing the modifications that I started to enable expected calls to match multiple calls. I'm still merging all the changes of the main branch into my outdated code (almost a year full of commits!), but I've detected a bug that I've just fixed, so I'm submitting this standalone PR for it.

Here goes the bug description and fixing notes:

The present code can copy the output parameters of an expected call, but finally fulfill a different one.

This happens for example if an expected call for a function that returns output parameters and ignores other parameters is declared before an expected call for the same function, that also returns expected parameters, but that doesn't ignore parameters.

The solution has been to just prioritize output parameter finalization of expected calls that don't ignore parameters over calls that can ignore them (in the same way that call fulfillment works), instead of just picking the first one.

BTW, some optimizations have been also applied on the affected code, to avoid traversing the expected calls list twice (first to check if there is a call that matches some criteria, then again to get that call), and therefore some methods that are not necessary any more have been deleted.