### PR TITLE
Create an equivalent IGNORE macro for C-only code

### DIFF
--- a/include/CppUTest/TestHarness_c.h
+++ b/include/CppUTest/TestHarness_c.h
@@ -107,6 +107,10 @@
     extern void test_##group_name##_##test_name##_wrapper_c(void);\
     void test_##group_name##_##test_name##_wrapper_c()
 
+#define IGNORE_TEST_C(group_name, test_name) \
+    extern void ignore_##group_name##_##test_name##_wrapper_c(void);\
+    void ignore_##group_name##_##test_name##_wrapper_c()
+
 
 /* For use in C++ file */
 
@@ -129,6 +133,12 @@
     extern "C" void test_##group_name##_##test_name##_wrapper_c(); \
     TEST(group_name, test_name) { \
         test_##group_name##_##test_name##_wrapper_c(); \
+    }
+
+#define IGNORE_TEST_C_WRAPPER(group_name, test_name) \
+    extern "C" void ignore_##group_name##_##test_name##_wrapper_c(); \
+    IGNORE_TEST(group_name, test_name) { \
+        ignore_##group_name##_##test_name##_wrapper_c(); \
     }
 
 #ifdef __cplusplus

--- a/tests/CppUTest/TestHarness_cTest.cpp
+++ b/tests/CppUTest/TestHarness_cTest.cpp
@@ -46,6 +46,7 @@ TEST_GROUP_C_WRAPPER(TestGroupInC)
 };
 
 TEST_C_WRAPPER(TestGroupInC, checkThatTheTestHasRun)
+IGNORE_TEST_C_WRAPPER(TestGroupInC, ignoreMacroForCFile)
 
 /*
  * This test is a bit strange. They use the fact that you can do -r2 for repeating the same run.

--- a/tests/CppUTest/TestHarness_cTestCFile.c
+++ b/tests/CppUTest/TestHarness_cTestCFile.c
@@ -29,3 +29,8 @@ TEST_C(TestGroupInC, checkThatTheTestHasRun)
 {
     test_was_called_in_test_group_in_C++;
 }
+
+IGNORE_TEST_C(TestGroupInC, ignoreMacroForCFile)
+{
+    test_was_called_in_test_group_in_C++;
+}


### PR DESCRIPTION
I'd like to set native C tests to be ignored to have the same behavior as the C++ macro. I created two (IGNORE_TEST_C_WRAPPER and IGNORE_TEST_C) to be explicit whether you're looking at the C test or the Cpp wrappers.

In looking at the tests for the current IGNORE_TEST macro, there were a lot that tested whether or not other macros could work inside the test. Are those needed here? Since we are wrapping around the normal IGNORE_TEST macro, it seems like that has already been covered. The only thing left is to use it (which is what I've done.)