### PR TITLE
Fix MinGW 32-bit crashes on appveyor, some minor CMake cleanup too

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,13 +20,20 @@ if(HAVE_STRDUP)
   add_definitions(-DCPPUTEST_HAVE_STRDUP=1)
 endif(HAVE_STRDUP)
 
-# Apply workaround for MinGW timespec redefinition (pthread.h / time.h)
 if (MINGW)
+    # Apply workaround for MinGW timespec redefinition (pthread.h / time.h)
     include(CheckStructHasMember)
     check_struct_has_member("struct timespec" tv_sec time.h HAVE_STRUCT_TIMESPEC)
     if (HAVE_STRUCT_TIMESPEC)
         add_definitions(-D_TIMESPEC_DEFINED=1)
     endif()
+
+    # Apply workaround for static/shared libraries on MinGW C/C++ compiler
+    # Issue occurs with CMake >= 3.9.0, it doesn't filter out gcc,gcc_s,gcc_eh from
+    # the implicit library list anymore, so the C++ linker is getting passed the static
+    # gcc_eh library since that's what the C linker uses by default. Only solution appears
+    # to be to force static linkage.
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static")
 endif()
 
 option(STD_C "Use the standard C library" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,8 +126,13 @@ if(PkgHelpers_AVAILABLE)
     ${CMAKE_CURRENT_BINARY_DIR}/CppUTestConfig.cmake
     INSTALL_DESTINATION ${CMAKE_CURRENT_BINARY_DIR}
     PATH_VARS INCLUDE_DIR CMAKE_CURRENT_BINARY_DIR)
-  export(TARGETS CppUTest CppUTestExt
-    FILE "${CMAKE_CURRENT_BINARY_DIR}/CppUTestTargets.cmake")
+  if (EXTENSIONS)
+    export(TARGETS CppUTest CppUTestExt
+      FILE "${CMAKE_CURRENT_BINARY_DIR}/CppUTestTargets.cmake")
+  else()
+    export(TARGETS CppUTest
+      FILE "${CMAKE_CURRENT_BINARY_DIR}/CppUTestTargets.cmake")
+  endif()
   write_basic_package_version_file(
     ${CMAKE_CURRENT_BINARY_DIR}/CppUTestConfigVersion.cmake
     VERSION ${CppUTest_version_major}.${CppUTest_version_minor}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@ environment:
     PlatformToolset: v140
 
 install:
-- ps: if ($env:Platform -like 'MinGW*') { choco install mingw --version $env:PlatformToolset $( if ($env:Platform -like '*32') { Write-Output -forcex86 } ) | Out-Null }
+- ps: if ($env:Platform -like 'MinGW*') { choco install mingw --version $env:PlatformToolset $( if ($env:Platform -like '*32') { Write-Output --forcex86 } ) }
 
 build_script:
 - ps: scripts\appveyor_ci_build.ps1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: 3.7.0-ci{build}
 
-image: Previous Visual Studio 2015
+image: Visual Studio 2015
 
 cache:
   - C:\ProgramData\chocolatey\bin -> appveyor.yml

--- a/cmake/Modules/CppUTestConfigurationOptions.cmake
+++ b/cmake/Modules/CppUTestConfigurationOptions.cmake
@@ -45,7 +45,7 @@ if (LONGLONG)
 endif (LONGLONG)
 
 if (MAP_FILE AND NOT MSVC)
-    set(CPPUTEST_LD_FLAGS "${CPPUTEST_LD_FLAGS} -Wl,-map,$<.map.txt")
+    set(CPPUTEST_LD_FLAGS "${CPPUTEST_LD_FLAGS} -Wl,-Map,$<.map.txt")
 endif (MAP_FILE AND NOT MSVC)
 
 if (COVERAGE AND NOT MSVC)

--- a/scripts/appveyor_ci_build.ps1
+++ b/scripts/appveyor_ci_build.ps1
@@ -76,6 +76,7 @@ switch -Wildcard ($env:Platform)
         # Add mingw to the path
         Add-PathFolder $mingw_path
 
+        Invoke-BuildCommand "cmake --version"
         Invoke-BuildCommand "cmake -G 'MinGW Makefiles' .." 'cpputest_build'
         Invoke-BuildCommand "mingw32-make all" 'cpputest_build'
 

--- a/scripts/appveyor_ci_test.ps1
+++ b/scripts/appveyor_ci_test.ps1
@@ -37,8 +37,12 @@ function Invoke-Tests($executable)
 {
     # Run tests and output the results using junit
     $TestCommand = "$executable -ojunit"
-    Write-Host $TestCommand
+    Write-Host $TestCommand -NoNewline
     Invoke-Expression $TestCommand
+    Write-Host " - return code: $LASTEXITCODE"
+    if ($LASTEXITCODE -lt 0) {
+        Write-Error "Runtime Exception during test execution"
+    }
 }
 
 function Invoke-CygwinTests($executable)
@@ -94,10 +98,10 @@ switch -Wildcard ($env:Platform)
     {
         $mingw_path = Get-MinGWBin
 
-        Add-PathFolder $mingw_path
+        Set-Path "$mingw_path;C:\Windows;C:\Windows\System32"
         Invoke-Tests '.\cpputest_build\tests\CppUTest\CppUTestTests.exe'
         Invoke-Tests '.\cpputest_build\tests\CppUTestExt\CppUTestExtTests.exe'
-        Remove-PathFolder $mingw_path
+        Restore-Path
     }
 
     default

--- a/scripts/appveyor_helpers.ps1
+++ b/scripts/appveyor_helpers.ps1
@@ -74,3 +74,13 @@ function Remove-PathFolder($folder)
     $env:Path = $pathFolders -join ";"
 }
 
+function Set-Path($newPath)
+{
+    $env:RestorePath = $env:Path
+    $env:Path = $newPath
+}
+
+function Restore-Path()
+{
+    $env:Path = $env:RestorePath
+}

--- a/scripts/travis_ci_build.sh
+++ b/scripts/travis_ci_build.sh
@@ -34,6 +34,7 @@ if [ "x$BUILD" = "xautotools" ]; then
 fi
 
 if [ "x$BUILD" = "xcmake" ]; then
+    cmake --version
     cmake -DWERROR=ON -DC++11=${CPP11} ..
     make
     ctest -V


### PR DESCRIPTION
Fixes #1120 

I finally found a more permanent fix than using the old image on appveyor.  By forcing static linkage I'm able to get the right set of libraries to be used and avoid any funny conflicts in the exception handling.  Now all of the appveyor builds are working properly again and should continue to as they update software more.

At present I've only applied my fix when running under MinGW, since the version of CMake on travis-ci is so old, I'm unable to tell if any changes need to be made there as well.