### PR TITLE
TestPlugin: Avoid generating warnings in client codes from old style …

### DIFF
--- a/include/CppUTest/TestPlugin.h
+++ b/include/CppUTest/TestPlugin.h
@@ -98,7 +98,11 @@ public:
     };
 };
 
+#ifdef __cplusplus
+#define UT_PTR_SET(a, b) { CppUTestStore( reinterpret_cast<void**>(&a) ); a = b; }
+#else
 #define UT_PTR_SET(a, b) { CppUTestStore( (void**)&a ); a = b; }
+#endif
 
 ///////////// Null Plugin
 


### PR DESCRIPTION
…casts

When -Wold-style-cast is enabled