### PR TITLE
Gcc5 C++14 related issue fixed for CMake

### DIFF
--- a/cmake/Modules/CppUTestWarningFlags.cmake
+++ b/cmake/Modules/CppUTestWarningFlags.cmake
@@ -67,6 +67,7 @@ else (MSVC)
            ${WARNING_CXX_FLAGS}
            Wno-c++98-compat
            Wno-c++98-compat-pedantic
+           Wno-c++14-compat
            )
     endif (C++11)
 


### PR DESCRIPTION
This fixes #991 for **Gcc5** on **CMake** (if C++11 is _enabled_). Because of the CMake flag issue (fixed in #1025), the problem didn't occur earlier for those builds.

As solution, the `-Wno-c++14-compat` flag is added, if C++11 is enabled (as #997 does for autotools).