### PR TITLE
Differentiated const and non-const objects

### DIFF
--- a/include/CppUTestExt/MockNamedValue.h
+++ b/include/CppUTestExt/MockNamedValue.h
@@ -112,7 +112,8 @@ public:
     virtual void setValue(void (*value)());
     virtual void setValue(const char* value);
     virtual void setMemoryBuffer(const unsigned char* value, size_t size);
-    virtual void setObjectPointer(const SimpleString& type, const void* objectPtr);
+    virtual void setConstObjectPointer(const SimpleString& type, const void* objectPtr);
+    virtual void setObjectPointer(const SimpleString& type, void* objectPtr);
     virtual void setSize(size_t size);
 
     virtual void setName(const char* name);
@@ -136,7 +137,8 @@ public:
     virtual const void* getConstPointerValue() const;
     virtual void (*getFunctionPointerValue() const)();
     virtual const unsigned char* getMemoryBuffer() const;
-    virtual const void* getObjectPointer() const;
+    virtual const void* getConstObjectPointer() const;
+    virtual void* getObjectPointer() const;
     virtual size_t getSize() const;
 
     virtual MockNamedValueComparator* getComparator() const;
@@ -158,7 +160,8 @@ private:
         const void* constPointerValue_;
         void (*functionPointerValue_)();
         const unsigned char* memoryBufferValue_;
-        const void* objectPointerValue_;
+        const void* constObjectPointerValue_;
+        void* objectPointerValue_;
         const void* outputPointerValue_;
     } value_;
     size_t size_;

--- a/include/CppUTestExt/MockSupport.h
+++ b/include/CppUTestExt/MockSupport.h
@@ -83,6 +83,7 @@ public:
     void setData(const SimpleString& name, const void* value);
     void setData(const SimpleString& name, void (*value)());
     void setDataObject(const SimpleString& name, const SimpleString& type, void* value);
+    void setDataConstObject(const SimpleString& name, const SimpleString& type, const void* value);
     MockNamedValue getData(const SimpleString& name);
 
     MockSupport* getMockSupportScope(const SimpleString& name);

--- a/include/CppUTestExt/MockSupport_c.h
+++ b/include/CppUTestExt/MockSupport_c.h
@@ -64,7 +64,8 @@ typedef struct SMockValue_c
         const void* constPointerValue;
         void (*functionPointerValue)(void);
         const unsigned char* memoryBufferValue;
-        const void* objectValue;
+        void* objectValue;
+        const void* constObjectValue;
     } value;
 } MockValue_c;
 
@@ -184,6 +185,7 @@ struct SMockSupport_c
     void (*setConstPointerData) (const char* name, const void* value);
     void (*setFunctionPointerData) (const char* name, void (*value)(void));
     void (*setDataObject) (const char* name, const char* type, void* value);
+    void (*setDataConstObject) (const char* name, const char* type, const void* value);
     MockValue_c (*getData)(const char* name);
 
     void (*disable)(void);

--- a/src/CppUTestExt/MockActualCall.cpp
+++ b/src/CppUTestExt/MockActualCall.cpp
@@ -87,7 +87,7 @@ void MockCheckedActualCall::copyOutputParameters(MockCheckedExpectedCall* expect
         MockNamedValueCopier* copier = outputParameter.getCopier();
         if (copier)
         {
-            copier->copy(p->ptr_, outputParameter.getObjectPointer());
+            copier->copy(p->ptr_, outputParameter.getConstObjectPointer());
         }
         else if ((outputParameter.getType() == "const void*") && (p->type_ == "void*"))
         {
@@ -292,7 +292,7 @@ MockActualCall& MockCheckedActualCall::withMemoryBufferParameter(const SimpleStr
 MockActualCall& MockCheckedActualCall::withParameterOfType(const SimpleString& type, const SimpleString& name, const void* value)
 {
     MockNamedValue actualParameter(name);
-    actualParameter.setObjectPointer(type, value);
+    actualParameter.setConstObjectPointer(type, value);
 
     if (actualParameter.getComparator() == NULL) {
         MockNoWayToCompareCustomTypeFailure failure(getTest(), type);
@@ -319,7 +319,7 @@ MockActualCall& MockCheckedActualCall::withOutputParameterOfType(const SimpleStr
     addOutputParameter(name, type, output);
 
     MockNamedValue outputParameter(name);
-    outputParameter.setObjectPointer(type, output);
+    outputParameter.setConstObjectPointer(type, output);
     checkOutputParameter(outputParameter);
 
     return *this;

--- a/src/CppUTestExt/MockExpectedCall.cpp
+++ b/src/CppUTestExt/MockExpectedCall.cpp
@@ -177,7 +177,7 @@ MockExpectedCall& MockCheckedExpectedCall::withParameterOfType(const SimpleStrin
 {
     MockNamedValue* newParameter = new MockExpectedFunctionParameter(name);
     inputParameters_->add(newParameter);
-    newParameter->setObjectPointer(type, value);
+    newParameter->setConstObjectPointer(type, value);
     return *this;
 }
 
@@ -194,7 +194,7 @@ MockExpectedCall& MockCheckedExpectedCall::withOutputParameterOfTypeReturning(co
 {
     MockNamedValue* newParameter = new MockExpectedFunctionParameter(name);
     outputParameters_->add(newParameter);
-    newParameter->setObjectPointer(type, value);
+    newParameter->setConstObjectPointer(type, value);
     return *this;
 }
 

--- a/src/CppUTestExt/MockNamedValue.cpp
+++ b/src/CppUTestExt/MockNamedValue.cpp
@@ -113,7 +113,18 @@ void MockNamedValue::setMemoryBuffer(const unsigned char* value, size_t size)
     size_ = size;
 }
 
-void MockNamedValue::setObjectPointer(const SimpleString& type, const void* objectPtr)
+void MockNamedValue::setConstObjectPointer(const SimpleString& type, const void* objectPtr)
+{
+    type_ = type;
+    value_.constObjectPointerValue_ = objectPtr;
+    if (defaultRepository_)
+    {
+        comparator_ = defaultRepository_->getComparatorForType(type);
+        copier_ = defaultRepository_->getCopierForType(type);
+    }
+}
+
+void MockNamedValue::setObjectPointer(const SimpleString& type, void* objectPtr)
 {
     type_ = type;
     value_.objectPointerValue_ = objectPtr;
@@ -231,7 +242,12 @@ const unsigned char* MockNamedValue::getMemoryBuffer() const
     return value_.memoryBufferValue_;
 }
 
-const void* MockNamedValue::getObjectPointer() const
+const void* MockNamedValue::getConstObjectPointer() const
+{
+    return value_.constObjectPointerValue_;
+}
+
+void* MockNamedValue::getObjectPointer() const
 {
     return value_.objectPointerValue_;
 }
@@ -309,7 +325,7 @@ bool MockNamedValue::equals(const MockNamedValue& p) const
     }
 
     if (comparator_)
-        return comparator_->isEqual(value_.objectPointerValue_, p.value_.objectPointerValue_);
+        return comparator_->isEqual(value_.constObjectPointerValue_, p.value_.constObjectPointerValue_);
 
     return false;
 }
@@ -350,7 +366,7 @@ SimpleString MockNamedValue::toString() const
         return StringFromBinaryWithSizeOrNull(value_.memoryBufferValue_, size_);
 
     if (comparator_)
-        return comparator_->valueToString(value_.objectPointerValue_);
+        return comparator_->valueToString(value_.constObjectPointerValue_);
 
     return StringFromFormat("No comparator found for type: \"%s\"", type_.asCharString());
 

--- a/src/CppUTestExt/MockSupport.cpp
+++ b/src/CppUTestExt/MockSupport.cpp
@@ -419,6 +419,12 @@ void MockSupport::setDataObject(const SimpleString& name, const SimpleString& ty
     newData->setObjectPointer(type, value);
 }
 
+void MockSupport::setDataConstObject(const SimpleString& name, const SimpleString& type, const void* value)
+{
+    MockNamedValue* newData = retrieveDataFromStore(name);
+    newData->setConstObjectPointer(type, value);
+}
+
 MockNamedValue MockSupport::getData(const SimpleString& name)
 {
     MockNamedValue* value = data_.getValueByName(name);

--- a/src/CppUTestExt/MockSupport_c.cpp
+++ b/src/CppUTestExt/MockSupport_c.cpp
@@ -134,6 +134,7 @@ void setPointerData_c(const char* name, void* value);
 void setConstPointerData_c(const char* name, const void* value);
 void setFunctionPointerData_c(const char* name, void (*value)());
 void setDataObject_c(const char* name, const char* type, void* value);
+void setDataConstObject_c(const char* name, const char* type, const void* value);
 MockValue_c getData_c(const char* name);
 int hasReturnValue_c();
 
@@ -335,6 +336,7 @@ static MockSupport_c gMockSupport = {
         setConstPointerData_c,
         setFunctionPointerData_c,
         setDataObject_c,
+        setDataConstObject_c,
         getData_c,
         disable_c,
         enable_c,
@@ -857,6 +859,11 @@ void setFunctionPointerData_c(const char* name, void (*value)())
 void setDataObject_c(const char* name, const char* type, void* value)
 {
     currentMockSupport->setDataObject(name, type, value);
+}
+
+void setDataConstObject_c(const char* name, const char* type, const void* value)
+{
+    currentMockSupport->setDataConstObject(name, type, value);
 }
 
 MockValue_c getData_c(const char* name)

--- a/tests/CppUTestExt/MockComparatorCopierTest.cpp
+++ b/tests/CppUTestExt/MockComparatorCopierTest.cpp
@@ -205,7 +205,7 @@ TEST(MockComparatorCopierTest, unexpectedCustomTypeOutputParameter)
     MockExpectedCallsListForTest expectations;
     expectations.addFunction("foo");
     MockNamedValue parameter("parameterName");
-    parameter.setObjectPointer("MyTypeForTesting", &actualObject);
+    parameter.setConstObjectPointer("MyTypeForTesting", &actualObject);
     MockUnexpectedOutputParameterFailure expectedFailure(mockFailureTest(), "foo", parameter, expectations);
 
     mock().expectOneCall("foo");
@@ -250,7 +250,7 @@ TEST(MockComparatorCopierTest, customTypeOutputParameterOfWrongType)
     MockExpectedCallsListForTest expectations;
     expectations.addFunction("foo")->withOutputParameterOfTypeReturning("MyTypeForTesting", "output", &expectedObject);
     MockNamedValue parameter("output");
-    parameter.setObjectPointer("OtherTypeForTesting", &actualObject);
+    parameter.setConstObjectPointer("OtherTypeForTesting", &actualObject);
     MockUnexpectedOutputParameterFailure expectedFailure(mockFailureTest(), "foo", parameter, expectations);
 
     mock().expectOneCall("foo").withOutputParameterOfTypeReturning("MyTypeForTesting", "output", &expectedObject);

--- a/tests/CppUTestExt/MockExpectedCallTest.cpp
+++ b/tests/CppUTestExt/MockExpectedCallTest.cpp
@@ -293,7 +293,7 @@ TEST(MockExpectedCall, callWithObjectParameter)
     const SimpleString paramName = "paramName";
     void* value = (void*) 0x123;
     call->withParameterOfType("ClassName", paramName, value);
-    POINTERS_EQUAL(value, call->getInputParameter(paramName).getObjectPointer());
+    POINTERS_EQUAL(value, call->getInputParameter(paramName).getConstObjectPointer());
     STRCMP_EQUAL("ClassName", call->getInputParameterType(paramName).asCharString());
     STRCMP_CONTAINS("funcName -> ClassName paramName: <No comparator found for type: \"ClassName\">", call->callToString().asCharString());
 }
@@ -302,7 +302,7 @@ TEST(MockExpectedCall, callWithObjectParameterUnequalComparison)
 {
     TypeForTestingExpectedFunctionCall type(1), unequalType(2);
     MockNamedValue parameter("name");
-    parameter.setObjectPointer("type", &unequalType);
+    parameter.setConstObjectPointer("type", &unequalType);
     call->withParameterOfType("type", "name", &type);
     CHECK(!call->hasInputParameter(parameter));
 }
@@ -311,7 +311,7 @@ TEST(MockExpectedCall, callWithObjectParameterEqualComparisonButFailsWithoutRepo
 {
     TypeForTestingExpectedFunctionCall type(1), equalType(1);
     MockNamedValue parameter("name");
-    parameter.setObjectPointer("type", &equalType);
+    parameter.setConstObjectPointer("type", &equalType);
     call->withParameterOfType("type", "name", &type);
     CHECK(!call->hasInputParameter(parameter));
 }
@@ -323,7 +323,7 @@ TEST(MockExpectedCall, callWithObjectParameterEqualComparisonButFailsWithoutComp
 
     TypeForTestingExpectedFunctionCall type(1), equalType(1);
     MockNamedValue parameter("name");
-    parameter.setObjectPointer("type", &equalType);
+    parameter.setConstObjectPointer("type", &equalType);
     call->withParameterOfType("type", "name", &type);
     CHECK(!call->hasInputParameter(parameter));
 }
@@ -337,7 +337,7 @@ TEST(MockExpectedCall, callWithObjectParameterEqualComparison)
 
     TypeForTestingExpectedFunctionCall type(1), equalType(1);
     MockNamedValue parameter("name");
-    parameter.setObjectPointer("type", &equalType);
+    parameter.setConstObjectPointer("type", &equalType);
 
     call->withParameterOfType("type", "name", &type);
     CHECK(call->hasInputParameter(parameter));
@@ -352,7 +352,7 @@ TEST(MockExpectedCall, getParameterValueOfObjectType)
 
     TypeForTestingExpectedFunctionCall type(1);
     call->withParameterOfType("type", "name", &type);
-    POINTERS_EQUAL(&type, call->getInputParameter("name").getObjectPointer());
+    POINTERS_EQUAL(&type, call->getInputParameter("name").getConstObjectPointer());
     STRCMP_EQUAL("1", call->getInputParameterValueString("name").asCharString());
 }
 
@@ -681,7 +681,7 @@ TEST(MockExpectedCall, hasOutputParameterOfType)
     TypeForTestingExpectedFunctionCall object(6789);
     call->withOutputParameterOfTypeReturning("TypeForTestingExpectedFunctionCall", "foo", &object);
     MockNamedValue foo("foo");
-    foo.setObjectPointer("TypeForTestingExpectedFunctionCall", &object);
+    foo.setConstObjectPointer("TypeForTestingExpectedFunctionCall", &object);
     CHECK(call->hasOutputParameter(foo));
 }
 
@@ -690,7 +690,7 @@ TEST(MockExpectedCall, hasNoOutputParameterOfTypeSameTypeButInput)
     TypeForTestingExpectedFunctionCall object(543);
     call->withParameterOfType("TypeForTestingExpectedFunctionCall", "foo", &object);
     MockNamedValue foo("foo");
-    foo.setObjectPointer("TypeForTestingExpectedFunctionCall", &object);
+    foo.setConstObjectPointer("TypeForTestingExpectedFunctionCall", &object);
     CHECK_FALSE(call->hasOutputParameter(foo));
 }
 
@@ -699,7 +699,7 @@ TEST(MockExpectedCall, hasNoOutputParameterOfTypeDifferentType)
     TypeForTestingExpectedFunctionCall object(543);
     call->withOutputParameterOfTypeReturning("TypeForTestingExpectedFunctionCall", "foo", &object);
     MockNamedValue foo("foo");
-    foo.setObjectPointer("OtherTypeForTestingExpectedFunctionCall", &object);
+    foo.setConstObjectPointer("OtherTypeForTestingExpectedFunctionCall", &object);
     CHECK_FALSE(call->hasOutputParameter(foo));
 }
 

--- a/tests/CppUTestExt/MockSupportTest.cpp
+++ b/tests/CppUTestExt/MockSupportTest.cpp
@@ -134,6 +134,14 @@ TEST(MockSupportTest, setDataObject)
     STRCMP_EQUAL("type", mock().getData("data").getType().asCharString());
 }
 
+TEST(MockSupportTest, setDataConstObject)
+{
+    void * ptr = (void*) 0x011;
+    mock().setDataConstObject("data", "type", ptr);
+    POINTERS_EQUAL(ptr, mock().getData("data").getConstObjectPointer());
+    STRCMP_EQUAL("type", mock().getData("data").getType().asCharString());
+}
+
 TEST(MockSupportTest, tracing)
 {
     mock().tracing(true);

--- a/tests/CppUTestExt/MockSupport_cTest.cpp
+++ b/tests/CppUTestExt/MockSupport_cTest.cpp
@@ -519,6 +519,12 @@ TEST(MockSupport_c, MockSupportSetDataObject)
     POINTERS_EQUAL((void*) 1, mock_c()->getData("name").value.objectValue);
 }
 
+TEST(MockSupport_c, MockSupportSetDataConstObject)
+{
+    mock_c()->setDataConstObject("name", "type", (const void*) 5);
+    POINTERS_EQUAL((void*) 5, mock_c()->getData("name").value.constObjectValue);
+}
+
 TEST(MockSupport_c, WorksInCFile)
 {
     all_mock_support_c_calls();


### PR DESCRIPTION
Differentiated const and non-const objects used as aux data stored by MockSupport.

BTW, this PR avoids the necessity to perform const casts that are not liked by clang (see #1137 discussion).