### PR TITLE
Fix for IAR project

### DIFF
--- a/platforms/iar/CppUTest.ewp
+++ b/platforms/iar/CppUTest.ewp
@@ -1912,6 +1912,9 @@
         <name>$PROJ_DIR$\..\..\src\CppUTest\SimpleString.cpp</name>
       </file>
       <file>
+        <name>$PROJ_DIR$\..\..\src\CppUTest\TeamCityTestOutput.cpp</name>
+      </file>
+      <file>
         <name>$PROJ_DIR$\..\..\src\CppUTest\TestFailure.cpp</name>
       </file>
       <file>
@@ -1934,6 +1937,9 @@
       </file>
       <file>
         <name>$PROJ_DIR$\..\..\src\CppUTest\TestResult.cpp</name>
+      </file>
+      <file>
+        <name>$PROJ_DIR$\..\..\src\CppUTest\TestTestingFixture.cpp</name>
       </file>
       <file>
         <name>$PROJ_DIR$\..\..\src\CppUTest\Utest.cpp</name>

--- a/platforms/iar/CppUTestTest.icf
+++ b/platforms/iar/CppUTestTest.icf
@@ -5,7 +5,7 @@
 define symbol __ICFEDIT_intvec_start__ = 0x00000000;
 /*-Memory Regions-*/
 define symbol __ICFEDIT_region_IROM1_start__ = 0x00000080;
-define symbol __ICFEDIT_region_IROM1_end__   = 0x0007FFFF;
+define symbol __ICFEDIT_region_IROM1_end__   = 0x0008FFFF;
 define symbol __ICFEDIT_region_IROM2_start__ = 0x0;
 define symbol __ICFEDIT_region_IROM2_end__   = 0x0;
 define symbol __ICFEDIT_region_EROM1_start__ = 0x0;


### PR DESCRIPTION
Added some missing references in the IAR platform. Also increased the flash size in the CppuTestTest project as I got an out of memory error from the linker. Now running fine on EWARM 7.50.3.10751.