### PR TITLE
Simplified MockSupport::expectNoCall() method implementation.

### DIFF
--- a/include/CppUTestExt/MockSupport.h
+++ b/include/CppUTestExt/MockSupport.h
@@ -131,7 +131,6 @@ private:
     MockFailureReporter *standardReporter_;
     MockFailureReporter defaultReporter_;
     MockExpectedCallsList expectations_;
-    MockExpectedCallsList unExpectations_;
     bool ignoreOtherCalls_;
     bool enabled_;
     MockCheckedActualCall *lastActualFunctionCall_;
@@ -150,8 +149,7 @@ private:
 
     MockSupport* getMockSupport(MockNamedValueListNode* node);
 
-    bool hasntExpectationWithName(const SimpleString& functionName);
-    bool hasntUnexpectationWithName(const SimpleString& functionName);
+    bool callIsIgnored(const SimpleString& functionName);
     bool hasCallsOutOfOrder();
 
     SimpleString appendScopeToName(const SimpleString& functionName);

--- a/src/CppUTestExt/MockSupport.cpp
+++ b/src/CppUTestExt/MockSupport.cpp
@@ -119,7 +119,6 @@ void MockSupport::clear()
     MockActualCallTrace::instance().clear();
 
     expectations_.deleteAllExpectationsAndClearList();
-    unExpectations_.deleteAllExpectationsAndClearList();
     ignoreOtherCalls_ = false;
     enabled_ = true;
     actualCallOrder_ = 0;
@@ -154,13 +153,7 @@ MockExpectedCall& MockSupport::expectOneCall(const SimpleString& functionName)
 
 void MockSupport::expectNoCall(const SimpleString& functionName)
 {
-    if (!enabled_) return;
-
-    countCheck();
-
-    MockCheckedExpectedCall* call = new MockCheckedExpectedCall;
-    call->withName(appendScopeToName(functionName));
-    unExpectations_.addExpectedCall(call);
+    expectNCalls(0, functionName);
 }
 
 MockExpectedCall& MockSupport::expectNCalls(unsigned int amount, const SimpleString& functionName)
@@ -185,14 +178,9 @@ MockCheckedActualCall* MockSupport::createActualCall()
     return lastActualFunctionCall_;
 }
 
-bool MockSupport::hasntExpectationWithName(const SimpleString& functionName)
+bool MockSupport::callIsIgnored(const SimpleString& functionName)
 {
-    return !expectations_.hasExpectationWithName(functionName) && ignoreOtherCalls_;
-}
-
-bool MockSupport::hasntUnexpectationWithName(const SimpleString& functionName)
-{
-    return !unExpectations_.hasExpectationWithName(functionName);
+    return ignoreOtherCalls_ && !expectations_.hasExpectationWithName(functionName);
 }
 
 MockActualCall& MockSupport::actualCall(const SimpleString& functionName)
@@ -209,7 +197,7 @@ MockActualCall& MockSupport::actualCall(const SimpleString& functionName)
     if (tracing_) return MockActualCallTrace::instance().withName(scopeFuntionName);
 
 
-    if (hasntUnexpectationWithName(scopeFuntionName) && hasntExpectationWithName(scopeFuntionName)) {
+    if (callIsIgnored(scopeFuntionName)) {
         return MockIgnoredActualCall::instance();
     }
 

--- a/tests/CppUTestExt/MockCallTest.cpp
+++ b/tests/CppUTestExt/MockCallTest.cpp
@@ -198,6 +198,7 @@ TEST(MockCallTest, expectNoCallThatHappened)
     MockFailureReporterInstaller failureReporterInstaller;
 
     MockExpectedCallsListForTest expectations;
+    expectations.addFunction(0, "lazy");
     MockUnexpectedCallHappenedFailure expectedFailure(mockFailureTest(), "lazy", expectations);
 
     mock().expectNoCall("lazy");
@@ -211,6 +212,7 @@ TEST(MockCallTest, expectNoCallDoesntInfluenceExpectOneCall)
     MockFailureReporterInstaller failureReporterInstaller;
 
     MockExpectedCallsListForTest expectations;
+    expectations.addFunction(0, "lazy");
     expectations.addFunction("influence")->callWasMade(1);
     MockUnexpectedCallHappenedFailure expectedFailure(mockFailureTest(), "lazy", expectations);
 
@@ -227,6 +229,7 @@ TEST(MockCallTest, expectNoCallOnlyFailureOnceWhenMultipleHappened)
     MockFailureReporterInstaller failureReporterInstaller;
 
     MockExpectedCallsListForTest expectations;
+    expectations.addFunction(0, "lazy");
     MockUnexpectedCallHappenedFailure expectedFailure(mockFailureTest(), "lazy", expectations);
 
     mock().expectNoCall("lazy");
@@ -240,6 +243,7 @@ TEST(MockCallTest, ignoreOtherCallsExceptForTheUnExpectedOne)
     MockFailureReporterInstaller failureReporterInstaller;
 
     MockExpectedCallsListForTest expectations;
+    expectations.addFunction(0, "lazy");
     MockUnexpectedCallHappenedFailure expectedFailure(mockFailureTest(), "lazy", expectations);
 
     mock().expectNoCall("lazy");
@@ -258,6 +262,7 @@ TEST(MockCallTest, expectNoCallInScopeThatHappened)
     MockFailureReporterInstaller failureReporterInstaller;
 
     MockExpectedCallsListForTest expectations;
+    expectations.addFunction(0, "scope::lazy");
     MockUnexpectedCallHappenedFailure expectedFailure(mockFailureTest(), "scope::lazy", expectations);
 
     mock("scope").expectNoCall("lazy");


### PR DESCRIPTION
MockSupport::expectNoCall() now uses a multi-matching expected call with zero expected calls, thus avoiding the usage of a dedicated list to keep track of "unexpectations" and therefore simplifying the architecture of the MockSupport class.