### PR TITLE
Use Appveyor cache for MinGW

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,8 @@ image: Visual Studio 2015
 cache:
   - C:\ProgramData\chocolatey\bin -> appveyor.yml
   - C:\ProgramData\chocolatey\lib -> appveyor.yml
-  - C:\Tools\MinGW* -> appveyor.yml
+  - C:\Tools\MinGW32 -> appveyor.yml
+  - C:\Tools\MinGW64 -> appveyor.yml
 
 environment:
   Configuration: Release

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,11 @@ version: 3.7.0-ci{build}
 
 image: Visual Studio 2015
 
+cache:
+  - C:\ProgramData\chocolatey\bin -> appveyor.yml
+  - C:\ProgramData\chocolatey\lib -> appveyor.yml
+  - C:\Tools\MinGW* -> appveyor.yml
+
 environment:
   Configuration: Release
   matrix:


### PR DESCRIPTION
Hopefully this fixes the issues we've seen with the appveyor build reliability (such as #1016).  I added the install folders to the appveyor cache so that it stores them between builds.  That way the install is already done and doesn't have to download MinGW, which is where the failure seemed to occur.  If appveyor.yml changes, then the cache is invalidated, since the version of MinGW used is defined in appveyor.yml.

Only part I don't quite like are the yellow messages about missing folders to cache.