### PR TITLE
Reduced Travis CI runtime

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ sudo: false
 matrix:
     include:
     - compiler: clang
-      env: BUILD=autotools
-    - compiler: clang
       env: BUILD=cmake CPP11=OFF
     - compiler: clang
       env: BUILD=cmake CPP11=ON
@@ -16,8 +14,19 @@ matrix:
       env: BUILD=cmake CPP11=OFF
     - compiler: gcc
       env: BUILD=cmake CPP11=ON
+
     - compiler: gcc
       env: BUILD=autotools
+      addons:
+        apt:
+          packages:
+            - valgrind
+    - compiler: clang
+      env: BUILD=autotools
+      addons:
+        apt:
+          packages:
+            - valgrind
 
     - compiler: gcc
       env: BUILD=cmake_coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,10 @@ matrix:
           packages:
             - dosbox
 
+    - compiler: clang
+      os: osx
+      env: BUILD=cmake
+
 
 before_script:
     - export CPPUTEST_BUILD_DIR=$TRAVIS_BUILD_DIR/cpputest_build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: cpp
 
+dist: trusty
 sudo: false
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,18 +7,17 @@ matrix:
     include:
     - compiler: clang
       env: BUILD=autotools
+    - compiler: clang
+      env: BUILD=cmake CPP11=OFF
+    - compiler: clang
+      env: BUILD=cmake CPP11=ON
+
+    - compiler: gcc
+      env: BUILD=cmake CPP11=OFF
+    - compiler: gcc
+      env: BUILD=cmake CPP11=ON
     - compiler: gcc
       env: BUILD=autotools
-
-    - compiler: clang
-      env: BUILD=cmake CPP11=OFF
-    - compiler: clang
-      env: BUILD=cmake CPP11=ON
-
-    - compiler: gcc
-      env: BUILD=cmake CPP11=OFF
-    - compiler: gcc
-      env: BUILD=cmake CPP11=ON
 
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ matrix:
     - compiler: gcc
       env: BUILD=autotools
 
+    - compiler: gcc
+      env: BUILD=cmake_coverage
+
 
 before_script:
     - export CPPUTEST_BUILD_DIR=$TRAVIS_BUILD_DIR/cpputest_build

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,12 @@ matrix:
 
     - compiler: gcc
       env: BUILD=cmake_coverage
+    - compiler: wcl
+      env: BUILD=make_dos
+      addons:
+        apt:
+          packages:
+            - dosbox
 
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,16 @@ sudo: false
 
 matrix:
     include:
-    #- compiler: clang
-      #env: BUILD=autotools
+    - compiler: clang
+      env: BUILD=autotools
+    - compiler: gcc
+      env: BUILD=autotools
+
     - compiler: clang
       env: BUILD=cmake CPP11=OFF
     - compiler: clang
       env: BUILD=cmake CPP11=ON
 
-    #- compiler: gcc
-      #env: BUILD=autotools
     - compiler: gcc
       env: BUILD=cmake CPP11=OFF
     - compiler: gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,17 @@ matrix:
     #- compiler: clang
       #env: BUILD=autotools
     - compiler: clang
-      env: BUILD=cmake
+      env: BUILD=cmake CPP11=OFF
+    - compiler: clang
+      env: BUILD=cmake CPP11=ON
 
     #- compiler: gcc
       #env: BUILD=autotools
     - compiler: gcc
-      env: BUILD=cmake
+      env: BUILD=cmake CPP11=OFF
+    - compiler: gcc
+      env: BUILD=cmake CPP11=ON
+
 
 before_script:
     - export CPPUTEST_BUILD_DIR=$TRAVIS_BUILD_DIR/cpputest_build

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ matrix:
 
     - compiler: gcc
       env: BUILD=cmake_coverage
+    - compiler: gcc
+      env: BUILD=cmake_gtest
     - compiler: wcl
       env: BUILD=make_dos
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,96 +1,25 @@
 language: cpp
+
 sudo: false
+
 matrix:
     include:
-    - compiler: clang
-      env: BUILD=autotools
-      addons:
-        apt:
-          packages:
-          - valgrind
+    #- compiler: clang
+      #env: BUILD=autotools
     - compiler: clang
       env: BUILD=cmake
-    - compiler: clang
-      env: BUILD=autotools_gtest
-    - compiler: clang
-      env: BUILD=cmake_gtest
-    - compiler: gcc
-      env: BUILD=autotools
-      addons:
-        apt:
-          packages:
-          - valgrind
+
+    #- compiler: gcc
+      #env: BUILD=autotools
     - compiler: gcc
       env: BUILD=cmake
-    - compiler: gcc
-      env: BUILD=autotools_gtest
-    - compiler: gcc
-      env: BUILD=cmake_gtest
-    - compiler: gcc
-      env: BUILD=cmake_coverage
-    - compiler: gcc
-      env: BUILD=test_report
-    - compiler: clang
-      os: osx
-      env: BUILD=autotools
-      addons:
-        apt:
-          packages:
-          - valgrind
-    - compiler: clang
-      os: osx
-      env: BUILD=cmake
-    - compiler: clang
-      os: osx
-      env: BUILD=autotools_gtest
-    - compiler: clang
-      os: osx
-      env: BUILD=cmake_gtest
-    - compiler: gcc
-      os: osx
-      env: BUILD=autotools
-      addons:
-        apt:
-          packages:
-          - valgrind
-    - compiler: gcc
-      os: osx
-      env: BUILD=cmake
-    - compiler: gcc
-      os: osx
-      env: BUILD=autotools_gtest
-    - compiler: gcc
-      os: osx
-      env: BUILD=cmake_gtest
-    - compiler: gcc
-      os: osx
-      env: BUILD=cmake_coverage
-    - compiler: gcc
-      os: osx
-      env: BUILD=test_report
-    - compiler: wcl
-      env: BUILD=make_dos
-      addons:
-        apt:
-          packages:
-          - dosbox
-global:
-- os: linux
-- rvm: '1.9.3'
-- secure: |-
-    P05xUfJVw5YM4hF7hzQLjyMzDD4Q1/fyWP9Uk5aK5VrSWNY99EuxldXI5QK/
-    vA1NkcW49tQW1wQvBlRtdlLNOmUfDP/oiJFXPwNn4dqwOIOEet2P7JO/5hnH
-    MNHlZmGu2WpoZREhOFBfsIhK0IP8mloqLDq2XemBdga/LWygrLU=
-- secure: |-
-    Y/8iNkf6uEbE3qltnM+7mGlCvFWzyttwwRGgVGw1m9xOiUJcobvOImQRU8XZ
-    91dgO+Fz0A3mljqs1sK1OPjpXmFGE1jP/NlotMw0WlDOuSIDjQ4ubwdTNGAw
-    NY53R9ygbIjEmqxHAJm9mOZqxW2hNaoI7TcX6oX248/hLibyx8M=
+
 before_script:
-- export CPPUTEST_BUILD_DIR=$TRAVIS_BUILD_DIR/cpputest_build
-- mkdir -p $CPPUTEST_BUILD_DIR && cd $CPPUTEST_BUILD_DIR
+    - export CPPUTEST_BUILD_DIR=$TRAVIS_BUILD_DIR/cpputest_build
+    - mkdir -p $CPPUTEST_BUILD_DIR && cd $CPPUTEST_BUILD_DIR
 script:
-- "../scripts/travis_ci_build.sh"
+    - "../scripts/travis_ci_build.sh"
 after_failure:
-- "../scripts/travis_ci_after.sh"
+    - "../scripts/travis_ci_after.sh"
 after_success:
-- "../scripts/travis_ci_after.sh"
+    - "../scripts/travis_ci_after.sh"

--- a/scripts/travis_ci_build.sh
+++ b/scripts/travis_ci_build.sh
@@ -2,7 +2,7 @@
 # Script run in the travis CI
 set -ex
 
-if [[ "$CXX" == "lang" ]]; then
+if [[ "$CXX" == "clang*" ]]; then
     export CXXFLAGS="-stdlib=libc++"
 fi
 
@@ -12,8 +12,10 @@ if [ "x$BUILD" = "xautotools" ]; then
     ../configure
     echo "CONFIGURATION DONE. Compiling now."
 
-    # TODO: Move this to a nightly build
-    #make check_all
+    if [ "${TRAVIS_EVENT_TYPE}" == "cron" ]; then
+        make check_all
+    fi
+
 
     if [ "x$TRAVIS_OS_NAME" = "xosx" ]; then
         COPYFILE_DISABLE=1 make dist

--- a/scripts/travis_ci_build.sh
+++ b/scripts/travis_ci_build.sh
@@ -25,7 +25,7 @@ if [ "x$BUILD" = "xautotools" ]; then
 fi
 
 if [ "x$BUILD" = "xcmake" ]; then
-    cmake .. -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE -DWERROR=ON
+    cmake -DWERROR=ON ..
     make
     ctest -V
 
@@ -45,8 +45,8 @@ fi
 
 if [ "x$BUILD" = "xcmake_gtest" ]; then
     pwd
-	  wget https://github.com/google/googletest/archive/release-1.6.0.zip -O gtest-1.6.0.zip  && unzip gtest-1.6.0.zip;
-	  wget https://github.com/google/googlemock/archive/release-1.6.0.zip -O gmock-1.6.0.zip  && unzip gmock-1.6.0.zip;
+      wget https://github.com/google/googletest/archive/release-1.6.0.zip -O gtest-1.6.0.zip  && unzip gtest-1.6.0.zip;
+      wget https://github.com/google/googlemock/archive/release-1.6.0.zip -O gmock-1.6.0.zip  && unzip gmock-1.6.0.zip;
     unzip gtest-1.6.0.zip -d $TRAVIS_BUILD_DIR
     unzip gmock-1.6.0.zip -d $TRAVIS_BUILD_DIR
     cd $TRAVIS_BUILD_DIR

--- a/scripts/travis_ci_build.sh
+++ b/scripts/travis_ci_build.sh
@@ -46,8 +46,8 @@ fi
 
 if [ "x$BUILD" = "xcmake_gtest" ]; then
     pwd
-      wget https://github.com/google/googletest/archive/release-1.6.0.zip -O gtest-1.6.0.zip  && unzip gtest-1.6.0.zip;
-      wget https://github.com/google/googlemock/archive/release-1.6.0.zip -O gmock-1.6.0.zip  && unzip gmock-1.6.0.zip;
+    wget https://github.com/google/googletest/archive/release-1.6.0.zip -O gtest-1.6.0.zip  && unzip gtest-1.6.0.zip;
+    wget https://github.com/google/googlemock/archive/release-1.6.0.zip -O gmock-1.6.0.zip  && unzip gmock-1.6.0.zip;
     unzip gtest-1.6.0.zip -d $TRAVIS_BUILD_DIR
     unzip gmock-1.6.0.zip -d $TRAVIS_BUILD_DIR
     cd $TRAVIS_BUILD_DIR

--- a/scripts/travis_ci_build.sh
+++ b/scripts/travis_ci_build.sh
@@ -11,7 +11,9 @@ if [ "x$BUILD" = "xautotools" ]; then
     autoreconf -i ..
     ../configure
     echo "CONFIGURATION DONE. Compiling now."
-    make check_all
+
+    # TODO: Move this to a nightly build
+    #make check_all
 
     if [ "x$TRAVIS_OS_NAME" = "xosx" ]; then
         COPYFILE_DISABLE=1 make dist

--- a/scripts/travis_ci_build.sh
+++ b/scripts/travis_ci_build.sh
@@ -2,6 +2,11 @@
 # Script run in the travis CI
 set -ex
 
+if [[ "$CXX" == "lang" ]]; then
+    export CXXFLAGS="-stdlib=libc++"
+fi
+
+
 if [ "x$BUILD" = "xautotools" ]; then
     autoreconf -i ..
     ../configure

--- a/scripts/travis_ci_build.sh
+++ b/scripts/travis_ci_build.sh
@@ -78,7 +78,7 @@ fi
 if [ "x$BUILD" = "xcmake_coverage" ]; then
     pip install --user cpp-coveralls
 
-    cmake .. -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE -DCOVERAGE=ON -DLONGLONG=ON
+    cmake .. -DCMAKE_BUILD_TYPE=C++11=ON -DCOVERAGE=ON -DLONGLONG=ON
     make
     ctest
 

--- a/scripts/travis_ci_build.sh
+++ b/scripts/travis_ci_build.sh
@@ -25,15 +25,9 @@ if [ "x$BUILD" = "xautotools" ]; then
 fi
 
 if [ "x$BUILD" = "xcmake" ]; then
-    cmake -DWERROR=ON ..
+    cmake -DWERROR=ON -DC++11=${CPP11} ..
     make
     ctest -V
-
-    if [ "x$CXX" != "xg++" ]; then
-        cmake .. -DC++11=ON -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE -DWERROR=ON
-        make
-        ctest -V
-    fi
 fi
 
 if [ "x$BUILD" = "xautotools_gtest" ]; then


### PR DESCRIPTION
This addresses the very long runtimes of Travis CI builds (#1070). The number of builds is reduced and each build is kept within some minutes.

Currently the total time has been decreased from *2 1/2 hours* to *5 minutes*.

### CI Builds

- [ ] Clang and GCC
 - [ ] C++11 on / off
 - [ ] CMake
 - [ ] Autotools
- [ ] WCL
- [ ] OS X (clang only)
- [ ] GTest
- [ ] Coverage 

### Cron Builds

In addition to the faster CI builds, long running steps are moved into *Cron Builds*.

- [ ] Full check (`make full_check`; autotools only)