### PR TITLE
allow building CppUTest as a sub-project of a cross-platform application (fixes #1102)

### DIFF
--- a/src/CppUTest/CMakeIntegration-README.md
+++ b/src/CppUTest/CMakeIntegration-README.md
@@ -1,0 +1,24 @@
+It is possible to integrate CppUTest as a sub-module of an enclosing CMake
+project. This may be useful if CppUTest is being built for a target platform
+other than that of the development host. The following is an example how an
+external project can refer to this CMakeLists.txt to build CppUTest as a
+library and include it as a target dependency.
+
+```cmake
+cmake_minimum_required(VERSION 3.7)
+project(trying_CppUtest)
+
+SET(CppUTestRootDirectory /path/to/cpputest)
+
+# Either set CPP_PLATFORM to one of the provided platforms under
+# ${CppUTestRootDirectory}/src/Platforms/, or provide a project-specific
+# platform.cpp (as shown below)
+add_subdirectory(${CppUTestRootDirectory}/src/CppUTest CppUTest)
+target_sources(CppUTest
+	PRIVATE
+		${PROJECT_SOURCE_DIR}/UtestPlatform.cpp
+)
+
+add_executable(trying_CppUtest main.cpp)
+target_link_libraries(trying_CppUtest CppUTest)
+```

--- a/src/CppUTest/CMakeLists.txt
+++ b/src/CppUTest/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(CppUTest_src
+add_library(CppUTest
         CommandLineArguments.cpp
         MemoryLeakWarningPlugin.cpp
         TestHarness_c.cpp
@@ -17,7 +17,20 @@ set(CppUTest_src
         TestTestingFixture.cpp
         SimpleMutex.cpp
         Utest.cpp
-        ../Platforms/${CPP_PLATFORM}/UtestPlatform.cpp
+)
+
+if (CPP_PLATFORM) #[[Set CPP_PLATFORM in a parent CMakeLists.txt if reusing one of the provided platforms,
+                     else supply the missing definitions]]
+    target_sources(CppUTest
+        PRIVATE
+            ../Platforms/${CPP_PLATFORM}/UtestPlatform.cpp
+    )
+endif(CPP_PLATFORM)
+
+#[[Arrange for ../../include to be added to the include paths of any CMake target depending on CppUTest.]]
+target_include_directories(CppUTest
+    PUBLIC
+        ../../include
 )
 
 set(CppUTest_headers
@@ -48,7 +61,6 @@ set(CppUTest_headers
         ${CppUTestRootDirectory}/include/CppUTest/UtestMacros.h
 )
 
-add_library(CppUTest STATIC ${CppUTest_src} ${CppUTest_headers})
 if (WIN32)
     target_link_libraries(CppUTest winmm.lib)
 endif (WIN32)

--- a/src/CppUTest/CMakeLists.txt
+++ b/src/CppUTest/CMakeLists.txt
@@ -27,10 +27,11 @@ if (CPP_PLATFORM) #[[Set CPP_PLATFORM in a parent CMakeLists.txt if reusing one 
     )
 endif(CPP_PLATFORM)
 
-#[[Arrange for ../../include to be added to the include paths of any CMake target depending on CppUTest.]]
+#[[Arrange for the include directory to be added to the include paths of any CMake target depending on CppUTest.]]
 target_include_directories(CppUTest
     PUBLIC
-        ../../include
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../include>
+        $<INSTALL_INTERFACE:include/CppUTest>
 )
 
 set(CppUTest_headers


### PR DESCRIPTION
I have made the following changes:

* add a section to declare the include folder as a PUBLIC property. This means that any project depending on this CMakeLists.txt would automatically inherit the include folder.

```cmake
target_include_directories(CppUTest
    PUBLIC
        ../../include
)
```

* use a relative path for referring to include. This removes the need for an external definition of the variable CppUTestRootDirectory.

* remove `STATIC` from ```add_library(CppUTest STATIC ${CppUTest_src} ${CppUTest_headers})```. There is no need to be specific about building a STATIC library. The enclosing project could choose alternatives to static linking.

* remove the unconditional addition of `../Platforms/${CPP_PLATFORM}/UtestPlatform.cpp` to the sources that get compiled into the CppUTest library. It may be that the enclosing project wants to provide its own Platform.cpp without re-using one of the standard Platforms or dropping in a new one under `../Platforms/` . Platform.cpp could be project-specific, and therefore a user should have the flexibility to add it to the build externally.

* `add_library(CppUTest ...)` should not need to mention the headers as dependencies.

* Finally, I provide a README containing an example CMakeLists.txt showing how CppUTest could be embedded into a project.
