### PR TITLE
Expected calls matching several actual calls - (1) Preparation

### DIFF
--- a/include/CppUTestExt/MockCheckedActualCall.h
+++ b/include/CppUTestExt/MockCheckedActualCall.h
@@ -100,8 +100,8 @@ protected:
     SimpleString getName() const;
     virtual UtestShell* getTest() const;
     virtual void callHasSucceeded();
-    virtual void finalizeOutputParameters(MockCheckedExpectedCall* call);
-    virtual void finalizeCallWhenFulfilled();
+    virtual void copyOutputParameters(MockCheckedExpectedCall* call);
+    virtual void completeCallWhenMatchIsFound();
     virtual void failTest(const MockFailure& failure);
     virtual void checkInputParameter(const MockNamedValue& actualParameter);
     virtual void checkOutputParameter(const MockNamedValue& outputParameter);
@@ -120,9 +120,9 @@ private:
     MockFailureReporter* reporter_;
 
     ActualCallState state_;
-    MockCheckedExpectedCall* fulfilledExpectation_;
+    MockCheckedExpectedCall* matchingExpectation_;
 
-    MockExpectedCallsList unfulfilledExpectations_;
+    MockExpectedCallsList potentiallyMatchingExpectations_;
     const MockExpectedCallsList& allExpectations_;
 
     class MockOutputParametersListNode

--- a/include/CppUTestExt/MockCheckedExpectedCall.h
+++ b/include/CppUTestExt/MockCheckedExpectedCall.h
@@ -84,17 +84,18 @@ public:
     virtual bool relatesToObject(const void* objectPtr) const;
 
     virtual bool isFulfilled();
-    virtual bool isFulfilledWithoutIgnoredParameters();
-    virtual bool areParametersFulfilled();
-    virtual bool areIgnoredParametersFulfilled();
+    virtual bool canMatchActualCalls();
+    virtual bool isMatchingActualCallAndFinalized();
+    virtual bool isMatchingActualCall();
+    virtual bool areParametersMatchingActualCall();
     virtual bool isOutOfOrder() const;
 
     virtual void callWasMade(int callOrder);
     virtual void inputParameterWasPassed(const SimpleString& name);
     virtual void outputParameterWasPassed(const SimpleString& name);
-    virtual void parametersWereIgnored();
+    virtual void finalizeActualCallMatch();
     virtual void wasPassedToObject();
-    virtual void resetExpectation();
+    virtual void resetActualCallMatchingState();
 
     virtual SimpleString callToString();
     virtual SimpleString missingParametersToString();
@@ -113,18 +114,18 @@ private:
     {
     public:
         MockExpectedFunctionParameter(const SimpleString& name);
-        void setFulfilled(bool b);
-        bool isFulfilled() const;
+        void setMatchesActualCall(bool b);
+        bool isMatchingActualCall() const;
 
     private:
-        bool fulfilled_;
+        bool matchesActualCall_;
     };
 
     MockExpectedFunctionParameter* item(MockNamedValueListNode* node);
 
     bool ignoreOtherParameters_;
-    bool parametersWereIgnored_;
-    int callOrder_;
+    bool isActualCallMatchFinalized_;
+    int actualCallOrder_;
     int expectedCallOrder_;
     bool outOfOrder_;
     MockNamedValueList* inputParameters_;

--- a/include/CppUTestExt/MockExpectedCallsList.h
+++ b/include/CppUTestExt/MockExpectedCallsList.h
@@ -43,7 +43,8 @@ public:
     virtual int amountOfExpectationsFor(const SimpleString& name) const;
     virtual int amountOfUnfulfilledExpectations() const;
     virtual bool hasUnfulfilledExpectations() const;
-    virtual bool hasUnfulfilledExpectationsBecauseOfMissingParameters() const;
+    virtual bool hasFinalizedMatchingExpectations() const;
+    virtual bool hasUnmatchingExpectationsBecauseOfMissingParameters() const;
     virtual bool hasExpectationWithName(const SimpleString& name) const;
     virtual bool hasCallsOutOfOrder() const;
     virtual bool isEmpty() const;
@@ -53,7 +54,7 @@ public:
     virtual void addExpectationsRelatedTo(const SimpleString& name, const MockExpectedCallsList& list);
 
     virtual void onlyKeepOutOfOrderExpectations();
-    virtual void addUnfulfilledExpectations(const MockExpectedCallsList& list);
+    virtual void addPotentiallyMatchingExpectations(const MockExpectedCallsList& list);
 
     virtual void onlyKeepExpectationsRelatedTo(const SimpleString& name);
     virtual void onlyKeepExpectationsWithInputParameter(const MockNamedValue& parameter);
@@ -61,13 +62,13 @@ public:
     virtual void onlyKeepExpectationsWithOutputParameter(const MockNamedValue& parameter);
     virtual void onlyKeepExpectationsWithOutputParameterName(const SimpleString& name);
     virtual void onlyKeepExpectationsOnObject(const void* objectPtr);
-    virtual void onlyKeepUnfulfilledExpectations();
+    virtual void onlyKeepUnmatchingExpectations();
 
-    virtual MockCheckedExpectedCall* removeOneFulfilledExpectation();
-    virtual MockCheckedExpectedCall* removeOneFulfilledExpectationWithIgnoredParameters();
-    virtual MockCheckedExpectedCall* getOneFulfilledExpectationWithIgnoredParameters();
+    virtual MockCheckedExpectedCall* removeFirstFinalizedMatchingExpectation();
+    virtual MockCheckedExpectedCall* removeFirstMatchingExpectation();
+    virtual MockCheckedExpectedCall* getFirstMatchingExpectation();
 
-    virtual void resetExpectations();
+    virtual void resetActualCallMatchingState();
     virtual void callWasMade(int callOrder);
     virtual void wasPassedToObject();
     virtual void parameterWasPassed(const SimpleString& parameterName);

--- a/include/CppUTestExt/MockSupport.h
+++ b/include/CppUTestExt/MockSupport.h
@@ -124,7 +124,7 @@ protected:
     void countCheck();
 
 private:
-    int callOrder_;
+    int actualCallOrder_;
     int expectedCallOrder_;
     bool strictOrdering_;
     MockFailureReporter *activeReporter_;
@@ -142,8 +142,8 @@ private:
 
     bool tracing_;
 
-    void checkExpectationsOfLastCall();
-    bool wasLastCallFulfilled();
+    void checkExpectationsOfLastActualCall();
+    bool wasLastActualCallFulfilled();
     void failTestWithUnexpectedCalls();
     void failTestWithOutOfOrderCalls();
 

--- a/src/CppUTestExt/MockActualCall.cpp
+++ b/src/CppUTestExt/MockActualCall.cpp
@@ -50,9 +50,9 @@ SimpleString MockCheckedActualCall::getName() const
 }
 
 MockCheckedActualCall::MockCheckedActualCall(int callOrder, MockFailureReporter* reporter, const MockExpectedCallsList& allExpectations)
-    : callOrder_(callOrder), reporter_(reporter), state_(CALL_SUCCEED), fulfilledExpectation_(NULL), allExpectations_(allExpectations), outputParameterExpectations_(NULL)
+    : callOrder_(callOrder), reporter_(reporter), state_(CALL_SUCCEED), matchingExpectation_(NULL), allExpectations_(allExpectations), outputParameterExpectations_(NULL)
 {
-    unfulfilledExpectations_.addUnfulfilledExpectations(allExpectations);
+    potentiallyMatchingExpectations_.addPotentiallyMatchingExpectations(allExpectations);
 }
 
 MockCheckedActualCall::~MockCheckedActualCall()
@@ -78,7 +78,7 @@ void MockCheckedActualCall::failTest(const MockFailure& failure)
     }
 }
 
-void MockCheckedActualCall::finalizeOutputParameters(MockCheckedExpectedCall* expectedCall)
+void MockCheckedActualCall::copyOutputParameters(MockCheckedExpectedCall* expectedCall)
 {
     for (MockOutputParametersListNode* p = outputParameterExpectations_; p; p = p->next_)
     {
@@ -103,19 +103,19 @@ void MockCheckedActualCall::finalizeOutputParameters(MockCheckedExpectedCall* ex
     }
 }
 
-void MockCheckedActualCall::finalizeCallWhenFulfilled()
+void MockCheckedActualCall::completeCallWhenMatchIsFound()
 {
-	// Expectations that don't ignore parameters have higher fulfillment preference than those that ignore parameters
+    // Expectations that don't ignore parameters have higher fulfillment preference than those that ignore parameters
 
-    fulfilledExpectation_ = unfulfilledExpectations_.removeOneFulfilledExpectation();
-    if (fulfilledExpectation_) {
-        finalizeOutputParameters(fulfilledExpectation_);
+    matchingExpectation_ = potentiallyMatchingExpectations_.removeFirstFinalizedMatchingExpectation();
+    if (matchingExpectation_) {
+        copyOutputParameters(matchingExpectation_);
         callHasSucceeded();
     } else {
-    	MockCheckedExpectedCall* fulfilledExpectationWithIgnoredParameters = unfulfilledExpectations_.getOneFulfilledExpectationWithIgnoredParameters();
-    	if (fulfilledExpectationWithIgnoredParameters) {
-    		finalizeOutputParameters(fulfilledExpectationWithIgnoredParameters);
-    	}
+        MockCheckedExpectedCall* matchingExpectationWithIgnoredParameters = potentiallyMatchingExpectations_.getFirstMatchingExpectation();
+        if (matchingExpectationWithIgnoredParameters) {
+            copyOutputParameters(matchingExpectationWithIgnoredParameters);
+        }
     }
 }
 
@@ -127,12 +127,12 @@ void MockCheckedActualCall::callHasSucceeded()
 void MockCheckedActualCall::callIsInProgress()
 {
     setState(CALL_IN_PROGRESS);
-    if (fulfilledExpectation_)
+    if (matchingExpectation_)
     {
-        fulfilledExpectation_->resetExpectation();
-        fulfilledExpectation_ = NULL;
+        matchingExpectation_->resetActualCallMatchingState();
+        matchingExpectation_ = NULL;
     }
-    unfulfilledExpectations_.onlyKeepUnfulfilledExpectations();
+    potentiallyMatchingExpectations_.onlyKeepUnmatchingExpectations();
 }
 
 MockActualCall& MockCheckedActualCall::withName(const SimpleString& name)
@@ -140,16 +140,15 @@ MockActualCall& MockCheckedActualCall::withName(const SimpleString& name)
     setName(name);
     callIsInProgress();
 
-    unfulfilledExpectations_.onlyKeepExpectationsRelatedTo(name);
-    if (unfulfilledExpectations_.isEmpty()) {
+    potentiallyMatchingExpectations_.onlyKeepExpectationsRelatedTo(name);
+    if (potentiallyMatchingExpectations_.isEmpty()) {
         MockUnexpectedCallHappenedFailure failure(getTest(), name, allExpectations_);
         failTest(failure);
         return *this;
     }
 
-    unfulfilledExpectations_.callWasMade(callOrder_);
-
-    finalizeCallWhenFulfilled();
+    potentiallyMatchingExpectations_.callWasMade(callOrder_);
+    completeCallWhenMatchIsFound();
 
     return *this;
 }
@@ -168,16 +167,16 @@ void MockCheckedActualCall::checkInputParameter(const MockNamedValue& actualPara
 
     callIsInProgress();
 
-    unfulfilledExpectations_.onlyKeepExpectationsWithInputParameter(actualParameter);
+    potentiallyMatchingExpectations_.onlyKeepExpectationsWithInputParameter(actualParameter);
 
-    if (unfulfilledExpectations_.isEmpty()) {
+    if (potentiallyMatchingExpectations_.isEmpty()) {
         MockUnexpectedInputParameterFailure failure(getTest(), getName(), actualParameter, allExpectations_);
         failTest(failure);
         return;
     }
 
-    unfulfilledExpectations_.parameterWasPassed(actualParameter.getName());
-    finalizeCallWhenFulfilled();
+    potentiallyMatchingExpectations_.parameterWasPassed(actualParameter.getName());
+    completeCallWhenMatchIsFound();
 }
 
 void MockCheckedActualCall::checkOutputParameter(const MockNamedValue& outputParameter)
@@ -189,16 +188,16 @@ void MockCheckedActualCall::checkOutputParameter(const MockNamedValue& outputPar
 
     callIsInProgress();
 
-    unfulfilledExpectations_.onlyKeepExpectationsWithOutputParameter(outputParameter);
+    potentiallyMatchingExpectations_.onlyKeepExpectationsWithOutputParameter(outputParameter);
 
-    if (unfulfilledExpectations_.isEmpty()) {
+    if (potentiallyMatchingExpectations_.isEmpty()) {
         MockUnexpectedOutputParameterFailure failure(getTest(), getName(), outputParameter, allExpectations_);
         failTest(failure);
         return;
     }
 
-    unfulfilledExpectations_.outputParameterWasPassed(outputParameter.getName());
-    finalizeCallWhenFulfilled();
+    potentiallyMatchingExpectations_.outputParameterWasPassed(outputParameter.getName());
+    completeCallWhenMatchIsFound();
 }
 
 MockActualCall& MockCheckedActualCall::withBoolParameter(const SimpleString& name, bool value)
@@ -339,21 +338,22 @@ void MockCheckedActualCall::checkExpectations()
 {
     if (state_ != CALL_IN_PROGRESS)
     {
-        unfulfilledExpectations_.resetExpectations();
+        potentiallyMatchingExpectations_.resetActualCallMatchingState();
         return;
     }
 
-    if (! unfulfilledExpectations_.hasUnfulfilledExpectations())
-        FAIL("Actual call is in progress. Checking expectations. But no unfulfilled expectations. Cannot happen.") // LCOV_EXCL_LINE
+    if (potentiallyMatchingExpectations_.hasFinalizedMatchingExpectations())
+        FAIL("Actual call is in progress, but there are finalized matching expectations when checking expectations. This cannot happen.") // LCOV_EXCL_LINE
 
-    fulfilledExpectation_ = unfulfilledExpectations_.removeOneFulfilledExpectationWithIgnoredParameters();
-    if (fulfilledExpectation_) {
+    matchingExpectation_ = potentiallyMatchingExpectations_.removeFirstMatchingExpectation();
+    if (matchingExpectation_) {
+        matchingExpectation_->finalizeActualCallMatch();
         callHasSucceeded();
-        unfulfilledExpectations_.resetExpectations();
+        potentiallyMatchingExpectations_.resetActualCallMatchingState();
         return;
     }
 
-    if (unfulfilledExpectations_.hasUnfulfilledExpectationsBecauseOfMissingParameters()) {
+    if (potentiallyMatchingExpectations_.hasUnmatchingExpectationsBecauseOfMissingParameters()) {
         MockExpectedParameterDidntHappenFailure failure(getTest(), getName(), allExpectations_);
         failTest(failure);
     }
@@ -371,8 +371,8 @@ void MockCheckedActualCall::setState(ActualCallState state)
 MockNamedValue MockCheckedActualCall::returnValue()
 {
     checkExpectations();
-    if (fulfilledExpectation_)
-        return fulfilledExpectation_->returnValue();
+    if (matchingExpectation_)
+        return matchingExpectation_->returnValue();
     return MockNamedValue("no return value");
 }
 
@@ -513,19 +513,23 @@ bool MockCheckedActualCall::hasReturnValue()
 
 MockActualCall& MockCheckedActualCall::onObject(const void* objectPtr)
 {
+    if(hasFailed()) {
+        return *this;
+    }
+
     callIsInProgress();
 
-    unfulfilledExpectations_.onlyKeepExpectationsOnObject(objectPtr);
+    potentiallyMatchingExpectations_.onlyKeepExpectationsOnObject(objectPtr);
 
-    if (unfulfilledExpectations_.isEmpty()) {
+    if (potentiallyMatchingExpectations_.isEmpty()) {
         MockUnexpectedObjectFailure failure(getTest(), getName(), objectPtr, allExpectations_);
         failTest(failure);
         return *this;
     }
 
-    unfulfilledExpectations_.wasPassedToObject();
+    potentiallyMatchingExpectations_.wasPassedToObject();
+    completeCallWhenMatchIsFound();
 
-    finalizeCallWhenFulfilled();
     return *this;
 }
 

--- a/src/CppUTestExt/MockExpectedCallsList.cpp
+++ b/src/CppUTestExt/MockExpectedCallsList.cpp
@@ -81,9 +81,24 @@ int MockExpectedCallsList::amountOfUnfulfilledExpectations() const
     return count;
 }
 
+bool MockExpectedCallsList::hasFinalizedMatchingExpectations() const
+{
+    for (MockExpectedCallsListNode* p = head_; p; p = p->next_) {
+        if (p->expectedCall_->isMatchingActualCallAndFinalized()) {
+            return true;
+        }
+    }
+    return false;
+}
+
 bool MockExpectedCallsList::hasUnfulfilledExpectations() const
 {
-    return amountOfUnfulfilledExpectations() != 0;
+    for (MockExpectedCallsListNode* p = head_; p; p = p->next_) {
+        if (!p->expectedCall_->isFulfilled()) {
+            return true;
+        }
+    }
+    return false;
 }
 
 bool MockExpectedCallsList::hasExpectationWithName(const SimpleString& name) const
@@ -107,10 +122,10 @@ void MockExpectedCallsList::addExpectedCall(MockCheckedExpectedCall* call)
     }
 }
 
-void MockExpectedCallsList::addUnfulfilledExpectations(const MockExpectedCallsList& list)
+void MockExpectedCallsList::addPotentiallyMatchingExpectations(const MockExpectedCallsList& list)
 {
     for (MockExpectedCallsListNode* p = list.head_; p; p = p->next_)
-        if (! p->expectedCall_->isFulfilled())
+        if (p->expectedCall_->canMatchActualCalls())
             addExpectedCall(p->expectedCall_);
 }
 
@@ -144,12 +159,12 @@ void MockExpectedCallsList::onlyKeepOutOfOrderExpectations()
     pruneEmptyNodeFromList();
 }
 
-void MockExpectedCallsList::onlyKeepUnfulfilledExpectations()
+void MockExpectedCallsList::onlyKeepUnmatchingExpectations()
 {
     for (MockExpectedCallsListNode* p = head_; p; p = p->next_)
-        if (p->expectedCall_->isFulfilled())
+        if (p->expectedCall_->isMatchingActualCallAndFinalized())
         {
-            p->expectedCall_->resetExpectation();
+            p->expectedCall_->resetActualCallMatchingState();
             p->expectedCall_ = NULL;
         }
 
@@ -196,38 +211,37 @@ void MockExpectedCallsList::onlyKeepExpectationsOnObject(const void* objectPtr)
     pruneEmptyNodeFromList();
 }
 
-MockCheckedExpectedCall* MockExpectedCallsList::removeOneFulfilledExpectation()
+MockCheckedExpectedCall* MockExpectedCallsList::removeFirstFinalizedMatchingExpectation()
 {
     for (MockExpectedCallsListNode* p = head_; p; p = p->next_) {
-        if (p->expectedCall_->isFulfilled()) {
-            MockCheckedExpectedCall* fulfilledCall = p->expectedCall_;
+        if (p->expectedCall_->isMatchingActualCallAndFinalized()) {
+            MockCheckedExpectedCall* matchingCall = p->expectedCall_;
             p->expectedCall_ = NULL;
             pruneEmptyNodeFromList();
-            return fulfilledCall;
+            return matchingCall;
         }
     }
     return NULL;
 }
 
-MockCheckedExpectedCall* MockExpectedCallsList::getOneFulfilledExpectationWithIgnoredParameters()
+MockCheckedExpectedCall* MockExpectedCallsList::getFirstMatchingExpectation()
 {
     for (MockExpectedCallsListNode* p = head_; p; p = p->next_) {
-        if (p->expectedCall_->isFulfilledWithoutIgnoredParameters()) {
+        if (p->expectedCall_->isMatchingActualCall()) {
             return p->expectedCall_;
         }
     }
     return NULL;
 }
 
-MockCheckedExpectedCall* MockExpectedCallsList::removeOneFulfilledExpectationWithIgnoredParameters()
+MockCheckedExpectedCall* MockExpectedCallsList::removeFirstMatchingExpectation()
 {
     for (MockExpectedCallsListNode* p = head_; p; p = p->next_) {
-        if (p->expectedCall_->isFulfilledWithoutIgnoredParameters()) {
-            MockCheckedExpectedCall* fulfilledCall = p->expectedCall_;
-            p->expectedCall_->parametersWereIgnored();
+        if (p->expectedCall_->isMatchingActualCall()) {
+            MockCheckedExpectedCall* matchingCall = p->expectedCall_;
             p->expectedCall_ = NULL;
             pruneEmptyNodeFromList();
-            return fulfilledCall;
+            return matchingCall;
         }
     }
     return NULL;
@@ -265,10 +279,10 @@ void MockExpectedCallsList::deleteAllExpectationsAndClearList()
     }
 }
 
-void MockExpectedCallsList::resetExpectations()
+void MockExpectedCallsList::resetActualCallMatchingState()
 {
     for (MockExpectedCallsListNode* p = head_; p; p = p->next_)
-        p->expectedCall_->resetExpectation();
+        p->expectedCall_->resetActualCallMatchingState();
 }
 
 void MockExpectedCallsList::callWasMade(int callOrder)
@@ -354,10 +368,10 @@ SimpleString MockExpectedCallsList::missingParametersToString() const
     return stringOrNoneTextWhenEmpty(str, "");
 }
 
-bool MockExpectedCallsList::hasUnfulfilledExpectationsBecauseOfMissingParameters() const
+bool MockExpectedCallsList::hasUnmatchingExpectationsBecauseOfMissingParameters() const
 {
     for (MockExpectedCallsListNode* p = head_; p; p = p->next_)
-        if (! p->expectedCall_->areParametersFulfilled())
+        if (! p->expectedCall_->areParametersMatchingActualCall())
             return true;
     return false;
 }

--- a/src/CppUTestExt/MockSupport.cpp
+++ b/src/CppUTestExt/MockSupport.cpp
@@ -44,7 +44,7 @@ MockSupport& mock(const SimpleString& mockName, MockFailureReporter* failureRepo
 }
 
 MockSupport::MockSupport(const SimpleString& mockName)
-    : callOrder_(0), expectedCallOrder_(0), strictOrdering_(false), standardReporter_(&defaultReporter_), ignoreOtherCalls_(false), enabled_(true), lastActualFunctionCall_(NULL), mockName_(mockName), tracing_(false)
+    : actualCallOrder_(0), expectedCallOrder_(0), strictOrdering_(false), standardReporter_(&defaultReporter_), ignoreOtherCalls_(false), enabled_(true), lastActualFunctionCall_(NULL), mockName_(mockName), tracing_(false)
 {
     setActiveReporter(NULL);
 }
@@ -123,7 +123,7 @@ void MockSupport::clear()
     compositeCalls_.clear();
     ignoreOtherCalls_ = false;
     enabled_ = true;
-    callOrder_ = 0;
+    actualCallOrder_ = 0;
     expectedCallOrder_ = 0;
     strictOrdering_ = false;
 
@@ -184,7 +184,7 @@ MockExpectedCall& MockSupport::expectNCalls(int amount, const SimpleString& func
 
 MockCheckedActualCall* MockSupport::createActualFunctionCall()
 {
-    lastActualFunctionCall_ = new MockCheckedActualCall(++callOrder_, activeReporter_, expectations_);
+    lastActualFunctionCall_ = new MockCheckedActualCall(++actualCallOrder_, activeReporter_, expectations_);
     return lastActualFunctionCall_;
 }
 
@@ -268,13 +268,13 @@ bool MockSupport::expectedCallsLeft()
     return callsLeft != 0;
 }
 
-bool MockSupport::wasLastCallFulfilled()
+bool MockSupport::wasLastActualCallFulfilled()
 {
     if (lastActualFunctionCall_ && !lastActualFunctionCall_->isFulfilled())
         return false;
 
     for (MockNamedValueListNode* p = data_.begin(); p; p = p->next())
-        if (getMockSupport(p) && !getMockSupport(p)->wasLastCallFulfilled())
+        if (getMockSupport(p) && !getMockSupport(p)->wasLastActualCallFulfilled())
                 return false;
 
     return true;
@@ -318,7 +318,7 @@ void MockSupport::countCheck()
     UtestShell::getCurrent()->countCheck();
 }
 
-void MockSupport::checkExpectationsOfLastCall()
+void MockSupport::checkExpectationsOfLastActualCall()
 {
     if(lastActualFunctionCall_)
         lastActualFunctionCall_->checkExpectations();
@@ -344,9 +344,9 @@ bool MockSupport::hasCallsOutOfOrder()
 
 void MockSupport::checkExpectations()
 {
-    checkExpectationsOfLastCall();
+    checkExpectationsOfLastActualCall();
 
-    if (wasLastCallFulfilled() && expectedCallsLeft())
+    if (wasLastActualCallFulfilled() && expectedCallsLeft())
         failTestWithUnexpectedCalls();
 
     if (hasCallsOutOfOrder())

--- a/tests/CppUTestExt/ExpectedFunctionsListTest.cpp
+++ b/tests/CppUTestExt/ExpectedFunctionsListTest.cpp
@@ -63,7 +63,7 @@ TEST_GROUP(MockExpectedCallsList)
 TEST(MockExpectedCallsList, emptyList)
 {
     CHECK(! list->hasUnfulfilledExpectations());
-    CHECK(list->size() == list->amountOfUnfulfilledExpectations());
+    CHECK(! list->hasFinalizedMatchingExpectations());
     LONGS_EQUAL(0, list->size());
 }
 
@@ -74,7 +74,7 @@ TEST(MockExpectedCallsList, addingCalls)
     LONGS_EQUAL(2, list->size());
 }
 
-TEST(MockExpectedCallsList, listWithFulfilledExpectationHasNoUnfillfilledOnes)
+TEST(MockExpectedCallsList, listWithFulfilledExpectationHasNoUnfulfilledOnes)
 {
     call1->callWasMade(1);
     call2->callWasMade(2);
@@ -112,7 +112,7 @@ TEST(MockExpectedCallsList, deleteAllExpectationsAndClearList)
     list->deleteAllExpectationsAndClearList();
 }
 
-TEST(MockExpectedCallsList, onlyKeepUnfulfilledExpectations)
+TEST(MockExpectedCallsList, onlyKeepUnmatchingExpectations)
 {
     call1->withName("relate");
     call2->withName("unrelate");
@@ -122,7 +122,7 @@ TEST(MockExpectedCallsList, onlyKeepUnfulfilledExpectations)
     list->addExpectedCall(call1);
     list->addExpectedCall(call2);
     list->addExpectedCall(call3);
-    list->onlyKeepUnfulfilledExpectations();
+    list->onlyKeepUnmatchingExpectations();
     LONGS_EQUAL(1, list->size());
 }
 
@@ -200,21 +200,21 @@ TEST(MockExpectedCallsList, onlyKeepExpectationsWithInputParameter)
     LONGS_EQUAL(2, list->size());
 }
 
-TEST(MockExpectedCallsList, addUnfilfilledExpectationsWithEmptyList)
+TEST(MockExpectedCallsList, addPotentiallyMatchingExpectationsWithEmptyList)
 {
     MockExpectedCallsList newList;
-    newList.addUnfulfilledExpectations(*list);
+    newList.addPotentiallyMatchingExpectations(*list);
     LONGS_EQUAL(0, newList.size());
 }
 
-TEST(MockExpectedCallsList, addUnfilfilledExpectationsMultipleUnfulfilledExpectations)
+TEST(MockExpectedCallsList, addPotentiallyMatchingExpectationsMultipleUnmatchedExpectations)
 {
     call2->callWasMade(1);
     list->addExpectedCall(call1);
     list->addExpectedCall(call2);
     list->addExpectedCall(call3);
     MockExpectedCallsList newList;
-    newList.addUnfulfilledExpectations(*list);
+    newList.addPotentiallyMatchingExpectations(*list);
     LONGS_EQUAL(2, newList.size());
 }
 
@@ -266,14 +266,14 @@ TEST(MockExpectedCallsList, callToStringForFulfilledFunctions)
     STRCMP_EQUAL(expectedString.asCharString(), list->fulfilledCallsToString().asCharString());
 }
 
-TEST(MockExpectedCallsList, removeOneFulfilledExpectationFromEmptyList)
+TEST(MockExpectedCallsList, removeOneFinalizedMatchingExpectationFromEmptyList)
 {
-    POINTERS_EQUAL(NULL, list->removeOneFulfilledExpectation());
+    POINTERS_EQUAL(NULL, list->removeFirstFinalizedMatchingExpectation());
 }
 
-TEST(MockExpectedCallsList, getOneFulfilledExpectationWithIgnoredParametersFromEmptyList)
+TEST(MockExpectedCallsList, getOneMatchingExpectationFromEmptyList)
 {
-    POINTERS_EQUAL(NULL, list->getOneFulfilledExpectationWithIgnoredParameters());
+    POINTERS_EQUAL(NULL, list->getFirstMatchingExpectation());
 }
 
 TEST(MockExpectedCallsList, toStringOnEmptyList)

--- a/tests/CppUTestExt/ExpectedFunctionsListTest.cpp
+++ b/tests/CppUTestExt/ExpectedFunctionsListTest.cpp
@@ -280,3 +280,14 @@ TEST(MockExpectedCallsList, toStringOnEmptyList)
 {
     STRCMP_EQUAL("<none>", list->unfulfilledCallsToString().asCharString());
 }
+
+TEST(MockExpectedCallsList, hasFinalizedMatchingExpectations)
+{
+    call1->ignoreOtherParameters();
+    list->addExpectedCall(call1);
+    CHECK(! list->hasFinalizedMatchingExpectations());
+
+    call1->callWasMade(1);
+    call1->finalizeActualCallMatch();
+    CHECK(list->hasFinalizedMatchingExpectations());
+}

--- a/tests/CppUTestExt/ExpectedFunctionsListTest.cpp
+++ b/tests/CppUTestExt/ExpectedFunctionsListTest.cpp
@@ -281,13 +281,48 @@ TEST(MockExpectedCallsList, toStringOnEmptyList)
     STRCMP_EQUAL("<none>", list->unfulfilledCallsToString().asCharString());
 }
 
-TEST(MockExpectedCallsList, hasFinalizedMatchingExpectations)
+TEST(MockExpectedCallsList, hasFinalizedMatchingExpectations_emptyList)
 {
-    call1->ignoreOtherParameters();
-    list->addExpectedCall(call1);
     CHECK(! list->hasFinalizedMatchingExpectations());
+}
 
+TEST(MockExpectedCallsList, hasFinalizedMatchingExpectations_listHasNonMatchingCalls)
+{
+    list->addExpectedCall(call1);
+    list->addExpectedCall(call2);
+    list->addExpectedCall(call3);
+
+    CHECK(! list->hasFinalizedMatchingExpectations());
+}
+
+TEST(MockExpectedCallsList, hasFinalizedMatchingExpectations_listHasMatchingButNotFinalizedCall)
+{
+    list->addExpectedCall(call1);
+    list->addExpectedCall(call2);
+    call1->ignoreOtherParameters();
+    call1->callWasMade(1);
+
+    CHECK(! list->hasFinalizedMatchingExpectations());
+}
+
+TEST(MockExpectedCallsList, hasFinalizedMatchingExpectations_listHasFinalizedCallThatIgnoresParameters)
+{
+    list->addExpectedCall(call1);
+    list->addExpectedCall(call2);
+    call1->ignoreOtherParameters();
     call1->callWasMade(1);
     call1->finalizeActualCallMatch();
+
+    CHECK(list->hasFinalizedMatchingExpectations());
+}
+
+TEST(MockExpectedCallsList, hasFinalizedMatchingExpectations_listHasFinalizedCallThatDoesntIgnoreParameters)
+{
+    list->addExpectedCall(call1);
+    list->addExpectedCall(call2);
+    call1->withParameter("param", 1);
+    call1->callWasMade(1);
+    call1->inputParameterWasPassed("param");
+
     CHECK(list->hasFinalizedMatchingExpectations());
 }

--- a/tests/CppUTestExt/MockActualCallTest.cpp
+++ b/tests/CppUTestExt/MockActualCallTest.cpp
@@ -80,6 +80,19 @@ TEST(MockCheckedActualCall, unExpectedCallWithAnOutputParameter)
     CHECK_EXPECTED_MOCK_FAILURE(expectedFailure);
 }
 
+TEST(MockCheckedActualCall, unExpectedCallOnObject)
+{
+    int object;
+
+    MockCheckedActualCall actualCall(1, reporter, *emptyList);
+    actualCall.withName("unexpected").onObject(&object);
+
+    MockUnexpectedCallHappenedFailure expectedFailure(mockFailureTest(), "unexpected", *list);
+    CHECK_EXPECTED_MOCK_FAILURE(expectedFailure);
+
+    CHECK(actualCall.hasFailed()); // Checks that onObject() doesn't "reset" call state
+}
+
 TEST(MockCheckedActualCall, actualCallWithNoReturnValueAndMeaninglessCallOrderForCoverage)
 {
     MockCheckedActualCall actualCall(1, reporter, *emptyList);

--- a/tests/CppUTestExt/MockParameterTest.cpp
+++ b/tests/CppUTestExt/MockParameterTest.cpp
@@ -442,7 +442,7 @@ TEST(MockParameterTest, ignoreOtherParametersMultipleCallsButOneDidntHappen)
     MockCheckedExpectedCall* call = expectations.addFunction("boo");
     call->ignoreOtherParameters();
     call->callWasMade(1);
-    call->parametersWereIgnored();
+    call->finalizeActualCallMatch();
     call->ignoreOtherParameters();
     expectations.addFunction("boo")->ignoreOtherParameters();
     MockExpectedCallsDidntHappenFailure expectedFailure(mockFailureTest(), expectations);


### PR DESCRIPTION
As discussed in PR #1018, I submit here some small refactoring changes in preparation for the next modifications.

These modifications don't change or add any functionality, they just rename some methods and attributes, and add a couple of additional methods, in preparation for the actual implementation of multi-matching expected calls.

The key concepts changed are about **matching** actual calls, and **fulfilling** expected calls. 

Until now, an expected call could _match_ a single actual call, and when this _match_ was done, then the expected call was _fulfilled_, so _matching_ and _fulfilling_ was rather the same thing. 

From now on, these two concepts will be separated: During the processing an actual call, expected calls will be able to _match_ it under certain conditions (i.e. parameters and object match, the expected call hasn't reached the maximum number of actual calls that it can match, etc.). However, an expected call will be considered _fulfilled_ when it has _matched_ its minimum and its maximum number of actual calls.

This means that an expected call will be considered to be _fulfilled_ as soon as it reaches its minimum number of _matched_ actual calls, but that it will be able to _match_ actual calls until it reaches its maximum.

Additionally, expected calls have another associated concept: **finalized**. Calls that don't ignore parameters are automatically considered to be _finalized_ when they have matched its object and all its parameters (if they have any). However, calls that can ignore parameters are not _finalized_ until the actual call is finalized (i.e. checkExpectations() has been called on the actual call). I think that this clarifies a bit the "...WithoutIgnoredParameters" and "...WithIgnoredParameters" methods in expected calls list, because this nomenclature was a bit confusing (does that mean that we look for calls that can ignore parameters, or that have actually ignored already some?).

Notice that the state stored in expected calls relative to _"matching"_ will be only relevant while an actual call is being processed, but the state stored relative to _"fulfilling"_ will be relevant during the whole life cycle of the expected call.