### PR TITLE
Made expectation objects optional.

### DIFF
--- a/include/CppUTestExt/MockCheckedExpectedCall.h
+++ b/include/CppUTestExt/MockCheckedExpectedCall.h
@@ -135,6 +135,7 @@ private:
     MockNamedValueList* outputParameters_;
     MockNamedValue returnValue_;
     void* objectPtr_;
+    bool isSpecificObjectExpected_;
     bool wasPassedToObject_;
     unsigned int actualCalls_;
     unsigned int expectedCalls_;

--- a/src/CppUTestExt/MockActualCall.cpp
+++ b/src/CppUTestExt/MockActualCall.cpp
@@ -527,19 +527,22 @@ MockActualCall& MockCheckedActualCall::onObject(const void* objectPtr)
         return *this;
     }
 
-    setState(CALL_IN_PROGRESS);
-    discardCurrentlyMatchingExpectations();
+    // Currently matching expectations are not discarded because the passed object
+    // is ignored if not specifically set in the expectation
 
     potentiallyMatchingExpectations_.onlyKeepExpectationsOnObject(objectPtr);
 
-    if (potentiallyMatchingExpectations_.isEmpty()) {
+    if ((!matchingExpectation_) && potentiallyMatchingExpectations_.isEmpty()) {
         MockUnexpectedObjectFailure failure(getTest(), getName(), objectPtr, allExpectations_);
         failTest(failure);
         return *this;
     }
 
     potentiallyMatchingExpectations_.wasPassedToObject();
-    completeCallWhenMatchIsFound();
+
+    if (!matchingExpectation_) {
+        completeCallWhenMatchIsFound();
+    }
 
     return *this;
 }

--- a/src/CppUTestExt/MockExpectedCall.cpp
+++ b/src/CppUTestExt/MockExpectedCall.cpp
@@ -54,7 +54,7 @@ SimpleString MockCheckedExpectedCall::getName() const
 MockCheckedExpectedCall::MockCheckedExpectedCall()
     : ignoreOtherParameters_(false), isActualCallMatchFinalized_(false),
       initialExpectedCallOrder_(NO_EXPECTED_CALL_ORDER), finalExpectedCallOrder_(NO_EXPECTED_CALL_ORDER),
-      outOfOrder_(false), returnValue_(""), objectPtr_(NULL), wasPassedToObject_(true),
+      outOfOrder_(false), returnValue_(""), objectPtr_(NULL), isSpecificObjectExpected_(false), wasPassedToObject_(true),
       actualCalls_(0), expectedCalls_(1)
 {
     inputParameters_ = new MockNamedValueList();
@@ -64,7 +64,7 @@ MockCheckedExpectedCall::MockCheckedExpectedCall()
 MockCheckedExpectedCall::MockCheckedExpectedCall(unsigned int numCalls)
     : ignoreOtherParameters_(false), isActualCallMatchFinalized_(false),
       initialExpectedCallOrder_(NO_EXPECTED_CALL_ORDER), finalExpectedCallOrder_(NO_EXPECTED_CALL_ORDER),
-      outOfOrder_(false), returnValue_(""), objectPtr_(NULL), wasPassedToObject_(true),
+      outOfOrder_(false), returnValue_(""), objectPtr_(NULL), isSpecificObjectExpected_(false), wasPassedToObject_(true),
       actualCalls_(0), expectedCalls_(numCalls)
 {
     inputParameters_ = new MockNamedValueList();
@@ -291,7 +291,7 @@ void MockCheckedExpectedCall::wasPassedToObject()
 
 void MockCheckedExpectedCall::resetActualCallMatchingState()
 {
-    wasPassedToObject_ = (objectPtr_ == NULL);
+    wasPassedToObject_ = !isSpecificObjectExpected_;
     isActualCallMatchFinalized_ = false;
 
     MockNamedValueListNode* p;
@@ -339,7 +339,7 @@ bool MockCheckedExpectedCall::hasOutputParameter(const MockNamedValue& parameter
 SimpleString MockCheckedExpectedCall::callToString()
 {
     SimpleString str;
-    if (objectPtr_)
+    if (isSpecificObjectExpected_)
         str = StringFromFormat("(object address: %p)::", objectPtr_);
 
     str += getName();
@@ -409,7 +409,7 @@ bool MockCheckedExpectedCall::relatesTo(const SimpleString& functionName)
 
 bool MockCheckedExpectedCall::relatesToObject(const void* objectPtr) const
 {
-    return objectPtr_ == objectPtr;
+    return (!isSpecificObjectExpected_) || (objectPtr_ == objectPtr);
 }
 
 MockCheckedExpectedCall::MockExpectedFunctionParameter* MockCheckedExpectedCall::item(MockNamedValueListNode* node)
@@ -504,6 +504,7 @@ MockExpectedCall& MockCheckedExpectedCall::andReturnValue(void (*value)())
 
 MockExpectedCall& MockCheckedExpectedCall::onObject(void* objectPtr)
 {
+    isSpecificObjectExpected_ = true;
     wasPassedToObject_ = false;
     objectPtr_ = objectPtr;
     return *this;

--- a/tests/CppUTestExt/MockCallTest.cpp
+++ b/tests/CppUTestExt/MockCallTest.cpp
@@ -366,6 +366,31 @@ TEST(MockCallTest, OnObject)
     mock().actualCall("boo").onObject(objectPtr);
 }
 
+TEST(MockCallTest, OnObjectIgnored_MatchingAlreadyWhenObjectPassed)
+{
+    void* objectPtr = (void*) 0x001;
+    mock().expectOneCall("boo");
+    mock().actualCall("boo").onObject(objectPtr);
+}
+
+TEST(MockCallTest, OnObjectIgnored_NotMatchingYetWhenObjectPassed)
+{
+    void* objectPtr = (void*) 0x001;
+    mock().expectOneCall("boo").withBoolParameter("p", true);
+    mock().actualCall("boo").onObject(objectPtr).withBoolParameter("p", true);
+}
+
+TEST(MockCallTest, OnObjectIgnored_InitialMatchDiscarded)
+{
+    void* objectPtr1 = (void*) 0x001;
+    void* objectPtr2 = (void*) 0x002;
+
+    mock().expectOneCall("boo");
+    mock().expectOneCall("boo").withBoolParameter("p", true);
+    mock().actualCall("boo").onObject(objectPtr2).withBoolParameter("p", true);;
+    mock().actualCall("boo").onObject(objectPtr1);
+}
+
 TEST(MockCallTest, OnObjectFails)
 {
     MockFailureReporterInstaller failureReporterInstaller;


### PR DESCRIPTION
With this modifications, if onObject() is called on a expected call, it is considered that the expectation matches only the specific object passed; but if it's not called, it's considered that the expectation matches any object.

Therefore, when onObject() is called on an actual call, both the expectations that target the passed object and the expectations that do not target a specific object will match.

This is a solution for #1019.