### PR TITLE
Removing IEEE754 implementation from Mac OSx

### DIFF
--- a/examples/AllTests/FEDemoTest.cpp
+++ b/examples/AllTests/FEDemoTest.cpp
@@ -28,9 +28,9 @@
 #include "CppUTest/CommandLineTestRunner.h"
 #include "CppUTest/TestHarness.h"
 #include "CppUTest/TestRegistry.h"
-#include "CppUTestExt/IEEE754ExceptionsPlugin.h"
 
 #ifdef CPPUTEST_HAVE_FENV
+#include "CppUTestExt/IEEE754ExceptionsPlugin.h"
 
 /*
  * To see a demonstration of tests failing as a result of IEEE754ExceptionsPlugin

--- a/include/CppUTest/CppUTestConfig.h
+++ b/include/CppUTest/CppUTestConfig.h
@@ -172,7 +172,7 @@
  * Works on non-Visual C++ compilers and Visual C++ 2008 and newer
  */
 
-#if CPPUTEST_USE_STD_C_LIB && (!defined(_MSC_VER) || (_MSC_VER >= 1800))
+#if CPPUTEST_USE_STD_C_LIB && (!defined(_MSC_VER) || (_MSC_VER >= 1800)) && (!defined(__APPLE__))
 #define CPPUTEST_HAVE_FENV
 #if defined(__WATCOMC__) || defined(__ARMEL__) || defined(__m68k__)
 #define CPPUTEST_FENV_IS_WORKING_PROPERLY 0

--- a/src/CppUTestExt/IEEE754ExceptionsPlugin.cpp
+++ b/src/CppUTestExt/IEEE754ExceptionsPlugin.cpp
@@ -100,4 +100,54 @@ void IEEE754ExceptionsPlugin::ieee754Check(UtestShell& test, TestResult& result,
     }
 }
 
+#else
+
+
+bool IEEE754ExceptionsPlugin::inexactDisabled_ = true;
+
+IEEE754ExceptionsPlugin::IEEE754ExceptionsPlugin(const SimpleString& name)
+    : TestPlugin(name)
+{
+}
+
+void IEEE754ExceptionsPlugin::preTestAction(UtestShell&, TestResult&)
+{
+}
+
+void IEEE754ExceptionsPlugin::postTestAction(UtestShell&, TestResult&)
+{
+}
+
+void IEEE754ExceptionsPlugin::disableInexact()
+{
+}
+
+void IEEE754ExceptionsPlugin::enableInexact()
+{
+}
+
+bool IEEE754ExceptionsPlugin::checkIeee754OverflowExceptionFlag()
+{
+    return false;
+}
+
+bool IEEE754ExceptionsPlugin::checkIeee754UnderflowExceptionFlag()
+{
+    return false;
+}
+
+bool IEEE754ExceptionsPlugin::checkIeee754InexactExceptionFlag()
+{
+    return false;
+}
+
+bool IEEE754ExceptionsPlugin::checkIeee754DivByZeroExceptionFlag()
+{
+    return false;
+}
+
+void IEEE754ExceptionsPlugin::ieee754Check(UtestShell&, TestResult&, int, const char*)
+{
+}
+
 #endif

--- a/tests/CppUTestExt/IEEE754PluginTest.cpp
+++ b/tests/CppUTestExt/IEEE754PluginTest.cpp
@@ -31,6 +31,7 @@
 #include "CppUTest/TestTestingFixture.h"
 #include "CppUTestExt/IEEE754ExceptionsPlugin.h"
 
+#ifdef CPPUTEST_HAVE_FENV
 #if CPPUTEST_FENV_IS_WORKING_PROPERLY
 
 extern "C"
@@ -142,4 +143,5 @@ IGNORE_TEST(IEEE754ExceptionsPlugin2, should_not_fail_in_ignored_test)
     set_everything_c();
 }
 
+#endif
 #endif


### PR DESCRIPTION
The solution was in code using preprocessor conditionals, because there was already those conditionals there, so I just expanded a little. 

It is not the best solution because it may mislead code coverage, ideally we should select in the build the presence or not of the plugin, but it broke the examples, so I rolled back to the preprocessor solution.