### PR TITLE
Fixed SimpleString::copyToBuffer handling of undersized buffers

### DIFF
--- a/src/CppUTest/SimpleString.cpp
+++ b/src/CppUTest/SimpleString.cpp
@@ -423,7 +423,7 @@ void SimpleString::copyToBuffer(char* bufferToCopy, size_t bufferSize) const
 {
     if (bufferToCopy == NULL || bufferSize == 0) return;
 
-    size_t sizeToCopy = (bufferSize-1 < size()) ? bufferSize : size();
+    size_t sizeToCopy = (bufferSize-1 < size()) ? (bufferSize-1) : size();
 
     StrNCpy(bufferToCopy, buffer_, sizeToCopy);
     bufferToCopy[sizeToCopy] = '\0';

--- a/tests/CppUTest/SimpleStringTest.cpp
+++ b/tests/CppUTest/SimpleStringTest.cpp
@@ -448,6 +448,17 @@ TEST(SimpleString, copyInBufferWithBiggerBufferThanNeeded)
     free(buffer);
 }
 
+TEST(SimpleString, copyInBufferWithSmallerBufferThanNeeded)
+{
+    SimpleString str("Hello");
+    size_t bufferSize = str.size();
+    char* buffer= (char*) malloc(bufferSize);
+    str.copyToBuffer(buffer, bufferSize);
+    STRNCMP_EQUAL(str.asCharString(), buffer, (bufferSize-1));
+    LONGS_EQUAL( 0, buffer[bufferSize-1]);
+    free(buffer);
+}
+
 TEST(SimpleString, ContainsNull)
 {
     SimpleString s(0);

--- a/tests/CppUTest/SimpleStringTest.cpp
+++ b/tests/CppUTest/SimpleStringTest.cpp
@@ -455,7 +455,7 @@ TEST(SimpleString, copyInBufferWithSmallerBufferThanNeeded)
     char* buffer= (char*) malloc(bufferSize);
     str.copyToBuffer(buffer, bufferSize);
     STRNCMP_EQUAL(str.asCharString(), buffer, (bufferSize-1));
-    LONGS_EQUAL( 0, buffer[bufferSize-1]);
+    LONGS_EQUAL(0, buffer[bufferSize-1]);
     free(buffer);
 }
 


### PR DESCRIPTION
For undersized buffers, the current implementation of SimpleString::copyToBuffer will attempt to set the null terminator outside of the buffer bounds.  I've added a unit test for undersized buffers and modified the implementation to pass.  Additionally, all other tests continue to pass.

Also, I'd like to thank you for this great framework.