### PR TITLE
Fix float warning

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: 3.7.0-ci{build}
 
-image: Visual Studio 2015
+image: Previous Visual Studio 2015
 
 cache:
   - C:\ProgramData\chocolatey\bin -> appveyor.yml

--- a/tests/CppUTest/UtestTest.cpp
+++ b/tests/CppUTest/UtestTest.cpp
@@ -56,9 +56,10 @@ static void _exitTestMethod()
     FAIL("Should not get here");
 }
 
+static volatile double zero = 0.0;
+
 TEST(UtestShell, compareDoubles)
 {
-    double zero = 0.0;
     double not_a_number = zero / zero;
     double infinity = 1 / zero;
     CHECK(doubles_equal(1.0, 1.001, 0.01));

--- a/tests/CppUTestExt/IEEE754PluginTest_c.c
+++ b/tests/CppUTestExt/IEEE754PluginTest_c.c
@@ -28,11 +28,12 @@
 #include "IEEE754PluginTest_c.h"
 
 static volatile float f;
+static volatile float zero_float = 0.0f;
 
 void set_divisionbyzero_c(void)
 {
     f = 1.0f;
-    f /= 0.0f;
+    f /= zero_float;
 }
 
 void set_overflow_c(void)


### PR DESCRIPTION
Visual C++ detects the divide by zero at compile time unless the variables are volatile.  This fixes one of the warnings reported in #1079.

Changing the build image was needed in order to keep the MinGW32 build working. It's not a permanent fix, but I'm not sure what will be yet.