### PR TITLE
Pedantic flag added to CMake

### DIFF
--- a/cmake/Modules/CppUTestWarningFlags.cmake
+++ b/cmake/Modules/CppUTestWarningFlags.cmake
@@ -32,6 +32,7 @@ else (MSVC)
         Weverything
         Wall
         Wextra
+        pedantic
         Wshadow
         Wswitch-default
         Wswitch-enum


### PR DESCRIPTION
Adds `-pedantic` to C and C++ flags on CMake builds.

_**Note:** Build failures are related to #1034._