### PR TITLE
Disable EXPECT_N_LEAKS() if memleak detection disabled

### DIFF
--- a/src/CppUTest/MemoryLeakWarningPlugin.cpp
+++ b/src/CppUTest/MemoryLeakWarningPlugin.cpp
@@ -570,8 +570,15 @@ void MemoryLeakWarningPlugin::postTestAction(UtestShell& test, TestResult& resul
     int leaks = memLeakDetector_->totalMemoryLeaks(mem_leak_period_checking);
 
     if (!ignoreAllWarnings_ && expectedLeaks_ != leaks && failureCount_ == result.getFailureCount()) {
-        TestFailure f(&test, memLeakDetector_->report(mem_leak_period_checking));
-        result.addFailure(f);
+        if(MemoryLeakWarningPlugin::areNewDeleteOverloaded()) {
+            TestFailure f(&test, memLeakDetector_->report(mem_leak_period_checking));
+            result.addFailure(f);
+        } else if(expectedLeaks_ > 0) {
+            result.print("Warning: Expected ");
+            result.print(StringFrom(expectedLeaks_).asCharString());
+            result.print(expectedLeaks_ == 1 ? " leak" : " leaks");
+            result.print(", but leak detection was disabled");
+        }
     }
     memLeakDetector_->markCheckingPeriodLeaksAsNonCheckingPeriod();
     ignoreAllWarnings_ = false;


### PR DESCRIPTION
EXPECT_N_LEAKS() can't be supported when CppUTest is configured with --disable-memory-leak-detection, since there's nothing to make sure we hit the expected number of leaks.

In one sense, it would be nice for tests that use EXPECT_N_LEAKS() to go ahead and continue running with whatever capabilities CppUTest is configured with.  This change would allow that behavior.

But on the other hand, I guess someone that really expected leaks might want to see the failure to know that CppUTest wasn't configured like they expected.

Is the intended behavior for tests using EXPECT_N_LEAKS() to fail when CppUTest is configured with --disable-memory-leak-detection, or was this just a miss? Thoughts?
