### PR TITLE
Fixed compilation using CMake with Clang + MinGW bintools in Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,12 +28,14 @@ if (MINGW)
         add_definitions(-D_TIMESPEC_DEFINED=1)
     endif()
 
-    # Apply workaround for static/shared libraries on MinGW C/C++ compiler
-    # Issue occurs with CMake >= 3.9.0, it doesn't filter out gcc,gcc_s,gcc_eh from
-    # the implicit library list anymore, so the C++ linker is getting passed the static
-    # gcc_eh library since that's what the C linker uses by default. Only solution appears
-    # to be to force static linkage.
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static")
+    if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+        # Apply workaround for static/shared libraries on MinGW C/C++ compiler
+        # Issue occurs with CMake >= 3.9.0, it doesn't filter out gcc,gcc_s,gcc_eh from
+        # the implicit library list anymore, so the C++ linker is getting passed the static
+        # gcc_eh library since that's what the C linker uses by default. Only solution appears
+        # to be to force static linkage.
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static")
+    endif()
 endif()
 
 option(STD_C "Use the standard C library" ON)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,6 +20,10 @@ environment:
     PlatformToolset: 5.3.0
   - Platform: MinGW64
     PlatformToolset: 5.3.0
+  - Platform: MinGWClang64
+    PlatformToolset: 5.3.0
+  - Platform: MinGWClang32
+    PlatformToolset: 5.3.0
   - Platform: Win32
     PlatformToolset: v90
   - Platform: Win32

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,7 +34,7 @@ environment:
     PlatformToolset: v140
 
 install:
-- ps: if ($env:Platform -like 'MinGW*') { choco install mingw --version $env:PlatformToolset $( if ($env:Platform -like '*32') { Write-Output --forcex86 } ) }
+- ps: if ($env:Platform -like 'MinGW*') { choco install mingw --version $env:PlatformToolset $( if ($env:Platform -like '*32') { Write-Output --forcex86 --params /exception:dwarf } ) }
 
 build_script:
 - ps: scripts\appveyor_ci_build.ps1

--- a/cmake/clang+mingw-win32.toolchain.cmake
+++ b/cmake/clang+mingw-win32.toolchain.cmake
@@ -1,6 +1,6 @@
 # Toolchain to use Clang compiler with MinGW binutils (e.g. linker) in Windows to generate 32-bits executables
 
 set(CMAKE_C_COMPILER clang)
-set(CMAKE_C_FLAGS "-target x86_64-w64-mingw32 -m32" CACHE STRING "" FORCE)
+set(CMAKE_C_FLAGS "-target i686-w64-mingw32 -m32" CACHE STRING "" FORCE)
 set(CMAKE_CXX_COMPILER clang++)
 set(CMAKE_CXX_FLAGS "-target i686-w64-mingw32 -m32" CACHE STRING "" FORCE)

--- a/cmake/clang+mingw-win32.toolchain.cmake
+++ b/cmake/clang+mingw-win32.toolchain.cmake
@@ -1,0 +1,6 @@
+# Toolchain to use Clang compiler with MinGW binutils (e.g. linker) in Windows to generate 32-bits executables
+
+set(CMAKE_C_COMPILER clang)
+set(CMAKE_C_FLAGS "-target x86_64-w64-mingw32 -m32" CACHE STRING "" FORCE)
+set(CMAKE_CXX_COMPILER clang++)
+set(CMAKE_CXX_FLAGS "-target i686-w64-mingw32 -m32" CACHE STRING "" FORCE)

--- a/cmake/clang+mingw-win64.toolchain.cmake
+++ b/cmake/clang+mingw-win64.toolchain.cmake
@@ -1,0 +1,6 @@
+# Toolchain to use Clang compiler with MinGW binutils (e.g. linker) in Windows to generate 64-bits executables
+
+set(CMAKE_C_COMPILER clang)
+set(CMAKE_C_FLAGS "-target x86_64-w64-mingw32" CACHE STRING "" FORCE)
+set(CMAKE_CXX_COMPILER clang++)
+set(CMAKE_CXX_FLAGS "-target x86_64-w64-mingw32" CACHE STRING "" FORCE)

--- a/scripts/appveyor_ci_build.ps1
+++ b/scripts/appveyor_ci_build.ps1
@@ -72,12 +72,19 @@ switch -Wildcard ($env:Platform)
     'MinGW*'
     {
         $mingw_path = Get-MinGWBin
+        
+        if ($env:Platform -like 'MinGWClang*')
+        {
+            $toolchain_filename = Get-ClangToolchainFilename
+            $toolchain_path = (Join-Path (Split-Path $MyInvocation.MyCommand.Path) "..\cmake\$toolchain_filename")
+            $toolchain = "-DCMAKE_TOOLCHAIN_FILE=$toolchain_path" 
+        }
 
         # Add mingw to the path
         Add-PathFolder $mingw_path
 
         Invoke-BuildCommand "cmake --version"
-        Invoke-BuildCommand "cmake -G 'MinGW Makefiles' .." 'cpputest_build'
+        Invoke-BuildCommand "cmake -G 'MinGW Makefiles' $toolchain .." 'cpputest_build'
         Invoke-BuildCommand "mingw32-make all" 'cpputest_build'
 
         Remove-PathFolder $mingw_path

--- a/scripts/appveyor_helpers.ps1
+++ b/scripts/appveyor_helpers.ps1
@@ -18,6 +18,16 @@ function Get-MinGWBin() {
     }
 }
 
+# Helper function to provide the toolchain file for clang
+function Get-ClangToolchainFilename() {
+    if ($env:Platform -like '*64') {
+        Write-Output 'clang+mingw-win64.toolchain.cmake'
+    }
+    else {
+        Write-Output 'clang+mingw-win32.toolchain.cmake'
+    }
+}
+
 # Helper function to provide the bin-folder path to cygwin
 function Get-CygwinBin() {
     if ($env:Platform -like '*64') {


### PR DESCRIPTION
The workaround to fix CMake + MinGW compilation breaks CMake + Clang + MinGW bintools compilation, so it's fixed to apply only if the compiler is not Clang (for some dark reason CMake flags Clang as a MinGW compiler).

Besides that I've added a couple of toolchain files for CMake to simplify using this toolchain combination, and added it to CI builds.