### PR TITLE
IAR: Moving test source files to fix error introduced with 02513e80353…

### DIFF
--- a/platforms/iar/CppUTestTest.ewp
+++ b/platforms/iar/CppUTestTest.ewp
@@ -1928,91 +1928,91 @@
     <group>
       <name>passing</name>
       <file>
-        <name>$PROJ_DIR$\..\..\tests\AllocationInCFile.c</name>
+        <name>$PROJ_DIR$\..\..\tests\CppUTest\AllocationInCFile.c</name>
       </file>
       <file>
-        <name>$PROJ_DIR$\..\..\tests\AllocationInCppFile.cpp</name>
+        <name>$PROJ_DIR$\..\..\tests\CppUTest\AllocationInCppFile.cpp</name>
       </file>
       <file>
-        <name>$PROJ_DIR$\..\..\tests\AllocLetTestFree.c</name>
+        <name>$PROJ_DIR$\..\..\tests\CppUTest\AllocLetTestFree.c</name>
       </file>
       <file>
-        <name>$PROJ_DIR$\..\..\tests\AllocLetTestFreeTest.cpp</name>
+        <name>$PROJ_DIR$\..\..\tests\CppUTest\AllocLetTestFreeTest.cpp</name>
       </file>
       <file>
-        <name>$PROJ_DIR$\..\..\tests\CheatSheetTest.cpp</name>
+        <name>$PROJ_DIR$\..\..\tests\CppUTest\CheatSheetTest.cpp</name>
       </file>
       <file>
-        <name>$PROJ_DIR$\..\..\tests\CommandLineArgumentsTest.cpp</name>
+        <name>$PROJ_DIR$\..\..\tests\CppUTest\CommandLineArgumentsTest.cpp</name>
       </file>
       <file>
-        <name>$PROJ_DIR$\..\..\tests\CommandLineTestRunnerTest.cpp</name>
+        <name>$PROJ_DIR$\..\..\tests\CppUTest\CommandLineTestRunnerTest.cpp</name>
       </file>
       <file>
-        <name>$PROJ_DIR$\..\..\tests\JUnitOutputTest.cpp</name>
+        <name>$PROJ_DIR$\..\..\tests\CppUTest\JUnitOutputTest.cpp</name>
       </file>
       <file>
-        <name>$PROJ_DIR$\..\..\tests\MemoryLeakDetectorTest.cpp</name>
+        <name>$PROJ_DIR$\..\..\tests\CppUTest\MemoryLeakDetectorTest.cpp</name>
       </file>
       <file>
-        <name>$PROJ_DIR$\..\..\tests\MemoryLeakWarningTest.cpp</name>
+        <name>$PROJ_DIR$\..\..\tests\CppUTest\MemoryLeakWarningTest.cpp</name>
       </file>
       <file>
-        <name>$PROJ_DIR$\..\..\tests\MemoryOperatorOverloadTest.cpp</name>
+        <name>$PROJ_DIR$\..\..\tests\CppUTest\MemoryOperatorOverloadTest.cpp</name>
       </file>
       <file>
-        <name>$PROJ_DIR$\..\..\tests\PluginTest.cpp</name>
+        <name>$PROJ_DIR$\..\..\tests\CppUTest\PluginTest.cpp</name>
       </file>
       <file>
-        <name>$PROJ_DIR$\..\..\tests\PreprocessorTest.cpp</name>
+        <name>$PROJ_DIR$\..\..\tests\CppUTest\PreprocessorTest.cpp</name>
       </file>
       <file>
-        <name>$PROJ_DIR$\..\..\tests\SetPluginTest.cpp</name>
+        <name>$PROJ_DIR$\..\..\tests\CppUTest\SetPluginTest.cpp</name>
       </file>
       <file>
-        <name>$PROJ_DIR$\..\..\tests\SimpleMutexTest.cpp</name>
+        <name>$PROJ_DIR$\..\..\tests\CppUTest\SimpleMutexTest.cpp</name>
       </file>
       <file>
-        <name>$PROJ_DIR$\..\..\tests\SimpleStringTest.cpp</name>
+        <name>$PROJ_DIR$\..\..\tests\CppUTest\SimpleStringTest.cpp</name>
       </file>
       <file>
-        <name>$PROJ_DIR$\..\..\tests\TestFailureNaNTest.cpp</name>
+        <name>$PROJ_DIR$\..\..\tests\CppUTest\TestFailureNaNTest.cpp</name>
       </file>
       <file>
-        <name>$PROJ_DIR$\..\..\tests\TestFailureTest.cpp</name>
+        <name>$PROJ_DIR$\..\..\tests\CppUTest\TestFailureTest.cpp</name>
       </file>
       <file>
-        <name>$PROJ_DIR$\..\..\tests\TestFilterTest.cpp</name>
+        <name>$PROJ_DIR$\..\..\tests\CppUTest\TestFilterTest.cpp</name>
       </file>
       <file>
-        <name>$PROJ_DIR$\..\..\tests\TestHarness_cTest.cpp</name>
+        <name>$PROJ_DIR$\..\..\tests\CppUTest\TestHarness_cTest.cpp</name>
       </file>
       <file>
-        <name>$PROJ_DIR$\..\..\tests\TestHarness_cTestCFile.c</name>
+        <name>$PROJ_DIR$\..\..\tests\CppUTest\TestHarness_cTestCFile.c</name>
       </file>
       <file>
-        <name>$PROJ_DIR$\..\..\tests\TestInstallerTest.cpp</name>
+        <name>$PROJ_DIR$\..\..\tests\CppUTest\TestInstallerTest.cpp</name>
       </file>
       <file>
-        <name>$PROJ_DIR$\..\..\tests\TestMemoryAllocatorTest.cpp</name>
+        <name>$PROJ_DIR$\..\..\tests\CppUTest\TestMemoryAllocatorTest.cpp</name>
       </file>
       <file>
-        <name>$PROJ_DIR$\..\..\tests\TestOutputTest.cpp</name>
+        <name>$PROJ_DIR$\..\..\tests\CppUTest\TestOutputTest.cpp</name>
       </file>
       <file>
-        <name>$PROJ_DIR$\..\..\tests\TestRegistryTest.cpp</name>
+        <name>$PROJ_DIR$\..\..\tests\CppUTest\TestRegistryTest.cpp</name>
       </file>
       <file>
-        <name>$PROJ_DIR$\..\..\tests\TestResultTest.cpp</name>
+        <name>$PROJ_DIR$\..\..\tests\CppUTest\TestResultTest.cpp</name>
       </file>
       <file>
-        <name>$PROJ_DIR$\..\..\tests\TestUTestMacro.cpp</name>
+        <name>$PROJ_DIR$\..\..\tests\CppUTest\TestUTestMacro.cpp</name>
       </file>
       <file>
-        <name>$PROJ_DIR$\..\..\tests\UtestPlatformTest.cpp</name>
+        <name>$PROJ_DIR$\..\..\tests\CppUTest\UtestPlatformTest.cpp</name>
       </file>
       <file>
-        <name>$PROJ_DIR$\..\..\tests\UtestTest.cpp</name>
+        <name>$PROJ_DIR$\..\..\tests\CppUTest\UtestTest.cpp</name>
       </file>
     </group>
     <group>

--- a/platforms/iar/CppUTestTest.icf
+++ b/platforms/iar/CppUTestTest.icf
@@ -5,7 +5,7 @@
 define symbol __ICFEDIT_intvec_start__ = 0x00000000;
 /*-Memory Regions-*/
 define symbol __ICFEDIT_region_IROM1_start__ = 0x00000080;
-define symbol __ICFEDIT_region_IROM1_end__   = 0x0008FFFF;
+define symbol __ICFEDIT_region_IROM1_end__   = 0x0009FFFF;
 define symbol __ICFEDIT_region_IROM2_start__ = 0x0;
 define symbol __ICFEDIT_region_IROM2_end__   = 0x0;
 define symbol __ICFEDIT_region_EROM1_start__ = 0x0;


### PR DESCRIPTION
Pull request #1059 broke the IAR build as the test source files were moved. Now the IAR project reflect these changes.

Also increasing the virtual flash size to make room for more tests in the IAR environment.