### PR TITLE
Fix clang 5.0.0 errors

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,6 +25,10 @@ environment:
   - Platform: Win32
     PlatformToolset: v100
   - Platform: Win32
+    PlatformToolset: v110
+  - Platform: Win32
+    PlatformToolset: v120
+  - Platform: Win32
     PlatformToolset: v140
   - Platform: x64
     PlatformToolset: v140

--- a/include/CppUTest/CommandLineArguments.h
+++ b/include/CppUTest/CommandLineArguments.h
@@ -37,7 +37,7 @@ class TestPlugin;
 class CommandLineArguments
 {
 public:
-    explicit CommandLineArguments(int ac, const char** av);
+    explicit CommandLineArguments(int ac, const char *const *av);
     virtual ~CommandLineArguments();
 
     bool parse(TestPlugin* plugin);
@@ -63,7 +63,7 @@ private:
         OUTPUT_ECLIPSE, OUTPUT_JUNIT, OUTPUT_TEAMCITY
     };
     int ac_;
-    const char** av_;
+    const char *const *av_;
 
     bool verbose_;
     bool color_;
@@ -77,19 +77,19 @@ private:
     OutputType outputType_;
     SimpleString packageName_;
 
-    SimpleString getParameterField(int ac, const char** av, int& i, const SimpleString& parameterName);
-    void SetRepeatCount(int ac, const char** av, int& index);
-    void AddGroupFilter(int ac, const char** av, int& index);
-    void AddStrictGroupFilter(int ac, const char** av, int& index);
-    void AddExcludeGroupFilter(int ac, const char** av, int& index);
-    void AddExcludeStrictGroupFilter(int ac, const char** av, int& index);
-    void AddNameFilter(int ac, const char** av, int& index);
-    void AddStrictNameFilter(int ac, const char** av, int& index);
-    void AddExcludeNameFilter(int ac, const char** av, int& index);
-    void AddExcludeStrictNameFilter(int ac, const char** av, int& index);
-    void AddTestToRunBasedOnVerboseOutput(int ac, const char** av, int& index, const char* parameterName);
-    bool SetOutputType(int ac, const char** av, int& index);
-    void SetPackageName(int ac, const char** av, int& index);
+    SimpleString getParameterField(int ac, const char *const *av, int& i, const SimpleString& parameterName);
+    void SetRepeatCount(int ac, const char *const *av, int& index);
+    void AddGroupFilter(int ac, const char *const *av, int& index);
+    void AddStrictGroupFilter(int ac, const char *const *av, int& index);
+    void AddExcludeGroupFilter(int ac, const char *const *av, int& index);
+    void AddExcludeStrictGroupFilter(int ac, const char *const *av, int& index);
+    void AddNameFilter(int ac, const char *const *av, int& index);
+    void AddStrictNameFilter(int ac, const char *const *av, int& index);
+    void AddExcludeNameFilter(int ac, const char *const *av, int& index);
+    void AddExcludeStrictNameFilter(int ac, const char *const *av, int& index);
+    void AddTestToRunBasedOnVerboseOutput(int ac, const char *const *av, int& index, const char* parameterName);
+    bool SetOutputType(int ac, const char *const *av, int& index);
+    void SetPackageName(int ac, const char *const *av, int& index);
 
     CommandLineArguments(const CommandLineArguments&);
     CommandLineArguments& operator=(const CommandLineArguments&);

--- a/include/CppUTest/CommandLineTestRunner.h
+++ b/include/CppUTest/CommandLineTestRunner.h
@@ -41,10 +41,10 @@ class TestRegistry;
 class CommandLineTestRunner
 {
 public:
-    static int RunAllTests(int ac, const char** av);
+    static int RunAllTests(int ac, const char *const *av);
     static int RunAllTests(int ac, char** av);
 
-    CommandLineTestRunner(int ac, const char** av, TestRegistry* registry);
+    CommandLineTestRunner(int ac, const char *const *av, TestRegistry* registry);
     virtual ~CommandLineTestRunner();
 
     int runAllTestsMain();

--- a/include/CppUTest/CppUTestConfig.h
+++ b/include/CppUTest/CppUTestConfig.h
@@ -267,8 +267,17 @@ typedef struct cpputest_ulonglong cpputest_ulonglong;
 #if defined(__cplusplus) && ((__cplusplus >= 201103L) || (defined(_MSC_VER) && (_MSC_VER >= 1600)))
 #define CPPUTEST_COMPILER_FULLY_SUPPORTS_CXX11
 #define _override override
+#define NULLPTR nullptr
 #else
 #define _override
+#define NULLPTR NULL
+#endif
+
+/* Visual C++ 11.0+ (2012+) supports the override keyword on destructors */
+#if defined(__cplusplus) && ((__cplusplus >= 201103L) || (defined(_MSC_VER) && (_MSC_VER >= 1700)))
+#define _destructor_override override
+#else
+#define _destructor_override
 #endif
 
 /* MinGW-w64 prefers to act like Visual C++, but we want the ANSI behaviors instead */
@@ -278,5 +287,6 @@ typedef struct cpputest_ulonglong cpputest_ulonglong;
 #ifdef __clang__
  #pragma clang diagnostic pop
 #endif
+
 
 #endif

--- a/include/CppUTest/JUnitTestOutput.h
+++ b/include/CppUTest/JUnitTestOutput.h
@@ -38,7 +38,7 @@ class JUnitTestOutput: public TestOutput
 {
 public:
     JUnitTestOutput();
-    virtual ~JUnitTestOutput();
+    virtual ~JUnitTestOutput() _destructor_override;
 
     virtual void printTestsStarted() _override;
     virtual void printTestsEnded(const TestResult& result) _override;

--- a/include/CppUTest/MemoryLeakDetector.h
+++ b/include/CppUTest/MemoryLeakDetector.h
@@ -117,7 +117,7 @@ private:
 struct MemoryLeakDetectorNode
 {
     MemoryLeakDetectorNode() :
-        size_(0), number_(0), memory_(0), file_(0), line_(0), allocator_(0), period_(mem_leak_period_enabled), next_(0)
+        size_(0), number_(0), memory_(NULLPTR), file_(NULLPTR), line_(0), allocator_(NULLPTR), period_(mem_leak_period_enabled), next_(NULLPTR)
     {
     }
 
@@ -139,7 +139,7 @@ private:
 struct MemoryLeakDetectorList
 {
     MemoryLeakDetectorList() :
-        head_(0)
+        head_(NULLPTR)
     {}
 
     void addNewNode(MemoryLeakDetectorNode* node);

--- a/include/CppUTest/MemoryLeakWarningPlugin.h
+++ b/include/CppUTest/MemoryLeakWarningPlugin.h
@@ -42,8 +42,8 @@ class MemoryLeakFailure;
 class MemoryLeakWarningPlugin: public TestPlugin
 {
 public:
-    MemoryLeakWarningPlugin(const SimpleString& name, MemoryLeakDetector* localDetector = 0);
-    virtual ~MemoryLeakWarningPlugin();
+    MemoryLeakWarningPlugin(const SimpleString& name, MemoryLeakDetector* localDetector = NULLPTR);
+    virtual ~MemoryLeakWarningPlugin() _destructor_override;
 
     virtual void preTestAction(UtestShell& test, TestResult& result) _override;
     virtual void postTestAction(UtestShell& test, TestResult& result) _override;

--- a/include/CppUTest/SimpleString.h
+++ b/include/CppUTest/SimpleString.h
@@ -97,7 +97,7 @@ public:
     static size_t StrLen(const char*);
     static int StrNCmp(const char* s1, const char* s2, size_t n);
     static char* StrNCpy(char* s1, const char* s2, size_t n);
-    static char* StrStr(const char* s1, const char* s2);
+    static const char* StrStr(const char* s1, const char* s2);
     static char ToLower(char ch);
     static int MemCmp(const void* s1, const void *s2, size_t n);
     static char* allocStringBuffer(size_t size, const char* file, int line);

--- a/include/CppUTest/TeamCityTestOutput.h
+++ b/include/CppUTest/TeamCityTestOutput.h
@@ -8,7 +8,7 @@ class TeamCityTestOutput: public ConsoleTestOutput
 {
 public:
     TeamCityTestOutput(void);
-    virtual ~TeamCityTestOutput(void);
+    virtual ~TeamCityTestOutput(void) _destructor_override;
 
     virtual void printCurrentTestStarted(const UtestShell& test) _override;
     virtual void printCurrentTestEnded(const TestResult& res) _override;

--- a/include/CppUTest/TestMemoryAllocator.h
+++ b/include/CppUTest/TestMemoryAllocator.h
@@ -56,9 +56,9 @@ public:
     virtual char* alloc_memory(size_t size, const char* file, int line);
     virtual void free_memory(char* memory, const char* file, int line);
 
-    virtual const char* name();
-    virtual const char* alloc_name();
-    virtual const char* free_name();
+    virtual const char* name() const;
+    virtual const char* alloc_name() const;
+    virtual const char* free_name() const;
 
     virtual bool isOfEqualType(TestMemoryAllocator* allocator);
 

--- a/include/CppUTest/TestOutput.h
+++ b/include/CppUTest/TestOutput.h
@@ -113,7 +113,7 @@ public:
     explicit ConsoleTestOutput()
     {
     }
-    virtual ~ConsoleTestOutput()
+    virtual ~ConsoleTestOutput() _destructor_override
     {
     }
 
@@ -141,7 +141,7 @@ public:
     {
     }
 
-    virtual ~StringBufferTestOutput();
+    virtual ~StringBufferTestOutput() _destructor_override;
 
     void printBuffer(const char* s) _override
     {

--- a/include/CppUTest/TestPlugin.h
+++ b/include/CppUTest/TestPlugin.h
@@ -46,14 +46,14 @@ public:
     {
     }
 
-    virtual bool parseArguments(int /* ac */, const char** /* av */, int /* index */ )
+    virtual bool parseArguments(int /* ac */, const char *const * /* av */, int /* index */ )
     {
         return false;
     }
 
     virtual void runAllPreTestAction(UtestShell&, TestResult&);
     virtual void runAllPostTestAction(UtestShell&, TestResult&);
-    virtual bool parseAllArguments(int ac, const char** av, int index);
+    virtual bool parseAllArguments(int ac, const char *const *av, int index);
     virtual bool parseAllArguments(int ac, char** av, int index);
 
     virtual TestPlugin* addPlugin(TestPlugin*);

--- a/include/CppUTest/TestTestingFixture.h
+++ b/include/CppUTest/TestTestingFixture.h
@@ -50,7 +50,7 @@ public:
 
     virtual ~TestTestingFixture()
     {
-        registry_->setCurrentRegistry(0);
+        registry_->setCurrentRegistry(NULLPTR);
         delete registry_;
         delete result_;
         delete output_;

--- a/include/CppUTest/Utest.h
+++ b/include/CppUTest/Utest.h
@@ -70,14 +70,14 @@ class NormalTestTerminator : public TestTerminator
 {
 public:
     virtual void exitCurrentTest() const _override;
-    virtual ~NormalTestTerminator();
+    virtual ~NormalTestTerminator() _destructor_override;
 };
 
 class TestTerminatorWithoutExceptions  : public TestTerminator
 {
 public:
     virtual void exitCurrentTest() const _override;
-    virtual ~TestTerminatorWithoutExceptions();
+    virtual ~TestTerminatorWithoutExceptions() _destructor_override;
 };
 
 //////////////////// UtestShell
@@ -202,9 +202,9 @@ public:
     void (*teardown_)();
     void (*testFunction_)();
 
-    ExecFunctionTestShell(void(*set)() = 0, void(*tear)() = 0) :
+    ExecFunctionTestShell(void(*set)() = NULLPTR, void(*tear)() = NULLPTR) :
         UtestShell("Generic", "Generic", "Generic", 1), setup_(set), teardown_(
-                tear), testFunction_(0)
+                tear), testFunction_(NULLPTR)
     {
     }
     Utest* createTest() { return new ExecFunctionTest(this); }
@@ -225,7 +225,7 @@ class IgnoredUtestShell : public UtestShell
 {
 public:
     IgnoredUtestShell();
-    virtual ~IgnoredUtestShell();
+    virtual ~IgnoredUtestShell() _destructor_override;
     explicit IgnoredUtestShell(const char* groupName, const char* testName,
             const char* fileName, int lineNumber);
     virtual bool willRun() const _override;

--- a/include/CppUTest/UtestMacros.h
+++ b/include/CppUTest/UtestMacros.h
@@ -265,7 +265,7 @@
     POINTERS_EQUAL_LOCATION((expected), (actual), text, __FILE__, __LINE__)
 
 #define POINTERS_EQUAL_LOCATION(expected, actual, text, file, line)\
-  { UtestShell::getCurrent()->assertPointersEqual((void *)expected, (void *)actual, text, file, line); }
+  { UtestShell::getCurrent()->assertPointersEqual((const void *)expected, (const void *)actual, text, file, line); }
 
 #define FUNCTIONPOINTERS_EQUAL(expected, actual)\
     FUNCTIONPOINTERS_EQUAL_LOCATION((expected), (actual), NULL, __FILE__, __LINE__)

--- a/include/CppUTest/UtestMacros.h
+++ b/include/CppUTest/UtestMacros.h
@@ -99,32 +99,32 @@
 // Different checking macros
 
 #define CHECK(condition)\
-  CHECK_TRUE_LOCATION(condition, "CHECK", #condition, NULL, __FILE__, __LINE__)
+  CHECK_TRUE_LOCATION(condition, "CHECK", #condition, NULLPTR, __FILE__, __LINE__)
 
 #define CHECK_TEXT(condition, text) \
   CHECK_TRUE_LOCATION(condition, "CHECK", #condition, text, __FILE__, __LINE__)
 
 #define CHECK_TRUE(condition)\
-  CHECK_TRUE_LOCATION(condition, "CHECK_TRUE", #condition, NULL, __FILE__, __LINE__)
+  CHECK_TRUE_LOCATION(condition, "CHECK_TRUE", #condition, NULLPTR, __FILE__, __LINE__)
 
 #define CHECK_TRUE_TEXT(condition, text)\
   CHECK_TRUE_LOCATION(condition, "CHECK_TRUE", #condition, text, __FILE__, __LINE__)
 
 #define CHECK_FALSE(condition)\
-  CHECK_FALSE_LOCATION(condition, "CHECK_FALSE", #condition, NULL, __FILE__, __LINE__)
+  CHECK_FALSE_LOCATION(condition, "CHECK_FALSE", #condition, NULLPTR, __FILE__, __LINE__)
 
 #define CHECK_FALSE_TEXT(condition, text)\
   CHECK_FALSE_LOCATION(condition, "CHECK_FALSE", #condition, text, __FILE__, __LINE__)
 
 #define CHECK_TRUE_LOCATION(condition, checkString, conditionString, text, file, line)\
-  { UtestShell::getCurrent()->assertTrue((condition) != 0, checkString, conditionString, text, file, line); }
+  { UtestShell::getCurrent()->assertTrue((condition), checkString, conditionString, text, file, line); }
 
 #define CHECK_FALSE_LOCATION(condition, checkString, conditionString, text, file, line)\
-  { UtestShell::getCurrent()->assertTrue((condition) == 0, checkString, conditionString, text, file, line); }
+  { UtestShell::getCurrent()->assertTrue(!(condition), checkString, conditionString, text, file, line); }
 
 //This check needs the operator!=(), and a StringFrom(YourType) function
 #define CHECK_EQUAL(expected, actual)\
-  CHECK_EQUAL_LOCATION(expected, actual, NULL, __FILE__, __LINE__)
+  CHECK_EQUAL_LOCATION(expected, actual, NULLPTR, __FILE__, __LINE__)
 
 #define CHECK_EQUAL_TEXT(expected, actual, text)\
   CHECK_EQUAL_LOCATION(expected, actual, text, __FILE__, __LINE__)
@@ -139,11 +139,11 @@
   } \
   else \
   { \
-    UtestShell::getCurrent()->assertLongsEqual((long)0, (long)0, NULL, file, line); \
+    UtestShell::getCurrent()->assertLongsEqual((long)0, (long)0, NULLPTR, file, line); \
   } }
 
 #define CHECK_COMPARE(first, relop, second)\
-  CHECK_COMPARE_TEXT(first, relop, second, NULL)
+  CHECK_COMPARE_TEXT(first, relop, second, NULLPTR)
 
 #define CHECK_COMPARE_TEXT(first, relop, second, text)\
   CHECK_COMPARE_LOCATION(first, relop, second, text, __FILE__, __LINE__)
@@ -159,7 +159,7 @@
 //This check checks for char* string equality using strcmp.
 //This makes up for the fact that CHECK_EQUAL only compares the pointers to char*'s
 #define STRCMP_EQUAL(expected, actual)\
-  STRCMP_EQUAL_LOCATION(expected, actual, NULL, __FILE__, __LINE__)
+  STRCMP_EQUAL_LOCATION(expected, actual, NULLPTR, __FILE__, __LINE__)
 
 #define STRCMP_EQUAL_TEXT(expected, actual, text)\
   STRCMP_EQUAL_LOCATION(expected, actual, text, __FILE__, __LINE__)
@@ -168,7 +168,7 @@
   { UtestShell::getCurrent()->assertCstrEqual(expected, actual, text, file, line); }
 
 #define STRNCMP_EQUAL(expected, actual, length)\
-  STRNCMP_EQUAL_LOCATION(expected, actual, length, NULL, __FILE__, __LINE__)
+  STRNCMP_EQUAL_LOCATION(expected, actual, length, NULLPTR, __FILE__, __LINE__)
 
 #define STRNCMP_EQUAL_TEXT(expected, actual, length, text)\
   STRNCMP_EQUAL_LOCATION(expected, actual, length, text, __FILE__, __LINE__)
@@ -177,7 +177,7 @@
   { UtestShell::getCurrent()->assertCstrNEqual(expected, actual, length, text, file, line); }
 
 #define STRCMP_NOCASE_EQUAL(expected, actual)\
-  STRCMP_NOCASE_EQUAL_LOCATION(expected, actual, NULL, __FILE__, __LINE__)
+  STRCMP_NOCASE_EQUAL_LOCATION(expected, actual, NULLPTR, __FILE__, __LINE__)
 
 #define STRCMP_NOCASE_EQUAL_TEXT(expected, actual, text)\
   STRCMP_NOCASE_EQUAL_LOCATION(expected, actual, text, __FILE__, __LINE__)
@@ -186,7 +186,7 @@
   { UtestShell::getCurrent()->assertCstrNoCaseEqual(expected, actual, text, file, line); }
 
 #define STRCMP_CONTAINS(expected, actual)\
-  STRCMP_CONTAINS_LOCATION(expected, actual, NULL, __FILE__, __LINE__)
+  STRCMP_CONTAINS_LOCATION(expected, actual, NULLPTR, __FILE__, __LINE__)
 
 #define STRCMP_CONTAINS_TEXT(expected, actual, text)\
   STRCMP_CONTAINS_LOCATION(expected, actual, text, __FILE__, __LINE__)
@@ -195,7 +195,7 @@
   { UtestShell::getCurrent()->assertCstrContains(expected, actual, text, file, line); }
 
 #define STRCMP_NOCASE_CONTAINS(expected, actual)\
-  STRCMP_NOCASE_CONTAINS_LOCATION(expected, actual, NULL, __FILE__, __LINE__)
+  STRCMP_NOCASE_CONTAINS_LOCATION(expected, actual, NULLPTR, __FILE__, __LINE__)
 
 #define STRCMP_NOCASE_CONTAINS_TEXT(expected, actual, text)\
   STRCMP_NOCASE_CONTAINS_LOCATION(expected, actual, text, __FILE__, __LINE__)
@@ -211,7 +211,7 @@
   LONGS_EQUAL_LOCATION((expected), (actual), text, __FILE__, __LINE__)
 
 #define UNSIGNED_LONGS_EQUAL(expected, actual)\
-  UNSIGNED_LONGS_EQUAL_LOCATION((expected), (actual), NULL, __FILE__, __LINE__)
+  UNSIGNED_LONGS_EQUAL_LOCATION((expected), (actual), NULLPTR, __FILE__, __LINE__)
 
 #define UNSIGNED_LONGS_EQUAL_TEXT(expected, actual, text)\
   UNSIGNED_LONGS_EQUAL_LOCATION((expected), (actual), text, __FILE__, __LINE__)
@@ -223,13 +223,13 @@
   { UtestShell::getCurrent()->assertUnsignedLongsEqual((unsigned long)expected, (unsigned long)actual, text, file, line); }
 
 #define LONGLONGS_EQUAL(expected, actual)\
-  LONGLONGS_EQUAL_LOCATION(expected, actual, NULL, __FILE__, __LINE__)
+  LONGLONGS_EQUAL_LOCATION(expected, actual, NULLPTR, __FILE__, __LINE__)
 
 #define LONGLONGS_EQUAL_TEXT(expected, actual, text)\
   LONGLONGS_EQUAL_LOCATION(expected, actual, text, __FILE__, __LINE__)
 
 #define UNSIGNED_LONGLONGS_EQUAL(expected, actual)\
-  UNSIGNED_LONGLONGS_EQUAL_LOCATION(expected, actual, NULL, __FILE__, __LINE__)
+  UNSIGNED_LONGLONGS_EQUAL_LOCATION(expected, actual, NULLPTR, __FILE__, __LINE__)
 
 #define UNSIGNED_LONGLONGS_EQUAL_TEXT(expected, actual, text)\
   UNSIGNED_LONGLONGS_EQUAL_LOCATION(expected, actual, text, __FILE__, __LINE__)
@@ -250,7 +250,7 @@
     SIGNED_BYTES_EQUAL_LOCATION(expected, actual, __FILE__, __LINE__)
 
 #define SIGNED_BYTES_EQUAL_LOCATION(expected, actual, file, line) \
-       { UtestShell::getCurrent()->assertSignedBytesEqual(expected, actual, NULL, file, line); }
+       { UtestShell::getCurrent()->assertSignedBytesEqual(expected, actual, NULLPTR, file, line); }
 
 #define SIGNED_BYTES_EQUAL_TEXT(expected, actual, text)\
     SIGNED_BYTES_EQUAL_TEXT_LOCATION(expected, actual, text, __FILE__, __LINE__)
@@ -259,7 +259,7 @@
         { UtestShell::getCurrent()->assertSignedBytesEqual(expected, actual, text, file, line); }
 
 #define POINTERS_EQUAL(expected, actual)\
-    POINTERS_EQUAL_LOCATION((expected), (actual), NULL, __FILE__, __LINE__)
+    POINTERS_EQUAL_LOCATION((expected), (actual), NULLPTR, __FILE__, __LINE__)
 
 #define POINTERS_EQUAL_TEXT(expected, actual, text)\
     POINTERS_EQUAL_LOCATION((expected), (actual), text, __FILE__, __LINE__)
@@ -268,7 +268,7 @@
   { UtestShell::getCurrent()->assertPointersEqual((const void *)expected, (const void *)actual, text, file, line); }
 
 #define FUNCTIONPOINTERS_EQUAL(expected, actual)\
-    FUNCTIONPOINTERS_EQUAL_LOCATION((expected), (actual), NULL, __FILE__, __LINE__)
+    FUNCTIONPOINTERS_EQUAL_LOCATION((expected), (actual), NULLPTR, __FILE__, __LINE__)
 
 #define FUNCTIONPOINTERS_EQUAL_TEXT(expected, actual, text)\
     FUNCTIONPOINTERS_EQUAL_LOCATION((expected), (actual), text, __FILE__, __LINE__)
@@ -278,7 +278,7 @@
 
 //Check two doubles for equality within a tolerance threshold
 #define DOUBLES_EQUAL(expected, actual, threshold)\
-  DOUBLES_EQUAL_LOCATION(expected, actual, threshold, NULL, __FILE__, __LINE__)
+  DOUBLES_EQUAL_LOCATION(expected, actual, threshold, NULLPTR, __FILE__, __LINE__)
 
 #define DOUBLES_EQUAL_TEXT(expected, actual, threshold, text)\
   DOUBLES_EQUAL_LOCATION(expected, actual, threshold, text, __FILE__, __LINE__)
@@ -287,7 +287,7 @@
   { UtestShell::getCurrent()->assertDoublesEqual(expected, actual, threshold, text, file, line); }
 
 #define MEMCMP_EQUAL(expected, actual, size)\
-  MEMCMP_EQUAL_LOCATION(expected, actual, size, NULL, __FILE__, __LINE__)
+  MEMCMP_EQUAL_LOCATION(expected, actual, size, NULLPTR, __FILE__, __LINE__)
 
 #define MEMCMP_EQUAL_TEXT(expected, actual, size, text)\
   MEMCMP_EQUAL_LOCATION(expected, actual, size, text, __FILE__, __LINE__)
@@ -296,7 +296,7 @@
   { UtestShell::getCurrent()->assertBinaryEqual(expected, actual, size, text, file, line); }
 
 #define BITS_EQUAL(expected, actual, mask)\
-  BITS_LOCATION(expected, actual, mask, NULL, __FILE__, __LINE__)
+  BITS_LOCATION(expected, actual, mask, NULLPTR, __FILE__, __LINE__)
 
 #define BITS_EQUAL_TEXT(expected, actual, mask, text)\
   BITS_LOCATION(expected, actual, mask, text, __FILE__, __LINE__)

--- a/include/CppUTestExt/CodeMemoryReportFormatter.h
+++ b/include/CppUTestExt/CodeMemoryReportFormatter.h
@@ -39,7 +39,7 @@ private:
 
 public:
     CodeMemoryReportFormatter(TestMemoryAllocator* internalAllocator);
-    virtual ~CodeMemoryReportFormatter();
+    virtual ~CodeMemoryReportFormatter() _destructor_override;
 
     virtual void report_testgroup_start(TestResult* result, UtestShell& test) _override;
     virtual void report_testgroup_end(TestResult* /*result*/, UtestShell& /*test*/) _override {} // LCOV_EXCL_LINE

--- a/include/CppUTestExt/MemoryReportAllocator.h
+++ b/include/CppUTestExt/MemoryReportAllocator.h
@@ -40,7 +40,7 @@ protected:
     MemoryReportFormatter* formatter_;
 public:
     MemoryReportAllocator();
-    virtual ~MemoryReportAllocator();
+    virtual ~MemoryReportAllocator() _destructor_override;
 
     virtual void setFormatter(MemoryReportFormatter* formatter);
     virtual void setTestResult(TestResult* result);

--- a/include/CppUTestExt/MemoryReportAllocator.h
+++ b/include/CppUTestExt/MemoryReportAllocator.h
@@ -51,9 +51,9 @@ public:
     virtual char* alloc_memory(size_t size, const char* file, int line) _override;
     virtual void free_memory(char* memory, const char* file, int line) _override;
 
-    virtual const char* name() _override;
-    virtual const char* alloc_name() _override;
-    virtual const char* free_name() _override;
+    virtual const char* name() const _override;
+    virtual const char* alloc_name() const _override;
+    virtual const char* free_name() const _override;
 };
 
 #endif

--- a/include/CppUTestExt/MemoryReportFormatter.h
+++ b/include/CppUTestExt/MemoryReportFormatter.h
@@ -50,7 +50,7 @@ class NormalMemoryReportFormatter : public MemoryReportFormatter
 {
 public:
     NormalMemoryReportFormatter();
-    virtual ~NormalMemoryReportFormatter();
+    virtual ~NormalMemoryReportFormatter() _destructor_override;
 
     virtual void report_testgroup_start(TestResult* /*result*/, UtestShell& /*test*/) _override;
     virtual void report_testgroup_end(TestResult* /*result*/, UtestShell& /*test*/) _override {} // LCOV_EXCL_LINE

--- a/include/CppUTestExt/MemoryReporterPlugin.h
+++ b/include/CppUTestExt/MemoryReporterPlugin.h
@@ -44,7 +44,7 @@ class MemoryReporterPlugin : public TestPlugin
     SimpleString currentTestGroup_;
 public:
     MemoryReporterPlugin();
-    virtual ~MemoryReporterPlugin();
+    virtual ~MemoryReporterPlugin() _destructor_override;
 
     virtual void preTestAction(UtestShell & test, TestResult & result) _override;
     virtual void postTestAction(UtestShell & test, TestResult & result) _override;

--- a/include/CppUTestExt/MemoryReporterPlugin.h
+++ b/include/CppUTestExt/MemoryReporterPlugin.h
@@ -48,7 +48,7 @@ public:
 
     virtual void preTestAction(UtestShell & test, TestResult & result) _override;
     virtual void postTestAction(UtestShell & test, TestResult & result) _override;
-    virtual bool parseArguments(int, const char**, int) _override;
+    virtual bool parseArguments(int, const char *const *, int) _override;
 
 protected:
     virtual MemoryReportFormatter* createMemoryFormatter(const SimpleString& type);

--- a/include/CppUTestExt/MockCheckedActualCall.h
+++ b/include/CppUTestExt/MockCheckedActualCall.h
@@ -35,7 +35,7 @@ class MockCheckedActualCall : public MockActualCall
 {
 public:
     MockCheckedActualCall(unsigned int callOrder, MockFailureReporter* reporter, const MockExpectedCallsList& expectations);
-    virtual ~MockCheckedActualCall();
+    virtual ~MockCheckedActualCall() _destructor_override;
 
     virtual MockActualCall& withName(const SimpleString& name) _override;
     virtual MockActualCall& withCallOrder(unsigned int) _override;
@@ -135,7 +135,7 @@ private:
 
         MockOutputParametersListNode* next_;
         MockOutputParametersListNode(const SimpleString& name, const SimpleString& type, void* ptr)
-            : name_(name), type_(type), ptr_(ptr), next_(NULL) {}
+            : name_(name), type_(type), ptr_(ptr), next_(NULLPTR) {}
     };
 
     MockOutputParametersListNode* outputParameterExpectations_;
@@ -148,7 +148,7 @@ class MockActualCallTrace : public MockActualCall
 {
 public:
     MockActualCallTrace();
-    virtual ~MockActualCallTrace();
+    virtual ~MockActualCallTrace() _destructor_override;
 
     virtual MockActualCall& withName(const SimpleString& name) _override;
     virtual MockActualCall& withCallOrder(unsigned int) _override;
@@ -256,13 +256,13 @@ public:
     virtual const char * returnStringValue() _override { return ""; }
     virtual const char * returnStringValueOrDefault(const char * value) _override { return value; }
 
-    virtual void * returnPointerValue() _override { return NULL; }
+    virtual void * returnPointerValue() _override { return NULLPTR; }
     virtual void * returnPointerValueOrDefault(void * value) _override { return value; }
 
-    virtual const void * returnConstPointerValue() _override { return NULL; }
+    virtual const void * returnConstPointerValue() _override { return NULLPTR; }
     virtual const void * returnConstPointerValueOrDefault(const void * value) _override { return value; }
 
-    virtual void (*returnFunctionPointerValue())() _override { return NULL; }
+    virtual void (*returnFunctionPointerValue())() _override { return NULLPTR; }
     virtual void (*returnFunctionPointerValueOrDefault(void (*value)()))() _override { return value; }
 
     virtual MockActualCall& onObject(const void* ) _override { return *this; }

--- a/include/CppUTestExt/MockCheckedExpectedCall.h
+++ b/include/CppUTestExt/MockCheckedExpectedCall.h
@@ -37,7 +37,7 @@ class MockCheckedExpectedCall : public MockExpectedCall
 public:
     MockCheckedExpectedCall();
     MockCheckedExpectedCall(unsigned int numCalls);
-    virtual ~MockCheckedExpectedCall();
+    virtual ~MockCheckedExpectedCall() _destructor_override;
 
     virtual MockExpectedCall& withName(const SimpleString& name) _override;
     virtual MockExpectedCall& withCallOrder(unsigned int callOrder) _override { return withCallOrder(callOrder, callOrder); }

--- a/include/CppUTestExt/MockExpectedCallsList.h
+++ b/include/CppUTestExt/MockExpectedCallsList.h
@@ -87,7 +87,7 @@ protected:
 
         MockExpectedCallsListNode* next_;
         MockExpectedCallsListNode(MockCheckedExpectedCall* expectedCall)
-            : expectedCall_(expectedCall), next_(NULL) {}
+            : expectedCall_(expectedCall), next_(NULLPTR) {}
     };
 
 private:

--- a/include/CppUTestExt/MockSupport.h
+++ b/include/CppUTestExt/MockSupport.h
@@ -37,7 +37,7 @@ class UtestShell;
 class MockSupport;
 
 /* This allows access to "the global" mocking support for easier testing */
-MockSupport& mock(const SimpleString& mockName = "", MockFailureReporter* failureReporterForThisCall = NULL);
+MockSupport& mock(const SimpleString& mockName = "", MockFailureReporter* failureReporterForThisCall = NULLPTR);
 
 class MockSupport
 {

--- a/include/CppUTestExt/MockSupportPlugin.h
+++ b/include/CppUTestExt/MockSupportPlugin.h
@@ -35,7 +35,7 @@ class MockSupportPlugin : public TestPlugin
 {
 public:
     MockSupportPlugin(const SimpleString& name = "MockSupportPLugin");
-    virtual ~MockSupportPlugin();
+    virtual ~MockSupportPlugin() _destructor_override;
 
     virtual void preTestAction(UtestShell&, TestResult&) _override;
     virtual void postTestAction(UtestShell&, TestResult&) _override;

--- a/src/CppUTest/CommandLineArguments.cpp
+++ b/src/CppUTest/CommandLineArguments.cpp
@@ -30,7 +30,7 @@
 #include "CppUTest/PlatformSpecificFunctions.h"
 
 CommandLineArguments::CommandLineArguments(int ac, const char *const *av) :
-    ac_(ac), av_(av), verbose_(false), color_(false), runTestsAsSeperateProcess_(false), listTestGroupNames_(false), listTestGroupAndCaseNames_(false), runIgnored_(false), repeat_(1), groupFilters_(NULL), nameFilters_(NULL), outputType_(OUTPUT_ECLIPSE)
+    ac_(ac), av_(av), verbose_(false), color_(false), runTestsAsSeperateProcess_(false), listTestGroupNames_(false), listTestGroupAndCaseNames_(false), runIgnored_(false), repeat_(1), groupFilters_(NULLPTR), nameFilters_(NULLPTR), outputType_(OUTPUT_ECLIPSE)
 {
 }
 

--- a/src/CppUTest/CommandLineArguments.cpp
+++ b/src/CppUTest/CommandLineArguments.cpp
@@ -29,7 +29,7 @@
 #include "CppUTest/CommandLineArguments.h"
 #include "CppUTest/PlatformSpecificFunctions.h"
 
-CommandLineArguments::CommandLineArguments(int ac, const char** av) :
+CommandLineArguments::CommandLineArguments(int ac, const char *const *av) :
     ac_(ac), av_(av), verbose_(false), color_(false), runTestsAsSeperateProcess_(false), listTestGroupNames_(false), listTestGroupAndCaseNames_(false), runIgnored_(false), repeat_(1), groupFilters_(NULL), nameFilters_(NULL), outputType_(OUTPUT_ECLIPSE)
 {
 }
@@ -134,7 +134,7 @@ const TestFilter* CommandLineArguments::getNameFilters() const
     return nameFilters_;
 }
 
-void CommandLineArguments::SetRepeatCount(int ac, const char** av, int& i)
+void CommandLineArguments::SetRepeatCount(int ac, const char *const *av, int& i)
 {
     repeat_ = 0;
 
@@ -149,7 +149,7 @@ void CommandLineArguments::SetRepeatCount(int ac, const char** av, int& i)
 
 }
 
-SimpleString CommandLineArguments::getParameterField(int ac, const char** av, int& i, const SimpleString& parameterName)
+SimpleString CommandLineArguments::getParameterField(int ac, const char * const *av, int& i, const SimpleString& parameterName)
 {
     size_t parameterLength = parameterName.size();
     SimpleString parameter(av[i]);
@@ -158,27 +158,27 @@ SimpleString CommandLineArguments::getParameterField(int ac, const char** av, in
     return "";
 }
 
-void CommandLineArguments::AddGroupFilter(int ac, const char** av, int& i)
+void CommandLineArguments::AddGroupFilter(int ac, const char *const *av, int& i)
 {
     TestFilter* groupFilter = new TestFilter(getParameterField(ac, av, i, "-g"));
     groupFilters_ = groupFilter->add(groupFilters_);
 }
 
-void CommandLineArguments::AddStrictGroupFilter(int ac, const char** av, int& i)
+void CommandLineArguments::AddStrictGroupFilter(int ac, const char *const *av, int& i)
 {
     TestFilter* groupFilter = new TestFilter(getParameterField(ac, av, i, "-sg"));
     groupFilter->strictMatching();
     groupFilters_ = groupFilter->add(groupFilters_);
 }
 
-void CommandLineArguments::AddExcludeGroupFilter(int ac, const char** av, int& i)
+void CommandLineArguments::AddExcludeGroupFilter(int ac, const char *const *av, int& i)
 {
     TestFilter* groupFilter = new TestFilter(getParameterField(ac, av, i, "-xg"));
     groupFilter->invertMatching();
     groupFilters_ = groupFilter->add(groupFilters_);
 }
 
-void CommandLineArguments::AddExcludeStrictGroupFilter(int ac, const char** av, int& i)
+void CommandLineArguments::AddExcludeStrictGroupFilter(int ac, const char *const *av, int& i)
 {
     TestFilter* groupFilter = new TestFilter(getParameterField(ac, av, i, "-xsg"));
     groupFilter->strictMatching();
@@ -186,27 +186,27 @@ void CommandLineArguments::AddExcludeStrictGroupFilter(int ac, const char** av, 
     groupFilters_ = groupFilter->add(groupFilters_);
 }
 
-void CommandLineArguments::AddNameFilter(int ac, const char** av, int& i)
+void CommandLineArguments::AddNameFilter(int ac, const char *const *av, int& i)
 {
     TestFilter* nameFilter = new TestFilter(getParameterField(ac, av, i, "-n"));
     nameFilters_ = nameFilter->add(nameFilters_);
 }
 
-void CommandLineArguments::AddStrictNameFilter(int ac, const char** av, int& index)
+void CommandLineArguments::AddStrictNameFilter(int ac, const char *const *av, int& index)
 {
     TestFilter* nameFilter = new TestFilter(getParameterField(ac, av, index, "-sn"));
     nameFilter->strictMatching();
     nameFilters_= nameFilter->add(nameFilters_);
 }
 
-void CommandLineArguments::AddExcludeNameFilter(int ac, const char** av, int& index)
+void CommandLineArguments::AddExcludeNameFilter(int ac, const char *const *av, int& index)
 {
     TestFilter* nameFilter = new TestFilter(getParameterField(ac, av, index, "-xn"));
     nameFilter->invertMatching();
     nameFilters_= nameFilter->add(nameFilters_);
 }
 
-void CommandLineArguments::AddExcludeStrictNameFilter(int ac, const char** av, int& index)
+void CommandLineArguments::AddExcludeStrictNameFilter(int ac, const char *const *av, int& index)
 {
     TestFilter* nameFilter = new TestFilter(getParameterField(ac, av, index, "-xsn"));
     nameFilter->invertMatching();
@@ -214,7 +214,7 @@ void CommandLineArguments::AddExcludeStrictNameFilter(int ac, const char** av, i
     nameFilters_= nameFilter->add(nameFilters_);
 }
 
-void CommandLineArguments::AddTestToRunBasedOnVerboseOutput(int ac, const char** av, int& index, const char* parameterName)
+void CommandLineArguments::AddTestToRunBasedOnVerboseOutput(int ac, const char *const *av, int& index, const char* parameterName)
 {
     SimpleString wholename = getParameterField(ac, av, index, parameterName);
     SimpleString testname = wholename.subStringFromTill(',', ')');
@@ -227,7 +227,7 @@ void CommandLineArguments::AddTestToRunBasedOnVerboseOutput(int ac, const char**
     nameFilters_ = namefilter->add(nameFilters_);
 }
 
-void CommandLineArguments::SetPackageName(int ac, const char** av, int& i)
+void CommandLineArguments::SetPackageName(int ac, const char *const *av, int& i)
 {
     SimpleString packageName = getParameterField(ac, av, i, "-k");
     if (packageName.size() == 0) return;
@@ -235,7 +235,7 @@ void CommandLineArguments::SetPackageName(int ac, const char** av, int& i)
     packageName_ = packageName;
 }
 
-bool CommandLineArguments::SetOutputType(int ac, const char** av, int& i)
+bool CommandLineArguments::SetOutputType(int ac, const char *const *av, int& i)
 {
     SimpleString outputType = getParameterField(ac, av, i, "-o");
     if (outputType.size() == 0) return false;

--- a/src/CppUTest/CommandLineTestRunner.cpp
+++ b/src/CppUTest/CommandLineTestRunner.cpp
@@ -59,7 +59,7 @@ int CommandLineTestRunner::RunAllTests(int ac, const char *const *av)
 }
 
 CommandLineTestRunner::CommandLineTestRunner(int ac, const char *const *av, TestRegistry* registry) :
-    output_(NULL), arguments_(NULL), registry_(registry)
+    output_(NULLPTR), arguments_(NULLPTR), registry_(registry)
 {
     arguments_ = new CommandLineArguments(ac, av);
 }
@@ -134,7 +134,7 @@ TestOutput* CommandLineTestRunner::createTeamCityOutput()
 TestOutput* CommandLineTestRunner::createJUnitOutput(const SimpleString& packageName)
 {
     JUnitTestOutput* junitOutput = new JUnitTestOutput;
-    if (junitOutput != NULL) {
+    if (junitOutput != NULLPTR) {
       junitOutput->setPackageName(packageName);
     }
     return junitOutput;

--- a/src/CppUTest/CommandLineTestRunner.cpp
+++ b/src/CppUTest/CommandLineTestRunner.cpp
@@ -34,10 +34,10 @@
 
 int CommandLineTestRunner::RunAllTests(int ac, char** av)
 {
-    return RunAllTests(ac, (const char**) av);
+    return RunAllTests(ac, (const char *const *) av);
 }
 
-int CommandLineTestRunner::RunAllTests(int ac, const char** av)
+int CommandLineTestRunner::RunAllTests(int ac, const char *const *av)
 {
     int result = 0;
     ConsoleTestOutput backupOutput;
@@ -58,7 +58,7 @@ int CommandLineTestRunner::RunAllTests(int ac, const char** av)
     return result;
 }
 
-CommandLineTestRunner::CommandLineTestRunner(int ac, const char** av, TestRegistry* registry) :
+CommandLineTestRunner::CommandLineTestRunner(int ac, const char *const *av, TestRegistry* registry) :
     output_(NULL), arguments_(NULL), registry_(registry)
 {
     arguments_ = new CommandLineArguments(ac, av);

--- a/src/CppUTest/JUnitTestOutput.cpp
+++ b/src/CppUTest/JUnitTestOutput.cpp
@@ -34,7 +34,7 @@
 struct JUnitTestCaseResultNode
 {
     JUnitTestCaseResultNode() :
-        execTime_(0), failure_(0), ignored_(false), lineNumber_ (0), checkCount_ (0), next_(0)
+        execTime_(0), failure_(NULLPTR), ignored_(false), lineNumber_ (0), checkCount_ (0), next_(NULLPTR)
     {
     }
 
@@ -51,7 +51,7 @@ struct JUnitTestCaseResultNode
 struct JUnitTestGroupResult
 {
     JUnitTestGroupResult() :
-        testCount_(0), failureCount_(0), totalCheckCount_(0), startTime_(0), groupExecTime_(0), head_(0), tail_(0)
+        testCount_(0), failureCount_(0), totalCheckCount_(0), startTime_(0), groupExecTime_(0), head_(NULLPTR), tail_(NULLPTR)
     {
     }
 
@@ -97,8 +97,8 @@ void JUnitTestOutput::resetTestGroupResult()
         delete cur;
         cur = tmp;
     }
-    impl_->results_.head_ = 0;
-    impl_->results_.tail_ = 0;
+    impl_->results_.head_ = NULLPTR;
+    impl_->results_.tail_ = NULLPTR;
 }
 
 void JUnitTestOutput::printTestsStarted()
@@ -133,7 +133,7 @@ void JUnitTestOutput::printCurrentTestStarted(const UtestShell& test)
     impl_->results_.group_ = test.getGroup();
     impl_->results_.startTime_ = GetPlatformSpecificTimeInMillis();
 
-    if (impl_->results_.tail_ == 0) {
+    if (impl_->results_.tail_ == NULLPTR) {
         impl_->results_.head_ = impl_->results_.tail_
                 = new JUnitTestCaseResultNode;
     }
@@ -160,7 +160,7 @@ SimpleString JUnitTestOutput::createFileName(const SimpleString& group)
 
 void JUnitTestOutput::setPackageName(const SimpleString& package)
 {
-    if (impl_ != NULL) {
+    if (impl_ != NULLPTR) {
         impl_->package_ = package;
     }
 }
@@ -277,7 +277,7 @@ void JUnitTestOutput::flush()
 
 void JUnitTestOutput::printFailure(const TestFailure& failure)
 {
-    if (impl_->results_.tail_->failure_ == 0) {
+    if (impl_->results_.tail_->failure_ == NULLPTR) {
         impl_->results_.failureCount_++;
         impl_->results_.tail_->failure_ = new TestFailure(failure);
     }

--- a/src/CppUTest/MemoryLeakDetector.cpp
+++ b/src/CppUTest/MemoryLeakDetector.cpp
@@ -273,7 +273,7 @@ bool MemoryLeakDetectorList::isInPeriod(MemoryLeakDetectorNode* node, MemLeakPer
 void MemoryLeakDetectorList::clearAllAccounting(MemLeakPeriod period)
 {
     MemoryLeakDetectorNode* cur = head_;
-    MemoryLeakDetectorNode* prev = 0;
+    MemoryLeakDetectorNode* prev = NULLPTR;
 
     while (cur) {
         if (isInPeriod(cur, period)) {
@@ -301,7 +301,7 @@ void MemoryLeakDetectorList::addNewNode(MemoryLeakDetectorNode* node)
 MemoryLeakDetectorNode* MemoryLeakDetectorList::removeNode(char* memory)
 {
     MemoryLeakDetectorNode* cur = head_;
-    MemoryLeakDetectorNode* prev = 0;
+    MemoryLeakDetectorNode* prev = NULLPTR;
     while (cur) {
         if (cur->memory_ == memory) {
             if (prev) {
@@ -316,7 +316,7 @@ MemoryLeakDetectorNode* MemoryLeakDetectorList::removeNode(char* memory)
         prev = cur;
         cur = cur->next_;
     }
-    return 0;
+    return NULLPTR;
 }
 
 MemoryLeakDetectorNode* MemoryLeakDetectorList::retrieveNode(char* memory)
@@ -327,14 +327,14 @@ MemoryLeakDetectorNode* MemoryLeakDetectorList::retrieveNode(char* memory)
       return cur;
     cur = cur->next_;
   }
-  return NULL;
+  return NULLPTR;
 }
 
 MemoryLeakDetectorNode* MemoryLeakDetectorList::getLeakFrom(MemoryLeakDetectorNode* node, MemLeakPeriod period)
 {
     for (MemoryLeakDetectorNode* cur = node; cur; cur = cur->next_)
         if (isInPeriod(cur, period)) return cur;
-    return 0;
+    return NULLPTR;
 }
 
 MemoryLeakDetectorNode* MemoryLeakDetectorList::getFirstLeak(MemLeakPeriod period)
@@ -398,7 +398,7 @@ MemoryLeakDetectorNode* MemoryLeakDetectorTable::getFirstLeak(MemLeakPeriod peri
         MemoryLeakDetectorNode* node = table_[i].getFirstLeak(period);
         if (node) return node;
     }
-    return 0;
+    return NULLPTR;
 }
 
 MemoryLeakDetectorNode* MemoryLeakDetectorTable::getNextLeak(MemoryLeakDetectorNode* leak, MemLeakPeriod period)
@@ -411,7 +411,7 @@ MemoryLeakDetectorNode* MemoryLeakDetectorTable::getNextLeak(MemoryLeakDetectorN
         node = table_[i].getFirstLeak(period);
         if (node) return node;
     }
-    return 0;
+    return NULLPTR;
 }
 
 /////////////////////////////////////////////////////////////
@@ -504,7 +504,7 @@ void MemoryLeakDetector::storeLeakInformation(MemoryLeakDetectorNode * node, cha
 char* MemoryLeakDetector::reallocateMemoryAndLeakInformation(TestMemoryAllocator* allocator, char* memory, size_t size, const char* file, int line, bool allocatNodesSeperately)
 {
     char* new_memory = reallocateMemoryWithAccountingInformation(allocator, memory, size, file, line, allocatNodesSeperately);
-    if (new_memory == NULL) return NULL;
+    if (new_memory == NULLPTR) return NULLPTR;
 
     MemoryLeakDetectorNode *node = createMemoryLeakAccountingInformation(allocator, size, new_memory, allocatNodesSeperately);
     storeLeakInformation(node, new_memory, size, allocator, file, line);
@@ -580,7 +580,7 @@ char* MemoryLeakDetector::allocMemory(TestMemoryAllocator* allocator, size_t siz
      */
 
     char* memory = allocateMemoryWithAccountingInformation(allocator, size, file, line, allocatNodesSeperately);
-    if (memory == NULL) return NULL;
+    if (memory == NULLPTR) return NULLPTR;
     MemoryLeakDetectorNode* node = createMemoryLeakAccountingInformation(allocator, size, memory, allocatNodesSeperately);
 
     storeLeakInformation(node, memory, size, allocator, file, line);
@@ -595,10 +595,10 @@ void MemoryLeakDetector::removeMemoryLeakInformationWithoutCheckingOrDeallocatin
 
 void MemoryLeakDetector::deallocMemory(TestMemoryAllocator* allocator, void* memory, const char* file, int line, bool allocatNodesSeperately)
 {
-    if (memory == 0) return;
+    if (memory == NULLPTR) return;
 
     MemoryLeakDetectorNode* node = memoryTable_.removeNode((char*) memory);
-    if (node == NULL) {
+    if (node == NULLPTR) {
         outputBuffer_.reportDeallocateNonAllocatedMemoryFailure(file, line, allocator, reporter_);
         return;
     }
@@ -617,9 +617,9 @@ char* MemoryLeakDetector::reallocMemory(TestMemoryAllocator* allocator, char* me
 {
     if (memory) {
         MemoryLeakDetectorNode* node = memoryTable_.removeNode(memory);
-        if (node == NULL) {
+        if (node == NULLPTR) {
             outputBuffer_.reportDeallocateNonAllocatedMemoryFailure(file, line, allocator, reporter_);
-            return NULL;
+            return NULLPTR;
         }
         checkForCorruption(node, file, line, allocator, allocatNodesSeperately);
     }

--- a/src/CppUTest/MemoryLeakDetector.cpp
+++ b/src/CppUTest/MemoryLeakDetector.cpp
@@ -30,7 +30,7 @@
 #include "CppUTest/PlatformSpecificFunctions.h"
 #include "CppUTest/SimpleMutex.h"
 
-#define UNKNOWN ((char*)("<unknown>"))
+static const char* UNKNOWN = "<unknown>";
 
 SimpleStringBuffer::SimpleStringBuffer() :
     positions_filled_(0), write_limit_(SIMPLE_STRING_BUFFER_LEN-1)

--- a/src/CppUTest/MemoryLeakWarningPlugin.cpp
+++ b/src/CppUTest/MemoryLeakWarningPlugin.cpp
@@ -150,7 +150,7 @@ static void* threadsafe_mem_leak_operator_new_nothrow (size_t size) UT_NOTHROW
 static void* threadsafe_mem_leak_operator_new_debug (size_t size, const char* file, int line) UT_THROW(std::bad_alloc)
 {
     MemLeakScopedMutex lock;
-    void *memory = MemoryLeakWarningPlugin::getGlobalDetector()->allocMemory(getCurrentNewAllocator(), size, (char*) file, line);
+    void *memory = MemoryLeakWarningPlugin::getGlobalDetector()->allocMemory(getCurrentNewAllocator(), size, file, line);
     UT_THROW_BAD_ALLOC_WHEN_NULL(memory);
     return memory;
 }
@@ -172,7 +172,7 @@ static void* threadsafe_mem_leak_operator_new_array_nothrow (size_t size) UT_NOT
 static void* threadsafe_mem_leak_operator_new_array_debug (size_t size, const char* file, int line) UT_THROW(std::bad_alloc)
 {
     MemLeakScopedMutex lock;
-    void* memory = MemoryLeakWarningPlugin::getGlobalDetector()->allocMemory(getCurrentNewArrayAllocator(), size, (char*) file, line);
+    void* memory = MemoryLeakWarningPlugin::getGlobalDetector()->allocMemory(getCurrentNewArrayAllocator(), size, file, line);
     UT_THROW_BAD_ALLOC_WHEN_NULL(memory);
     return memory;
 }
@@ -206,7 +206,7 @@ static void* mem_leak_operator_new_nothrow (size_t size) UT_NOTHROW
 
 static void* mem_leak_operator_new_debug (size_t size, const char* file, int line) UT_THROW(std::bad_alloc)
 {
-    void *memory = MemoryLeakWarningPlugin::getGlobalDetector()->allocMemory(getCurrentNewAllocator(), size, (char*) file, line);
+    void *memory = MemoryLeakWarningPlugin::getGlobalDetector()->allocMemory(getCurrentNewAllocator(), size, file, line);
     UT_THROW_BAD_ALLOC_WHEN_NULL(memory);
     return memory;
 }
@@ -225,7 +225,7 @@ static void* mem_leak_operator_new_array_nothrow (size_t size) UT_NOTHROW
 
 static void* mem_leak_operator_new_array_debug (size_t size, const char* file, int line) UT_THROW(std::bad_alloc)
 {
-    void* memory = MemoryLeakWarningPlugin::getGlobalDetector()->allocMemory(getCurrentNewArrayAllocator(), size, (char*) file, line);
+    void* memory = MemoryLeakWarningPlugin::getGlobalDetector()->allocMemory(getCurrentNewArrayAllocator(), size, file, line);
     UT_THROW_BAD_ALLOC_WHEN_NULL(memory);
     return memory;
 }

--- a/src/CppUTest/MemoryLeakWarningPlugin.cpp
+++ b/src/CppUTest/MemoryLeakWarningPlugin.cpp
@@ -128,7 +128,7 @@ void cpputest_free_location_with_leak_detection(void* buffer, const char* file, 
 #undef new
 
 #if CPPUTEST_USE_STD_CPP_LIB
-#define UT_THROW_BAD_ALLOC_WHEN_NULL(memory) if (memory == NULL) throw std::bad_alloc();
+#define UT_THROW_BAD_ALLOC_WHEN_NULL(memory) if (memory == NULLPTR) throw std::bad_alloc();
 #else
 #define UT_THROW_BAD_ALLOC_WHEN_NULL(memory)
 #endif
@@ -475,12 +475,12 @@ public:
     } // LCOV_EXCL_LINE
 };
 
-static MemoryLeakFailure* globalReporter = 0;
-static MemoryLeakDetector* globalDetector = 0;
+static MemoryLeakFailure* globalReporter = NULLPTR;
+static MemoryLeakDetector* globalDetector = NULLPTR;
 
 MemoryLeakDetector* MemoryLeakWarningPlugin::getGlobalDetector()
 {
-    if (globalDetector == 0) {
+    if (globalDetector == NULLPTR) {
         bool newDeleteOverloaded = areNewDeleteOverloaded();
         turnOffNewDeleteOverloads();
 
@@ -513,11 +513,11 @@ void MemoryLeakWarningPlugin::destroyGlobalDetector()
     turnOffNewDeleteOverloads();
     delete globalDetector;
     delete globalReporter;
-    globalDetector = NULL;
+    globalDetector = NULLPTR;
 }
 
 
-MemoryLeakWarningPlugin* MemoryLeakWarningPlugin::firstPlugin_ = 0;
+MemoryLeakWarningPlugin* MemoryLeakWarningPlugin::firstPlugin_ = NULLPTR;
 
 MemoryLeakWarningPlugin* MemoryLeakWarningPlugin::getFirstPlugin()
 {
@@ -542,7 +542,7 @@ void MemoryLeakWarningPlugin::expectLeaksInTest(int n)
 MemoryLeakWarningPlugin::MemoryLeakWarningPlugin(const SimpleString& name, MemoryLeakDetector* localDetector) :
     TestPlugin(name), ignoreAllWarnings_(false), destroyGlobalDetectorAndTurnOfMemoryLeakDetectionInDestructor_(false), expectedLeaks_(0)
 {
-    if (firstPlugin_ == 0) firstPlugin_ = this;
+    if (firstPlugin_ == NULLPTR) firstPlugin_ = this;
 
     if (localDetector) memLeakDetector_ = localDetector;
     else memLeakDetector_ = getGlobalDetector();

--- a/src/CppUTest/SimpleString.cpp
+++ b/src/CppUTest/SimpleString.cpp
@@ -30,11 +30,11 @@
 #include "CppUTest/PlatformSpecificFunctions.h"
 #include "CppUTest/TestMemoryAllocator.h"
 
-TestMemoryAllocator* SimpleString::stringAllocator_ = NULL;
+TestMemoryAllocator* SimpleString::stringAllocator_ = NULLPTR;
 
 TestMemoryAllocator* SimpleString::getStringAllocator()
 {
-    if (stringAllocator_ == NULL)
+    if (stringAllocator_ == NULLPTR)
         return defaultNewArrayAllocator();
     return stringAllocator_;
 }
@@ -108,7 +108,7 @@ char* SimpleString::StrNCpy(char* s1, const char* s2, size_t n)
 {
     char* result = s1;
 
-    if((NULL == s1) || (0 == n)) return result;
+    if((NULLPTR == s1) || (0 == n)) return result;
 
     while ((*s1++ = *s2++) && --n != 0)
         ;
@@ -121,7 +121,7 @@ const char* SimpleString::StrStr(const char* s1, const char* s2)
     for (; *s1; s1++)
         if (StrNCmp(s1, s2, StrLen(s2)) == 0)
             return s1;
-    return NULL;
+    return NULLPTR;
 }
 
 char SimpleString::ToLower(char ch)
@@ -146,7 +146,7 @@ int SimpleString::MemCmp(const void* s1, const void *s2, size_t n)
 
 SimpleString::SimpleString(const char *otherBuffer)
 {
-    if (otherBuffer == 0) {
+    if (otherBuffer == NULLPTR) {
         buffer_ = getEmptyString();
     }
     else {
@@ -183,7 +183,7 @@ SimpleString& SimpleString::operator=(const SimpleString& other)
 
 bool SimpleString::contains(const SimpleString& other) const
 {
-    return StrStr(buffer_, other.buffer_) != 0;
+    return StrStr(buffer_, other.buffer_) != NULLPTR;
 }
 
 bool SimpleString::containsNoCase(const SimpleString& other) const
@@ -421,7 +421,7 @@ char* SimpleString::copyToNewBuffer(const char* bufferToCopy, size_t bufferSize)
 
 void SimpleString::copyToBuffer(char* bufferToCopy, size_t bufferSize) const
 {
-    if (bufferToCopy == NULL || bufferSize == 0) return;
+    if (bufferToCopy == NULLPTR || bufferSize == 0) return;
 
     size_t sizeToCopy = (bufferSize-1 < size()) ? (bufferSize-1) : size();
 
@@ -816,7 +816,7 @@ SimpleString StringFromOrdinalNumber(unsigned int number)
 
 SimpleStringCollection::SimpleStringCollection()
 {
-    collection_ = 0;
+    collection_ = NULLPTR;
     size_ = 0;
 }
 

--- a/src/CppUTest/SimpleString.cpp
+++ b/src/CppUTest/SimpleString.cpp
@@ -84,7 +84,7 @@ int SimpleString::StrCmp(const char* s1, const char* s2)
        ++s1;
        ++s2;
    }
-   return *(unsigned char *) s1 - *(unsigned char *) s2;
+   return *(const unsigned char *) s1 - *(const unsigned char *) s2;
 }
 
 size_t SimpleString::StrLen(const char* str)
@@ -101,7 +101,7 @@ int SimpleString::StrNCmp(const char* s1, const char* s2, size_t n)
         ++s1;
         ++s2;
     }
-    return n ? *(unsigned char *) s1 - *(unsigned char *) s2 : 0;
+    return n ? *(const unsigned char *) s1 - *(const unsigned char *) s2 : 0;
 }
 
 char* SimpleString::StrNCpy(char* s1, const char* s2, size_t n)
@@ -115,12 +115,12 @@ char* SimpleString::StrNCpy(char* s1, const char* s2, size_t n)
     return result;
 }
 
-char* SimpleString::StrStr(const char* s1, const char* s2)
+const char* SimpleString::StrStr(const char* s1, const char* s2)
 {
-    if(!*s2) return (char*) s1;
+    if(!*s2) return s1;
     for (; *s1; s1++)
         if (StrNCmp(s1, s2, StrLen(s2)) == 0)
-            return (char*) s1;
+            return s1;
     return NULL;
 }
 
@@ -211,7 +211,7 @@ bool SimpleString::endsWith(const SimpleString& other) const
 size_t SimpleString::count(const SimpleString& substr) const
 {
     size_t num = 0;
-    char* str = buffer_;
+    const char* str = buffer_;
     while (*str && (str = StrStr(str, substr.buffer_))) {
         num++;
         str++;
@@ -225,8 +225,8 @@ void SimpleString::split(const SimpleString& delimiter, SimpleStringCollection& 
     size_t extraEndToken = (endsWith(delimiter)) ? 0 : 1U;
     col.allocate(num + extraEndToken);
 
-    char* str = buffer_;
-    char* prev;
+    const char* str = buffer_;
+    const char* prev;
     for (size_t i = 0; i < num; ++i) {
         prev = str;
         str = StrStr(str, delimiter.buffer_) + 1;

--- a/src/CppUTest/TeamCityTestOutput.cpp
+++ b/src/CppUTest/TeamCityTestOutput.cpp
@@ -1,7 +1,7 @@
 #include "CppUTest/TestHarness.h"
 #include "CppUTest/TeamCityTestOutput.h"
 
-TeamCityTestOutput::TeamCityTestOutput() : currtest_(0), currGroup_()
+TeamCityTestOutput::TeamCityTestOutput() : currtest_(NULLPTR), currGroup_()
 {
 }
 

--- a/src/CppUTest/TestFilter.cpp
+++ b/src/CppUTest/TestFilter.cpp
@@ -28,16 +28,16 @@
 #include "CppUTest/CppUTestConfig.h"
 #include "CppUTest/TestFilter.h"
 
-TestFilter::TestFilter() : strictMatching_(false), invertMatching_(false), next_(NULL)
+TestFilter::TestFilter() : strictMatching_(false), invertMatching_(false), next_(NULLPTR)
 {
 }
 
-TestFilter::TestFilter(const SimpleString& filter) : strictMatching_(false), invertMatching_(false), next_(NULL)
+TestFilter::TestFilter(const SimpleString& filter) : strictMatching_(false), invertMatching_(false), next_(NULLPTR)
 {
     filter_ = filter;
 }
 
-TestFilter::TestFilter(const char* filter) : strictMatching_(false), invertMatching_(false), next_(NULL)
+TestFilter::TestFilter(const char* filter) : strictMatching_(false), invertMatching_(false), next_(NULLPTR)
 {
     filter_ = filter;
 }

--- a/src/CppUTest/TestHarness_c.cpp
+++ b/src/CppUTest/TestHarness_c.cpp
@@ -36,72 +36,72 @@ extern "C"
 
 void CHECK_EQUAL_C_BOOL_LOCATION(int expected, int actual, const char* fileName, int lineNumber)
 {
-    UtestShell::getCurrent()->assertEquals(!!expected != !!actual, expected ? "true" : "false", actual ? "true" : "false", NULL, fileName, lineNumber, TestTerminatorWithoutExceptions());
+    UtestShell::getCurrent()->assertEquals(!!expected != !!actual, expected ? "true" : "false", actual ? "true" : "false", NULLPTR, fileName, lineNumber, TestTerminatorWithoutExceptions());
 }
 
 void CHECK_EQUAL_C_INT_LOCATION(int expected, int actual, const char* fileName, int lineNumber)
 {
-    UtestShell::getCurrent()->assertLongsEqual((long)expected, (long)actual, NULL, fileName, lineNumber, TestTerminatorWithoutExceptions());
+    UtestShell::getCurrent()->assertLongsEqual((long)expected, (long)actual, NULLPTR, fileName, lineNumber, TestTerminatorWithoutExceptions());
 }
 
 void CHECK_EQUAL_C_UINT_LOCATION(unsigned int expected, unsigned int actual, const char* fileName, int lineNumber)
 {
-    UtestShell::getCurrent()->assertUnsignedLongsEqual((unsigned long)expected, (unsigned long)actual, NULL, fileName, lineNumber, TestTerminatorWithoutExceptions());
+    UtestShell::getCurrent()->assertUnsignedLongsEqual((unsigned long)expected, (unsigned long)actual, NULLPTR, fileName, lineNumber, TestTerminatorWithoutExceptions());
 }
 
 void CHECK_EQUAL_C_LONG_LOCATION(long expected, long actual, const char* fileName, int lineNumber)
 {
-    UtestShell::getCurrent()->assertLongsEqual(expected, actual, NULL, fileName, lineNumber, TestTerminatorWithoutExceptions());
+    UtestShell::getCurrent()->assertLongsEqual(expected, actual, NULLPTR, fileName, lineNumber, TestTerminatorWithoutExceptions());
 }
 
 void CHECK_EQUAL_C_ULONG_LOCATION(unsigned long expected, unsigned long actual, const char* fileName, int lineNumber)
 {
-    UtestShell::getCurrent()->assertUnsignedLongsEqual(expected, actual, NULL, fileName, lineNumber, TestTerminatorWithoutExceptions());
+    UtestShell::getCurrent()->assertUnsignedLongsEqual(expected, actual, NULLPTR, fileName, lineNumber, TestTerminatorWithoutExceptions());
 }
 
 void CHECK_EQUAL_C_LONGLONG_LOCATION(cpputest_longlong expected, cpputest_longlong actual, const char* fileName, int lineNumber)
 {
-    UtestShell::getCurrent()->assertLongLongsEqual(expected, actual, NULL, fileName, lineNumber, TestTerminatorWithoutExceptions());
+    UtestShell::getCurrent()->assertLongLongsEqual(expected, actual, NULLPTR, fileName, lineNumber, TestTerminatorWithoutExceptions());
 }
 
 void CHECK_EQUAL_C_ULONGLONG_LOCATION(cpputest_ulonglong expected, cpputest_ulonglong actual, const char* fileName, int lineNumber)
 {
-    UtestShell::getCurrent()->assertUnsignedLongLongsEqual(expected, actual, NULL, fileName, lineNumber, TestTerminatorWithoutExceptions());
+    UtestShell::getCurrent()->assertUnsignedLongLongsEqual(expected, actual, NULLPTR, fileName, lineNumber, TestTerminatorWithoutExceptions());
 }
 
 void CHECK_EQUAL_C_REAL_LOCATION(double expected, double actual, double threshold, const char* fileName, int lineNumber)
 {
-    UtestShell::getCurrent()->assertDoublesEqual(expected, actual, threshold, NULL, fileName, lineNumber, TestTerminatorWithoutExceptions());
+    UtestShell::getCurrent()->assertDoublesEqual(expected, actual, threshold, NULLPTR, fileName, lineNumber, TestTerminatorWithoutExceptions());
 }
 
 void CHECK_EQUAL_C_CHAR_LOCATION(char expected, char actual, const char* fileName, int lineNumber)
 {
-    UtestShell::getCurrent()->assertEquals(((expected) != (actual)), StringFrom(expected).asCharString(), StringFrom(actual).asCharString(), NULL, fileName, lineNumber, TestTerminatorWithoutExceptions());
+    UtestShell::getCurrent()->assertEquals(((expected) != (actual)), StringFrom(expected).asCharString(), StringFrom(actual).asCharString(), NULLPTR, fileName, lineNumber, TestTerminatorWithoutExceptions());
 }
 
 extern void CHECK_EQUAL_C_UBYTE_LOCATION(unsigned char expected, unsigned char actual, const char* fileName, int lineNumber)\
 {
-    UtestShell::getCurrent()->assertEquals(((expected) != (actual)),StringFrom((int)expected).asCharString(), StringFrom((int) actual).asCharString(), NULL, fileName, lineNumber, TestTerminatorWithoutExceptions());
+    UtestShell::getCurrent()->assertEquals(((expected) != (actual)),StringFrom((int)expected).asCharString(), StringFrom((int) actual).asCharString(), NULLPTR, fileName, lineNumber, TestTerminatorWithoutExceptions());
 }
 
 void CHECK_EQUAL_C_SBYTE_LOCATION(char signed expected, signed char actual, const char* fileName, int lineNumber)
 {
-    UtestShell::getCurrent()->assertEquals(((expected) != (actual)),StringFrom((int)expected).asCharString(), StringFrom((int) actual).asCharString(), NULL, fileName, lineNumber, TestTerminatorWithoutExceptions());
+    UtestShell::getCurrent()->assertEquals(((expected) != (actual)),StringFrom((int)expected).asCharString(), StringFrom((int) actual).asCharString(), NULLPTR, fileName, lineNumber, TestTerminatorWithoutExceptions());
 }
 
 void CHECK_EQUAL_C_STRING_LOCATION(const char* expected, const char* actual, const char* fileName, int lineNumber)
 {
-    UtestShell::getCurrent()->assertCstrEqual(expected, actual, NULL, fileName, lineNumber, TestTerminatorWithoutExceptions());
+    UtestShell::getCurrent()->assertCstrEqual(expected, actual, NULLPTR, fileName, lineNumber, TestTerminatorWithoutExceptions());
 }
 
 void CHECK_EQUAL_C_POINTER_LOCATION(const void* expected, const void* actual, const char* fileName, int lineNumber)
 {
-    UtestShell::getCurrent()->assertPointersEqual(expected, actual, NULL, fileName, lineNumber, TestTerminatorWithoutExceptions());
+    UtestShell::getCurrent()->assertPointersEqual(expected, actual, NULLPTR, fileName, lineNumber, TestTerminatorWithoutExceptions());
 }
 
 extern void CHECK_EQUAL_C_BITS_LOCATION(unsigned int expected, unsigned int actual, unsigned int mask, size_t size, const char* fileName, int lineNumber)
 {
-    UtestShell::getCurrent()->assertBitsEqual(expected, actual, mask, size, NULL, fileName, lineNumber, TestTerminatorWithoutExceptions());
+    UtestShell::getCurrent()->assertBitsEqual(expected, actual, mask, size, NULLPTR, fileName, lineNumber, TestTerminatorWithoutExceptions());
 }
 
 void FAIL_TEXT_C_LOCATION(const char* text, const char* fileName, int lineNumber)
@@ -116,7 +116,7 @@ void FAIL_C_LOCATION(const char* fileName, int lineNumber)
 
 void CHECK_C_LOCATION(int condition, const char* conditionString, const char* fileName, int lineNumber)
 {
-    UtestShell::getCurrent()->assertTrue(condition != 0, "CHECK_C", conditionString, NULL, fileName, lineNumber, TestTerminatorWithoutExceptions());
+    UtestShell::getCurrent()->assertTrue(condition != 0, "CHECK_C", conditionString, NULLPTR, fileName, lineNumber, TestTerminatorWithoutExceptions());
 }
 
 enum { NO_COUNTDOWN = -1, OUT_OF_MEMORRY = 0 };

--- a/src/CppUTest/TestMemoryAllocator.cpp
+++ b/src/CppUTest/TestMemoryAllocator.cpp
@@ -33,14 +33,14 @@
 static char* checkedMalloc(size_t size)
 {
     char* mem = (char*) PlatformSpecificMalloc(size);
-    if (mem == 0)
+    if (mem == NULLPTR)
     FAIL("malloc returned null pointer");
     return mem;
 }
 
-static TestMemoryAllocator* currentNewAllocator = 0;
-static TestMemoryAllocator* currentNewArrayAllocator = 0;
-static TestMemoryAllocator* currentMallocAllocator = 0;
+static TestMemoryAllocator* currentNewAllocator = NULLPTR;
+static TestMemoryAllocator* currentNewArrayAllocator = NULLPTR;
+static TestMemoryAllocator* currentMallocAllocator = NULLPTR;
 
 void setCurrentNewAllocator(TestMemoryAllocator* allocator)
 {
@@ -49,7 +49,7 @@ void setCurrentNewAllocator(TestMemoryAllocator* allocator)
 
 TestMemoryAllocator* getCurrentNewAllocator()
 {
-    if (currentNewAllocator == 0) setCurrentNewAllocatorToDefault();
+    if (currentNewAllocator == NULLPTR) setCurrentNewAllocatorToDefault();
     return currentNewAllocator;
 }
 
@@ -71,7 +71,7 @@ void setCurrentNewArrayAllocator(TestMemoryAllocator* allocator)
 
 TestMemoryAllocator* getCurrentNewArrayAllocator()
 {
-    if (currentNewArrayAllocator == 0) setCurrentNewArrayAllocatorToDefault();
+    if (currentNewArrayAllocator == NULLPTR) setCurrentNewArrayAllocatorToDefault();
     return currentNewArrayAllocator;
 }
 
@@ -93,7 +93,7 @@ void setCurrentMallocAllocator(TestMemoryAllocator* allocator)
 
 TestMemoryAllocator* getCurrentMallocAllocator()
 {
-    if (currentMallocAllocator == 0) setCurrentMallocAllocatorToDefault();
+    if (currentMallocAllocator == NULLPTR) setCurrentMallocAllocatorToDefault();
     return currentMallocAllocator;
 }
 
@@ -184,7 +184,7 @@ char* CrashOnAllocationAllocator::alloc_memory(size_t size, const char* file, in
 
 char* NullUnknownAllocator::alloc_memory(size_t /*size*/, const char*, int)
 {
-    return 0;
+    return NULLPTR;
 }
 
 void NullUnknownAllocator::free_memory(char* /*memory*/, const char*, int)
@@ -238,11 +238,11 @@ class LocationToFailAllocNode
     }
 
   private:
-    void init(LocationToFailAllocNode* next = NULL)
+    void init(LocationToFailAllocNode* next = NULLPTR)
     {
       allocNumberToFail_ = 0;
       actualAllocNumber_ = 0;
-      file_ = NULL;
+      file_ = NULLPTR;
       line_ = 0;
       next_ = next;
     }
@@ -250,7 +250,7 @@ class LocationToFailAllocNode
 };
 
 FailableMemoryAllocator::FailableMemoryAllocator(const char* name_str, const char* alloc_name_str, const char* free_name_str)
-: TestMemoryAllocator(name_str, alloc_name_str, free_name_str), head_(NULL), currentAllocNumber_(0)
+: TestMemoryAllocator(name_str, alloc_name_str, free_name_str), head_(NULLPTR), currentAllocNumber_(0)
 {
 }
 
@@ -272,7 +272,7 @@ char* FailableMemoryAllocator::alloc_memory(size_t size, const char* file, int l
 {
     currentAllocNumber_++;
     LocationToFailAllocNode* current = head_;
-    LocationToFailAllocNode* previous = NULL;
+    LocationToFailAllocNode* previous = NULLPTR;
 
     while (current) {
       if (current->shouldFail(currentAllocNumber_, file, line)) {
@@ -280,7 +280,7 @@ char* FailableMemoryAllocator::alloc_memory(size_t size, const char* file, int l
         else head_ = current->next_;
 
         free_memory((char*) current, __FILE__, __LINE__);
-        return NULL;
+        return NULLPTR;
       }
       previous = current;
       current = current->next_;

--- a/src/CppUTest/TestMemoryAllocator.cpp
+++ b/src/CppUTest/TestMemoryAllocator.cpp
@@ -149,17 +149,17 @@ void TestMemoryAllocator::free_memory(char* memory, const char*, int)
 {
     PlatformSpecificFree(memory);
 }
-const char* TestMemoryAllocator::name()
+const char* TestMemoryAllocator::name() const
 {
     return name_;
 }
 
-const char* TestMemoryAllocator::alloc_name()
+const char* TestMemoryAllocator::alloc_name() const
 {
     return alloc_name_;
 }
 
-const char* TestMemoryAllocator::free_name()
+const char* TestMemoryAllocator::free_name() const
 {
     return free_name_;
 }

--- a/src/CppUTest/TestOutput.cpp
+++ b/src/CppUTest/TestOutput.cpp
@@ -269,7 +269,7 @@ StringBufferTestOutput::~StringBufferTestOutput()
 }
 
 CompositeTestOutput::CompositeTestOutput()
-  : outputOne_(NULL), outputTwo_(NULL)
+  : outputOne_(NULLPTR), outputTwo_(NULLPTR)
 {
 }
 

--- a/src/CppUTest/TestPlugin.cpp
+++ b/src/CppUTest/TestPlugin.cpp
@@ -90,7 +90,7 @@ TestPlugin* TestPlugin::getNext()
 }
 TestPlugin* TestPlugin::removePluginByName(const SimpleString& name)
 {
-    TestPlugin* removed = 0;
+    TestPlugin* removed = NULLPTR;
     if (next_ && next_->getName() == name) {
         removed = next_;
         next_ = next_->next_;
@@ -150,7 +150,7 @@ void SetPointerPlugin::postTestAction(UtestShell& /*test*/, TestResult& /*result
 //////// NullPlugin
 
 NullTestPlugin::NullTestPlugin() :
-    TestPlugin(0)
+    TestPlugin(NULLPTR)
 {
 }
 

--- a/src/CppUTest/TestPlugin.cpp
+++ b/src/CppUTest/TestPlugin.cpp
@@ -62,10 +62,10 @@ void TestPlugin::runAllPostTestAction(UtestShell& test, TestResult& result)
 
 bool TestPlugin::parseAllArguments(int ac, char** av, int index)
 {
-    return parseAllArguments(ac, const_cast<const char**> (av), index);
+    return parseAllArguments(ac, const_cast<const char *const *> (av), index);
 }
 
-bool TestPlugin::parseAllArguments(int ac, const char** av, int index)
+bool TestPlugin::parseAllArguments(int ac, const char *const *av, int index)
 {
     if (parseArguments(ac, av, index)) return true;
     if (next_) return next_->parseAllArguments(ac, av, index);

--- a/src/CppUTest/TestRegistry.cpp
+++ b/src/CppUTest/TestRegistry.cpp
@@ -29,7 +29,7 @@
 #include "CppUTest/TestRegistry.h"
 
 TestRegistry::TestRegistry() :
-    tests_(NULL), nameFilters_(NULL), groupFilters_(NULL), firstPlugin_(NullTestPlugin::instance()), runInSeperateProcess_(false), currentRepetition_(0), runIgnored_(false)
+    tests_(NULLPTR), nameFilters_(NULLPTR), groupFilters_(NULLPTR), firstPlugin_(NullTestPlugin::instance()), runInSeperateProcess_(false), currentRepetition_(0), runIgnored_(false)
 
 {
 }
@@ -48,7 +48,7 @@ void TestRegistry::runAllTests(TestResult& result)
     bool groupStart = true;
 
     result.testsStarted();
-    for (UtestShell *test = tests_; test != NULL; test = test->getNext()) {
+    for (UtestShell *test = tests_; test != NULLPTR; test = test->getNext()) {
         if (runInSeperateProcess_) test->setRunInSeperateProcess();
         if (runIgnored_) test->setRunIgnored();
 
@@ -77,7 +77,7 @@ void TestRegistry::listTestGroupNames(TestResult& result)
 {
     SimpleString groupList;
 
-    for (UtestShell *test = tests_; test != NULL; test = test->getNext()) {
+    for (UtestShell *test = tests_; test != NULLPTR; test = test->getNext()) {
         SimpleString gname;
         gname += "#";
         gname += test->getGroup();
@@ -100,7 +100,7 @@ void TestRegistry::listTestGroupAndCaseNames(TestResult& result)
 {
     SimpleString groupAndNameList;
 
-    for (UtestShell *test = tests_; test != NULL; test = test->getNext()) {
+    for (UtestShell *test = tests_; test != NULLPTR; test = test->getNext()) {
         if (testShouldRun(test, result)) {
             SimpleString groupAndName;
             groupAndName += "#";
@@ -133,12 +133,12 @@ int TestRegistry::countTests()
     return tests_ ? tests_->countTests() : 0;
 }
 
-TestRegistry* TestRegistry::currentRegistry_ = 0;
+TestRegistry* TestRegistry::currentRegistry_ = NULLPTR;
 
 TestRegistry* TestRegistry::getCurrentRegistry()
 {
     static TestRegistry registry;
-    return (currentRegistry_ == 0) ? &registry : currentRegistry_;
+    return (currentRegistry_ == NULLPTR) ? &registry : currentRegistry_;
 }
 
 void TestRegistry::setCurrentRegistry(TestRegistry* registry)
@@ -148,7 +148,7 @@ void TestRegistry::setCurrentRegistry(TestRegistry* registry)
 
 void TestRegistry::unDoLastAddTest()
 {
-    tests_ = tests_ ? tests_->getNext() : NULL;
+    tests_ = tests_ ? tests_->getNext() : NULLPTR;
 
 }
 
@@ -243,7 +243,7 @@ UtestShell* TestRegistry::findTestWithName(const SimpleString& name)
             return current;
         current = current->getNext();
     }
-    return NULL;
+    return NULLPTR;
 }
 
 UtestShell* TestRegistry::findTestWithGroup(const SimpleString& group)
@@ -254,6 +254,6 @@ UtestShell* TestRegistry::findTestWithGroup(const SimpleString& group)
             return current;
         current = current->getNext();
     }
-    return NULL;
+    return NULLPTR;
 }
 

--- a/src/CppUTest/Utest.cpp
+++ b/src/CppUTest/Utest.cpp
@@ -132,12 +132,12 @@ extern "C" {
 /******************************** */
 
 UtestShell::UtestShell() :
-    group_("UndefinedTestGroup"), name_("UndefinedTest"), file_("UndefinedFile"), lineNumber_(0), next_(NULL), isRunAsSeperateProcess_(false), hasFailed_(false)
+    group_("UndefinedTestGroup"), name_("UndefinedTest"), file_("UndefinedFile"), lineNumber_(0), next_(NULLPTR), isRunAsSeperateProcess_(false), hasFailed_(false)
 {
 }
 
 UtestShell::UtestShell(const char* groupName, const char* testName, const char* fileName, int lineNumber) :
-    group_(groupName), name_(testName), file_(fileName), lineNumber_(lineNumber), next_(NULL), isRunAsSeperateProcess_(false), hasFailed_(false)
+    group_(groupName), name_(testName), file_(fileName), lineNumber_(lineNumber), next_(NULLPTR), isRunAsSeperateProcess_(false), hasFailed_(false)
 {
 }
 
@@ -153,7 +153,7 @@ UtestShell::~UtestShell()
 // LCOV_EXCL_START - actually covered but not in .gcno due to race condition
 static void defaultCrashMethod()
 {
-    UtestShell* ptr = (UtestShell*) 0x0; ptr->countTests();
+    UtestShell* ptr = (UtestShell*) NULLPTR; ptr->countTests();
 }
 // LCOV_EXCL_STOP
 
@@ -322,9 +322,9 @@ int UtestShell::getLineNumber() const
 
 bool UtestShell::match(const char* target, const TestFilter* filters) const
 {
-    if(filters == NULL) return true;
+    if(filters == NULLPTR) return true;
 
-    for(; filters != NULL; filters = filters->getNext())
+    for(; filters != NULLPTR; filters = filters->getNext())
         if(filters->match(target)) return true;
 
     return false;
@@ -368,8 +368,8 @@ void UtestShell::fail(const char *text, const char* fileName, int lineNumber, co
 void UtestShell::assertCstrEqual(const char* expected, const char* actual, const char* text, const char* fileName, int lineNumber, const TestTerminator& testTerminator)
 {
     getTestResult()->countCheck();
-    if (actual == 0 && expected == 0) return;
-    if (actual == 0 || expected == 0)
+    if (actual == NULLPTR && expected == NULLPTR) return;
+    if (actual == NULLPTR || expected == NULLPTR)
         failWith(StringEqualFailure(this, fileName, lineNumber, expected, actual, text), testTerminator);
     if (SimpleString::StrCmp(expected, actual) != 0)
         failWith(StringEqualFailure(this, fileName, lineNumber, expected, actual, text), testTerminator);
@@ -378,8 +378,8 @@ void UtestShell::assertCstrEqual(const char* expected, const char* actual, const
 void UtestShell::assertCstrNEqual(const char* expected, const char* actual, size_t length, const char* text, const char* fileName, int lineNumber, const TestTerminator& testTerminator)
 {
     getTestResult()->countCheck();
-    if (actual == 0 && expected == 0) return;
-    if (actual == 0 || expected == 0)
+    if (actual == NULLPTR && expected == NULLPTR) return;
+    if (actual == NULLPTR || expected == NULLPTR)
         failWith(StringEqualFailure(this, fileName, lineNumber, expected, actual, text), testTerminator);
     if (SimpleString::StrNCmp(expected, actual, length) != 0)
         failWith(StringEqualFailure(this, fileName, lineNumber, expected, actual, text), testTerminator);
@@ -388,8 +388,8 @@ void UtestShell::assertCstrNEqual(const char* expected, const char* actual, size
 void UtestShell::assertCstrNoCaseEqual(const char* expected, const char* actual, const char* text, const char* fileName, int lineNumber)
 {
     getTestResult()->countCheck();
-    if (actual == 0 && expected == 0) return;
-    if (actual == 0 || expected == 0)
+    if (actual == NULLPTR && expected == NULLPTR) return;
+    if (actual == NULLPTR || expected == NULLPTR)
         failWith(StringEqualNoCaseFailure(this, fileName, lineNumber, expected, actual, text));
     if (!SimpleString(expected).equalsNoCase(actual))
         failWith(StringEqualNoCaseFailure(this, fileName, lineNumber, expected, actual, text));
@@ -398,8 +398,8 @@ void UtestShell::assertCstrNoCaseEqual(const char* expected, const char* actual,
 void UtestShell::assertCstrContains(const char* expected, const char* actual, const char* text, const char* fileName, int lineNumber)
 {
     getTestResult()->countCheck();
-    if (actual == 0 && expected == 0) return;
-    if(actual == 0 || expected == 0)
+    if (actual == NULLPTR && expected == NULLPTR) return;
+    if (actual == NULLPTR || expected == NULLPTR)
         failWith(ContainsFailure(this, fileName, lineNumber, expected, actual, text));
     if (!SimpleString(actual).contains(expected))
         failWith(ContainsFailure(this, fileName, lineNumber, expected, actual, text));
@@ -408,8 +408,8 @@ void UtestShell::assertCstrContains(const char* expected, const char* actual, co
 void UtestShell::assertCstrNoCaseContains(const char* expected, const char* actual, const char* text, const char* fileName, int lineNumber)
 {
     getTestResult()->countCheck();
-    if (actual == 0 && expected == 0) return;
-    if(actual == 0 || expected == 0)
+    if (actual == NULLPTR && expected == NULLPTR) return;
+    if (actual == NULLPTR || expected == NULLPTR)
         failWith(ContainsFailure(this, fileName, lineNumber, expected, actual, text));
     if (!SimpleString(actual).containsNoCase(expected))
         failWith(ContainsFailure(this, fileName, lineNumber, expected, actual, text));
@@ -486,8 +486,8 @@ void UtestShell::assertDoublesEqual(double expected, double actual, double thres
 void UtestShell::assertBinaryEqual(const void *expected, const void *actual, size_t length, const char* text, const char *fileName, int lineNumber, const TestTerminator& testTerminator)
 {
     getTestResult()->countCheck();
-    if (actual == 0 && expected == 0) return;
-    if (actual == 0 || expected == 0)
+    if (actual == NULLPTR && expected == NULLPTR) return;
+    if (actual == NULLPTR || expected == NULLPTR)
         failWith(BinaryEqualFailure(this, fileName, lineNumber, (const unsigned char *) expected, (const unsigned char *) actual, length, text), testTerminator);
     if (SimpleString::MemCmp(expected, actual, length) != 0)
         failWith(BinaryEqualFailure(this, fileName, lineNumber, (const unsigned char *) expected, (const unsigned char *) actual, length, text), testTerminator);
@@ -530,8 +530,8 @@ void UtestShell::print(const SimpleString& text, const char* fileName, int lineN
     print(text.asCharString(), fileName, lineNumber);
 }
 
-TestResult* UtestShell::testResult_ = NULL;
-UtestShell* UtestShell::currentTest_ = NULL;
+TestResult* UtestShell::testResult_ = NULLPTR;
+UtestShell* UtestShell::currentTest_ = NULLPTR;
 
 void UtestShell::setTestResult(TestResult* result)
 {
@@ -545,14 +545,14 @@ void UtestShell::setCurrentTest(UtestShell* test)
 
 TestResult* UtestShell::getTestResult()
 {
-    if (testResult_ == NULL)
+    if (testResult_ == NULLPTR)
         return &OutsideTestRunnerUTest::instance().getTestResult();
     return testResult_;
 }
 
 UtestShell* UtestShell::getCurrent()
 {
-    if (currentTest_ == NULL)
+    if (currentTest_ == NULLPTR)
         return &OutsideTestRunnerUTest::instance();
     return currentTest_;
 }

--- a/src/CppUTestExt/CodeMemoryReportFormatter.cpp
+++ b/src/CppUTestExt/CodeMemoryReportFormatter.cpp
@@ -44,7 +44,7 @@ struct CodeReportingAllocationNode
 };
 
 CodeMemoryReportFormatter::CodeMemoryReportFormatter(TestMemoryAllocator* internalAllocator)
-    : codeReportingList_(NULL), internalAllocator_(internalAllocator)
+    : codeReportingList_(NULLPTR), internalAllocator_(internalAllocator)
 {
 }
 
@@ -165,7 +165,7 @@ void CodeMemoryReportFormatter::report_free_memory(TestResult* result, TestMemor
     SimpleString variableName;
     CodeReportingAllocationNode* node = findNode(memory);
 
-    if (memory == NULL) variableName = "NULL";
+    if (memory == NULLPTR) variableName = "NULL";
     else variableName = node->variableName_;
 
     result->print(StringFromFormat("\t%s\n", getDeallocationString(allocator, variableName, file, line).asCharString()).asCharString());

--- a/src/CppUTestExt/MemoryReportAllocator.cpp
+++ b/src/CppUTestExt/MemoryReportAllocator.cpp
@@ -37,17 +37,17 @@ MemoryReportAllocator::~MemoryReportAllocator()
 {
 }
 
-const char* MemoryReportAllocator::name()
+const char* MemoryReportAllocator::name() const
 {
     return realAllocator_->name();
 }
 
-const char* MemoryReportAllocator::alloc_name()
+const char* MemoryReportAllocator::alloc_name() const
 {
     return realAllocator_->alloc_name();
 }
 
-const char* MemoryReportAllocator::free_name()
+const char* MemoryReportAllocator::free_name() const
 {
     return realAllocator_->free_name();
 }

--- a/src/CppUTestExt/MemoryReportAllocator.cpp
+++ b/src/CppUTestExt/MemoryReportAllocator.cpp
@@ -29,7 +29,7 @@
 #include "CppUTestExt/MemoryReportAllocator.h"
 #include "CppUTestExt/MemoryReportFormatter.h"
 
-MemoryReportAllocator::MemoryReportAllocator() : result_(NULL), realAllocator_(NULL), formatter_(NULL)
+MemoryReportAllocator::MemoryReportAllocator() : result_(NULLPTR), realAllocator_(NULLPTR), formatter_(NULLPTR)
 {
 }
 

--- a/src/CppUTestExt/MemoryReporterPlugin.cpp
+++ b/src/CppUTestExt/MemoryReporterPlugin.cpp
@@ -31,7 +31,7 @@
 #include "CppUTestExt/CodeMemoryReportFormatter.h"
 
 MemoryReporterPlugin::MemoryReporterPlugin()
-    : TestPlugin("MemoryReporterPlugin"), formatter_(NULL)
+    : TestPlugin("MemoryReporterPlugin"), formatter_(NULLPTR)
 {
 }
 
@@ -62,7 +62,7 @@ MemoryReportFormatter* MemoryReporterPlugin::createMemoryFormatter(const SimpleS
     else if (type == "code") {
         return new CodeMemoryReportFormatter(defaultMallocAllocator());
     }
-    return NULL;
+    return NULLPTR;
 }
 
 void MemoryReporterPlugin::destroyMemoryFormatter(MemoryReportFormatter* formatter)
@@ -104,7 +104,7 @@ void MemoryReporterPlugin::initializeAllocator(MemoryReportAllocator* allocator,
 
 void MemoryReporterPlugin::preTestAction(UtestShell& test, TestResult& result)
 {
-    if (formatter_ == NULL) return;
+    if (formatter_ == NULLPTR) return;
 
     initializeAllocator(&mallocAllocator, result);
     initializeAllocator(&newAllocator, result);
@@ -122,11 +122,11 @@ void MemoryReporterPlugin::preTestAction(UtestShell& test, TestResult& result)
 
 void MemoryReporterPlugin::postTestAction(UtestShell& test, TestResult& result)
 {
-    if (formatter_ == NULL) return;
+    if (formatter_ == NULLPTR) return;
 
     removeGlobalMemoryReportAllocators();
     formatter_->report_test_end(&result, test);
 
-    if (test.getNext() == NULL || test.getNext()->getGroup() != currentTestGroup_)
+    if (test.getNext() == NULLPTR || test.getNext()->getGroup() != currentTestGroup_)
         formatter_->report_testgroup_end(&result, test);
 }

--- a/src/CppUTestExt/MemoryReporterPlugin.cpp
+++ b/src/CppUTestExt/MemoryReporterPlugin.cpp
@@ -41,7 +41,7 @@ MemoryReporterPlugin::~MemoryReporterPlugin()
     destroyMemoryFormatter(formatter_);
 }
 
-bool MemoryReporterPlugin::parseArguments(int /* ac */, const char** av, int index)
+bool MemoryReporterPlugin::parseArguments(int /* ac */, const char *const *av, int index)
 {
     SimpleString argument (av[index]);
     if (argument.contains("-pmemoryreport=")) {

--- a/src/CppUTestExt/MockActualCall.cpp
+++ b/src/CppUTestExt/MockActualCall.cpp
@@ -50,8 +50,8 @@ SimpleString MockCheckedActualCall::getName() const
 }
 
 MockCheckedActualCall::MockCheckedActualCall(unsigned int callOrder, MockFailureReporter* reporter, const MockExpectedCallsList& allExpectations)
-    : callOrder_(callOrder), reporter_(reporter), state_(CALL_SUCCEED), expectationsChecked_(false), matchingExpectation_(NULL),
-      allExpectations_(allExpectations), outputParameterExpectations_(NULL)
+    : callOrder_(callOrder), reporter_(reporter), state_(CALL_SUCCEED), expectationsChecked_(false), matchingExpectation_(NULLPTR),
+      allExpectations_(allExpectations), outputParameterExpectations_(NULLPTR)
 {
     potentiallyMatchingExpectations_.addPotentiallyMatchingExpectations(allExpectations);
 }
@@ -130,7 +130,7 @@ void MockCheckedActualCall::discardCurrentlyMatchingExpectations()
     if (matchingExpectation_)
     {
         matchingExpectation_->resetActualCallMatchingState();
-        matchingExpectation_ = NULL;
+        matchingExpectation_ = NULLPTR;
     }
     potentiallyMatchingExpectations_.onlyKeepUnmatchingExpectations();
 }
@@ -294,7 +294,7 @@ MockActualCall& MockCheckedActualCall::withParameterOfType(const SimpleString& t
     MockNamedValue actualParameter(name);
     actualParameter.setConstObjectPointer(type, value);
 
-    if (actualParameter.getComparator() == NULL) {
+    if (actualParameter.getComparator() == NULLPTR) {
         MockNoWayToCompareCustomTypeFailure failure(getTest(), type);
         failTest(failure);
         return *this;
@@ -548,7 +548,7 @@ void MockCheckedActualCall::addOutputParameter(const SimpleString& name, const S
 {
     MockOutputParametersListNode* newNode = new MockOutputParametersListNode(name, type, ptr);
 
-    if (outputParameterExpectations_ == NULL)
+    if (outputParameterExpectations_ == NULLPTR)
         outputParameterExpectations_ = newNode;
     else {
         MockOutputParametersListNode* lastNode = outputParameterExpectations_;
@@ -560,7 +560,7 @@ void MockCheckedActualCall::addOutputParameter(const SimpleString& name, const S
 void MockCheckedActualCall::cleanUpOutputParameterList()
 {
     MockOutputParametersListNode* current = outputParameterExpectations_;
-    MockOutputParametersListNode* toBeDeleted = NULL;
+    MockOutputParametersListNode* toBeDeleted = NULLPTR;
 
     while (current) {
         toBeDeleted = current;
@@ -763,17 +763,17 @@ unsigned int MockActualCallTrace::returnUnsignedIntValue()
 
 void * MockActualCallTrace::returnPointerValue()
 {
-    return NULL;
+    return NULLPTR;
 }
 
 const void * MockActualCallTrace::returnConstPointerValue()
 {
-    return NULL;
+    return NULLPTR;
 }
 
 void (*MockActualCallTrace::returnFunctionPointerValue())()
 {
-    return NULL;
+    return NULLPTR;
 }
 
 const void * MockActualCallTrace::returnConstPointerValueOrDefault(const void *)

--- a/src/CppUTestExt/MockExpectedCall.cpp
+++ b/src/CppUTestExt/MockExpectedCall.cpp
@@ -54,7 +54,7 @@ SimpleString MockCheckedExpectedCall::getName() const
 MockCheckedExpectedCall::MockCheckedExpectedCall()
     : ignoreOtherParameters_(false), isActualCallMatchFinalized_(false),
       initialExpectedCallOrder_(NO_EXPECTED_CALL_ORDER), finalExpectedCallOrder_(NO_EXPECTED_CALL_ORDER),
-      outOfOrder_(false), returnValue_(""), objectPtr_(NULL), wasPassedToObject_(true),
+      outOfOrder_(false), returnValue_(""), objectPtr_(NULLPTR), wasPassedToObject_(true),
       actualCalls_(0), expectedCalls_(1)
 {
     inputParameters_ = new MockNamedValueList();
@@ -64,7 +64,7 @@ MockCheckedExpectedCall::MockCheckedExpectedCall()
 MockCheckedExpectedCall::MockCheckedExpectedCall(unsigned int numCalls)
     : ignoreOtherParameters_(false), isActualCallMatchFinalized_(false),
       initialExpectedCallOrder_(NO_EXPECTED_CALL_ORDER), finalExpectedCallOrder_(NO_EXPECTED_CALL_ORDER),
-      outOfOrder_(false), returnValue_(""), objectPtr_(NULL), wasPassedToObject_(true),
+      outOfOrder_(false), returnValue_(""), objectPtr_(NULLPTR), wasPassedToObject_(true),
       actualCalls_(0), expectedCalls_(numCalls)
 {
     inputParameters_ = new MockNamedValueList();
@@ -207,13 +207,13 @@ SimpleString MockCheckedExpectedCall::getInputParameterType(const SimpleString& 
 bool MockCheckedExpectedCall::hasInputParameterWithName(const SimpleString& name)
 {
     MockNamedValue * p = inputParameters_->getValueByName(name);
-    return p != NULL;
+    return p != NULLPTR;
 }
 
 bool MockCheckedExpectedCall::hasOutputParameterWithName(const SimpleString& name)
 {
     MockNamedValue * p = outputParameters_->getValueByName(name);
-    return p != NULL;
+    return p != NULLPTR;
 }
 
 MockNamedValue MockCheckedExpectedCall::getInputParameter(const SimpleString& name)
@@ -291,7 +291,7 @@ void MockCheckedExpectedCall::wasPassedToObject()
 
 void MockCheckedExpectedCall::resetActualCallMatchingState()
 {
-    wasPassedToObject_ = (objectPtr_ == NULL);
+    wasPassedToObject_ = (objectPtr_ == NULLPTR);
     isActualCallMatchFinalized_ = false;
 
     MockNamedValueListNode* p;
@@ -352,7 +352,7 @@ SimpleString MockCheckedExpectedCall::callToString()
         }
     }
 
-    if (inputParameters_->begin() == NULL && outputParameters_->begin() == NULL) {
+    if (inputParameters_->begin() == NULLPTR && outputParameters_->begin() == NULLPTR) {
         str += (ignoreOtherParameters_) ? "all parameters ignored" : "no parameters";
     } else {
         MockNamedValueListNode* p;

--- a/src/CppUTestExt/MockExpectedCallsList.cpp
+++ b/src/CppUTestExt/MockExpectedCallsList.cpp
@@ -29,7 +29,7 @@
 #include "CppUTestExt/MockExpectedCallsList.h"
 #include "CppUTestExt/MockCheckedExpectedCall.h"
 
-MockExpectedCallsList::MockExpectedCallsList() : head_(NULL)
+MockExpectedCallsList::MockExpectedCallsList() : head_(NULLPTR)
 {
 }
 
@@ -60,7 +60,7 @@ unsigned int MockExpectedCallsList::size() const
 
 bool MockExpectedCallsList::isEmpty() const
 {
-    return head_ == NULL;
+    return head_ == NULLPTR;
 }
 
 unsigned int MockExpectedCallsList::amountOfActualCallsFulfilledFor(const SimpleString& name) const
@@ -114,7 +114,7 @@ void MockExpectedCallsList::addExpectedCall(MockCheckedExpectedCall* call)
 {
     MockExpectedCallsListNode* newCall = new MockExpectedCallsListNode(call);
 
-    if (head_ == NULL)
+    if (head_ == NULLPTR)
         head_ = newCall;
     else {
         MockExpectedCallsListNode* lastCall = head_;
@@ -147,7 +147,7 @@ void MockExpectedCallsList::onlyKeepExpectationsRelatedTo(const SimpleString& na
 {
     for (MockExpectedCallsListNode* p = head_; p; p = p->next_)
         if (! p->expectedCall_->relatesTo(name))
-            p->expectedCall_ = NULL;
+            p->expectedCall_ = NULLPTR;
 
     pruneEmptyNodeFromList();
 }
@@ -156,7 +156,7 @@ void MockExpectedCallsList::onlyKeepOutOfOrderExpectations()
 {
     for (MockExpectedCallsListNode* p = head_; p; p = p->next_)
         if (!p->expectedCall_->isOutOfOrder())
-            p->expectedCall_ = NULL;
+            p->expectedCall_ = NULLPTR;
     pruneEmptyNodeFromList();
 }
 
@@ -166,7 +166,7 @@ void MockExpectedCallsList::onlyKeepUnmatchingExpectations()
         if (p->expectedCall_->isMatchingActualCallAndFinalized())
         {
             p->expectedCall_->resetActualCallMatchingState();
-            p->expectedCall_ = NULL;
+            p->expectedCall_ = NULLPTR;
         }
 
     pruneEmptyNodeFromList();
@@ -176,7 +176,7 @@ void MockExpectedCallsList::onlyKeepExpectationsWithInputParameterName(const Sim
 {
     for (MockExpectedCallsListNode* p = head_; p; p = p->next_)
         if (! p->expectedCall_->hasInputParameterWithName(name))
-            p->expectedCall_ = NULL;
+            p->expectedCall_ = NULLPTR;
     pruneEmptyNodeFromList();
 }
 
@@ -184,7 +184,7 @@ void MockExpectedCallsList::onlyKeepExpectationsWithOutputParameterName(const Si
 {
     for (MockExpectedCallsListNode* p = head_; p; p = p->next_)
         if (! p->expectedCall_->hasOutputParameterWithName(name))
-            p->expectedCall_ = NULL;
+            p->expectedCall_ = NULLPTR;
     pruneEmptyNodeFromList();
 }
 
@@ -192,7 +192,7 @@ void MockExpectedCallsList::onlyKeepExpectationsWithInputParameter(const MockNam
 {
     for (MockExpectedCallsListNode* p = head_; p; p = p->next_)
         if (! p->expectedCall_->hasInputParameter(parameter))
-            p->expectedCall_ = NULL;
+            p->expectedCall_ = NULLPTR;
     pruneEmptyNodeFromList();
 }
 
@@ -200,7 +200,7 @@ void MockExpectedCallsList::onlyKeepExpectationsWithOutputParameter(const MockNa
 {
     for (MockExpectedCallsListNode* p = head_; p; p = p->next_)
         if (! p->expectedCall_->hasOutputParameter(parameter))
-            p->expectedCall_ = NULL;
+            p->expectedCall_ = NULLPTR;
     pruneEmptyNodeFromList();
 }
 
@@ -208,7 +208,7 @@ void MockExpectedCallsList::onlyKeepExpectationsOnObject(const void* objectPtr)
 {
     for (MockExpectedCallsListNode* p = head_; p; p = p->next_)
         if (! p->expectedCall_->relatesToObject(objectPtr))
-            p->expectedCall_ = NULL;
+            p->expectedCall_ = NULLPTR;
     pruneEmptyNodeFromList();
 }
 
@@ -217,12 +217,12 @@ MockCheckedExpectedCall* MockExpectedCallsList::removeFirstFinalizedMatchingExpe
     for (MockExpectedCallsListNode* p = head_; p; p = p->next_) {
         if (p->expectedCall_->isMatchingActualCallAndFinalized()) {
             MockCheckedExpectedCall* matchingCall = p->expectedCall_;
-            p->expectedCall_ = NULL;
+            p->expectedCall_ = NULLPTR;
             pruneEmptyNodeFromList();
             return matchingCall;
         }
     }
-    return NULL;
+    return NULLPTR;
 }
 
 MockCheckedExpectedCall* MockExpectedCallsList::getFirstMatchingExpectation()
@@ -232,7 +232,7 @@ MockCheckedExpectedCall* MockExpectedCallsList::getFirstMatchingExpectation()
             return p->expectedCall_;
         }
     }
-    return NULL;
+    return NULLPTR;
 }
 
 MockCheckedExpectedCall* MockExpectedCallsList::removeFirstMatchingExpectation()
@@ -240,24 +240,24 @@ MockCheckedExpectedCall* MockExpectedCallsList::removeFirstMatchingExpectation()
     for (MockExpectedCallsListNode* p = head_; p; p = p->next_) {
         if (p->expectedCall_->isMatchingActualCall()) {
             MockCheckedExpectedCall* matchingCall = p->expectedCall_;
-            p->expectedCall_ = NULL;
+            p->expectedCall_ = NULLPTR;
             pruneEmptyNodeFromList();
             return matchingCall;
         }
     }
-    return NULL;
+    return NULLPTR;
 }
 
 void MockExpectedCallsList::pruneEmptyNodeFromList()
 {
     MockExpectedCallsListNode* current = head_;
-    MockExpectedCallsListNode* previous = NULL;
-    MockExpectedCallsListNode* toBeDeleted = NULL;
+    MockExpectedCallsListNode* previous = NULLPTR;
+    MockExpectedCallsListNode* toBeDeleted = NULLPTR;
 
     while (current) {
-        if (current->expectedCall_ == NULL) {
+        if (current->expectedCall_ == NULLPTR) {
             toBeDeleted = current;
-            if (previous == NULL)
+            if (previous == NULLPTR)
                 head_ = current = current->next_;
             else
                 current = previous->next_ = current->next_;

--- a/src/CppUTestExt/MockNamedValue.cpp
+++ b/src/CppUTestExt/MockNamedValue.cpp
@@ -30,14 +30,14 @@
 #include "CppUTest/PlatformSpecificFunctions.h"
 
 
-MockNamedValueComparatorsAndCopiersRepository* MockNamedValue::defaultRepository_ = NULL;
+MockNamedValueComparatorsAndCopiersRepository* MockNamedValue::defaultRepository_ = NULLPTR;
 
 void MockNamedValue::setDefaultComparatorsAndCopiersRepository(MockNamedValueComparatorsAndCopiersRepository* repository)
 {
     defaultRepository_ = repository;
 }
 
-MockNamedValue::MockNamedValue(const SimpleString& name) : name_(name), type_("int"), size_(0), comparator_(NULL), copier_(NULL)
+MockNamedValue::MockNamedValue(const SimpleString& name) : name_(name), type_("int"), size_(0), comparator_(NULLPTR), copier_(NULLPTR)
 {
     value_.intValue_ = 0;
 }
@@ -393,7 +393,7 @@ void MockNamedValueListNode::destroy()
 }
 
 MockNamedValueListNode::MockNamedValueListNode(MockNamedValue* newValue)
-    : data_(newValue), next_(NULL)
+    : data_(newValue), next_(NULLPTR)
 {
 }
 
@@ -407,7 +407,7 @@ SimpleString MockNamedValueListNode::getType() const
     return data_->getType();
 }
 
-MockNamedValueList::MockNamedValueList() : head_(NULL)
+MockNamedValueList::MockNamedValueList() : head_(NULLPTR)
 {
 }
 
@@ -424,7 +424,7 @@ void MockNamedValueList::clear()
 void MockNamedValueList::add(MockNamedValue* newValue)
 {
     MockNamedValueListNode* newNode = new MockNamedValueListNode(newValue);
-    if (head_ == NULL)
+    if (head_ == NULLPTR)
         head_ = newNode;
     else {
         MockNamedValueListNode* lastNode = head_;
@@ -438,7 +438,7 @@ MockNamedValue* MockNamedValueList::getValueByName(const SimpleString& name)
     for (MockNamedValueListNode * p = head_; p; p = p->next())
         if (p->getName() == name)
             return p->item();
-    return NULL;
+    return NULLPTR;
 }
 
 MockNamedValueListNode* MockNamedValueList::begin()
@@ -449,9 +449,9 @@ MockNamedValueListNode* MockNamedValueList::begin()
 struct MockNamedValueComparatorsAndCopiersRepositoryNode
 {
     MockNamedValueComparatorsAndCopiersRepositoryNode(const SimpleString& name, MockNamedValueComparator* comparator, MockNamedValueComparatorsAndCopiersRepositoryNode* next)
-        : name_(name), comparator_(comparator), copier_(NULL), next_(next) {}
+        : name_(name), comparator_(comparator), copier_(NULLPTR), next_(next) {}
     MockNamedValueComparatorsAndCopiersRepositoryNode(const SimpleString& name, MockNamedValueCopier* copier, MockNamedValueComparatorsAndCopiersRepositoryNode* next)
-        : name_(name), comparator_(NULL), copier_(copier), next_(next) {}
+        : name_(name), comparator_(NULLPTR), copier_(copier), next_(next) {}
     MockNamedValueComparatorsAndCopiersRepositoryNode(const SimpleString& name, MockNamedValueComparator* comparator, MockNamedValueCopier* copier, MockNamedValueComparatorsAndCopiersRepositoryNode* next)
         : name_(name), comparator_(comparator), copier_(copier), next_(next) {}
     SimpleString name_;
@@ -460,7 +460,7 @@ struct MockNamedValueComparatorsAndCopiersRepositoryNode
     MockNamedValueComparatorsAndCopiersRepositoryNode* next_;
 };
 
-MockNamedValueComparatorsAndCopiersRepository::MockNamedValueComparatorsAndCopiersRepository() : head_(NULL)
+MockNamedValueComparatorsAndCopiersRepository::MockNamedValueComparatorsAndCopiersRepository() : head_(NULLPTR)
 {
 
 }
@@ -493,14 +493,14 @@ MockNamedValueComparator* MockNamedValueComparatorsAndCopiersRepository::getComp
 {
     for (MockNamedValueComparatorsAndCopiersRepositoryNode* p = head_; p; p = p->next_)
             if (p->name_ == name && p->comparator_) return p->comparator_;
-    return NULL;
+    return NULLPTR;
 }
 
 MockNamedValueCopier* MockNamedValueComparatorsAndCopiersRepository::getCopierForType(const SimpleString& name)
 {
     for (MockNamedValueComparatorsAndCopiersRepositoryNode* p = head_; p; p = p->next_)
             if (p->name_ == name && p->copier_) return p->copier_;
-    return NULL;
+    return NULLPTR;
 }
 
 void MockNamedValueComparatorsAndCopiersRepository::installComparatorsAndCopiers(const MockNamedValueComparatorsAndCopiersRepository& repository)

--- a/src/CppUTestExt/MockSupport.cpp
+++ b/src/CppUTestExt/MockSupport.cpp
@@ -44,9 +44,9 @@ MockSupport& mock(const SimpleString& mockName, MockFailureReporter* failureRepo
 }
 
 MockSupport::MockSupport(const SimpleString& mockName)
-    : actualCallOrder_(0), expectedCallOrder_(0), strictOrdering_(false), standardReporter_(&defaultReporter_), ignoreOtherCalls_(false), enabled_(true), lastActualFunctionCall_(NULL), mockName_(mockName), tracing_(false)
+    : actualCallOrder_(0), expectedCallOrder_(0), strictOrdering_(false), standardReporter_(&defaultReporter_), ignoreOtherCalls_(false), enabled_(true), lastActualFunctionCall_(NULLPTR), mockName_(mockName), tracing_(false)
 {
-    setActiveReporter(NULL);
+    setActiveReporter(NULLPTR);
 }
 
 MockSupport::~MockSupport()
@@ -60,7 +60,7 @@ void MockSupport::crashOnFailure(bool shouldCrash)
 
 void MockSupport::setMockFailureStandardReporter(MockFailureReporter* reporter)
 {
-    standardReporter_ = (reporter != NULL) ? reporter : &defaultReporter_;
+    standardReporter_ = (reporter != NULLPTR) ? reporter : &defaultReporter_;
 
     if (lastActualFunctionCall_)
         lastActualFunctionCall_->setMockFailureReporter(standardReporter_);
@@ -113,7 +113,7 @@ void MockSupport::removeAllComparatorsAndCopiers()
 void MockSupport::clear()
 {
     delete lastActualFunctionCall_;
-    lastActualFunctionCall_ = NULL;
+    lastActualFunctionCall_ = NULLPTR;
 
     tracing_ = false;
     MockActualCallTrace::instance().clear();
@@ -202,7 +202,7 @@ MockActualCall& MockSupport::actualCall(const SimpleString& functionName)
     if (lastActualFunctionCall_) {
         lastActualFunctionCall_->checkExpectations();
         delete lastActualFunctionCall_;
-        lastActualFunctionCall_ = NULL;
+        lastActualFunctionCall_ = NULLPTR;
     }
 
     if (!enabled_) return MockIgnoredActualCall::instance();
@@ -352,13 +352,13 @@ void MockSupport::checkExpectations()
 
 bool MockSupport::hasData(const SimpleString& name)
 {
-    return data_.getValueByName(name) != NULL;
+    return data_.getValueByName(name) != NULLPTR;
 }
 
 MockNamedValue* MockSupport::retrieveDataFromStore(const SimpleString& name)
 {
     MockNamedValue* newData = data_.getValueByName(name);
-    if (newData == NULL) {
+    if (newData == NULLPTR) {
         newData = new MockNamedValue(name);
         data_.add(newData);
     }
@@ -428,7 +428,7 @@ void MockSupport::setDataConstObject(const SimpleString& name, const SimpleStrin
 MockNamedValue MockSupport::getData(const SimpleString& name)
 {
     MockNamedValue* value = data_.getValueByName(name);
-    if (value == NULL)
+    if (value == NULLPTR)
         return MockNamedValue("");
     return *value;
 }
@@ -468,7 +468,7 @@ MockSupport* MockSupport::getMockSupport(MockNamedValueListNode* node)
 {
     if (node->getType() == "MockSupport" && node->getName().contains(MOCK_SUPPORT_SCOPE_PREFIX))
         return static_cast<MockSupport*>( const_cast<void*>( node->item()->getObjectPointer() ) );
-    return NULL;
+    return NULLPTR;
 }
 
 MockNamedValue MockSupport::returnValue()

--- a/src/CppUTestExt/MockSupport.cpp
+++ b/src/CppUTestExt/MockSupport.cpp
@@ -455,7 +455,7 @@ MockSupport* MockSupport::getMockSupportScope(const SimpleString& name)
 
     if (hasData(mockingSupportName)) {
         STRCMP_EQUAL("MockSupport", getData(mockingSupportName).getType().asCharString());
-        return static_cast<MockSupport*>( const_cast<void*>( getData(mockingSupportName).getObjectPointer() ) );
+        return (MockSupport*) getData(mockingSupportName).getObjectPointer();
     }
 
     MockSupport *newMock = clone(name);
@@ -467,7 +467,7 @@ MockSupport* MockSupport::getMockSupportScope(const SimpleString& name)
 MockSupport* MockSupport::getMockSupport(MockNamedValueListNode* node)
 {
     if (node->getType() == "MockSupport" && node->getName().contains(MOCK_SUPPORT_SCOPE_PREFIX))
-        return static_cast<MockSupport*>( const_cast<void*>( node->item()->getObjectPointer() ) );
+        return (MockSupport*) node->item()->getObjectPointer();
     return NULLPTR;
 }
 

--- a/src/CppUTestExt/MockSupport.cpp
+++ b/src/CppUTestExt/MockSupport.cpp
@@ -455,7 +455,7 @@ MockSupport* MockSupport::getMockSupportScope(const SimpleString& name)
 
     if (hasData(mockingSupportName)) {
         STRCMP_EQUAL("MockSupport", getData(mockingSupportName).getType().asCharString());
-        return (MockSupport*) getData(mockingSupportName).getObjectPointer();
+        return static_cast<MockSupport*>( const_cast<void*>( getData(mockingSupportName).getObjectPointer() ) );
     }
 
     MockSupport *newMock = clone(name);
@@ -467,7 +467,7 @@ MockSupport* MockSupport::getMockSupportScope(const SimpleString& name)
 MockSupport* MockSupport::getMockSupport(MockNamedValueListNode* node)
 {
     if (node->getType() == "MockSupport" && node->getName().contains(MOCK_SUPPORT_SCOPE_PREFIX))
-        return  (MockSupport*) node->item()->getObjectPointer();
+        return static_cast<MockSupport*>( const_cast<void*>( node->item()->getObjectPointer() ) );
     return NULL;
 }
 

--- a/src/CppUTestExt/MockSupportPlugin.cpp
+++ b/src/CppUTestExt/MockSupportPlugin.cpp
@@ -72,7 +72,7 @@ void MockSupportPlugin::postTestAction(UtestShell& test, TestResult& result)
     if (!test.hasFailed())
         mock().checkExpectations();
     mock().clear();
-    mock().setMockFailureStandardReporter(NULL);
+    mock().setMockFailureStandardReporter(NULLPTR);
     mock().removeAllComparatorsAndCopiers();
 }
 

--- a/src/CppUTestExt/MockSupport_c.cpp
+++ b/src/CppUTestExt/MockSupport_c.cpp
@@ -49,7 +49,7 @@ public:
         TestTerminatorWithoutExceptions::exitCurrentTest();
     } // LCOV_EXCL_LINE
     // LCOV_EXCL_START
-    virtual ~MockFailureReporterTestTerminatorForInCOnlyCode()
+    virtual ~MockFailureReporterTestTerminatorForInCOnlyCode() _destructor_override
     {
     }
     // LCOV_EXCL_STOP
@@ -69,9 +69,9 @@ public:
 
 };
 
-static MockSupport* currentMockSupport = NULL;
-static MockExpectedCall* expectedCall = NULL;
-static MockActualCall* actualCall = NULL;
+static MockSupport* currentMockSupport = NULLPTR;
+static MockExpectedCall* expectedCall = NULLPTR;
+static MockActualCall* actualCall = NULLPTR;
 static MockFailureReporterForInCOnlyCode failureReporterForC;
 
 class MockCFunctionComparatorNode : public MockNamedValueComparator
@@ -79,7 +79,7 @@ class MockCFunctionComparatorNode : public MockNamedValueComparator
 public:
     MockCFunctionComparatorNode(MockCFunctionComparatorNode* next, MockTypeEqualFunction_c equal, MockTypeValueToStringFunction_c toString)
         : next_(next), equal_(equal), toString_(toString) {}
-    virtual ~MockCFunctionComparatorNode() {}
+    virtual ~MockCFunctionComparatorNode() _destructor_override {}
 
     virtual bool isEqual(const void* object1, const void* object2) _override
     {
@@ -95,14 +95,14 @@ public:
     MockTypeValueToStringFunction_c toString_;
 };
 
-static MockCFunctionComparatorNode* comparatorList_ = NULL;
+static MockCFunctionComparatorNode* comparatorList_ = NULLPTR;
 
 class MockCFunctionCopierNode : public MockNamedValueCopier
 {
 public:
     MockCFunctionCopierNode(MockCFunctionCopierNode* next, MockTypeCopyFunction_c copier)
         : next_(next), copier_(copier) {}
-    virtual ~MockCFunctionCopierNode() {}
+    virtual ~MockCFunctionCopierNode() _destructor_override {}
 
     virtual void copy(void* dst, const void* src) _override
     {
@@ -113,7 +113,7 @@ public:
     MockTypeCopyFunction_c copier_;
 };
 
-static MockCFunctionCopierNode* copierList_ = NULL;
+static MockCFunctionCopierNode* copierList_ = NULLPTR;
 
 extern "C" {
 

--- a/src/CppUTestExt/OrderedTest.cpp
+++ b/src/CppUTestExt/OrderedTest.cpp
@@ -29,10 +29,10 @@
 #include "CppUTest/TestRegistry.h"
 #include "CppUTestExt/OrderedTest.h"
 
-OrderedTestShell* OrderedTestShell::_orderedTestsHead = 0;
+OrderedTestShell* OrderedTestShell::_orderedTestsHead = NULLPTR;
 
 OrderedTestShell::OrderedTestShell() :
-    _nextOrderedTest(0), _level(0)
+    _nextOrderedTest(NULLPTR), _level(0)
 {
 }
 
@@ -62,7 +62,7 @@ OrderedTestShell* OrderedTestShell::getOrderedTestHead()
 
 bool OrderedTestShell::firstOrderedTest()
 {
-    return (getOrderedTestHead() == 0);
+    return (getOrderedTestHead() == NULLPTR);
 }
 
 OrderedTestShell* OrderedTestShell::addOrderedTest(OrderedTestShell* test)
@@ -77,7 +77,7 @@ void OrderedTestShell::addOrderedTestToHead(OrderedTestShell* test)
     TestRegistry *reg = TestRegistry::getCurrentRegistry();
     UtestShell* head = getOrderedTestHead();
 
-    if (NULL == reg->getFirstTest() || head == reg->getFirstTest()) {
+    if (NULLPTR == reg->getFirstTest() || head == reg->getFirstTest()) {
         reg->addTest(test);
     }
     else {

--- a/src/Platforms/Gcc/UtestPlatform.cpp
+++ b/src/Platforms/Gcc/UtestPlatform.cpp
@@ -184,7 +184,7 @@ static long TimeInMillisImplementation()
 
 static const char* TimeStringImplementation()
 {
-    time_t tm = time(NULL);
+    time_t tm = time(NULLPTR);
     static char dateTime[80];
     struct tm *tmp = localtime(&tm);
     strftime(dateTime, 80, "%Y-%m-%dT%H:%M:%S", tmp);
@@ -263,7 +263,7 @@ static PlatformSpecificMutex PThreadMutexCreate(void)
 {
     pthread_mutex_t *mutex = new pthread_mutex_t;
 
-    pthread_mutex_init(mutex, NULL);
+    pthread_mutex_init(mutex, NULLPTR);
 
     return (PlatformSpecificMutex)mutex;
 }

--- a/src/Platforms/Gcc/UtestPlatform.cpp
+++ b/src/Platforms/Gcc/UtestPlatform.cpp
@@ -199,6 +199,9 @@ const char* (*GetPlatformSpecificTimeString)() = TimeStringImplementation;
 #pragma clang diagnostic ignored "-Wformat-nonliteral"
 #endif
 
+#ifdef __clang__
+#pragma clang diagnostic ignored "-Wused-but-marked-unused"
+#endif
 int (*PlatformSpecificVSNprintf)(char *str, size_t size, const char* format, va_list va_args_list) = vsnprintf;
 
 static PlatformSpecificFile PlatformSpecificFOpenImplementation(const char* filename, const char* flag)

--- a/tests/CppUTest/AllTests.cpp
+++ b/tests/CppUTest/AllTests.cpp
@@ -27,12 +27,12 @@
 
 #include "CppUTest/CommandLineTestRunner.h"
 
-int main(int ac, const char** av)
+int main(int ac, char **av)
 {
     /* These checks are here to make sure assertions outside test runs don't crash */
     CHECK(true);
     LONGS_EQUAL(1, 1);
 
-    return CommandLineTestRunner::RunAllTests(ac, const_cast<char**>(av)); /* cover alternate method */
+    return CommandLineTestRunner::RunAllTests(ac, av); /* cover alternate method */
 }
 

--- a/tests/CppUTest/CommandLineArgumentsTest.cpp
+++ b/tests/CppUTest/CommandLineArgumentsTest.cpp
@@ -53,7 +53,7 @@ TEST_GROUP(CommandLineArguments)
     void setup()
     {
         plugin = new OptionsPlugin("options");
-        args = NULL;
+        args = NULLPTR;
     }
     void teardown()
     {
@@ -391,8 +391,8 @@ TEST(CommandLineArguments, checkDefaultArguments)
     CHECK(newArgumentParser(argc, argv));
     CHECK(!args->isVerbose());
     LONGS_EQUAL(1, args->getRepeatCount());
-    CHECK(NULL == args->getGroupFilters());
-    CHECK(NULL == args->getNameFilters());
+    CHECK(NULLPTR == args->getGroupFilters());
+    CHECK(NULLPTR == args->getNameFilters());
     CHECK(args->isEclipseOutput());
     CHECK(SimpleString("") == args->getPackageName());
 }

--- a/tests/CppUTest/CommandLineArgumentsTest.cpp
+++ b/tests/CppUTest/CommandLineArgumentsTest.cpp
@@ -39,7 +39,7 @@ public:
     ~OptionsPlugin()
     {
     }
-    bool parseArguments(int /*ac*/, const char** /*av*/, int /*index*/)
+    bool parseArguments(int /*ac*/, const char *const * /*av*/, int /*index*/)
     {
         return true;
     }
@@ -61,7 +61,7 @@ TEST_GROUP(CommandLineArguments)
         delete plugin;
     }
 
-    bool newArgumentParser(int argc, const char** argv)
+    bool newArgumentParser(int argc, const char *const *argv)
     {
         args = new CommandLineArguments(argc, argv);
         return args->parse(plugin);

--- a/tests/CppUTest/CommandLineTestRunnerTest.cpp
+++ b/tests/CppUTest/CommandLineTestRunnerTest.cpp
@@ -47,7 +47,7 @@ public:
     {
     }
 
-    virtual bool parseArguments(int, const char**, int)
+    virtual bool parseArguments(int, const char *const *, int)
     {
         /* Remove ourselves from the count */
         amountOfPlugins = registry_->countPlugins() - 1;
@@ -64,7 +64,7 @@ public:
   StringBufferTestOutput* fakeConsoleOutputWhichIsReallyABuffer;
   StringBufferTestOutput* fakeTCOutputWhichIsReallyABuffer;
 
-  CommandLineTestRunnerWithStringBufferOutput(int argc, const char** argv, TestRegistry* registry)
+  CommandLineTestRunnerWithStringBufferOutput(int argc, const char *const *argv, TestRegistry* registry)
     : CommandLineTestRunner(argc, argv, registry), fakeJUnitOutputWhichIsReallyABuffer_(NULL),
     fakeConsoleOutputWhichIsReallyABuffer(NULL), fakeTCOutputWhichIsReallyABuffer(NULL)
   {}

--- a/tests/CppUTest/CommandLineTestRunnerTest.cpp
+++ b/tests/CppUTest/CommandLineTestRunnerTest.cpp
@@ -65,8 +65,8 @@ public:
   StringBufferTestOutput* fakeTCOutputWhichIsReallyABuffer;
 
   CommandLineTestRunnerWithStringBufferOutput(int argc, const char *const *argv, TestRegistry* registry)
-    : CommandLineTestRunner(argc, argv, registry), fakeJUnitOutputWhichIsReallyABuffer_(NULL),
-    fakeConsoleOutputWhichIsReallyABuffer(NULL), fakeTCOutputWhichIsReallyABuffer(NULL)
+    : CommandLineTestRunner(argc, argv, registry), fakeJUnitOutputWhichIsReallyABuffer_(NULLPTR),
+    fakeConsoleOutputWhichIsReallyABuffer(NULLPTR), fakeTCOutputWhichIsReallyABuffer(NULLPTR)
   {}
 
   TestOutput* createConsoleOutput()
@@ -137,7 +137,7 @@ TEST(CommandLineTestRunner, TeamcityOutputEnabled)
     const char* argv[] = {"tests.exe", "-oteamcity"};
     CommandLineTestRunnerWithStringBufferOutput commandLineTestRunner(2, argv, &registry);
     commandLineTestRunner.runAllTestsMain();
-    CHECK(commandLineTestRunner.fakeTCOutputWhichIsReallyABuffer);
+    CHECK(commandLineTestRunner.fakeTCOutputWhichIsReallyABuffer != NULLPTR);
 }
 
 TEST(CommandLineTestRunner, JunitOutputEnabled)
@@ -146,7 +146,7 @@ TEST(CommandLineTestRunner, JunitOutputEnabled)
 
     CommandLineTestRunnerWithStringBufferOutput commandLineTestRunner(2, argv, &registry);
     commandLineTestRunner.runAllTestsMain();
-    CHECK(commandLineTestRunner.fakeJUnitOutputWhichIsReallyABuffer_);
+    CHECK(commandLineTestRunner.fakeJUnitOutputWhichIsReallyABuffer_ != NULLPTR);
 }
 
 TEST(CommandLineTestRunner, JunitOutputAndVerboseEnabled)
@@ -205,7 +205,7 @@ struct FakeOutput
     }
     static PlatformSpecificFile fopen_fake(const char*, const char*)
     {
-        return (PlatformSpecificFile)0;
+        return (PlatformSpecificFile) NULLPTR;
     }
     static void fputs_fake(const char* str, PlatformSpecificFile)
     {

--- a/tests/CppUTest/JUnitOutputTest.cpp
+++ b/tests/CppUTest/JUnitOutputTest.cpp
@@ -94,7 +94,7 @@ class FileSystemForJUnitTestOutputTests
     FileForJUnitOutputTests* firstFile_;
 
 public:
-    FileSystemForJUnitTestOutputTests() : firstFile_(0) {}
+    FileSystemForJUnitTestOutputTests() : firstFile_(NULLPTR) {}
     ~FileSystemForJUnitTestOutputTests() { clear(); }
 
     void clear(void)
@@ -114,7 +114,7 @@ public:
 
     int amountOfFiles() {
         int totalAmountOfFiles = 0;
-        for (FileForJUnitOutputTests* current = firstFile_; current != NULL; current = current->nextFile())
+        for (FileForJUnitOutputTests* current = firstFile_; current != NULLPTR; current = current->nextFile())
             totalAmountOfFiles++;
         return totalAmountOfFiles;
     }
@@ -122,15 +122,15 @@ public:
     bool fileExists(const char* filename)
     {
         FileForJUnitOutputTests *searchedFile = file(filename);
-        return (searchedFile != NULL);
+        return (searchedFile != NULLPTR);
     }
 
     FileForJUnitOutputTests* file(const char* filename)
     {
-        for (FileForJUnitOutputTests* current = firstFile_; current != NULL; current = current->nextFile())
+        for (FileForJUnitOutputTests* current = firstFile_; current != NULLPTR; current = current->nextFile())
             if (current->name() == filename)
                 return current;
-        return NULL;
+        return NULLPTR;
     }
 };
 
@@ -163,7 +163,7 @@ class JUnitTestOutputTestRunner
 public:
 
     JUnitTestOutputTestRunner(TestResult result) :
-        result_(result), currentGroupName_(0), currentTest_(0), firstTestInGroup_(true), timeTheTestTakes_(0), numberOfChecksInTest_(0), testFailure_(0)
+        result_(result), currentGroupName_(NULLPTR), currentTest_(NULLPTR), firstTestInGroup_(true), timeTheTestTakes_(0), numberOfChecksInTest_(0), testFailure_(NULLPTR)
     {
         millisTime = 0;
         theTime =  "1978-10-03T00:00:00";
@@ -190,7 +190,7 @@ public:
     {
         endOfPreviousTestGroup();
         delete currentTest_;
-        currentTest_ = 0;
+        currentTest_ = NULLPTR;
         return *this;
     }
 
@@ -202,7 +202,7 @@ public:
             firstTestInGroup_ = true;
         }
 
-        currentGroupName_ = 0;
+        currentGroupName_ = NULLPTR;
     }
 
     JUnitTestOutputTestRunner& withGroup(const char* groupName)
@@ -250,7 +250,7 @@ public:
 
     void runPreviousTest()
     {
-        if (currentTest_ == 0) return;
+        if (currentTest_ == NULLPTR) return;
 
         if (firstTestInGroup_) {
             result_.currentGroupStarted(currentTest_);
@@ -267,7 +267,7 @@ public:
         if (testFailure_) {
             result_.addFailure(*testFailure_);
             delete testFailure_;
-            testFailure_ = 0;
+            testFailure_ = NULLPTR;
         }
 
         result_.currentTestEnded(currentTest_);
@@ -605,8 +605,8 @@ TEST(JUnitOutputTest, twoTestGroupsWriteToTwoDifferentFiles)
                 .withTest("testName")
             .end();
 
-    CHECK(fileSystem.file("cpputest_firstTestGroup.xml"));
-    CHECK(fileSystem.file("cpputest_secondTestGroup.xml"));
+    CHECK(fileSystem.file("cpputest_firstTestGroup.xml") != NULLPTR);
+    CHECK(fileSystem.file("cpputest_secondTestGroup.xml") != NULLPTR);
 
 }
 

--- a/tests/CppUTest/MemoryLeakDetectorTest.cpp
+++ b/tests/CppUTest/MemoryLeakDetectorTest.cpp
@@ -442,7 +442,7 @@ TEST(MemoryLeakDetectorTest, memoryCorruption)
 
 TEST(MemoryLeakDetectorTest, safelyDeleteNULL)
 {
-    detector->deallocMemory(defaultNewAllocator(), 0);
+    detector->deallocMemory(defaultNewAllocator(), NULLPTR);
     STRCMP_EQUAL("", reporter->message->asCharString());
 }
 
@@ -496,7 +496,7 @@ TEST(MemoryLeakDetectorTest, invalidateMemory)
 
 TEST(MemoryLeakDetectorTest, invalidateMemoryNULLShouldWork)
 {
-  detector->invalidateMemory(NULL);
+  detector->invalidateMemory(NULLPTR);
 }
 
 TEST_GROUP(MemoryLeakDetectorListTest)
@@ -514,7 +514,7 @@ TEST(MemoryLeakDetectorListTest, clearAllAccountingIsWorkingProperly)
 
     listForTesting.clearAllAccounting(mem_leak_period_enabled);
 
-    CHECK(NULL == listForTesting.getFirstLeak(mem_leak_period_enabled));
+    POINTERS_EQUAL(NULLPTR, listForTesting.getFirstLeak(mem_leak_period_enabled));
     CHECK(&node3 == listForTesting.getFirstLeak(mem_leak_period_disabled));
 }
 

--- a/tests/CppUTest/MemoryLeakWarningTest.cpp
+++ b/tests/CppUTest/MemoryLeakWarningTest.cpp
@@ -60,8 +60,8 @@ TEST_GROUP(MemoryLeakWarningLocalDetectorTest)
 
 TEST(MemoryLeakWarningLocalDetectorTest, localDetectorReturnsNewGlobalWhenNoneWasSet)
 {
-    MemoryLeakWarningPlugin memoryLeakWarningPlugin("TestMemoryLeakWarningPlugin", NULL);
-    CHECK(0 != memoryLeakWarningPlugin.getMemoryLeakDetector());
+    MemoryLeakWarningPlugin memoryLeakWarningPlugin("TestMemoryLeakWarningPlugin", NULLPTR);
+    CHECK(NULLPTR != memoryLeakWarningPlugin.getMemoryLeakDetector());
 }
 
 TEST(MemoryLeakWarningLocalDetectorTest, localDetectorIsTheOneSpecifiedInConstructor)
@@ -74,7 +74,7 @@ TEST(MemoryLeakWarningLocalDetectorTest, localDetectorIsTheOneSpecifiedInConstru
 TEST(MemoryLeakWarningLocalDetectorTest, localDetectorIsGlobalDetector)
 {
     MemoryLeakDetector* globalDetector = MemoryLeakWarningPlugin::getGlobalDetector();
-    MemoryLeakWarningPlugin memoryLeakWarningPlugin("TestMemoryLeakWarningPlugin", NULL);
+    MemoryLeakWarningPlugin memoryLeakWarningPlugin("TestMemoryLeakWarningPlugin", NULLPTR);
     MemoryLeakDetector* localDetector =  memoryLeakWarningPlugin.getMemoryLeakDetector();
     POINTERS_EQUAL(globalDetector, localDetector);
 }
@@ -93,8 +93,8 @@ TEST_GROUP(MemoryLeakWarningTest)
         fixture->registry_->installPlugin(memPlugin);
         memPlugin->enable();
 
-        leak1 = 0;
-        leak2 = 0;
+        leak1 = NULLPTR;
+        leak2 = NULLPTR;
     }
     void teardown()
     {
@@ -230,7 +230,7 @@ TEST(MemoryLeakWarningGlobalDetectorTest, turnOffNewOverloadsCausesNoAdditionalL
     char* arrayMemory = new char[100];
     char* nonArrayMemory = new char;
     char* mallocMemory = (char*) cpputest_malloc_location_with_leak_detection(10, "file", 10);
-    char* reallocMemory = (char*) cpputest_realloc_location_with_leak_detection(NULL, 10, "file", 10);
+    char* reallocMemory = (char*) cpputest_realloc_location_with_leak_detection(NULLPTR, 10, "file", 10);
 
     LONGS_EQUAL(storedAmountOfLeaks, detector->totalMemoryLeaks(mem_leak_period_all));
 
@@ -301,7 +301,7 @@ TEST(MemoryLeakWarningGlobalDetectorTest, crashOnLeakWithOperatorMalloc)
 
 TEST(MemoryLeakWarningGlobalDetectorTest, gettingTheGlobalDetectorDoesNotRestoreTheMemoryLeakOverloadsWhenTheyWereAlreadyOff)
 {
-    MemoryLeakWarningPlugin::setGlobalDetector(NULL, NULL);
+    MemoryLeakWarningPlugin::setGlobalDetector(NULLPTR, NULLPTR);
     MemoryLeakDetector* temporaryDetector = MemoryLeakWarningPlugin::getGlobalDetector();
     MemoryLeakFailure*  temporaryReporter = MemoryLeakWarningPlugin::getGlobalFailureReporter();
 

--- a/tests/CppUTest/MemoryOperatorOverloadTest.cpp
+++ b/tests/CppUTest/MemoryOperatorOverloadTest.cpp
@@ -16,8 +16,8 @@ TEST_GROUP(BasicBehavior)
 
 TEST(BasicBehavior, CanDeleteNullPointers)
 {
-    delete (char*) NULL;
-    delete [] (char*) NULL;
+    delete (char*) NULLPTR;
+    delete [] (char*) NULLPTR;
 }
 
 #ifndef CPPUTEST_MEM_LEAK_DETECTION_DISABLED
@@ -332,12 +332,12 @@ TEST(TestForExceptionsInConstructor,ConstructorThrowsAnExceptionAllocatedAsArray
 
 TEST(OutOfMemoryTestsForOperatorNew, FailingNewOperatorReturnsNull)
 {
-    POINTERS_EQUAL(NULL, new char);
+    POINTERS_EQUAL(NULLPTR, new char);
 }
 
 TEST(OutOfMemoryTestsForOperatorNew, FailingNewArrayOperatorReturnsNull)
 {
-    POINTERS_EQUAL(NULL, new char[10]);
+    POINTERS_EQUAL(NULLPTR, new char[10]);
 }
 
 #endif
@@ -386,24 +386,24 @@ TEST(OutOfMemoryTestsForOperatorNew, FailingNewArrayOperatorThrowsAnExceptionWhe
 
 TEST(OutOfMemoryTestsForOperatorNew, FailingNewOperatorReturnsNullWithoutOverride)
 {
-    POINTERS_EQUAL(NULL, new (std::nothrow) char);
+    POINTERS_EQUAL(NULLPTR, new (std::nothrow) char);
 }
 
 TEST(OutOfMemoryTestsForOperatorNew, FailingNewArrayOperatorReturnsNullWithoutOverride)
 {
-    POINTERS_EQUAL(NULL, new (std::nothrow) char[10]);
+    POINTERS_EQUAL(NULLPTR, new (std::nothrow) char[10]);
 }
 
 #else
 
 TEST(OutOfMemoryTestsForOperatorNew, FailingNewOperatorReturnsNullWithoutOverride)
 {
-    POINTERS_EQUAL(NULL, new char);
+    POINTERS_EQUAL(NULLPTR, new char);
 }
 
 TEST(OutOfMemoryTestsForOperatorNew, FailingNewArrayOperatorReturnsNullWithoutOverride)
 {
-    POINTERS_EQUAL(NULL, new char[10]);
+    POINTERS_EQUAL(NULLPTR, new char[10]);
 }
 
 #endif

--- a/tests/CppUTest/PluginTest.cpp
+++ b/tests/CppUTest/PluginTest.cpp
@@ -126,7 +126,7 @@ TEST(PluginTest, InstallMultiplePlugins)
     registry->installPlugin(thirdPlugin);
     CHECK_EQUAL(firstPlugin, registry->getPluginByName(GENERIC_PLUGIN));
     CHECK_EQUAL(thirdPlugin, registry->getPluginByName(GENERIC_PLUGIN3));
-    CHECK_EQUAL(0, registry->getPluginByName("I do not exist"));
+    POINTERS_EQUAL(NULLPTR, registry->getPluginByName("I do not exist"));
 }
 
 TEST(PluginTest, ActionsAllRun)

--- a/tests/CppUTest/PluginTest.cpp
+++ b/tests/CppUTest/PluginTest.cpp
@@ -70,7 +70,7 @@ public:
     {
     }
 
-    virtual bool parseArguments(int ac, const char** av, int index)
+    virtual bool parseArguments(int ac, const char *const *av, int index)
     {
         SimpleString argument (av[index]);
         if (argument == "-paccept")

--- a/tests/CppUTest/SetPluginTest.cpp
+++ b/tests/CppUTest/SetPluginTest.cpp
@@ -41,7 +41,7 @@ TEST_GROUP(SetPointerPluginTest)
 
     void teardown()
     {
-        myRegistry_->setCurrentRegistry(0);
+        myRegistry_->setCurrentRegistry(NULLPTR);
         delete myRegistry_;
         delete plugin_;
         delete output_;

--- a/tests/CppUTest/SimpleMutexTest.cpp
+++ b/tests/CppUTest/SimpleMutexTest.cpp
@@ -37,7 +37,7 @@ static int mutexDestroyCount = 0;
 static PlatformSpecificMutex StubMutexCreate(void)
 {
     mutexCreateCount++;
-    return 0;
+    return NULLPTR;
 }
 
 static void StubMutexLock(PlatformSpecificMutex)

--- a/tests/CppUTest/SimpleStringTest.cpp
+++ b/tests/CppUTest/SimpleStringTest.cpp
@@ -38,11 +38,11 @@ public:
 
     char* alloc_memory(size_t size, const char* file, int line)
     {
-      return MemoryLeakWarningPlugin::getGlobalDetector()->allocMemory(getCurrentNewArrayAllocator(), size, (char*) file, line);
+      return MemoryLeakWarningPlugin::getGlobalDetector()->allocMemory(getCurrentNewArrayAllocator(), size, file, line);
     }
     void free_memory(char* str, const char* file, int line)
     {
-      MemoryLeakWarningPlugin::getGlobalDetector()->deallocMemory(getCurrentNewArrayAllocator(), str, (char*) file, line);
+      MemoryLeakWarningPlugin::getGlobalDetector()->deallocMemory(getCurrentNewArrayAllocator(), str, file, line);
     }
 };
 

--- a/tests/CppUTest/SimpleStringTest.cpp
+++ b/tests/CppUTest/SimpleStringTest.cpp
@@ -56,13 +56,13 @@ TEST_GROUP(SimpleString)
   }
   void teardown()
   {
-    SimpleString::setStringAllocator(NULL);
+    SimpleString::setStringAllocator(NULLPTR);
   }
 };
 
 TEST(SimpleString, defaultAllocatorIsNewArrayAllocator)
 {
-  SimpleString::setStringAllocator(NULL);
+  SimpleString::setStringAllocator(NULLPTR);
   POINTERS_EQUAL(getCurrentNewArrayAllocator(), SimpleString::getStringAllocator());
 }
 
@@ -86,7 +86,7 @@ TEST(SimpleString, allocatorForSimpleStringCanBeReplaced)
     SimpleString::setStringAllocator(&myOwnAllocator);
     SimpleString simpleString;
     CHECK(myOwnAllocator.memoryWasAllocated);
-    SimpleString::setStringAllocator(NULL);
+    SimpleString::setStringAllocator(NULLPTR);
 }
 
 TEST(SimpleString, CreateSequence)
@@ -433,9 +433,9 @@ TEST(SimpleString, copyInBufferNormal)
 TEST(SimpleString, copyInBufferWithEmptyBuffer)
 {
     SimpleString str("Hello World");
-    char* buffer= NULL;
+    char* buffer= NULLPTR;
     str.copyToBuffer(buffer, 0);
-    POINTERS_EQUAL(NULL, buffer);
+    POINTERS_EQUAL(NULLPTR, buffer);
 }
 
 TEST(SimpleString, copyInBufferWithBiggerBufferThanNeeded)
@@ -461,13 +461,13 @@ TEST(SimpleString, copyInBufferWithSmallerBufferThanNeeded)
 
 TEST(SimpleString, ContainsNull)
 {
-    SimpleString s(0);
+    SimpleString s(NULLPTR);
     STRCMP_EQUAL("", s.asCharString());
 }
 
 TEST(SimpleString, NULLReportsNullString)
 {
-    STRCMP_EQUAL("(null)", StringFromOrNull((char*) NULL).asCharString());
+    STRCMP_EQUAL("(null)", StringFromOrNull((char*) NULLPTR).asCharString());
 }
 
 TEST(SimpleString, Booleans)
@@ -831,7 +831,7 @@ TEST(SimpleString, StrNCpy_zero_termination)
 
 TEST(SimpleString, StrNCpy_null_proof)
 {
-    POINTERS_EQUAL(NULL, SimpleString::StrNCpy(NULL, "woman", 6));
+    POINTERS_EQUAL(NULLPTR, SimpleString::StrNCpy(NULLPTR, "woman", 6));
 }
 
 TEST(SimpleString, StrNCpy_stops_at_end_of_string)
@@ -908,9 +908,9 @@ TEST(SimpleString, StrStr)
     char foobarfoo[] = "foobarfoo";
     char barf[] = "barf";
     CHECK(SimpleString::StrStr(foo, empty) == foo);
-    CHECK(SimpleString::StrStr(empty, foo) == 0);
+    CHECK(SimpleString::StrStr(empty, foo) == NULLPTR);
     CHECK(SimpleString::StrStr(foobarfoo, barf) == foobarfoo+3);
-    CHECK(SimpleString::StrStr(barf, foobarfoo) == 0);
+    CHECK(SimpleString::StrStr(barf, foobarfoo) == NULLPTR);
     CHECK(SimpleString::StrStr(foo, foo) == foo);
 }
 
@@ -939,7 +939,7 @@ TEST(SimpleString, Binary)
     STRCMP_EQUAL(expectedString, StringFromBinary(value, sizeof(value)).asCharString());
     STRCMP_EQUAL(expectedString, StringFromBinaryOrNull(value, sizeof(value)).asCharString());
     STRCMP_EQUAL("", StringFromBinary(value, 0).asCharString());
-    STRCMP_EQUAL("(null)", StringFromBinaryOrNull(NULL, 0).asCharString());
+    STRCMP_EQUAL("(null)", StringFromBinaryOrNull(NULLPTR, 0).asCharString());
 }
 
 TEST(SimpleString, BinaryWithSize)
@@ -950,7 +950,7 @@ TEST(SimpleString, BinaryWithSize)
     STRCMP_EQUAL(expectedString, StringFromBinaryWithSize(value, sizeof(value)).asCharString());
     STRCMP_EQUAL(expectedString, StringFromBinaryWithSizeOrNull(value, sizeof(value)).asCharString());
     STRCMP_EQUAL("Size = 0 | HexContents = ", StringFromBinaryWithSize(value, 0).asCharString());
-    STRCMP_EQUAL("(null)", StringFromBinaryWithSizeOrNull(NULL, 0).asCharString());
+    STRCMP_EQUAL("(null)", StringFromBinaryWithSizeOrNull(NULLPTR, 0).asCharString());
 }
 
 TEST(SimpleString, BinaryWithSizeLargerThan128)
@@ -970,7 +970,7 @@ TEST(SimpleString, MemCmp)
     LONGS_EQUAL(0, SimpleString::MemCmp(smaller, smaller, sizeof(smaller)));
     CHECK(SimpleString::MemCmp(smaller, greater, sizeof(smaller)) < 0);
     CHECK(SimpleString::MemCmp(greater, smaller, sizeof(smaller)) > 0);
-    LONGS_EQUAL(0, SimpleString::MemCmp(NULL, NULL, 0));
+    LONGS_EQUAL(0, SimpleString::MemCmp(NULLPTR, NULLPTR, 0));
 }
 
 TEST(SimpleString, MemCmpFirstLastNotMatching)

--- a/tests/CppUTest/TeamCityOutputTest.cpp
+++ b/tests/CppUTest/TeamCityOutputTest.cpp
@@ -9,7 +9,7 @@ public:
     {
     }
 
-    virtual ~TeamCityOutputToBuffer()
+    virtual ~TeamCityOutputToBuffer() _destructor_override
     {
     }
 

--- a/tests/CppUTest/TestFailureTest.cpp
+++ b/tests/CppUTest/TestFailureTest.cpp
@@ -78,13 +78,13 @@ TEST(TestFailure, EqualsFailure)
 
 TEST(TestFailure, EqualsFailureWithNullAsActual)
 {
-    EqualsFailure f(test, failFileName, failLineNumber, "expected", NULL, "");
+    EqualsFailure f(test, failFileName, failLineNumber, "expected", NULLPTR, "");
     FAILURE_EQUAL("expected <expected>\n\tbut was  <(null)>", f);
 }
 
 TEST(TestFailure, EqualsFailureWithNullAsExpected)
 {
-    EqualsFailure f(test, failFileName, failLineNumber, NULL, "actual", "");
+    EqualsFailure f(test, failFileName, failLineNumber, NULLPTR, "actual", "");
     FAILURE_EQUAL("expected <(null)>\n\tbut was  <actual>", f);
 }
 
@@ -238,14 +238,14 @@ TEST(TestFailure, StringsEqualFailureAtTheBeginning)
 
 TEST(TestFailure, StringsEqualFailureWithNullAsActual)
 {
-    StringEqualFailure f(test, failFileName, failLineNumber, "abc", NULL, "");
+    StringEqualFailure f(test, failFileName, failLineNumber, "abc", NULLPTR, "");
     FAILURE_EQUAL("expected <abc>\n"
                 "\tbut was  <(null)>", f);
 }
 
 TEST(TestFailure, StringsEqualFailureWithNullAsExpected)
 {
-    StringEqualFailure f(test, failFileName, failLineNumber, NULL, "abd", "");
+    StringEqualFailure f(test, failFileName, failLineNumber, NULLPTR, "abd", "");
     FAILURE_EQUAL("expected <(null)>\n"
                 "\tbut was  <abd>", f);
 }
@@ -271,14 +271,14 @@ TEST(TestFailure, StringsEqualNoCaseFailure)
 
 TEST(TestFailure, StringsEqualNoCaseFailureWithActualAsNull)
 {
-    StringEqualNoCaseFailure f(test, failFileName, failLineNumber, "ABC", NULL, "");
+    StringEqualNoCaseFailure f(test, failFileName, failLineNumber, "ABC", NULLPTR, "");
     FAILURE_EQUAL("expected <ABC>\n"
                 "\tbut was  <(null)>", f);
 }
 
 TEST(TestFailure, StringsEqualNoCaseFailureWithExpectedAsNull)
 {
-    StringEqualNoCaseFailure f(test, failFileName, failLineNumber, NULL, "abd", "");
+    StringEqualNoCaseFailure f(test, failFileName, failLineNumber, NULLPTR, "abd", "");
     FAILURE_EQUAL("expected <(null)>\n"
                 "\tbut was  <abd>", f);
 }
@@ -377,14 +377,14 @@ TEST(TestFailure, BinaryEqualLast)
 TEST(TestFailure, BinaryEqualActualNull)
 {
     const unsigned char expectedData[] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
-    BinaryEqualFailure f(test, failFileName, failLineNumber, expectedData, NULL, sizeof(expectedData), "");
+    BinaryEqualFailure f(test, failFileName, failLineNumber, expectedData, NULLPTR, sizeof(expectedData), "");
     FAILURE_EQUAL("expected <00 00 00 00 00 00 00>\n\tbut was  <(null)>", f);
 }
 
 TEST(TestFailure, BinaryEqualExpectedNull)
 {
     const unsigned char actualData[] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01};
-    BinaryEqualFailure f(test, failFileName, failLineNumber, NULL, actualData, sizeof(actualData), "");
+    BinaryEqualFailure f(test, failFileName, failLineNumber, NULLPTR, actualData, sizeof(actualData), "");
     FAILURE_EQUAL("expected <(null)>\n\tbut was  <00 00 00 00 00 00 01>", f);
 }
 

--- a/tests/CppUTest/TestFilterTest.cpp
+++ b/tests/CppUTest/TestFilterTest.cpp
@@ -141,7 +141,7 @@ TEST(TestFilter, stringFromWithStrictInvertMatching)
 
 TEST(TestFilter, listOfFilters)
 {
-    TestFilter *listOfFilters = NULL;
+    TestFilter *listOfFilters = NULLPTR;
     TestFilter first("foo");
     TestFilter secnd("bar");
     listOfFilters = first.add(listOfFilters);
@@ -150,7 +150,7 @@ TEST(TestFilter, listOfFilters)
     STRCMP_EQUAL("TestFilter: \"bar\"", StringFrom(*current).asCharString());
     current = current->getNext();
     STRCMP_EQUAL("TestFilter: \"foo\"", StringFrom(*current).asCharString());
-    POINTERS_EQUAL(NULL, current->getNext());
+    POINTERS_EQUAL(NULLPTR, current->getNext());
 }
 
 TEST(TestFilter, constructors)
@@ -158,9 +158,9 @@ TEST(TestFilter, constructors)
     TestFilter filter1;
     TestFilter filter2(SimpleString("a"));
     TestFilter filter3("a");
-    CHECK(filter1.getNext() == NULL);
-    CHECK(filter2.getNext() == NULL);
-    CHECK(filter3.getNext() == NULL);
+    CHECK(filter1.getNext() == NULLPTR);
+    CHECK(filter2.getNext() == NULLPTR);
+    CHECK(filter3.getNext() == NULLPTR);
     CHECK(filter2.match("ab"));
     CHECK(filter3.match("ab"));
 }

--- a/tests/CppUTest/TestHarness_cTest.cpp
+++ b/tests/CppUTest/TestHarness_cTest.cpp
@@ -316,12 +316,12 @@ TEST(TestHarness_c, checkString)
 static void _failPointerMethod()
 {
     HasTheDestructorBeenCalledChecker checker;
-    CHECK_EQUAL_C_POINTER(NULL, (void *)0x1);
+    CHECK_EQUAL_C_POINTER(NULLPTR, (void *)0x1);
 }
 
 TEST(TestHarness_c, checkPointer)
 {
-    CHECK_EQUAL_C_POINTER(NULL, NULL);
+    CHECK_EQUAL_C_POINTER(NULLPTR, NULLPTR);
     fixture->setTestFunction(_failPointerMethod);
     fixture->runAllTests();
     fixture->assertPrintContains("expected <0x0>\n	but was  <0x1>");
@@ -337,7 +337,7 @@ static void _failBitsMethod()
 
 TEST(TestHarness_c, checkBits)
 {
-    CHECK_EQUAL_C_POINTER(NULL, NULL);
+    CHECK_EQUAL_C_POINTER(NULLPTR, NULLPTR);
     fixture->setTestFunction(_failBitsMethod);
     fixture->runAllTests();
     fixture->assertPrintContains("expected <00000000 00000001>\n\tbut was  <00000000 00000011>");
@@ -395,11 +395,11 @@ TEST(TestHarness_c, checkCheck)
 TEST(TestHarness_c, cpputest_malloc_out_of_memory)
 {
     cpputest_malloc_set_out_of_memory();
-    CHECK(0 == cpputest_malloc(100));
+    CHECK(NULLPTR == cpputest_malloc(100));
 
     cpputest_malloc_set_not_out_of_memory();
     void * mem = cpputest_malloc(100);
-    CHECK(0 != mem);
+    CHECK(NULLPTR != mem);
     cpputest_free(mem);
 }
 
@@ -409,9 +409,9 @@ TEST(TestHarness_c, cpputest_malloc_out_of_memory_after_n_mallocs)
     void * m1 = cpputest_malloc(10);
     void * m2 = cpputest_malloc(11);
     void * m3 = cpputest_malloc(12);
-    CHECK(m1);
-    CHECK(m2);
-    POINTERS_EQUAL(0, m3);
+    CHECK(m1 != NULLPTR);
+    CHECK(m2 != NULLPTR);
+    CHECK(m3 == NULLPTR);
     cpputest_malloc_set_not_out_of_memory();
     cpputest_free(m1);
     cpputest_free(m2);
@@ -421,7 +421,7 @@ TEST(TestHarness_c, cpputest_malloc_out_of_memory_after_0_mallocs)
 {
     cpputest_malloc_set_out_of_memory_countdown(0);
     void * m1 = cpputest_malloc(10);
-    CHECK(m1 == 0);
+    CHECK(m1 == NULLPTR);
     cpputest_malloc_set_not_out_of_memory();
 }
 
@@ -442,7 +442,7 @@ TEST(TestHarness_c, count_mallocs)
 TEST(TestHarness_c, cpputest_strdup)
 {
     char * mem = cpputest_strdup("0123456789");
-    CHECK(0 != mem);
+    CHECK(NULLPTR != mem);
     STRCMP_EQUAL("0123456789", mem)
     cpputest_free(mem);
 }
@@ -450,7 +450,7 @@ TEST(TestHarness_c, cpputest_strdup)
 TEST(TestHarness_c, cpputest_strndup)
 {
     char * mem = cpputest_strndup("0123456789", 3);
-    CHECK(0 != mem);
+    CHECK(NULLPTR != mem);
     STRCMP_EQUAL("012", mem)
     cpputest_free(mem);
 }
@@ -460,7 +460,7 @@ TEST(TestHarness_c, cpputest_strndup)
 TEST(TestHarness_c, cpputest_calloc)
 {
     void * mem = cpputest_calloc(10, 10);
-    CHECK(0 != mem);
+    CHECK(NULLPTR != mem);
     cpputest_free(mem);
 }
 
@@ -472,11 +472,11 @@ TEST(TestHarness_c, cpputest_realloc_larger)
 
     SimpleString::StrNCpy(mem1, number_string, 10);
 
-    CHECK(mem1 != 0);
+    CHECK(mem1 != NULLPTR);
 
     char* mem2 = (char*) cpputest_realloc(mem1, 1000);
 
-    CHECK(mem2 != 0);
+    CHECK(mem2 != NULLPTR);
     STRCMP_EQUAL(number_string, mem2);
 
     cpputest_free(mem2);
@@ -516,7 +516,7 @@ TEST(TestHarness_c, callocShouldReturnNULLWhenOutOfMeory)
 {
     cpputest_malloc_set_out_of_memory_countdown(0);
     void * m = cpputest_calloc(1, 1);
-    CHECK(m == 0);
+    CHECK(m == NULLPTR);
     cpputest_malloc_set_not_out_of_memory();
 }
 #endif

--- a/tests/CppUTest/TestInstallerTest.cpp
+++ b/tests/CppUTest/TestInstallerTest.cpp
@@ -50,7 +50,7 @@ TEST_GROUP(TestInstaller)
     }
     void teardown()
     {
-        myRegistry->setCurrentRegistry(0);
+        myRegistry->setCurrentRegistry(NULLPTR);
         testInstaller->unDo();
         delete testInstaller;
         delete myRegistry;

--- a/tests/CppUTest/TestMemoryAllocatorTest.cpp
+++ b/tests/CppUTest/TestMemoryAllocatorTest.cpp
@@ -35,7 +35,7 @@ TEST_GROUP(TestMemoryAllocatorTest)
 
     void setup()
     {
-        allocator = NULL;
+        allocator = NULLPTR;
     }
 
     void teardown()
@@ -158,14 +158,14 @@ TEST_GROUP(FailableMemoryAllocator)
 TEST(FailableMemoryAllocator, MallocWorksNormallyIfNotAskedToFail)
 {
     int *memory = (int*)malloc(sizeof(int));
-    CHECK(memory != NULL);
+    CHECK(memory != NULLPTR);
     free(memory);
 }
 
 TEST(FailableMemoryAllocator, FailFirstMalloc)
 {
     failableMallocAllocator.failAllocNumber(1);
-    POINTERS_EQUAL(NULL, (int*)malloc(sizeof(int)));
+    POINTERS_EQUAL(NULLPTR, (int*)malloc(sizeof(int)));
 }
 
 TEST(FailableMemoryAllocator, FailSecondAndFourthMalloc)
@@ -177,10 +177,10 @@ TEST(FailableMemoryAllocator, FailSecondAndFourthMalloc)
     int *memory3 = (int*)malloc(sizeof(int));
     int *memory4 = (int*)malloc(sizeof(int));
 
-    CHECK(NULL != memory1);
-    POINTERS_EQUAL(NULL, memory2);
-    CHECK(NULL != memory3);
-    POINTERS_EQUAL(NULL, memory4);
+    CHECK(NULLPTR != memory1);
+    POINTERS_EQUAL(NULLPTR, memory2);
+    CHECK(NULLPTR != memory3);
+    POINTERS_EQUAL(NULLPTR, memory4);
 
     free(memory1);
     free(memory3);
@@ -211,19 +211,19 @@ TEST(FailableMemoryAllocator, FailFirstAllocationAtGivenLine)
 {
     failableMallocAllocator.failNthAllocAt(1, __FILE__, __LINE__ + 2);
 
-    POINTERS_EQUAL(NULL, malloc(sizeof(int)));
+    POINTERS_EQUAL(NULLPTR, malloc(sizeof(int)));
 }
 
 TEST(FailableMemoryAllocator, FailThirdAllocationAtGivenLine)
 {
-    int *memory[10] = { NULL };
+    int *memory[10] = { NULLPTR };
     int allocation;
     failableMallocAllocator.failNthAllocAt(3, __FILE__, __LINE__ + 4);
 
     for (allocation = 1; allocation <= 10; allocation++)
     {
         memory[allocation - 1] = (int *)malloc(sizeof(int));
-        if (memory[allocation - 1] == NULL)
+        if (memory[allocation - 1] == NULLPTR)
             break;
     }
 

--- a/tests/CppUTest/TestRegistryTest.cpp
+++ b/tests/CppUTest/TestRegistryTest.cpp
@@ -132,7 +132,7 @@ TEST_GROUP(TestRegistry)
 
     void teardown()
     {
-        myRegistry->setCurrentRegistry(0);
+        myRegistry->setCurrentRegistry(NULLPTR);
         delete myRegistry;
         delete test1;
         delete test2;
@@ -236,7 +236,7 @@ TEST(TestRegistry, reallyUndoLastTest)
 
 TEST(TestRegistry, findTestWithNameDoesntExist)
 {
-    CHECK(myRegistry->findTestWithName("ThisTestDoesntExists") == NULL);
+    CHECK(myRegistry->findTestWithName("ThisTestDoesntExists") == NULLPTR);
 }
 
 TEST(TestRegistry, findTestWithName)
@@ -245,12 +245,12 @@ TEST(TestRegistry, findTestWithName)
     test2->setTestName("SomeOtherTest");
     myRegistry->addTest(test1);
     myRegistry->addTest(test2);
-    CHECK(myRegistry->findTestWithName("NameOfATestThatDoesExist"));
+    CHECK(myRegistry->findTestWithName("NameOfATestThatDoesExist") != NULLPTR);
 }
 
 TEST(TestRegistry, findTestWithGroupDoesntExist)
 {
-    CHECK(myRegistry->findTestWithGroup("ThisTestGroupDoesntExists") == NULL);
+    CHECK(myRegistry->findTestWithGroup("ThisTestGroupDoesntExists") == NULLPTR);
 }
 
 TEST(TestRegistry, findTestWithGroup)
@@ -259,7 +259,7 @@ TEST(TestRegistry, findTestWithGroup)
     test2->setGroupName("SomeOtherGroup");
     myRegistry->addTest(test1);
     myRegistry->addTest(test2);
-    CHECK(myRegistry->findTestWithGroup("GroupOfATestThatDoesExist"));
+    CHECK(myRegistry->findTestWithGroup("GroupOfATestThatDoesExist") != NULLPTR);
 }
 
 TEST(TestRegistry, nameFilterWorks)
@@ -311,7 +311,7 @@ class MyTestPluginDummy: public TestPlugin
 {
 public:
     MyTestPluginDummy(const SimpleString& name) : TestPlugin(name) {}
-    virtual ~MyTestPluginDummy() {}
+    virtual ~MyTestPluginDummy() _destructor_override {}
     virtual void runAllPreTestAction(UtestShell&, TestResult&) _override {}
     virtual void runAllPostTestAction(UtestShell&, TestResult&) _override {}
 };

--- a/tests/CppUTest/TestUTestMacro.cpp
+++ b/tests/CppUTest/TestUTestMacro.cpp
@@ -733,7 +733,7 @@ TEST(UnitTestMacros, FailureWithPOINTERS_EQUAL)
 
 TEST(UnitTestMacros, POINTERS_EQUALBehavesAsProperMacro)
 {
-    if (false) POINTERS_EQUAL(0, to_void_pointer(0xbeefbeef))
+    if (false) POINTERS_EQUAL(NULLPTR, to_void_pointer(0xbeefbeef))
     else POINTERS_EQUAL(to_void_pointer(0xdeadbeef), to_void_pointer(0xdeadbeef))
 }
 
@@ -758,7 +758,7 @@ TEST(UnitTestMacros, FailureWithPOINTERS_EQUAL_TEXT)
 
 TEST(UnitTestMacros, POINTERS_EQUAL_TEXTBehavesAsProperMacro)
 {
-    if (false) POINTERS_EQUAL_TEXT(0, to_void_pointer(0xbeefbeef), "Failed because it failed")
+    if (false) POINTERS_EQUAL_TEXT(NULLPTR, to_void_pointer(0xbeefbeef), "Failed because it failed")
     else POINTERS_EQUAL_TEXT(to_void_pointer(0xdeadbeef), to_void_pointer(0xdeadbeef), "Failed because it failed")
 }
 
@@ -783,7 +783,7 @@ TEST(UnitTestMacros, FailureWithFUNCTIONPOINTERS_EQUAL)
 
 TEST(UnitTestMacros, FUNCTIONPOINTERS_EQUALBehavesAsProperMacro)
 {
-    if (false) FUNCTIONPOINTERS_EQUAL(0, to_func_pointer(0xbeefbeef))
+    if (false) FUNCTIONPOINTERS_EQUAL(NULLPTR, to_func_pointer(0xbeefbeef))
     else FUNCTIONPOINTERS_EQUAL(to_func_pointer(0xdeadbeef), to_func_pointer(0xdeadbeef))
 }
 
@@ -808,7 +808,7 @@ TEST(UnitTestMacros, FailureWithFUNCTIONPOINTERS_EQUAL_TEXT)
 
 TEST(UnitTestMacros, FUNCTIONPOINTERS_EQUAL_TEXTBehavesAsProperMacro)
 {
-    if (false) FUNCTIONPOINTERS_EQUAL_TEXT(0, to_func_pointer(0xbeefbeef), "Failed because it failed")
+    if (false) FUNCTIONPOINTERS_EQUAL_TEXT(NULLPTR, to_func_pointer(0xbeefbeef), "Failed because it failed")
     else FUNCTIONPOINTERS_EQUAL_TEXT(to_func_pointer(0xdeadbeef), to_func_pointer(0xdeadbeef), "Failed because it failed")
 }
 
@@ -931,8 +931,8 @@ static int functionThatReturnsAValue()
     STRCMP_EQUAL_TEXT("THIS", "THIS", "Shouldn't fail");
     DOUBLES_EQUAL(1.0, 1.0, .01);
     DOUBLES_EQUAL_TEXT(1.0, 1.0, .01, "Shouldn't fail");
-    POINTERS_EQUAL(0, 0);
-    POINTERS_EQUAL_TEXT(0, 0, "Shouldn't fail");
+    POINTERS_EQUAL(NULLPTR, NULLPTR);
+    POINTERS_EQUAL_TEXT(NULLPTR, NULLPTR, "Shouldn't fail");
     MEMCMP_EQUAL("THIS", "THIS", 5);
     MEMCMP_EQUAL_TEXT("THIS", "THIS", 5, "Shouldn't fail");
     BITS_EQUAL(0x01, (unsigned char )0x01, 0xFF);
@@ -979,7 +979,7 @@ static void _MEMCMP_EQUALFailingTestMethodWithNullExpected()
 {
     unsigned char actualData[] = { 0x00, 0x01, 0x02, 0x03 };
 
-    MEMCMP_EQUAL(NULL, actualData, sizeof(actualData));
+    MEMCMP_EQUAL(NULLPTR, actualData, sizeof(actualData));
     TestTestingFixture::lineExecutedAfterCheck(); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
@@ -994,7 +994,7 @@ static void _MEMCMP_EQUALFailingTestMethodWithNullActual()
 {
     unsigned char expectedData[] = { 0x00, 0x01, 0x02, 0x03 };
 
-    MEMCMP_EQUAL(expectedData, NULL, sizeof(expectedData));
+    MEMCMP_EQUAL(expectedData, NULLPTR, sizeof(expectedData));
     TestTestingFixture::lineExecutedAfterCheck(); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
@@ -1007,8 +1007,8 @@ TEST(UnitTestMacros, MEMCMP_EQUALFailureWithNullActual)
 
 TEST(UnitTestMacros, MEMCMP_EQUALNullExpectedNullActual)
 {
-    MEMCMP_EQUAL(NULL, NULL, 0);
-    MEMCMP_EQUAL(NULL, NULL, 1024);
+    MEMCMP_EQUAL(NULLPTR, NULLPTR, 0);
+    MEMCMP_EQUAL(NULLPTR, NULLPTR, 1024);
 }
 
 static void _failingTestMethodWithMEMCMP_EQUAL_TEXT()

--- a/tests/CppUTest/TestUTestStringMacro.cpp
+++ b/tests/CppUTest/TestUTestStringMacro.cpp
@@ -38,7 +38,7 @@ TEST_GROUP(UnitTestStringMacros)
 
 static void _STRCMP_EQUALWithActualIsNULLTestMethod()
 {
-    STRCMP_EQUAL("ok", NULL);
+    STRCMP_EQUAL("ok", NULLPTR);
 } // LCOV_EXCL_LINE
 
 TEST(UnitTestStringMacros, FailureWithSTRCMP_EQUALAndActualIsNULL)
@@ -49,7 +49,7 @@ TEST(UnitTestStringMacros, FailureWithSTRCMP_EQUALAndActualIsNULL)
 
 static void _STRCMP_EQUALWithExpectedIsNULLTestMethod()
 {
-    STRCMP_EQUAL(NULL, "ok");
+    STRCMP_EQUAL(NULLPTR, "ok");
 } // LCOV_EXCL_LINE
 
 TEST(UnitTestStringMacros, FailureWithSTRCMP_EQUALAndExpectedIsNULL)
@@ -60,7 +60,7 @@ TEST(UnitTestStringMacros, FailureWithSTRCMP_EQUALAndExpectedIsNULL)
 
 static void _STRCMP_CONTAINSWithActualIsNULLTestMethod()
 {
-    STRCMP_CONTAINS("ok", NULL);
+    STRCMP_CONTAINS("ok", NULLPTR);
 } // LCOV_EXCL_LINE
 
 TEST(UnitTestStringMacros, FailureWithSTRCMP_CONTAINSAndActualIsNULL)
@@ -71,7 +71,7 @@ TEST(UnitTestStringMacros, FailureWithSTRCMP_CONTAINSAndActualIsNULL)
 
 static void _STRCMP_CONTAINSWithExpectedIsNULLTestMethod()
 {
-    STRCMP_CONTAINS(NULL, "ok");
+    STRCMP_CONTAINS(NULLPTR, "ok");
 } // LCOV_EXCL_LINE
 
 TEST(UnitTestStringMacros, FailureWithSTRCMP_CONTAINSAndExpectedIsNULL)
@@ -82,7 +82,7 @@ TEST(UnitTestStringMacros, FailureWithSTRCMP_CONTAINSAndExpectedIsNULL)
 
 static void _STRNCMP_EQUALWithActualIsNULLTestMethod()
 {
-    STRNCMP_EQUAL("ok", NULL, 2);
+    STRNCMP_EQUAL("ok", NULLPTR, 2);
 } // LCOV_EXCL_LINE
 
 TEST(UnitTestStringMacros, FailureWithSTRNCMP_EQUALAndActualIsNULL)
@@ -93,7 +93,7 @@ TEST(UnitTestStringMacros, FailureWithSTRNCMP_EQUALAndActualIsNULL)
 
 static void _STRNCMP_EQUALWithExpectedIsNULLTestMethod()
 {
-    STRNCMP_EQUAL(NULL, "ok", 2);
+    STRNCMP_EQUAL(NULLPTR, "ok", 2);
 } // LCOV_EXCL_LINE
 
 TEST(UnitTestStringMacros, FailureWithSTRNCMP_EQUALAndExpectedIsNULL)
@@ -104,7 +104,7 @@ TEST(UnitTestStringMacros, FailureWithSTRNCMP_EQUALAndExpectedIsNULL)
 
 static void _STRCMP_NOCASE_EQUALWithActualIsNULLTestMethod()
 {
-    STRCMP_NOCASE_EQUAL("ok", NULL);
+    STRCMP_NOCASE_EQUAL("ok", NULLPTR);
 } // LCOV_EXCL_LINE
 
 TEST(UnitTestStringMacros, FailureWithSTRCMP_NOCASE_EQUALAndActualIsNULL)
@@ -115,7 +115,7 @@ TEST(UnitTestStringMacros, FailureWithSTRCMP_NOCASE_EQUALAndActualIsNULL)
 
 static void _STRCMP_NOCASE_EQUALWithExpectedIsNULLTestMethod()
 {
-    STRCMP_NOCASE_EQUAL(NULL, "ok");
+    STRCMP_NOCASE_EQUAL(NULLPTR, "ok");
 } // LCOV_EXCL_LINE
 
 TEST(UnitTestStringMacros, FailureWithSTRCMP_NOCASE_EQUALAndExpectedIsNULL)
@@ -137,7 +137,7 @@ TEST(UnitTestStringMacros, FailureWithSTRCMP_NOCASE_EQUALAndUnequalInput)
 
 static void _STRCMP_NOCASE_CONTAINSWithActualIsNULLTestMethod()
 {
-    STRCMP_NOCASE_CONTAINS("ok", NULL);
+    STRCMP_NOCASE_CONTAINS("ok", NULLPTR);
 } // LCOV_EXCL_LINE
 
 TEST(UnitTestStringMacros, FailureWithSTRCMP_NOCASE_CONTAINSAndActualIsNULL)
@@ -148,7 +148,7 @@ TEST(UnitTestStringMacros, FailureWithSTRCMP_NOCASE_CONTAINSAndActualIsNULL)
 
 static void _STRCMP_NOCASE_CONTAINSWithExpectedIsNULLTestMethod()
 {
-    STRCMP_NOCASE_CONTAINS(NULL, "ok");
+    STRCMP_NOCASE_CONTAINS(NULLPTR, "ok");
 } // LCOV_EXCL_LINE
 
 TEST(UnitTestStringMacros, FailureWithSTRCMP_NOCASE_CONTAINSAndExpectedIsNULL)

--- a/tests/CppUTest/UtestPlatformTest.cpp
+++ b/tests/CppUTest/UtestPlatformTest.cpp
@@ -60,7 +60,7 @@ static void _failFunction()
 
 extern "C" {
 
-    static int (*original_waitpid)(int, int*, int) = NULL;
+    static int (*original_waitpid)(int, int*, int) = NULLPTR;
 
     static int fork_failed_stub(void) { return -1; }
 
@@ -85,7 +85,7 @@ extern "C" {
 
 static int _accessViolationTestFunction()
 {
-    return *(volatile int*) 0;
+    return *(volatile int*) NULLPTR;
 }
 
 #include <unistd.h>

--- a/tests/CppUTest/UtestTest.cpp
+++ b/tests/CppUTest/UtestTest.cpp
@@ -92,7 +92,7 @@ TEST(UtestShell, PassedCheckEqualWillIncreaseTheAmountOfChecks)
 
 IGNORE_TEST(UtestShell, IgnoreTestAccessingFixture)
 {
-    CHECK(&fixture != NULL);
+    CHECK(&fixture != NULLPTR);
 }
 
 TEST(UtestShell, MacrosUsedInSetup)
@@ -358,7 +358,7 @@ public:
     AllocateAndDeallocateInConstructorAndDestructor()
     {
         memory_ = new char[100];
-        morememory_ = NULL;
+        morememory_ = NULLPTR;
     }
     void allocateMoreMemory()
     {

--- a/tests/CppUTestExt/AllTests.cpp
+++ b/tests/CppUTestExt/AllTests.cpp
@@ -34,7 +34,7 @@
 #include "CppUTestExt/GTestConvertor.h"
 #endif
 
-int main(int ac, const char** av)
+int main(int ac, const char *const *av)
 {
 #ifdef CPPUTEST_INCLUDE_GTEST_TESTS
     GTestConvertor convertor;

--- a/tests/CppUTestExt/CodeMemoryReporterTest.cpp
+++ b/tests/CppUTestExt/CodeMemoryReporterTest.cpp
@@ -124,7 +124,7 @@ TEST(CodeMemoryReportFormatter, NewAllocatorGeneratesDeleteCode)
 
 TEST(CodeMemoryReportFormatter, DeleteNullWorksFine)
 {
-    formatter->report_free_memory(testResult, newAllocator, NULL, "boo", 4);
+    formatter->report_free_memory(testResult, newAllocator, NULLPTR, "boo", 4);
     TESTOUTPUT_CONTAINS("delete [] NULL; /* using delete at boo:4 */");
 }
 

--- a/tests/CppUTestExt/ExpectedFunctionsListTest.cpp
+++ b/tests/CppUTestExt/ExpectedFunctionsListTest.cpp
@@ -270,12 +270,12 @@ TEST(MockExpectedCallsList, callToStringForFulfilledFunctions)
 
 TEST(MockExpectedCallsList, removeOneFinalizedMatchingExpectationFromEmptyList)
 {
-    POINTERS_EQUAL(NULL, list->removeFirstFinalizedMatchingExpectation());
+    POINTERS_EQUAL(NULLPTR, list->removeFirstFinalizedMatchingExpectation());
 }
 
 TEST(MockExpectedCallsList, getOneMatchingExpectationFromEmptyList)
 {
-    POINTERS_EQUAL(NULL, list->getFirstMatchingExpectation());
+    POINTERS_EQUAL(NULLPTR, list->getFirstMatchingExpectation());
 }
 
 TEST(MockExpectedCallsList, toStringOnEmptyList)

--- a/tests/CppUTestExt/MemoryReporterPluginTest.cpp
+++ b/tests/CppUTestExt/MemoryReporterPluginTest.cpp
@@ -106,11 +106,11 @@ class TestMemoryAllocatorComparator : public MockNamedValueComparator
 public:
     bool isEqual(const void* object1, const void* object2)
     {
-        return ((TestMemoryAllocator*)object1)->name() == ((TestMemoryAllocator*)object2)->name();
+        return ((const TestMemoryAllocator*)object1)->name() == ((const TestMemoryAllocator*)object2)->name();
     }
     SimpleString valueToString(const void* object)
     {
-        return ((TestMemoryAllocator*)object)->name();
+        return ((const TestMemoryAllocator*)object)->name();
     }
 
 };

--- a/tests/CppUTestExt/MemoryReporterPluginTest.cpp
+++ b/tests/CppUTestExt/MemoryReporterPluginTest.cpp
@@ -255,7 +255,7 @@ public:
 
 TEST(MemoryReporterPlugin, endOfaTestGroupWillReportSo)
 {
-    UtestForMemoryReportingPlugingTest fourthTest("differentGroupName", NULL);
+    UtestForMemoryReportingPlugingTest fourthTest("differentGroupName", NULLPTR);
     UtestForMemoryReportingPlugingTest thirdTest("differentGroupName", &fourthTest);
     UtestForMemoryReportingPlugingTest secondTest("groupname", &thirdTest);
     UtestForMemoryReportingPlugingTest firstTest("groupname", &secondTest);

--- a/tests/CppUTestExt/MockActualCallTest.cpp
+++ b/tests/CppUTestExt/MockActualCallTest.cpp
@@ -74,7 +74,7 @@ TEST(MockCheckedActualCall, unExpectedCallWithAParameter)
 TEST(MockCheckedActualCall, unExpectedCallWithAnOutputParameter)
 {
     MockCheckedActualCall actualCall(1, reporter, *emptyList);
-    actualCall.withName("unexpected").withOutputParameter("bar", (void*)0);
+    actualCall.withName("unexpected").withOutputParameter("bar", NULLPTR);
 
     MockUnexpectedCallHappenedFailure expectedFailure(mockFailureTest(), "unexpected", *list);
     CHECK_EXPECTED_MOCK_FAILURE(expectedFailure);
@@ -165,11 +165,11 @@ TEST(MockCheckedActualCall, MockIgnoredActualCallWorksAsItShould)
     DOUBLES_EQUAL(1.5, actual.returnDoubleValueOrDefault(1.5), 0.0);
     STRCMP_EQUAL("bla", actual.returnStringValueOrDefault("bla"));
     STRCMP_EQUAL("", actual.returnStringValue());
-    CHECK(0 == actual.returnPointerValue());
+    CHECK(NULLPTR == actual.returnPointerValue());
     CHECK((void*) 0x2 == actual.returnPointerValueOrDefault((void*) 0x2));
-    CHECK(0 == actual.returnConstPointerValue());
+    CHECK(NULLPTR == actual.returnConstPointerValue());
     CHECK((const void*) 0x2 == actual.returnConstPointerValueOrDefault((const void*) 0x2));
-    CHECK(0 == actual.returnFunctionPointerValue());
+    CHECK(NULLPTR == actual.returnFunctionPointerValue());
     CHECK((void(*)()) 1 == actual.returnFunctionPointerValueOrDefault((void(*)()) 0x1));
     CHECK_FALSE(actual.hasReturnValue());
     CHECK(actual.returnValue().equals(MockNamedValue("")));
@@ -232,11 +232,11 @@ TEST(MockCheckedActualCall, remainderOfMockActualCallTraceWorksAsItShould)
     DOUBLES_EQUAL(0.0, actual.returnDoubleValueOrDefault(1.0), 0.0);
     STRCMP_EQUAL("", actual.returnStringValueOrDefault("bla"));
     STRCMP_EQUAL("", actual.returnStringValue());
-    CHECK(0 == actual.returnPointerValue());
-    CHECK(0 == actual.returnPointerValueOrDefault((void*) 0x0));
-    CHECK(0 == actual.returnConstPointerValue());
-    CHECK(0 == actual.returnConstPointerValueOrDefault((const void*) 0x0));
-    CHECK(0 == actual.returnFunctionPointerValue());
-    CHECK(0 == actual.returnFunctionPointerValueOrDefault((void (*)()) 0x0));
+    CHECK(NULLPTR == actual.returnPointerValue());
+    CHECK(NULLPTR == actual.returnPointerValueOrDefault((void*) NULLPTR));
+    CHECK(NULLPTR == actual.returnConstPointerValue());
+    CHECK(NULLPTR == actual.returnConstPointerValueOrDefault((const void*) NULLPTR));
+    CHECK(NULLPTR == actual.returnFunctionPointerValue());
+    CHECK(NULLPTR == actual.returnFunctionPointerValueOrDefault((void (*)()) NULLPTR));
 }
 

--- a/tests/CppUTestExt/MockComparatorCopierTest.cpp
+++ b/tests/CppUTestExt/MockComparatorCopierTest.cpp
@@ -117,12 +117,12 @@ TEST(MockComparatorCopierTest, customObjectParameterSucceeds)
 
 static bool myTypeIsEqual(const void* object1, const void* object2)
 {
-    return ((MyTypeForTesting*)object1)->value == ((MyTypeForTesting*)object2)->value;
+    return ((const MyTypeForTesting*)object1)->value == ((const MyTypeForTesting*)object2)->value;
 }
 
 static SimpleString myTypeValueToString(const void* object)
 {
-    return StringFrom(((MyTypeForTesting*)object)->value);
+    return StringFrom(((const MyTypeForTesting*)object)->value);
 }
 
 TEST(MockComparatorCopierTest, customObjectWithFunctionComparator)

--- a/tests/CppUTestExt/MockExpectedCallTest.cpp
+++ b/tests/CppUTestExt/MockExpectedCallTest.cpp
@@ -82,7 +82,7 @@ TEST_GROUP(MockNamedValueHandlerRepository)
 TEST(MockNamedValueHandlerRepository, getComparatorForNonExistingName)
 {
     MockNamedValueComparatorsAndCopiersRepository repository;
-    POINTERS_EQUAL(NULL, repository.getComparatorForType("typeName"));
+    POINTERS_EQUAL(NULLPTR, repository.getComparatorForType("typeName"));
 }
 
 TEST(MockNamedValueHandlerRepository, installComparator)
@@ -108,7 +108,7 @@ TEST(MockNamedValueHandlerRepository, installMultipleComparators)
 TEST(MockNamedValueHandlerRepository, getCopierForNonExistingName)
 {
     MockNamedValueComparatorsAndCopiersRepository repository;
-    POINTERS_EQUAL(NULL, repository.getCopierForType("typeName"));
+    POINTERS_EQUAL(NULLPTR, repository.getCopierForType("typeName"));
 }
 
 TEST(MockNamedValueHandlerRepository, installCopier)
@@ -713,7 +713,7 @@ TEST(MockIgnoredExpectedCall, worksAsItShould)
     ignored.withName("func");
     ignored.withCallOrder(1);
     ignored.withCallOrder(1, 1);
-    ignored.onObject((void*) 0);
+    ignored.onObject(NULLPTR);
     ignored.withBoolParameter("umm", true);
     ignored.withIntParameter("bla", (int) 1);
     ignored.withUnsignedIntParameter("foo", (unsigned int) 1);
@@ -721,13 +721,13 @@ TEST(MockIgnoredExpectedCall, worksAsItShould)
     ignored.withUnsignedLongIntParameter("bah", (unsigned long int) 1);
     ignored.withDoubleParameter("hah", (double) 1.1f);
     ignored.withStringParameter("goo", "hello");
-    ignored.withPointerParameter("pie", (void*) 0);
-    ignored.withConstPointerParameter("woo", (const void*) 0);
-    ignored.withFunctionPointerParameter("fop", (void(*)()) 0);
-    ignored.withMemoryBufferParameter("waa", (const unsigned char*) 0, 0);
-    ignored.withParameterOfType( "mytype", "top", (const void*) 0);
-    ignored.withOutputParameterReturning("bar", (void*) 0, 1);
-    ignored.withOutputParameterOfTypeReturning("mytype", "bar", (const void*) 0);
+    ignored.withPointerParameter("pie", (void*) NULLPTR);
+    ignored.withConstPointerParameter("woo", (const void*) NULLPTR);
+    ignored.withFunctionPointerParameter("fop", (void(*)()) NULLPTR);
+    ignored.withMemoryBufferParameter("waa", (const unsigned char*) NULLPTR, 0);
+    ignored.withParameterOfType( "mytype", "top", (const void*) NULLPTR);
+    ignored.withOutputParameterReturning("bar", (void*) NULLPTR, 1);
+    ignored.withOutputParameterOfTypeReturning("mytype", "bar", (const void*) NULLPTR);
     ignored.ignoreOtherParameters();
     ignored.andReturnValue(true);
     ignored.andReturnValue((double) 1.0f);
@@ -736,7 +736,7 @@ TEST(MockIgnoredExpectedCall, worksAsItShould)
     ignored.andReturnValue((unsigned long int) 1);
     ignored.andReturnValue((long int) 1);
     ignored.andReturnValue("boo");
-    ignored.andReturnValue((void*) 0);
-    ignored.andReturnValue((const void*) 0);
-    ignored.andReturnValue((void(*)()) 0);
+    ignored.andReturnValue((void*) NULLPTR);
+    ignored.andReturnValue((const void*) NULLPTR);
+    ignored.andReturnValue((void(*)()) NULLPTR);
 }

--- a/tests/CppUTestExt/MockFailureReporterForTest.cpp
+++ b/tests/CppUTestExt/MockFailureReporterForTest.cpp
@@ -45,7 +45,7 @@ MockFailureReporterInstaller::MockFailureReporterInstaller()
 
 MockFailureReporterInstaller::~MockFailureReporterInstaller()
 {
-  mock().setMockFailureStandardReporter(NULL);
+  mock().setMockFailureStandardReporter(NULLPTR);
 }
 
 UtestShell* mockFailureTest()

--- a/tests/CppUTestExt/MockNamedValueTest.cpp
+++ b/tests/CppUTestExt/MockNamedValueTest.cpp
@@ -37,7 +37,7 @@ class MyComparator : public MockNamedValueComparator
   public:
 
     MyComparator() {}
-    virtual ~MyComparator() {}
+    virtual ~MyComparator() _destructor_override {}
 
     virtual bool isEqual(const void*, const void*) _override { return false; }
     virtual SimpleString valueToString(const void*) _override { return ""; }
@@ -48,7 +48,7 @@ class MyCopier : public MockNamedValueCopier
   public:
 
     MyCopier() {}
-    virtual ~MyCopier() {}
+    virtual ~MyCopier() _destructor_override {}
 
     virtual void copy(void*, const void*) _override {}
 };

--- a/tests/CppUTestExt/MockParameterTest.cpp
+++ b/tests/CppUTestExt/MockParameterTest.cpp
@@ -713,12 +713,12 @@ TEST(MockParameterTest, ignoreOtherCallsIgnoresWithAllKindsOfParameters)
            .withParameter("foo", 1l)
            .withParameter("hey", 1ul)
            .withParameter("duh", 1.0)
-           .withParameter("yoo", (const void*) 0)
-           .withParameter("func", (void(*)()) 0)
-           .withParameter("mem", (const unsigned char*) 0, 0)
-           .withParameterOfType("hoo", "int", (const void*) 0)
-           .withOutputParameter("gah", (void*) 0)
-           .withOutputParameterOfType("goo", "int", (void*) 0);
+           .withParameter("yoo", (const void*) NULLPTR)
+           .withParameter("func", (void(*)()) NULLPTR)
+           .withParameter("mem", (const unsigned char*) NULLPTR, 0)
+           .withParameterOfType("hoo", "int", (const void*) NULLPTR)
+           .withOutputParameter("gah", (void*) NULLPTR)
+           .withOutputParameterOfType("goo", "int", (void*) NULLPTR);
 
     mock().checkExpectations();
 }

--- a/tests/CppUTestExt/MockPluginTest.cpp
+++ b/tests/CppUTestExt/MockPluginTest.cpp
@@ -106,8 +106,8 @@ TEST(MockPlugin, installComparatorRecordsTheComparatorButNotInstallsItYet)
 
     DummyComparator comparator;
     plugin.installComparator("myType", comparator);
-    mock().expectOneCall("foo").withParameterOfType("myType", "name", NULL);
-    mock().actualCall("foo").withParameterOfType("myType", "name", NULL);
+    mock().expectOneCall("foo").withParameterOfType("myType", "name", NULLPTR);
+    mock().actualCall("foo").withParameterOfType("myType", "name", NULLPTR);
 
     MockNoWayToCompareCustomTypeFailure failure(test, "myType");
     CHECK_EXPECTED_MOCK_FAILURE(failure);
@@ -128,8 +128,8 @@ TEST(MockPlugin, installCopierRecordsTheCopierButNotInstallsItYet)
 
     DummyCopier copier;
     plugin.installCopier("myType", copier);
-    mock().expectOneCall("foo").withOutputParameterOfTypeReturning("myType", "name", NULL);
-    mock().actualCall("foo").withOutputParameterOfType("myType", "name", NULL);
+    mock().expectOneCall("foo").withOutputParameterOfTypeReturning("myType", "name", NULLPTR);
+    mock().actualCall("foo").withOutputParameterOfType("myType", "name", NULLPTR);
 
     MockNoWayToCopyCustomTypeFailure failure(test, "myType");
     CHECK_EXPECTED_MOCK_FAILURE(failure);

--- a/tests/CppUTestExt/MockSupport_cTest.cpp
+++ b/tests/CppUTestExt/MockSupport_cTest.cpp
@@ -116,7 +116,7 @@ extern "C"{
 
     static void typeCopy(void* dst, const void* src)
     {
-        *(int*) dst = *(int*) src;
+        *(int*) dst = *(const int*) src;
     }
 
 }

--- a/tests/CppUTestExt/MockSupport_cTest.cpp
+++ b/tests/CppUTestExt/MockSupport_cTest.cpp
@@ -60,12 +60,12 @@ TEST(MockSupport_c, OrderObserved)
 TEST(MockSupport_c, hasReturnValue)
 {
     mock_c()->expectOneCall("foo");
-    CHECK(!mock_c()->actualCall("foo")->hasReturnValue());
-    CHECK(!mock_c()->hasReturnValue());
+    CHECK(mock_c()->actualCall("foo")->hasReturnValue() == 0);
+    CHECK(mock_c()->hasReturnValue() == 0);
 
     mock_c()->expectOneCall("foo2")->andReturnIntValue(1);
-    CHECK(mock_c()->actualCall("foo2")->hasReturnValue());
-    CHECK(mock_c()->hasReturnValue());
+    CHECK(mock_c()->actualCall("foo2")->hasReturnValue() != 0);
+    CHECK(mock_c()->hasReturnValue() != 0);
 }
 
 TEST(MockSupport_c, expectAndActualOneCall)

--- a/tests/CppUTestExt/OrderedTestTest.cpp
+++ b/tests/CppUTestExt/OrderedTestTest.cpp
@@ -46,7 +46,7 @@ TEST_GROUP(TestOrderedTest)
     void setup()
     {
         orderedTestCache = OrderedTestShell::getOrderedTestHead();
-        OrderedTestShell::setOrderedTestHead(0);
+        OrderedTestShell::setOrderedTestHead(NULLPTR);
 
         fixture = new TestTestingFixture();
         fixture->registry_->unDoLastAddTest();


### PR DESCRIPTION
This PR fixes the "errors" (warnings really) raised by Clang 5.0.0 and later, which make the cpputest builds to fail.

The PR is long and boring, but the changes are trivial, so it should not be difficult to review.

I've added also Visual Studio 2012 and 2013 to CI builds, as I've found while fixing clang errors that VS2010's implementation of C++11 is not "complete" (it doesn't allow override specs in destructors), so as builds are pretty fast I thought it would be better to ensure that it builds properly with these toolsets too.