### PR TITLE
Install copier correctly

### DIFF
--- a/src/CppUTestExt/MockNamedValue.cpp
+++ b/src/CppUTestExt/MockNamedValue.cpp
@@ -436,7 +436,7 @@ struct MockNamedValueComparatorsAndCopiersRepositoryNode
         : name_(name), comparator_(comparator), copier_(NULL), next_(next) {}
     MockNamedValueComparatorsAndCopiersRepositoryNode(const SimpleString& name, MockNamedValueCopier* copier, MockNamedValueComparatorsAndCopiersRepositoryNode* next)
         : name_(name), comparator_(NULL), copier_(copier), next_(next) {}
-	MockNamedValueComparatorsAndCopiersRepositoryNode(const SimpleString& name, MockNamedValueComparator* comparator, MockNamedValueCopier* copier, MockNamedValueComparatorsAndCopiersRepositoryNode* next)
+    MockNamedValueComparatorsAndCopiersRepositoryNode(const SimpleString& name, MockNamedValueComparator* comparator, MockNamedValueCopier* copier, MockNamedValueComparatorsAndCopiersRepositoryNode* next)
         : name_(name), comparator_(comparator), copier_(copier), next_(next) {}
     SimpleString name_;
     MockNamedValueComparator* comparator_;

--- a/src/CppUTestExt/MockNamedValue.cpp
+++ b/src/CppUTestExt/MockNamedValue.cpp
@@ -436,6 +436,8 @@ struct MockNamedValueComparatorsAndCopiersRepositoryNode
         : name_(name), comparator_(comparator), copier_(NULL), next_(next) {}
     MockNamedValueComparatorsAndCopiersRepositoryNode(const SimpleString& name, MockNamedValueCopier* copier, MockNamedValueComparatorsAndCopiersRepositoryNode* next)
         : name_(name), comparator_(NULL), copier_(copier), next_(next) {}
+    MockNamedValueComparatorsAndCopiersRepositoryNode(const SimpleString& name, MockNamedValueComparator* comparator, MockNamedValueCopier* copier, MockNamedValueComparatorsAndCopiersRepositoryNode* next)
+        : name_(name), comparator_(comparator), copier_(copier), next_(next) {}
     SimpleString name_;
     MockNamedValueComparator* comparator_;
     MockNamedValueCopier* copier_;
@@ -488,5 +490,5 @@ MockNamedValueCopier* MockNamedValueComparatorsAndCopiersRepository::getCopierFo
 void MockNamedValueComparatorsAndCopiersRepository::installComparatorsAndCopiers(const MockNamedValueComparatorsAndCopiersRepository& repository)
 {
     for (MockNamedValueComparatorsAndCopiersRepositoryNode* p = repository.head_; p; p = p->next_)
-      head_ = new MockNamedValueComparatorsAndCopiersRepositoryNode(p->name_, p->comparator_, head_);
+      head_ = new MockNamedValueComparatorsAndCopiersRepositoryNode(p->name_, p->comparator_, p->copier_, head_);
 }

--- a/src/CppUTestExt/MockNamedValue.cpp
+++ b/src/CppUTestExt/MockNamedValue.cpp
@@ -436,7 +436,7 @@ struct MockNamedValueComparatorsAndCopiersRepositoryNode
         : name_(name), comparator_(comparator), copier_(NULL), next_(next) {}
     MockNamedValueComparatorsAndCopiersRepositoryNode(const SimpleString& name, MockNamedValueCopier* copier, MockNamedValueComparatorsAndCopiersRepositoryNode* next)
         : name_(name), comparator_(NULL), copier_(copier), next_(next) {}
-    MockNamedValueComparatorsAndCopiersRepositoryNode(const SimpleString& name, MockNamedValueComparator* comparator, MockNamedValueCopier* copier, MockNamedValueComparatorsAndCopiersRepositoryNode* next)
+	MockNamedValueComparatorsAndCopiersRepositoryNode(const SimpleString& name, MockNamedValueComparator* comparator, MockNamedValueCopier* copier, MockNamedValueComparatorsAndCopiersRepositoryNode* next)
         : name_(name), comparator_(comparator), copier_(copier), next_(next) {}
     SimpleString name_;
     MockNamedValueComparator* comparator_;

--- a/tests/CppUTestExt/MockNamedValueTest.cpp
+++ b/tests/CppUTestExt/MockNamedValueTest.cpp
@@ -74,3 +74,22 @@ TEST(ComparatorsAndCopiersRepository, ComparatorAndCopierByTheSameNameShouldBoth
   repository.clear();
 }
 
+TEST(ComparatorsAndCopiersRepository, InstallComparatorsAndCopiersFromRepository)
+{
+  MyComparator comparator;
+  MyCopier copier;
+  MockNamedValueComparatorsAndCopiersRepository source;
+  MockNamedValueComparatorsAndCopiersRepository target;
+	
+  source.installCopier("MyType", copier);
+  source.installComparator("MyType", comparator);
+  
+  target.installComparatorsAndCopiers(source);
+  
+  POINTERS_EQUAL(&comparator, target.getComparatorForType("MyType"));
+  POINTERS_EQUAL(&copier, target.getCopierForType("MyType"));
+  
+  source.clear();
+  target.clear();
+}
+


### PR DESCRIPTION
These changes fix a bug in CppUMock where copiers are not installed correctly (especially when used with the MockSupportPlugin)