### PR TITLE
Clang Static Analyzer - "uninitialized argument value" warning fix

### DIFF
--- a/tests/CppUTest/TestMemoryAllocatorTest.cpp
+++ b/tests/CppUTest/TestMemoryAllocatorTest.cpp
@@ -216,7 +216,7 @@ TEST(FailableMemoryAllocator, FailFirstAllocationAtGivenLine)
 
 TEST(FailableMemoryAllocator, FailThirdAllocationAtGivenLine)
 {
-    int *memory[10];
+    int *memory[10] = { NULL };
     int allocation;
     failableMallocAllocator.failNthAllocAt(3, __FILE__, __LINE__ + 4);
 


### PR DESCRIPTION
Another partial fix for issue #1126.