### PR TITLE
Werror as cmake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ option(LONGLONG "Support long long" OFF)
 option(MAP_FILE "Enable the creation of a map file" OFF)
 option(COVERAGE "Enable running with coverage" OFF)
 option(C++11 "Compile with C++11 support" OFF)
+option(WERROR "Compile with warnings as errors" OFF)
 
 option(TESTS "Compile and make tests for the code?" ON)
 option(TESTS_DETAILED "Run each test separately instead of grouped?" OFF)

--- a/cmake/Modules/CppUTestWarningFlags.cmake
+++ b/cmake/Modules/CppUTestWarningFlags.cmake
@@ -44,6 +44,11 @@ else (MSVC)
         Wno-long-long
         )
 
+    if (WERROR)
+        list(APPEND WARNING_C_FLAGS Werror)
+    endif (WERROR)
+
+
     set(WARNING_C_ONLY_FLAGS
         Wstrict-prototypes
         )


### PR DESCRIPTION
Adds the option `WERROR` to cmake, which will enable `Werror` for C and C++. To maintain compatibility the option is default *OFF*.

_**Related issue:** #1003_

