### PR TITLE
Fixing OSX build conflicts with strdup and strndup

### DIFF
--- a/include/CppUTest/MemoryLeakDetectorMallocMacros.h
+++ b/include/CppUTest/MemoryLeakDetectorMallocMacros.h
@@ -22,8 +22,6 @@ extern "C"
 #endif
 
 extern void* cpputest_malloc_location(size_t size, const char* file, int line);
-extern char* cpputest_strdup_location(const char* str, const char* file, int line);
-extern char* cpputest_strndup_location(const char* str, size_t n, const char* file, int line);
 extern void* cpputest_calloc_location(size_t count, size_t size, const char* file, int line);
 extern void* cpputest_realloc_location(void *, size_t, const char* file, int line);
 extern void cpputest_free_location(void* buffer, const char* file, int line);
@@ -34,13 +32,6 @@ extern void cpputest_free_location(void* buffer, const char* file, int line);
 
 extern void crash_on_allocation_number(unsigned number);
 
-#endif
-
-#ifdef CPPUTEST_HAVE_STRDUP
-#define strdup(str) cpputest_strdup_location(str, __FILE__, __LINE__)
-#define strndup(str, n) cpputest_strndup_location(str, n, __FILE__, __LINE__)
-#define CPPUTEST_USE_STRDUP_MACROS 1
-#endif
 
 #define malloc(a) cpputest_malloc_location(a, __FILE__, __LINE__)
 #define calloc(a, b) cpputest_calloc_location(a, b, __FILE__, __LINE__)
@@ -48,4 +39,30 @@ extern void crash_on_allocation_number(unsigned number);
 #define free(a) cpputest_free_location(a, __FILE__, __LINE__)
 
 #define CPPUTEST_USE_MALLOC_MACROS 1
+#endif /* CPPUTEST_USE_MALLOC_MACROS */
+
+/* This prevents strdup macros to get defined, unless it has been enabled by the user or generated config */
+#ifdef CPPUTEST_HAVE_STRDUP
+
+/* This prevents the declaration from done twice and makes sure the file only #defines strdup, so it can be included anywhere */
+#ifndef CPPUTEST_USE_STRDUP_MACROS
+
+#ifdef __cplusplus
+extern "C"
+{
 #endif
+
+extern char* cpputest_strdup_location(const char* str, const char* file, int line);
+extern char* cpputest_strndup_location(const char* str, size_t n, const char* file, int line);
+
+#ifdef __cplusplus
+}
+#endif
+
+#define strdup(str) cpputest_strdup_location(str, __FILE__, __LINE__)
+#define strndup(str, n) cpputest_strndup_location(str, n, __FILE__, __LINE__)
+
+#define CPPUTEST_USE_STRDUP_MACROS 1
+#endif /* CPPUTEST_USE_STRDUP_MACROS */
+#endif /* CPPUTEST_HAVE_STRDUP */
+#endif /* CPPUTEST_USE_MEM_LEAK_DETECTION */

--- a/include/CppUTest/MemoryLeakDetectorNewMacros.h
+++ b/include/CppUTest/MemoryLeakDetectorNewMacros.h
@@ -28,9 +28,27 @@
 #ifndef CPPUTEST_USE_NEW_MACROS
 
     #if CPPUTEST_USE_STD_CPP_LIB
+        #ifdef CPPUTEST_USE_STRDUP_MACROS
+            #if CPPUTEST_USE_STRDUP_MACROS == 1
+            /*
+             * Some platforms (OSx, i.e.) will get <string.h> or <cstring> included when using <memory> header,
+             *  in order to avoid conflicts with strdup and strndup macros defined by MemoryLeakDetectorMallocMacros.h
+             *  we will undefined those macros, include the C++ headers and then reinclude MemoryLeakDetectorMallocMacros.h.
+             * The check `#if CPPUTEST_USE_STRDUP_MACROS` will ensure we only include MemoryLeakDetectorMallocMacros.h if
+             *  it has already been includeded earlier.
+             */
+                #undef strdup
+                #undef strndup
+                #undef CPPUTEST_USE_STRDUP_MACROS
+                #define __CPPUTEST_REINCLUDE_MALLOC_MEMORY_LEAK_DETECTOR
+            #endif
+        #endif
         #include <new>
         #include <memory>
         #include <string>
+        #ifdef __CPPUTEST_REINCLUDE_MALLOC_MEMORY_LEAK_DETECTOR
+            #include "MemoryLeakDetectorMallocMacros.h"
+        #endif
     #endif
 
     void* operator new(size_t size, const char* file, int line) UT_THROW (std::bad_alloc);

--- a/src/CppUTest/TestHarness_c.cpp
+++ b/src/CppUTest/TestHarness_c.cpp
@@ -202,7 +202,7 @@ void* cpputest_malloc_location(size_t size, const char* file, int line)
     return cpputest_malloc_location_with_leak_detection(size, file, line);
 }
 
-static size_t strlen(const char * str)
+static size_t test_harness_c_strlen(const char * str)
 {
     size_t n = 0;
     while (*str++) n++;
@@ -213,20 +213,19 @@ static char* strdup_alloc(const char * str, size_t size, const char* file, int l
 {
     char* result = (char*) cpputest_malloc_location(size, file, line);
     PlatformSpecificMemCpy(result, str, size);
-    /* Reinforce null termination in case size is less than strlen(str) */
     result[size-1] = '\0';
     return result;
 }
 
 char* cpputest_strdup_location(const char * str, const char* file, int line)
 {
-    size_t length = 1 + strlen(str);
+    size_t length = 1 + test_harness_c_strlen(str);
     return strdup_alloc(str, length, file, line);
 }
 
 char* cpputest_strndup_location(const char * str, size_t n, const char* file, int line)
 {
-    size_t length = strlen(str);
+    size_t length = test_harness_c_strlen(str);
     length = length < n ? length : n;
     length = length + 1;
     return strdup_alloc(str, length, file, line);


### PR DESCRIPTION
- Renamed strlen function implemented in TestHarness_c;
- Created advanced inclusion control of strdup and strndup macros to avoid conflicts.