### PR TITLE
Reset dotCount_ to align progress indicators for repeat runs

### DIFF
--- a/src/CppUTest/TestOutput.cpp
+++ b/src/CppUTest/TestOutput.cpp
@@ -170,6 +170,8 @@ void TestOutput::printTestsEnded(const TestResult& result)
         print("\033[m");
     }
     print("\n\n");
+
+    dotCount_ = 0;
 }
 
 void TestOutput::printTestRun(int number, int total)

--- a/tests/CppUTest/TestOutputTest.cpp
+++ b/tests/CppUTest/TestOutputTest.cpp
@@ -117,6 +117,22 @@ TEST(TestOutput, PrintTestALot)
     STRCMP_EQUAL("..................................................\n..........", mock->getOutput().asCharString());
 }
 
+TEST(TestOutput, PrintTestALotAndSimulateRepeatRun)
+{
+    for (int i = 0; i < 60; ++i) {
+        printer->printCurrentTestEnded(*result);
+    }
+
+    printer->printTestsEnded(*result);
+
+    for (int i = 0; i < 60; ++i) {
+        printer->printCurrentTestEnded(*result);
+    }
+    STRCMP_EQUAL("..................................................\n.........." \
+        "\nOK (0 tests, 0 ran, 0 checks, 0 ignored, 0 filtered out, 10 ms)\n\n" \
+        "..................................................\n..........", mock->getOutput().asCharString());
+}
+
 TEST(TestOutput, SetProgressIndicator)
 {
     printer->setProgressIndicator(".");


### PR DESCRIPTION
If you run a test set with "-r#", the progress indicator dots don't line up from
one run to another. It makes it difficult to look for differences when the output
is different every time even though the tests run the same.