### PR TITLE
Add CMake option for quieter configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,8 @@ option(WERROR "Compile with warnings as errors" OFF)
 option(TESTS "Compile and make tests for the code?" ON)
 option(TESTS_DETAILED "Run each test separately instead of grouped?" OFF)
 
+option(VERBOSE_CONFIG "Print configuration to stdout during generation" ON)
+
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "What kind of build this is" FORCE)
 endif(NOT CMAKE_BUILD_TYPE)
@@ -151,7 +153,8 @@ else()
     " or write generators for CppUTestConfig.cmake by yourself.")
 endif()
 
-message("
+if(VERBOSE_CONFIG)
+  message("
 -------------------------------------------------------
 CppUTest Version ${CppUTest_version_major}.${CppUTest_version_minor}
 
@@ -180,3 +183,4 @@ Features configured in CppUTest:
 
 -------------------------------------------------------
 ")
+endif()


### PR DESCRIPTION
This pull request adds a new top-level option for CppUTest's CMake configuration that controls whether the verbose configuration text is printed during CMake's project generation phase.

The option is `VERBOSE_CONFIG`, and it is set to ON by default, preserving the current behavior.

If `-DVERBOSE_CONFIG=OFF` is passed to CMake, the configuration banner will not be printed.

(When generating multiple CMake configurations in parallel that all pull in CppUTest, the subsequent message output race conditions print a screen full of well-intended gibberish, so this gives users the option to silence it)