### PR TITLE
Clang Static Analyzer - "dead assignment" warning fixes

### DIFF
--- a/tests/CppUTest/AllocLetTestFree.c
+++ b/tests/CppUTest/AllocLetTestFree.c
@@ -22,6 +22,7 @@ void AllocLetTestFree_Destroy(AllocLetTestFree self)
     AllocLetTestFree no_use = self;
     self = NULL;
     self = no_use;
+    (void)self;
 
 }
 #endif

--- a/tests/CppUTestExt/MockCheatSheetTest.cpp
+++ b/tests/CppUTestExt/MockCheatSheetTest.cpp
@@ -25,6 +25,7 @@ static int productionCodeFooCalls()
 {
     int return_value;
     return_value = foo("value_string", 10);
+    (void)return_value;
     return_value = foo("value_string", 10);
     return return_value;
 }


### PR DESCRIPTION
Partial fix for #1126