### PR TITLE
Fix the example code build issue

### DIFF
--- a/include/CppUTest/MemoryLeakDetectorNewMacros.h
+++ b/include/CppUTest/MemoryLeakDetectorNewMacros.h
@@ -60,8 +60,6 @@
     void operator delete[](void* mem, const char* file, int line) UT_NOTHROW;
     void operator delete(void* mem) UT_NOTHROW;
     void operator delete[](void* mem) UT_NOTHROW;
-    void operator delete (void* mem, size_t size) UT_NOTHROW;
-    void operator delete[] (void* mem, size_t size) UT_NOTHROW;
 
 #endif
 


### PR DESCRIPTION
The example code report below like build issue if using gcc 5.4,
```
../include/CppUTest/MemoryLeakDetectorNewMacros.h:63:10: error: ‘void operator delete(void*, size_t)’ is a usual (non-placement) deallocation function in C++14 (or with -fsized-deallocation) [-Werror=c++14-compat]
     void operator delete (void* mem, size_t size) UT_NOTHROW;
          ^
../include/CppUTest/MemoryLeakDetectorNewMacros.h:64:10: error: ‘void operator delete [](void*, size_t)’ is a usual (non-placement) deallocation function in C++14 (or with -fsized-deallocation) [-Werror=c++14-compat]
     void operator delete[] (void* mem, size_t size) UT_NOTHROW;
          ^
```
After checked below discussion,

`http://stackoverflow.com/questions/25019041/placement-deallocation-function-is-not-called`

I think below 2 declarations will make gcc treat this as error,

    void operator delete (void* mem, size_t size) UT_NOTHROW;
    void operator delete[] (void* mem, size_t size) UT_NOTHROW;

Also check header files in latest CYGWIN GCC (file 'new'), and did not
provide such kind of 'delete()'.