### PR TITLE
MAC OS travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,44 @@ matrix:
       env: BUILD=cmake_coverage
     - compiler: gcc
       env: BUILD=test_report
+    - compiler: clang
+      os: osx
+      env: BUILD=autotools
+      addons:
+        apt:
+          packages:
+          - valgrind
+    - compiler: clang
+      os: osx
+      env: BUILD=cmake
+    - compiler: clang
+      os: osx
+      env: BUILD=autotools_gtest
+    - compiler: clang
+      os: osx
+      env: BUILD=cmake_gtest
+    - compiler: gcc
+      os: osx
+      env: BUILD=autotools
+      addons:
+        apt:
+          packages:
+          - valgrind
+    - compiler: gcc
+      os: osx
+      env: BUILD=cmake
+    - compiler: gcc
+      os: osx
+      env: BUILD=autotools_gtest
+    - compiler: gcc
+      os: osx
+      env: BUILD=cmake_gtest
+    - compiler: gcc
+      os: osx
+      env: BUILD=cmake_coverage
+    - compiler: gcc
+      os: osx
+      env: BUILD=test_report
     - compiler: wcl
       env: BUILD=make_dos
       addons:
@@ -52,3 +90,7 @@ before_script:
 - mkdir -p $CPPUTEST_BUILD_DIR && cd $CPPUTEST_BUILD_DIR
 script:
 - "../scripts/travis_ci_build.sh"
+after_failure:
+- "../scripts/travis_ci_after.sh"
+after_success:
+- "../scripts/travis_ci_after.sh"

--- a/scripts/travis_ci_after.sh
+++ b/scripts/travis_ci_after.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Script run in the travis CI
+set -ex
+
+FILE="./test-suite.log"
+
+if [ -f $FILE ]; then
+    cat $FILE
+else
+    echo "$FILE not found."
+fi

--- a/scripts/travis_ci_build.sh
+++ b/scripts/travis_ci_build.sh
@@ -75,7 +75,7 @@ if [ "x$BUILD" = "xtest_report" ]; then
 fi
 
 if [ "x$BUILD" = "xcmake_coverage" ]; then
-    pip install cpp-coveralls --user `whoami` 
+    pip install cpp-coveralls --user `whoami`
 
     cmake .. -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE -DCOVERAGE=ON -DLONGLONG=ON
     make

--- a/scripts/travis_ci_build.sh
+++ b/scripts/travis_ci_build.sh
@@ -75,7 +75,7 @@ if [ "x$BUILD" = "xtest_report" ]; then
 fi
 
 if [ "x$BUILD" = "xcmake_coverage" ]; then
-    pip install cpp-coveralls --user `whois` 
+    pip install cpp-coveralls --user `whoami` 
 
     cmake .. -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE -DCOVERAGE=ON -DLONGLONG=ON
     make

--- a/scripts/travis_ci_build.sh
+++ b/scripts/travis_ci_build.sh
@@ -75,7 +75,7 @@ if [ "x$BUILD" = "xtest_report" ]; then
 fi
 
 if [ "x$BUILD" = "xcmake_coverage" ]; then
-    pip install --user cpp-coveralls 
+    pip install cpp-coveralls --user `whois` 
 
     cmake .. -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE -DCOVERAGE=ON -DLONGLONG=ON
     make

--- a/scripts/travis_ci_build.sh
+++ b/scripts/travis_ci_build.sh
@@ -8,8 +8,14 @@ if [ "x$BUILD" = "xautotools" ]; then
     echo "CONFIGURATION DONE. Compiling now."
     make check_all
 
-    make dist
-    make dist-zip
+    if [ "x$TRAVIS_OS_NAME" = "xosx" ]; then
+        COPYFILE_DISABLE=1 make dist
+        COPYFILE_DISABLE=1 make dist-zip
+    else
+        make dist
+        make dist-zip
+    fi
+
 
     if [ "x$CXX" = "xg++" ]; then
       echo "Deploy please"

--- a/scripts/travis_ci_build.sh
+++ b/scripts/travis_ci_build.sh
@@ -56,6 +56,9 @@ if [ "x$BUILD" = "xcmake_gtest" ]; then
 fi
 
 if [ "x$BUILD" = "xtest_report" ]; then
+    if [ "x$TRAVIS_OS_NAME" = "xosx" ]; then
+        brew install ant
+    fi
     autoreconf -i ..
     ../configure
     make check
@@ -66,7 +69,7 @@ if [ "x$BUILD" = "xtest_report" ]; then
 fi
 
 if [ "x$BUILD" = "xcmake_coverage" ]; then
-    pip install cpp-coveralls --user `whoami`
+    pip install --user cpp-coveralls 
 
     cmake .. -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE -DCOVERAGE=ON -DLONGLONG=ON
     make


### PR DESCRIPTION
Added MAC builds on Travis

It's supposed to fail two mac builds due to IEEE754 
Next PR will contain the fix.

This PR has a conflict to merge,
To solve conflict, remove the `pip install --user cpp-coveralls` change from patch.