### PR TITLE
Add nothrow delete operator variant overload.

### DIFF
--- a/src/CppUTest/MemoryLeakWarningPlugin.cpp
+++ b/src/CppUTest/MemoryLeakWarningPlugin.cpp
@@ -356,9 +356,19 @@ void* operator new(size_t size, const std::nothrow_t&) UT_NOTHROW
     return operator_new_nothrow_fptr(size);
 }
 
+void operator delete(void* mem, const std::nothrow_t&) UT_NOTHROW
+{
+    operator_delete_fptr(mem);
+}
+
 void* operator new[](size_t size, const std::nothrow_t&) UT_NOTHROW
 {
     return operator_new_array_nothrow_fptr(size);
+}
+
+void operator delete[](void* mem, const std::nothrow_t&) UT_NOTHROW
+{
+    operator_delete_array_fptr(mem);
 }
 
 #else

--- a/tests/CppUTest/MemoryLeakWarningTest.cpp
+++ b/tests/CppUTest/MemoryLeakWarningTest.cpp
@@ -349,9 +349,9 @@ TEST(MemoryLeakWarningGlobalDetectorTest, turnOffNewOverloadsNoThrowCausesNoAddi
 
     LONGS_EQUAL(storedAmountOfLeaks, detector->totalMemoryLeaks(mem_leak_period_all));
 
-    delete nonMemoryNoThrow;
-    delete [] nonArrayMemoryNoThrow;
-    delete [] nonArrayMemoryThrow;
+    ::operator delete(nonMemoryNoThrow, std::nothrow);
+    ::operator delete[](nonArrayMemoryNoThrow, std::nothrow);
+    ::operator delete[](nonArrayMemoryThrow, std::nothrow);
 #ifdef CPPUTEST_USE_NEW_MACROS
     #include "CppUTest/MemoryLeakDetectorNewMacros.h"
 #endif


### PR DESCRIPTION
Fixes the failure case caused by this simple test program:

```
#include <iostream>
#include <algorithm>
#include <vector>

#include <CppUTest/CommandLineTestRunner.h>
#include <CppUTest/TestHarness.h>

TEST_GROUP(HelloWorld)
{
};

TEST(HelloWorld, OnlyTest)
{
    std::vector<int> v{0, 0, 3, 0, 2, 4, 5, 0, 7};
    std::stable_partition(v.begin(), v.end(), [](int n){return n>0;});
    for (int n : v) {
        std::cout << n << ' ';
    }
    std::cout << '\n';
}

int main(int argc, char** argv)
{
    return CommandLineTestRunner::RunAllTests(argc, argv);
}
```