### PR TITLE
Expected calls matching several actual calls - (2) More preparation

### DIFF
--- a/include/CppUTestExt/MockActualCall.h
+++ b/include/CppUTestExt/MockActualCall.h
@@ -42,7 +42,7 @@ public:
     virtual ~MockActualCall();
 
     virtual MockActualCall& withName(const SimpleString& name)=0;
-    virtual MockActualCall& withCallOrder(int callOrder)=0;
+    virtual MockActualCall& withCallOrder(unsigned int callOrder)=0;
     MockActualCall& withParameter(const SimpleString& name, bool value) { return withBoolParameter(name, value); }
     MockActualCall& withParameter(const SimpleString& name, int value) { return withIntParameter(name, value); }
     MockActualCall& withParameter(const SimpleString& name, unsigned int value) { return withUnsignedIntParameter(name, value); }

--- a/include/CppUTestExt/MockCheckedActualCall.h
+++ b/include/CppUTestExt/MockCheckedActualCall.h
@@ -34,11 +34,11 @@
 class MockCheckedActualCall : public MockActualCall
 {
 public:
-    MockCheckedActualCall(int callOrder, MockFailureReporter* reporter, const MockExpectedCallsList& expectations);
+    MockCheckedActualCall(unsigned int callOrder, MockFailureReporter* reporter, const MockExpectedCallsList& expectations);
     virtual ~MockCheckedActualCall();
 
     virtual MockActualCall& withName(const SimpleString& name) _override;
-    virtual MockActualCall& withCallOrder(int) _override;
+    virtual MockActualCall& withCallOrder(unsigned int) _override;
     virtual MockActualCall& withBoolParameter(const SimpleString& name, bool value) _override;
     virtual MockActualCall& withIntParameter(const SimpleString& name, int value) _override;
     virtual MockActualCall& withUnsignedIntParameter(const SimpleString& name, unsigned int value) _override;
@@ -116,7 +116,7 @@ protected:
 
 private:
     SimpleString functionName_;
-    int callOrder_;
+    unsigned int callOrder_;
     MockFailureReporter* reporter_;
 
     ActualCallState state_;
@@ -150,7 +150,7 @@ public:
     virtual ~MockActualCallTrace();
 
     virtual MockActualCall& withName(const SimpleString& name) _override;
-    virtual MockActualCall& withCallOrder(int) _override;
+    virtual MockActualCall& withCallOrder(unsigned int) _override;
     virtual MockActualCall& withBoolParameter(const SimpleString& name, bool value) _override;
     virtual MockActualCall& withIntParameter(const SimpleString& name, int value) _override;
     virtual MockActualCall& withUnsignedIntParameter(const SimpleString& name, unsigned int value) _override;
@@ -215,7 +215,7 @@ class MockIgnoredActualCall: public MockActualCall
 {
 public:
     virtual MockActualCall& withName(const SimpleString&) _override { return *this;}
-    virtual MockActualCall& withCallOrder(int) _override { return *this; }
+    virtual MockActualCall& withCallOrder(unsigned int) _override { return *this; }
     virtual MockActualCall& withBoolParameter(const SimpleString&, bool) _override { return *this; }
     virtual MockActualCall& withIntParameter(const SimpleString&, int) _override { return *this; }
     virtual MockActualCall& withUnsignedIntParameter(const SimpleString&, unsigned int) _override { return *this; }

--- a/include/CppUTestExt/MockCheckedExpectedCall.h
+++ b/include/CppUTestExt/MockCheckedExpectedCall.h
@@ -39,7 +39,7 @@ public:
     virtual ~MockCheckedExpectedCall();
 
     virtual MockExpectedCall& withName(const SimpleString& name) _override;
-    virtual MockExpectedCall& withCallOrder(int callOrder) _override;
+    virtual MockExpectedCall& withCallOrder(unsigned int callOrder) _override;
     virtual MockExpectedCall& withBoolParameter(const SimpleString& name, bool value) _override;
     virtual MockExpectedCall& withIntParameter(const SimpleString& name, int value) _override;
     virtual MockExpectedCall& withUnsignedIntParameter(const SimpleString& name, unsigned int value) _override;
@@ -90,7 +90,7 @@ public:
     virtual bool areParametersMatchingActualCall();
     virtual bool isOutOfOrder() const;
 
-    virtual void callWasMade(int callOrder);
+    virtual void callWasMade(unsigned int callOrder);
     virtual void inputParameterWasPassed(const SimpleString& name);
     virtual void outputParameterWasPassed(const SimpleString& name);
     virtual void finalizeActualCallMatch();
@@ -100,8 +100,8 @@ public:
     virtual SimpleString callToString();
     virtual SimpleString missingParametersToString();
 
-    enum { NOT_CALLED_YET = -1, NO_EXPECTED_CALL_ORDER = -1};
-    virtual int getCallOrder() const;
+    enum { NOT_CALLED_YET = 0, NO_EXPECTED_CALL_ORDER = 0 };
+    virtual unsigned int getCallOrder() const;
 
 protected:
     void setName(const SimpleString& name);
@@ -125,8 +125,8 @@ private:
 
     bool ignoreOtherParameters_;
     bool isActualCallMatchFinalized_;
-    int actualCallOrder_;
-    int expectedCallOrder_;
+    unsigned int actualCallOrder_;
+    unsigned int expectedCallOrder_;
     bool outOfOrder_;
     MockNamedValueList* inputParameters_;
     MockNamedValueList* outputParameters_;
@@ -143,7 +143,7 @@ public:
     virtual ~MockExpectedCallComposite();
 
     virtual MockExpectedCall& withName(const SimpleString& name) _override;
-    virtual MockExpectedCall& withCallOrder(int callOrder) _override;
+    virtual MockExpectedCall& withCallOrder(unsigned int callOrder) _override;
     virtual MockExpectedCall& withBoolParameter(const SimpleString& name, bool value) _override;
     virtual MockExpectedCall& withIntParameter(const SimpleString& name, int value) _override;
     virtual MockExpectedCall& withUnsignedIntParameter(const SimpleString& name, unsigned int value) _override;
@@ -184,7 +184,7 @@ class MockIgnoredExpectedCall: public MockExpectedCall
 public:
 
     virtual MockExpectedCall& withName(const SimpleString&) _override { return *this;}
-    virtual MockExpectedCall& withCallOrder(int) _override { return *this; }
+    virtual MockExpectedCall& withCallOrder(unsigned int) _override { return *this; }
     virtual MockExpectedCall& withBoolParameter(const SimpleString&, bool) _override { return *this; }
     virtual MockExpectedCall& withIntParameter(const SimpleString&, int) _override { return *this; }
     virtual MockExpectedCall& withUnsignedIntParameter(const SimpleString&, unsigned int) _override{ return *this; }

--- a/include/CppUTestExt/MockExpectedCall.h
+++ b/include/CppUTestExt/MockExpectedCall.h
@@ -39,7 +39,7 @@ public:
     virtual ~MockExpectedCall();
 
     virtual MockExpectedCall& withName(const SimpleString& name)=0;
-    virtual MockExpectedCall& withCallOrder(int)=0;
+    virtual MockExpectedCall& withCallOrder(unsigned int)=0;
     MockExpectedCall& withParameter(const SimpleString& name, bool value) { return withBoolParameter(name, value); }
     MockExpectedCall& withParameter(const SimpleString& name, int value) { return withIntParameter(name, value); }
     MockExpectedCall& withParameter(const SimpleString& name, unsigned int value) { return withUnsignedIntParameter(name, value); }

--- a/include/CppUTestExt/MockExpectedCallsList.h
+++ b/include/CppUTestExt/MockExpectedCallsList.h
@@ -39,9 +39,9 @@ public:
     virtual ~MockExpectedCallsList();
     virtual void deleteAllExpectationsAndClearList();
 
-    virtual int size() const;
-    virtual int amountOfExpectationsFor(const SimpleString& name) const;
-    virtual int amountOfUnfulfilledExpectations() const;
+    virtual unsigned int size() const;
+    virtual unsigned int amountOfExpectationsFor(const SimpleString& name) const;
+    virtual unsigned int amountOfUnfulfilledExpectations() const;
     virtual bool hasUnfulfilledExpectations() const;
     virtual bool hasFinalizedMatchingExpectations() const;
     virtual bool hasUnmatchingExpectationsBecauseOfMissingParameters() const;

--- a/include/CppUTestExt/MockExpectedCallsList.h
+++ b/include/CppUTestExt/MockExpectedCallsList.h
@@ -69,7 +69,7 @@ public:
     virtual MockCheckedExpectedCall* getFirstMatchingExpectation();
 
     virtual void resetActualCallMatchingState();
-    virtual void callWasMade(int callOrder);
+    virtual void callWasMade(unsigned int callOrder);
     virtual void wasPassedToObject();
     virtual void parameterWasPassed(const SimpleString& parameterName);
     virtual void outputParameterWasPassed(const SimpleString& parameterName);
@@ -91,7 +91,7 @@ protected:
             : expectedCall_(expectedCall), next_(NULL) {}
     };
 
-    virtual MockExpectedCallsListNode* findNodeWithCallOrderOf(int callOrder) const;
+    virtual MockExpectedCallsListNode* findNodeWithCallOrderOf(unsigned int callOrder) const;
 private:
     MockExpectedCallsListNode* head_;
 

--- a/include/CppUTestExt/MockSupport.h
+++ b/include/CppUTestExt/MockSupport.h
@@ -48,7 +48,7 @@ public:
     virtual void strictOrder();
     virtual MockExpectedCall& expectOneCall(const SimpleString& functionName);
     virtual void expectNoCall(const SimpleString& functionName);
-    virtual MockExpectedCall& expectNCalls(int amount, const SimpleString& functionName);
+    virtual MockExpectedCall& expectNCalls(unsigned int amount, const SimpleString& functionName);
     virtual MockActualCall& actualCall(const SimpleString& functionName);
     virtual bool hasReturnValue();
     virtual MockNamedValue returnValue();
@@ -124,8 +124,8 @@ protected:
     void countCheck();
 
 private:
-    int actualCallOrder_;
-    int expectedCallOrder_;
+    unsigned int actualCallOrder_;
+    unsigned int expectedCallOrder_;
     bool strictOrdering_;
     MockFailureReporter *activeReporter_;
     MockFailureReporter *standardReporter_;

--- a/include/CppUTestExt/MockSupport.h
+++ b/include/CppUTestExt/MockSupport.h
@@ -119,7 +119,7 @@ public:
 
 protected:
     MockSupport* clone(const SimpleString& mockName);
-    virtual MockCheckedActualCall *createActualFunctionCall();
+    virtual MockCheckedActualCall *createActualCall();
     virtual void failTest(MockFailure& failure);
     void countCheck();
 

--- a/include/CppUTestExt/MockSupport_c.h
+++ b/include/CppUTestExt/MockSupport_c.h
@@ -150,7 +150,7 @@ struct SMockSupport_c
     void (*strictOrder)(void);
     MockExpectedCall_c* (*expectOneCall)(const char* name);
     void (*expectNoCall)(const char* name);
-    MockExpectedCall_c* (*expectNCalls)(int number, const char* name);
+    MockExpectedCall_c* (*expectNCalls)(unsigned int number, const char* name);
     MockActualCall_c* (*actualCall)(const char* name);
     int (*hasReturnValue)(void);
     MockValue_c (*returnValue)(void);

--- a/src/CppUTestExt/MockActualCall.cpp
+++ b/src/CppUTestExt/MockActualCall.cpp
@@ -49,7 +49,7 @@ SimpleString MockCheckedActualCall::getName() const
     return functionName_;
 }
 
-MockCheckedActualCall::MockCheckedActualCall(int callOrder, MockFailureReporter* reporter, const MockExpectedCallsList& allExpectations)
+MockCheckedActualCall::MockCheckedActualCall(unsigned int callOrder, MockFailureReporter* reporter, const MockExpectedCallsList& allExpectations)
     : callOrder_(callOrder), reporter_(reporter), state_(CALL_SUCCEED), matchingExpectation_(NULL), allExpectations_(allExpectations), outputParameterExpectations_(NULL)
 {
     potentiallyMatchingExpectations_.addPotentiallyMatchingExpectations(allExpectations);
@@ -153,7 +153,7 @@ MockActualCall& MockCheckedActualCall::withName(const SimpleString& name)
     return *this;
 }
 
-MockActualCall& MockCheckedActualCall::withCallOrder(int)
+MockActualCall& MockCheckedActualCall::withCallOrder(unsigned int)
 {
     return *this;
 }
@@ -574,7 +574,7 @@ MockActualCall& MockActualCallTrace::withName(const SimpleString& name)
     return *this;
 }
 
-MockActualCall& MockActualCallTrace::withCallOrder(int callOrder)
+MockActualCall& MockActualCallTrace::withCallOrder(unsigned int callOrder)
 {
     traceBuffer_ += " withCallOrder:";
     traceBuffer_ += StringFrom(callOrder);

--- a/src/CppUTestExt/MockExpectedCall.cpp
+++ b/src/CppUTestExt/MockExpectedCall.cpp
@@ -254,7 +254,7 @@ bool MockCheckedExpectedCall::isMatchingActualCall()
     return (actualCallOrder_ != NOT_CALLED_YET) && areParametersMatchingActualCall() && wasPassedToObject_;
 }
 
-void MockCheckedExpectedCall::callWasMade(int callOrder)
+void MockCheckedExpectedCall::callWasMade(unsigned int callOrder)
 {
     actualCallOrder_ = callOrder;
     if (expectedCallOrder_ == NO_EXPECTED_CALL_ORDER)
@@ -495,12 +495,12 @@ MockNamedValue MockCheckedExpectedCall::returnValue()
     return returnValue_;
 }
 
-int MockCheckedExpectedCall::getCallOrder() const
+unsigned int MockCheckedExpectedCall::getCallOrder() const
 {
     return actualCallOrder_;
 }
 
-MockExpectedCall& MockCheckedExpectedCall::withCallOrder(int callOrder)
+MockExpectedCall& MockCheckedExpectedCall::withCallOrder(unsigned int callOrder)
 {
     expectedCallOrder_ = callOrder;
     return *this;
@@ -549,7 +549,7 @@ MockExpectedCall& MockExpectedCallComposite::withName(const SimpleString& name)
     return *this;
 }
 
-MockExpectedCall& MockExpectedCallComposite::withCallOrder(int)
+MockExpectedCall& MockExpectedCallComposite::withCallOrder(unsigned int)
 {
     FAIL("withCallOrder not supported for CompositeCalls");
     return *this; // LCOV_EXCL_LINE

--- a/src/CppUTestExt/MockExpectedCallsList.cpp
+++ b/src/CppUTestExt/MockExpectedCallsList.cpp
@@ -285,7 +285,7 @@ void MockExpectedCallsList::resetActualCallMatchingState()
         p->expectedCall_->resetActualCallMatchingState();
 }
 
-void MockExpectedCallsList::callWasMade(int callOrder)
+void MockExpectedCallsList::callWasMade(unsigned int callOrder)
 {
     for (MockExpectedCallsListNode* p = head_; p; p = p->next_)
         p->expectedCall_->callWasMade(callOrder);
@@ -310,7 +310,7 @@ void MockExpectedCallsList::outputParameterWasPassed(const SimpleString& paramet
         p->expectedCall_->outputParameterWasPassed(parameterName);
 }
 
-MockExpectedCallsList::MockExpectedCallsListNode* MockExpectedCallsList::findNodeWithCallOrderOf(int callOrder) const
+MockExpectedCallsList::MockExpectedCallsListNode* MockExpectedCallsList::findNodeWithCallOrderOf(unsigned int callOrder) const
 {
     for (MockExpectedCallsListNode* p = head_; p; p = p->next_)
         if (p->expectedCall_->getCallOrder() == callOrder && p->expectedCall_->isFulfilled())
@@ -351,7 +351,7 @@ SimpleString MockExpectedCallsList::fulfilledCallsToString(const SimpleString& l
     SimpleString str;
 
     MockExpectedCallsListNode* nextNodeInOrder;
-    for (int callOrder = 1; (nextNodeInOrder = findNodeWithCallOrderOf(callOrder)); callOrder++)
+    for (unsigned int callOrder = 1; (nextNodeInOrder = findNodeWithCallOrderOf(callOrder)); callOrder++)
         if (nextNodeInOrder)
             str = appendStringOnANewLine(str, linePrefix, nextNodeInOrder->expectedCall_->callToString());
 

--- a/src/CppUTestExt/MockExpectedCallsList.cpp
+++ b/src/CppUTestExt/MockExpectedCallsList.cpp
@@ -60,7 +60,7 @@ unsigned int MockExpectedCallsList::size() const
 
 bool MockExpectedCallsList::isEmpty() const
 {
-    return size() == 0;
+    return head_ == NULL;
 }
 
 

--- a/src/CppUTestExt/MockExpectedCallsList.cpp
+++ b/src/CppUTestExt/MockExpectedCallsList.cpp
@@ -50,9 +50,9 @@ bool MockExpectedCallsList::hasCallsOutOfOrder() const
     return false;
 }
 
-int MockExpectedCallsList::size() const
+unsigned int MockExpectedCallsList::size() const
 {
-    int count = 0;
+    unsigned int count = 0;
     for (MockExpectedCallsListNode* p = head_; p; p = p->next_)
         count++;
     return count;
@@ -64,18 +64,18 @@ bool MockExpectedCallsList::isEmpty() const
 }
 
 
-int MockExpectedCallsList::amountOfExpectationsFor(const SimpleString& name) const
+unsigned int MockExpectedCallsList::amountOfExpectationsFor(const SimpleString& name) const
 {
-    int count = 0;
+    unsigned int count = 0;
     for (MockExpectedCallsListNode* p = head_; p; p = p->next_)
         if (p->expectedCall_->relatesTo(name)) count++;
     return count;
 
 }
 
-int MockExpectedCallsList::amountOfUnfulfilledExpectations() const
+unsigned int MockExpectedCallsList::amountOfUnfulfilledExpectations() const
 {
-    int count = 0;
+    unsigned int count = 0;
     for (MockExpectedCallsListNode* p = head_; p; p = p->next_)
         if (! p->expectedCall_->isFulfilled()) count++;
     return count;

--- a/src/CppUTestExt/MockFailure.cpp
+++ b/src/CppUTestExt/MockFailure.cpp
@@ -103,8 +103,9 @@ MockExpectedCallsDidntHappenFailure::MockExpectedCallsDidntHappenFailure(UtestSh
 
 MockUnexpectedCallHappenedFailure::MockUnexpectedCallHappenedFailure(UtestShell* test, const SimpleString& name, const MockExpectedCallsList& expectations) : MockFailure(test)
 {
-    if (expectations.amountOfExpectationsFor(name)) {
-        SimpleString ordinalNumber = StringFromOrdinalNumber((unsigned)(expectations.amountOfExpectationsFor(name) + 1));
+    unsigned int amountOfExpectations = expectations.amountOfExpectationsFor(name);
+    if (amountOfExpectations > 0) {
+        SimpleString ordinalNumber = StringFromOrdinalNumber(amountOfExpectations + 1);
         message_ = StringFromFormat("Mock Failure: Unexpected additional (%s) call to function: ", ordinalNumber.asCharString());
     } else {
         message_ = "Mock Failure: Unexpected call to function: ";

--- a/src/CppUTestExt/MockSupport.cpp
+++ b/src/CppUTestExt/MockSupport.cpp
@@ -182,7 +182,7 @@ MockExpectedCall& MockSupport::expectNCalls(unsigned int amount, const SimpleStr
     return compositeCalls_;
 }
 
-MockCheckedActualCall* MockSupport::createActualFunctionCall()
+MockCheckedActualCall* MockSupport::createActualCall()
 {
     lastActualFunctionCall_ = new MockCheckedActualCall(++actualCallOrder_, activeReporter_, expectations_);
     return lastActualFunctionCall_;
@@ -216,7 +216,7 @@ MockActualCall& MockSupport::actualCall(const SimpleString& functionName)
         return MockIgnoredActualCall::instance();
     }
 
-    MockCheckedActualCall* call = createActualFunctionCall();
+    MockCheckedActualCall* call = createActualCall();
     call->withName(scopeFuntionName);
     return *call;
 }

--- a/src/CppUTestExt/MockSupport.cpp
+++ b/src/CppUTestExt/MockSupport.cpp
@@ -173,11 +173,11 @@ void MockSupport::expectNoCall(const SimpleString& functionName)
     unExpectations_.addExpectedCall(call);
 }
 
-MockExpectedCall& MockSupport::expectNCalls(int amount, const SimpleString& functionName)
+MockExpectedCall& MockSupport::expectNCalls(unsigned int amount, const SimpleString& functionName)
 {
     compositeCalls_.clear();
 
-    for (int i = 0; i < amount; i++)
+    for (unsigned int i = 0; i < amount; i++)
         compositeCalls_.add(expectOneCall(functionName));
     return compositeCalls_;
 }

--- a/src/CppUTestExt/MockSupport_c.cpp
+++ b/src/CppUTestExt/MockSupport_c.cpp
@@ -120,7 +120,7 @@ extern "C" {
 void strictOrder_c();
 MockExpectedCall_c* expectOneCall_c(const char* name);
 void expectNoCall_c(const char* name);
-MockExpectedCall_c* expectNCalls_c(const int number, const char* name);
+MockExpectedCall_c* expectNCalls_c(const unsigned int number, const char* name);
 MockActualCall_c* actualCall_c(const char* name);
 void disable_c();
 void enable_c();
@@ -568,7 +568,7 @@ void expectNoCall_c(const char* name)
     currentMockSupport->expectNoCall(name);
 }
 
-MockExpectedCall_c* expectNCalls_c(const int number, const char* name)
+MockExpectedCall_c* expectNCalls_c(const unsigned int number, const char* name)
 {
     expectedCall = &currentMockSupport->expectNCalls(number, name);
     return &gExpectedCall;

--- a/tests/CppUTestExt/MockCallTest.cpp
+++ b/tests/CppUTestExt/MockCallTest.cpp
@@ -192,7 +192,7 @@ TEST(MockCallTest, expectNoCallDoesntInfluenceExpectOneCall)
     MockFailureReporterInstaller failureReporterInstaller;
 
     MockExpectedCallsListForTest expectations;
-    expectations.addFunction("influence", MockCheckedExpectedCall::NO_EXPECTED_CALL_ORDER)->callWasMade(1);
+    expectations.addFunction("influence")->callWasMade(1);
     MockUnexpectedCallHappenedFailure expectedFailure(mockFailureTest(), "lazy", expectations);
 
     mock().expectNoCall("lazy");

--- a/tests/CppUTestExt/MockExpectedCallTest.cpp
+++ b/tests/CppUTestExt/MockExpectedCallTest.cpp
@@ -385,9 +385,9 @@ TEST(MockExpectedCall, callWithThreeDifferentParameter)
     DOUBLES_EQUAL(0.12, call->getInputParameter("double").getDoubleValue(), 0.05);
 }
 
-TEST(MockExpectedCall, withoutANameItsFulfilled)
+TEST(MockExpectedCall, withoutANameItsNotFulfilled)
 {
-    CHECK(call->isFulfilled());
+    CHECK(!call->isFulfilled());
 }
 
 TEST(MockExpectedCall, withANameItsNotFulfilled)

--- a/tests/CppUTestExt/MockFailureReporterForTest.cpp
+++ b/tests/CppUTestExt/MockFailureReporterForTest.cpp
@@ -104,7 +104,7 @@ MockCheckedExpectedCall* MockExpectedCallsListForTest::addFunction(const SimpleS
   return newCall;
 }
 
-MockCheckedExpectedCall* MockExpectedCallsListForTest::addFunction(const SimpleString& name, int order)
+MockCheckedExpectedCall* MockExpectedCallsListForTest::addFunction(const SimpleString& name, unsigned int order)
 {
   MockCheckedExpectedCall* newCall = addFunction(name);
   newCall->withCallOrder(order);

--- a/tests/CppUTestExt/MockFailureReporterForTest.cpp
+++ b/tests/CppUTestExt/MockFailureReporterForTest.cpp
@@ -104,7 +104,7 @@ MockCheckedExpectedCall* MockExpectedCallsListForTest::addFunction(const SimpleS
   return newCall;
 }
 
-MockCheckedExpectedCall* MockExpectedCallsListForTest::addFunction(const SimpleString& name, unsigned int order)
+MockCheckedExpectedCall* MockExpectedCallsListForTest::addFunctionOrdered(const SimpleString& name, unsigned int order)
 {
   MockCheckedExpectedCall* newCall = addFunction(name);
   newCall->withCallOrder(order);

--- a/tests/CppUTestExt/MockFailureReporterForTest.h
+++ b/tests/CppUTestExt/MockFailureReporterForTest.h
@@ -60,7 +60,7 @@ class MockExpectedCallsListForTest : public MockExpectedCallsList
   public:
     ~MockExpectedCallsListForTest();
     MockCheckedExpectedCall* addFunction(const SimpleString& name);
-    MockCheckedExpectedCall* addFunction(const SimpleString& name, int order);
+    MockCheckedExpectedCall* addFunction(const SimpleString& name, unsigned int order);
 };
 
 #endif

--- a/tests/CppUTestExt/MockFailureReporterForTest.h
+++ b/tests/CppUTestExt/MockFailureReporterForTest.h
@@ -60,7 +60,7 @@ class MockExpectedCallsListForTest : public MockExpectedCallsList
   public:
     ~MockExpectedCallsListForTest();
     MockCheckedExpectedCall* addFunction(const SimpleString& name);
-    MockCheckedExpectedCall* addFunction(const SimpleString& name, unsigned int order);
+    MockCheckedExpectedCall* addFunctionOrdered(const SimpleString& name, unsigned int order);
 };
 
 #endif

--- a/tests/CppUTestExt/MockStrictOrderTest.cpp
+++ b/tests/CppUTestExt/MockStrictOrderTest.cpp
@@ -66,9 +66,9 @@ TEST(MockStrictOrderTest, orderViolated)
     mock().strictOrder();
 
     MockExpectedCallsListForTest expectations;
-    expectations.addFunction("foo1", 1)->callWasMade(1);
-    expectations.addFunction("foo1", 2)->callWasMade(3);
-    expectations.addFunction("foo2", 3)->callWasMade(2);
+    expectations.addFunctionOrdered("foo1", 1)->callWasMade(1);
+    expectations.addFunctionOrdered("foo1", 2)->callWasMade(3);
+    expectations.addFunctionOrdered("foo2", 3)->callWasMade(2);
     MockCallOrderFailure expectedFailure(mockFailureTest(), expectations);
 
     mock().expectOneCall("foo1");
@@ -89,8 +89,8 @@ TEST(MockStrictOrderTest, orderViolatedWorksHierarchically)
     mock("bla").strictOrder();
 
     MockExpectedCallsListForTest expectations;
-    expectations.addFunction("foo::foo1", 1)->callWasMade(2);
-    expectations.addFunction("foo::foo2", 2)->callWasMade(1);
+    expectations.addFunctionOrdered("foo::foo1", 1)->callWasMade(2);
+    expectations.addFunctionOrdered("foo::foo2", 2)->callWasMade(1);
     MockCallOrderFailure expectedFailure(mockFailureTest(), expectations);
 
     mock("bla").expectOneCall("foo1");
@@ -113,8 +113,8 @@ TEST(MockStrictOrderTest, orderViolatedWorksWithExtraUnexpectedCall)
 	mock().ignoreOtherCalls();
 
     MockExpectedCallsListForTest expectations;
-    expectations.addFunction("foo::foo1", 1)->callWasMade(2);
-    expectations.addFunction("foo::foo2", 2)->callWasMade(1);
+    expectations.addFunctionOrdered("foo::foo1", 1)->callWasMade(2);
+    expectations.addFunctionOrdered("foo::foo2", 2)->callWasMade(1);
     MockCallOrderFailure expectedFailure(mockFailureTest(), expectations);
 
     mock("bla").expectOneCall("foo1");
@@ -137,8 +137,8 @@ TEST(MockStrictOrderTest, orderViolatedWithinAScope)
     mock().strictOrder();
 
     MockExpectedCallsListForTest expectations;
-    expectations.addFunction("scope::foo1", 1)->callWasMade(2);
-    expectations.addFunction("scope::foo2", 2)->callWasMade(1);
+    expectations.addFunctionOrdered("scope::foo1", 1)->callWasMade(2);
+    expectations.addFunctionOrdered("scope::foo2", 2)->callWasMade(1);
     MockCallOrderFailure expectedFailure(mockFailureTest(), expectations);
 
     mock("scope").expectOneCall("foo1");


### PR DESCRIPTION
These modifications don't change or add any functionality, they're just simple refactorings that will simplify reviewing subsequent PRs.

They consist in changing the "call order" or "call count" related attributes and methods to use unsigned integers instead of signed integers, renaming a couple of private/internal methods and the optimization of the expected calls list isEmpty() method.