### PR TITLE
define CHECK_RELATION() macro

### DIFF
--- a/include/CppUTest/TestFailure.h
+++ b/include/CppUTest/TestFailure.h
@@ -104,11 +104,16 @@ public:
     CheckEqualFailure(UtestShell* test, const char* fileName, int lineNumber, const SimpleString& expected, const SimpleString& actual, const SimpleString& text);
 };
 
+class ComparisonFailure : public TestFailure
+{
+public:
+    ComparisonFailure(UtestShell* test, const char *fileName, int lineNumber, const SimpleString& checkString, const SimpleString& comparisonString, const SimpleString& text);
+};
+
 class ContainsFailure: public TestFailure
 {
 public:
     ContainsFailure(UtestShell*, const char* fileName, int lineNumber, const SimpleString& expected, const SimpleString& actual, const SimpleString& text);
-
 };
 
 class CheckFailure : public TestFailure

--- a/include/CppUTest/Utest.h
+++ b/include/CppUTest/Utest.h
@@ -122,6 +122,7 @@ public:
     virtual void assertEquals(bool failed, const char* expected, const char* actual, const char* text, const char* file, int line, const TestTerminator& testTerminator = NormalTestTerminator());
     virtual void assertBinaryEqual(const void *expected, const void *actual, size_t length, const char* text, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
     virtual void assertBitsEqual(unsigned long expected, unsigned long actual, unsigned long mask, size_t byteCount, const char* text, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
+    virtual void assertCompare(bool comparison, const char *checkString, const char *comparisonString, const char *text, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
     virtual void fail(const char *text, const char *fileName, int lineNumber, const TestTerminator& testTerminator = NormalTestTerminator());
     virtual void exitTest(const TestTerminator& testTerminator = NormalTestTerminator());
 

--- a/include/CppUTest/UtestMacros.h
+++ b/include/CppUTest/UtestMacros.h
@@ -143,11 +143,17 @@
   } }
 
 #define CHECK_COMPARE(first, relop, second)\
+  CHECK_COMPARE_TEXT(first, relop, second, NULL)
+
+#define CHECK_COMPARE_TEXT(first, relop, second, text)\
+  CHECK_COMPARE_LOCATION(first, relop, second, text, __FILE__, __LINE__)
+
+#define CHECK_COMPARE_LOCATION(first, relop, second, text, file, line)\
  { SimpleString conditionString;\
    conditionString += StringFrom(first); conditionString += " ";\
    conditionString += #relop; conditionString += " ";\
    conditionString += StringFrom(second);\
-   UtestShell::getCurrent()->assertCompare((first) relop (second), "CHECK_COMPARE", conditionString.asCharString(), NULL, __FILE__, __LINE__);\
+   UtestShell::getCurrent()->assertCompare((first) relop (second), "CHECK_COMPARE", conditionString.asCharString(), text, __FILE__, __LINE__);\
  }
 
 //This check checks for char* string equality using strcmp.

--- a/include/CppUTest/UtestMacros.h
+++ b/include/CppUTest/UtestMacros.h
@@ -142,6 +142,14 @@
     UtestShell::getCurrent()->assertLongsEqual((long)0, (long)0, NULL, file, line); \
   } }
 
+#define CHECK_RELATION(first, relop, second)\
+ { SimpleString conditionString = "evaluates to ";\
+   conditionString += StringFrom(first); conditionString += " ";\
+   conditionString += #relop; conditionString += " ";\
+   conditionString += StringFrom(second);\
+   CHECK_TRUE_LOCATION((first) relop (second), "CHECK", #first " " #relop " " #second, conditionString.asCharString(), __FILE__, __LINE__)\
+ }
+
 //This check checks for char* string equality using strcmp.
 //This makes up for the fact that CHECK_EQUAL only compares the pointers to char*'s
 #define STRCMP_EQUAL(expected, actual)\

--- a/include/CppUTest/UtestMacros.h
+++ b/include/CppUTest/UtestMacros.h
@@ -142,12 +142,12 @@
     UtestShell::getCurrent()->assertLongsEqual((long)0, (long)0, NULL, file, line); \
   } }
 
-#define CHECK_RELATION(first, relop, second)\
- { SimpleString conditionString = "evaluates to ";\
+#define CHECK_COMPARE(first, relop, second)\
+ { SimpleString conditionString;\
    conditionString += StringFrom(first); conditionString += " ";\
    conditionString += #relop; conditionString += " ";\
    conditionString += StringFrom(second);\
-   CHECK_TRUE_LOCATION((first) relop (second), "CHECK", #first " " #relop " " #second, conditionString.asCharString(), __FILE__, __LINE__)\
+   UtestShell::getCurrent()->assertCompare((first) relop (second), "CHECK_COMPARE", conditionString.asCharString(), NULL, __FILE__, __LINE__);\
  }
 
 //This check checks for char* string equality using strcmp.

--- a/src/CppUTest/TestFailure.cpp
+++ b/src/CppUTest/TestFailure.cpp
@@ -163,7 +163,7 @@ SimpleString TestFailure::createUserText(const SimpleString& text)
     if (!text.isEmpty())
     {
         //This is a kludge to turn off "Message: " for this case.
-        //I don't think "Message: " adds anything,a s you get to see the
+        //I don't think "Message: " adds anything, as you get to see the
         //message. I propose we remove "Message: " lead in
         if (!text.startsWith("LONGS_EQUAL"))
             userMessage += "Message: ";
@@ -214,6 +214,16 @@ CheckEqualFailure::CheckEqualFailure(UtestShell* test, const char* fileName, int
     message_ += createButWasString(expected, actual);
     message_ += createDifferenceAtPosString(actual, failStart);
 
+}
+
+ComparisonFailure::ComparisonFailure(UtestShell *test, const char *fileName, int lineNumber, const SimpleString& checkString, const SimpleString &comparisonString, const SimpleString &text)
+: TestFailure(test, fileName, lineNumber)
+{
+    message_ = createUserText(text);
+    message_ += checkString;
+    message_ += "(";
+    message_ += comparisonString;
+    message_ += ") failed";
 }
 
 ContainsFailure::ContainsFailure(UtestShell* test, const char* fileName, int lineNumber, const SimpleString& expected, const SimpleString& actual, const SimpleString& text)

--- a/src/CppUTest/Utest.cpp
+++ b/src/CppUTest/Utest.cpp
@@ -507,6 +507,12 @@ void UtestShell::assertEquals(bool failed, const char* expected, const char* act
         failWith(CheckEqualFailure(this, file, line, expected, actual, text), testTerminator);
 }
 
+void UtestShell::assertCompare(bool comparison, const char *checkString, const char *comparisonString, const char *text, const char *fileName, int lineNumber, const TestTerminator &testTerminator)
+{
+    getTestResult()->countCheck();
+    if (!comparison)
+        failWith(ComparisonFailure(this, fileName, lineNumber, checkString, comparisonString, text), testTerminator);
+}
 
 void UtestShell::print(const char *text, const char* fileName, int lineNumber)
 {

--- a/tests/CppUTest/TestUTestMacro.cpp
+++ b/tests/CppUTest/TestUTestMacro.cpp
@@ -394,29 +394,28 @@ TEST(UnitTestMacros, FailureWithCHECK_EQUAL)
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <2>");
 }
 
-static void _failingTestMethodWithCHECK_RELATION()
+static void _failingTestMethodWithCHECK_COMPARE()
 {
     double actual = 0.5, minimum = 0.8;
-    CHECK_RELATION(actual, >=, minimum);
+    CHECK_COMPARE(actual, >=, minimum);
     TestTestingFixture::lineExecutedAfterCheck(); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
-TEST(UnitTestMacros, FailureWithCHECK_RELATION)
+TEST(UnitTestMacros, FailureWithCHECK_COMPARE)
 {
-    fixture.runTestWithMethod(_failingTestMethodWithCHECK_RELATION);
-    CHECK_TEST_FAILS_PROPER_WITH_TEXT("CHECK(actual >= minimum)");
-    CHECK_TEST_FAILS_PROPER_WITH_TEXT("0.5 >= 0.8");
+    fixture.runTestWithMethod(_failingTestMethodWithCHECK_COMPARE);
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("CHECK_COMPARE(0.5 >= 0.8)");
 }
 
-TEST(UnitTestMacros, CHECK_RELATIONBehavesAsProperMacro)
+TEST(UnitTestMacros, CHECK_COMPAREBehavesAsProperMacro)
 {
-    if (false) CHECK_RELATION(1, >, 2)
-    else CHECK_RELATION(1, <, 2)
+    if (false) CHECK_COMPARE(1, >, 2)
+    else CHECK_COMPARE(1, <, 2)
 }
 
-IGNORE_TEST(UnitTestMacros, CHECK_RELATIONWorksInAnIgnoredTest)
+IGNORE_TEST(UnitTestMacros, CHECK_COMPAREWorksInAnIgnoredTest)
 {
-  CHECK_RELATION(1, >, 2) // LCOV_EXCL_LINE
+  CHECK_COMPARE(1, >, 2) // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
 static int countInCountingMethod;

--- a/tests/CppUTest/TestUTestMacro.cpp
+++ b/tests/CppUTest/TestUTestMacro.cpp
@@ -394,6 +394,31 @@ TEST(UnitTestMacros, FailureWithCHECK_EQUAL)
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <2>");
 }
 
+static void _failingTestMethodWithCHECK_RELATION()
+{
+    double actual = 0.5, minimum = 0.8;
+    CHECK_RELATION(actual, >=, minimum);
+    TestTestingFixture::lineExecutedAfterCheck(); // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
+TEST(UnitTestMacros, FailureWithCHECK_RELATION)
+{
+    fixture.runTestWithMethod(_failingTestMethodWithCHECK_RELATION);
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("CHECK(actual >= minimum)");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("0.5 >= 0.8");
+}
+
+TEST(UnitTestMacros, CHECK_RELATIONBehavesAsProperMacro)
+{
+    if (false) CHECK_RELATION(1, >, 2)
+    else CHECK_RELATION(1, <, 2)
+}
+
+IGNORE_TEST(UnitTestMacros, CHECK_RELATIONWorksInAnIgnoredTest)
+{
+  CHECK_RELATION(1, >, 2) // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
 static int countInCountingMethod;
 static int _countingMethod()
 {

--- a/tests/CppUTest/TestUTestMacro.cpp
+++ b/tests/CppUTest/TestUTestMacro.cpp
@@ -396,8 +396,8 @@ TEST(UnitTestMacros, FailureWithCHECK_EQUAL)
 
 static void _failingTestMethodWithCHECK_COMPARE()
 {
-    double actual = 0.5, minimum = 0.8;
-    CHECK_COMPARE(actual, >=, minimum);
+    double small = 0.5, big = 0.8;
+    CHECK_COMPARE(small, >=, big);
     TestTestingFixture::lineExecutedAfterCheck(); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
@@ -416,6 +416,31 @@ TEST(UnitTestMacros, CHECK_COMPAREBehavesAsProperMacro)
 IGNORE_TEST(UnitTestMacros, CHECK_COMPAREWorksInAnIgnoredTest)
 {
   CHECK_COMPARE(1, >, 2) // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
+static void _failingTestMethodWithCHECK_COMPARE_TEXT()
+{
+    double small = 0.5, big = 0.8;
+    CHECK_COMPARE_TEXT(small, >=, big, "small bigger than big");
+    TestTestingFixture::lineExecutedAfterCheck(); // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
+TEST(UnitTestMacros, FailureWithCHECK_COMPARE_TEXT)
+{
+    fixture.runTestWithMethod(_failingTestMethodWithCHECK_COMPARE_TEXT);
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("CHECK_COMPARE(0.5 >= 0.8)");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("small bigger than big");
+}
+
+TEST(UnitTestMacros, CHECK_COMPARE_TEXTBehavesAsProperMacro)
+{
+  if (false) CHECK_COMPARE_TEXT(1, >, 2, "1 bigger than 2")
+  else CHECK_COMPARE_TEXT(1, <, 2, "1 smaller than 2")
+}
+
+IGNORE_TEST(UnitTestMacros, CHECK_COMPARE_TEXTWorksInAnIgnoredTest)
+{
+  CHECK_COMPARE_TEXT(1, >, 2, "1 smaller than 2") // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
 static int countInCountingMethod;


### PR DESCRIPTION
Hi,

I've taken a shot at implementing the `CHECK_RELATION()` macro described in #8.

On failure, the following kind of message will be shown in the output:

```
/Users/dlindelof/Work/cpputest/tests/CppUTest/TestUTestMacro.cpp:400: error:
	Message: evaluates to 0.5 >= 0.8
	CHECK(actual >= minimum) failed
```

Please let me know if this is something you still think could be useful.

