### PR TITLE
add support for long long integers as native types

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -203,7 +203,8 @@ CppUTestExtTests_SOURCES = \
 	tests/CppUTestExt/MockSupport_cTestCFile.c \
 	tests/CppUTestExt/MockStrictOrderTest.cpp \
 	tests/CppUTestExt/MockReturnValueTest.cpp \
-	tests/CppUTestExt/OrderedTestTest.cpp
+	tests/CppUTestExt/OrderedTestTest.cpp \
+	tests/CppUTestExt/MockFakeLongLong.cpp
 
 DISTCLEANFILES = \
 	filename.map.txt \

--- a/include/CppUTest/UtestMacros.h
+++ b/include/CppUTest/UtestMacros.h
@@ -235,10 +235,10 @@
   UNSIGNED_LONGLONGS_EQUAL_LOCATION(expected, actual, text, __FILE__, __LINE__)
 
 #define LONGLONGS_EQUAL_LOCATION(expected, actual, text, file, line)\
-        { UtestShell::getCurrent()->assertLongLongsEqual(expected, actual, text, file, line); }
+        { UtestShell::getCurrent()->assertLongLongsEqual((long long)expected, (long long)actual, text, file, line); }
 
 #define UNSIGNED_LONGLONGS_EQUAL_LOCATION(expected, actual, text, file, line)\
-        { UtestShell::getCurrent()->assertUnsignedLongLongsEqual(expected, actual, text, file, line); }
+        { UtestShell::getCurrent()->assertUnsignedLongLongsEqual((unsigned long long)expected, (unsigned long long)actual, text, file, line); }
 
 #define BYTES_EQUAL(expected, actual)\
     LONGS_EQUAL((expected) & 0xff,(actual) & 0xff)

--- a/include/CppUTestExt/MockActualCall.h
+++ b/include/CppUTestExt/MockActualCall.h
@@ -28,6 +28,7 @@
 #ifndef D_MockActualCall_h
 #define D_MockActualCall_h
 
+#include "CppUTest/CppUTestConfig.h"
 #include "CppUTest/TestHarness.h"
 #include "CppUTestExt/MockNamedValue.h"
 #include "CppUTestExt/MockExpectedCallsList.h"
@@ -48,6 +49,8 @@ public:
     MockActualCall& withParameter(const SimpleString& name, unsigned int value) { return withUnsignedIntParameter(name, value); }
     MockActualCall& withParameter(const SimpleString& name, long int value) { return withLongIntParameter(name, value); }
     MockActualCall& withParameter(const SimpleString& name, unsigned long int value) { return withUnsignedLongIntParameter(name, value); }
+    MockActualCall& withParameter(const SimpleString& name, cpputest_longlong value) { return withLongLongIntParameter(name, value); }
+    MockActualCall& withParameter(const SimpleString& name, cpputest_ulonglong value) { return withUnsignedLongLongIntParameter(name, value); }
     MockActualCall& withParameter(const SimpleString& name, double value) { return withDoubleParameter(name, value); }
     MockActualCall& withParameter(const SimpleString& name, const char* value) { return withStringParameter(name, value); }
     MockActualCall& withParameter(const SimpleString& name, void* value) { return withPointerParameter(name, value); }
@@ -63,6 +66,8 @@ public:
     virtual MockActualCall& withUnsignedIntParameter(const SimpleString& name, unsigned int value)=0;
     virtual MockActualCall& withLongIntParameter(const SimpleString& name, long int value)=0;
     virtual MockActualCall& withUnsignedLongIntParameter(const SimpleString& name, unsigned long int value)=0;
+    virtual MockActualCall& withLongLongIntParameter(const SimpleString& name, cpputest_longlong value)=0;
+    virtual MockActualCall& withUnsignedLongLongIntParameter(const SimpleString& name, cpputest_ulonglong value)=0;
     virtual MockActualCall& withDoubleParameter(const SimpleString& name, double value)=0;
     virtual MockActualCall& withStringParameter(const SimpleString& name, const char* value)=0;
     virtual MockActualCall& withPointerParameter(const SimpleString& name, void* value)=0;
@@ -84,6 +89,12 @@ public:
 
     virtual long int returnLongIntValue()=0;
     virtual long int returnLongIntValueOrDefault(long int default_value)=0;
+
+    virtual cpputest_ulonglong returnUnsignedLongLongIntValue()=0;
+    virtual cpputest_ulonglong returnUnsignedLongLongIntValueOrDefault(cpputest_ulonglong default_value)=0;
+
+    virtual cpputest_longlong returnLongLongIntValue()=0;
+    virtual cpputest_longlong returnLongLongIntValueOrDefault(cpputest_longlong default_value)=0;
 
     virtual unsigned int returnUnsignedIntValue()=0;
     virtual unsigned int returnUnsignedIntValueOrDefault(unsigned int default_value)=0;

--- a/include/CppUTestExt/MockCheckedActualCall.h
+++ b/include/CppUTestExt/MockCheckedActualCall.h
@@ -44,6 +44,8 @@ public:
     virtual MockActualCall& withUnsignedIntParameter(const SimpleString& name, unsigned int value) _override;
     virtual MockActualCall& withLongIntParameter(const SimpleString& name, long int value) _override;
     virtual MockActualCall& withUnsignedLongIntParameter(const SimpleString& name, unsigned long int value) _override;
+    virtual MockActualCall& withLongLongIntParameter(const SimpleString& name, cpputest_longlong value) _override;
+    virtual MockActualCall& withUnsignedLongLongIntParameter(const SimpleString& name, cpputest_ulonglong value) _override;
     virtual MockActualCall& withDoubleParameter(const SimpleString& name, double value) _override;
     virtual MockActualCall& withStringParameter(const SimpleString& name, const char* value) _override;
     virtual MockActualCall& withPointerParameter(const SimpleString& name, void* value) _override;
@@ -68,6 +70,12 @@ public:
 
     virtual long int returnLongIntValue() _override;
     virtual long int returnLongIntValueOrDefault(long int default_value) _override;
+
+    virtual cpputest_ulonglong returnUnsignedLongLongIntValue() _override;
+    virtual cpputest_ulonglong returnUnsignedLongLongIntValueOrDefault(cpputest_ulonglong default_value) _override;
+
+    virtual cpputest_longlong returnLongLongIntValue() _override;
+    virtual cpputest_longlong returnLongLongIntValueOrDefault(cpputest_longlong default_value) _override;
 
     virtual unsigned int returnUnsignedIntValue() _override;
     virtual unsigned int returnUnsignedIntValueOrDefault(unsigned int default_value) _override;
@@ -157,6 +165,8 @@ public:
     virtual MockActualCall& withUnsignedIntParameter(const SimpleString& name, unsigned int value) _override;
     virtual MockActualCall& withLongIntParameter(const SimpleString& name, long int value) _override;
     virtual MockActualCall& withUnsignedLongIntParameter(const SimpleString& name, unsigned long int value) _override;
+    virtual MockActualCall& withLongLongIntParameter(const SimpleString& name, cpputest_longlong value) _override;
+    virtual MockActualCall& withUnsignedLongLongIntParameter(const SimpleString& name, cpputest_ulonglong value) _override;
     virtual MockActualCall& withDoubleParameter(const SimpleString& name, double value) _override;
     virtual MockActualCall& withStringParameter(const SimpleString& name, const char* value) _override;
     virtual MockActualCall& withPointerParameter(const SimpleString& name, void* value) _override;
@@ -181,6 +191,12 @@ public:
 
     virtual long int returnLongIntValue() _override;
     virtual long int returnLongIntValueOrDefault(long int default_value) _override;
+
+    virtual cpputest_ulonglong returnUnsignedLongLongIntValue() _override;
+    virtual cpputest_ulonglong returnUnsignedLongLongIntValueOrDefault(cpputest_ulonglong default_value) _override;
+
+    virtual cpputest_longlong returnLongLongIntValue() _override;
+    virtual cpputest_longlong returnLongLongIntValueOrDefault(cpputest_longlong default_value) _override;
 
     virtual unsigned int returnUnsignedIntValue() _override;
     virtual unsigned int returnUnsignedIntValueOrDefault(unsigned int default_value) _override;
@@ -222,6 +238,8 @@ public:
     virtual MockActualCall& withUnsignedIntParameter(const SimpleString&, unsigned int) _override { return *this; }
     virtual MockActualCall& withLongIntParameter(const SimpleString&, long int) _override { return *this; }
     virtual MockActualCall& withUnsignedLongIntParameter(const SimpleString&, unsigned long int) _override { return *this; }
+    virtual MockActualCall& withLongLongIntParameter(const SimpleString&, cpputest_longlong) _override { return *this; }
+    virtual MockActualCall& withUnsignedLongLongIntParameter(const SimpleString&, cpputest_ulonglong) _override { return *this; }
     virtual MockActualCall& withDoubleParameter(const SimpleString&, double) _override { return *this; }
     virtual MockActualCall& withStringParameter(const SimpleString&, const char*) _override { return *this; }
     virtual MockActualCall& withPointerParameter(const SimpleString& , void*) _override { return *this; }
@@ -246,6 +264,12 @@ public:
 
     virtual long int returnLongIntValue() _override { return 0; }
     virtual long int returnLongIntValueOrDefault(long int value) _override { return value; }
+
+    virtual cpputest_ulonglong returnUnsignedLongLongIntValue() _override { return 0; }
+    virtual cpputest_ulonglong returnUnsignedLongLongIntValueOrDefault(cpputest_ulonglong value) _override { return value; }
+
+    virtual cpputest_longlong returnLongLongIntValue() _override { return 0; }
+    virtual cpputest_longlong returnLongLongIntValueOrDefault(cpputest_longlong value) _override { return value; }
 
     virtual unsigned int returnUnsignedIntValue() _override { return 0; }
     virtual unsigned int returnUnsignedIntValueOrDefault(unsigned int value) _override { return value; }

--- a/include/CppUTestExt/MockCheckedExpectedCall.h
+++ b/include/CppUTestExt/MockCheckedExpectedCall.h
@@ -47,6 +47,8 @@ public:
     virtual MockExpectedCall& withUnsignedIntParameter(const SimpleString& name, unsigned int value) _override;
     virtual MockExpectedCall& withLongIntParameter(const SimpleString& name, long int value) _override;
     virtual MockExpectedCall& withUnsignedLongIntParameter(const SimpleString& name, unsigned long int value) _override;
+    virtual MockExpectedCall& withLongLongIntParameter(const SimpleString& name, cpputest_longlong value) _override;
+    virtual MockExpectedCall& withUnsignedLongLongIntParameter(const SimpleString& name, cpputest_ulonglong value) _override;
     virtual MockExpectedCall& withDoubleParameter(const SimpleString& name, double value) _override;
     virtual MockExpectedCall& withStringParameter(const SimpleString& name, const char* value) _override;
     virtual MockExpectedCall& withPointerParameter(const SimpleString& name, void* value) _override;
@@ -63,6 +65,8 @@ public:
     virtual MockExpectedCall& andReturnValue(unsigned int value) _override;
     virtual MockExpectedCall& andReturnValue(long int value) _override;
     virtual MockExpectedCall& andReturnValue(unsigned long int value) _override;
+    virtual MockExpectedCall& andReturnValue(cpputest_longlong value) _override;
+    virtual MockExpectedCall& andReturnValue(cpputest_ulonglong value) _override;
     virtual MockExpectedCall& andReturnValue(double value) _override;
     virtual MockExpectedCall& andReturnValue(const char* value) _override;
     virtual MockExpectedCall& andReturnValue(void* value) _override;
@@ -153,6 +157,8 @@ public:
     virtual MockExpectedCall& withUnsignedIntParameter(const SimpleString&, unsigned int) _override{ return *this; }
     virtual MockExpectedCall& withLongIntParameter(const SimpleString&, long int) _override { return *this; }
     virtual MockExpectedCall& withUnsignedLongIntParameter(const SimpleString&, unsigned long int) _override { return *this; }
+    virtual MockExpectedCall& withLongLongIntParameter(const SimpleString&, cpputest_longlong) _override { return *this; }
+    virtual MockExpectedCall& withUnsignedLongLongIntParameter(const SimpleString&, cpputest_ulonglong) _override { return *this; }
     virtual MockExpectedCall& withDoubleParameter(const SimpleString&, double) _override { return *this; }
     virtual MockExpectedCall& withStringParameter(const SimpleString&, const char*) _override { return *this; }
     virtual MockExpectedCall& withPointerParameter(const SimpleString& , void*) _override { return *this; }
@@ -169,6 +175,8 @@ public:
     virtual MockExpectedCall& andReturnValue(unsigned int) _override { return *this; }
     virtual MockExpectedCall& andReturnValue(long int) _override { return *this; }
     virtual MockExpectedCall& andReturnValue(unsigned long int) _override { return *this; }
+    virtual MockExpectedCall& andReturnValue(cpputest_longlong) _override { return *this; }
+    virtual MockExpectedCall& andReturnValue(cpputest_ulonglong) _override { return *this; }
     virtual MockExpectedCall& andReturnValue(double) _override { return *this;}
     virtual MockExpectedCall& andReturnValue(const char*) _override { return *this; }
     virtual MockExpectedCall& andReturnValue(void*) _override { return *this; }

--- a/include/CppUTestExt/MockExpectedCall.h
+++ b/include/CppUTestExt/MockExpectedCall.h
@@ -28,6 +28,8 @@
 #ifndef D_MockExpectedCall_h
 #define D_MockExpectedCall_h
 
+#include "CppUTest/CppUTestConfig.h"
+
 class MockNamedValue;
 
 extern SimpleString StringFrom(const MockNamedValue& parameter);
@@ -46,6 +48,8 @@ public:
     MockExpectedCall& withParameter(const SimpleString& name, unsigned int value) { return withUnsignedIntParameter(name, value); }
     MockExpectedCall& withParameter(const SimpleString& name, long int value) { return withLongIntParameter(name, value); }
     MockExpectedCall& withParameter(const SimpleString& name, unsigned long int value) { return withUnsignedLongIntParameter(name, value); }
+    MockExpectedCall& withParameter(const SimpleString& name, cpputest_longlong value) { return withLongLongIntParameter(name, value); }
+    MockExpectedCall& withParameter(const SimpleString& name, cpputest_ulonglong value) { return withUnsignedLongLongIntParameter(name, value); }
     MockExpectedCall& withParameter(const SimpleString& name, double value) { return withDoubleParameter(name, value); }
     MockExpectedCall& withParameter(const SimpleString& name, const char* value) { return withStringParameter(name, value); }
     MockExpectedCall& withParameter(const SimpleString& name, void* value) { return withPointerParameter(name, value); }
@@ -62,6 +66,8 @@ public:
     virtual MockExpectedCall& withUnsignedIntParameter(const SimpleString& name, unsigned int value)=0;
     virtual MockExpectedCall& withLongIntParameter(const SimpleString& name, long int value)=0;
     virtual MockExpectedCall& withUnsignedLongIntParameter(const SimpleString& name, unsigned long int value)=0;
+    virtual MockExpectedCall& withLongLongIntParameter(const SimpleString& name, cpputest_longlong value)=0;
+    virtual MockExpectedCall& withUnsignedLongLongIntParameter(const SimpleString& name, cpputest_ulonglong value)=0;
     virtual MockExpectedCall& withDoubleParameter(const SimpleString& name, double value)=0;
     virtual MockExpectedCall& withStringParameter(const SimpleString& name, const char* value)=0;
     virtual MockExpectedCall& withPointerParameter(const SimpleString& name, void* value)=0;
@@ -73,6 +79,8 @@ public:
     virtual MockExpectedCall& andReturnValue(unsigned int value)=0;
     virtual MockExpectedCall& andReturnValue(long int value)=0;
     virtual MockExpectedCall& andReturnValue(unsigned long int value)=0;
+    virtual MockExpectedCall& andReturnValue(cpputest_longlong value)=0;
+    virtual MockExpectedCall& andReturnValue(cpputest_ulonglong value)=0;
     virtual MockExpectedCall& andReturnValue(double value)=0;
     virtual MockExpectedCall& andReturnValue(const char* value)=0;
     virtual MockExpectedCall& andReturnValue(void* value)=0;

--- a/include/CppUTestExt/MockNamedValue.h
+++ b/include/CppUTestExt/MockNamedValue.h
@@ -27,6 +27,9 @@
 
 #ifndef D_MockNamedValue_h
 #define D_MockNamedValue_h
+
+#include "CppUTest/CppUTestConfig.h"
+
 /*
  * MockNamedValueComparator is an interface that needs to be used when creating Comparators.
  * This is needed when comparing values of non-native type.
@@ -106,6 +109,8 @@ public:
     virtual void setValue(unsigned int value);
     virtual void setValue(long int value);
     virtual void setValue(unsigned long int value);
+    virtual void setValue(cpputest_longlong value);
+    virtual void setValue(cpputest_ulonglong value);
     virtual void setValue(double value);
     virtual void setValue(void* value);
     virtual void setValue(const void* value);
@@ -131,6 +136,8 @@ public:
     virtual unsigned int getUnsignedIntValue() const;
     virtual long int getLongIntValue() const;
     virtual unsigned long int getUnsignedLongIntValue() const;
+    virtual cpputest_longlong getLongLongIntValue() const;
+    virtual cpputest_ulonglong getUnsignedLongLongIntValue() const;
     virtual double getDoubleValue() const;
     virtual const char* getStringValue() const;
     virtual void* getPointerValue() const;
@@ -140,6 +147,7 @@ public:
     virtual const void* getConstObjectPointer() const;
     virtual void* getObjectPointer() const;
     virtual size_t getSize() const;
+
 
     virtual MockNamedValueComparator* getComparator() const;
     virtual MockNamedValueCopier* getCopier() const;
@@ -154,6 +162,12 @@ private:
         unsigned int unsignedIntValue_;
         long int longIntValue_;
         unsigned long int unsignedLongIntValue_;
+#ifdef CPPUTEST_USE_LONG_LONG
+        cpputest_longlong longLongIntValue_;
+        cpputest_ulonglong unsignedLongLongIntValue_;
+#else
+        char longLongPlaceholder_[CPPUTEST_SIZE_OF_FAKE_LONG_LONG_TYPE];
+#endif
         double doubleValue_;
         const char* stringValue_;
         void* pointerValue_;

--- a/include/CppUTestExt/MockSupport.h
+++ b/include/CppUTestExt/MockSupport.h
@@ -61,6 +61,10 @@ public:
     virtual long int returnLongIntValueOrDefault(long int defaultValue);
     virtual unsigned long int unsignedLongIntReturnValue();
     virtual unsigned long int returnUnsignedLongIntValueOrDefault(unsigned long int defaultValue);
+    virtual cpputest_longlong longLongIntReturnValue();
+    virtual cpputest_longlong returnLongLongIntValueOrDefault(cpputest_longlong defaultValue);
+    virtual cpputest_ulonglong unsignedLongLongIntReturnValue();
+    virtual cpputest_ulonglong returnUnsignedLongLongIntValueOrDefault(cpputest_ulonglong defaultValue);
     virtual unsigned int returnUnsignedIntValueOrDefault(unsigned int defaultValue);
     virtual const char* stringReturnValue();
     virtual const char* returnStringValueOrDefault(const char * defaultValue);

--- a/include/CppUTestExt/MockSupport_c.h
+++ b/include/CppUTestExt/MockSupport_c.h
@@ -32,6 +32,7 @@
 extern "C" {
 #endif
 
+#include "CppUTest/CppUTestConfig.h"
 #include "CppUTest/StandardCLibrary.h"
 
 typedef enum {
@@ -40,6 +41,8 @@ typedef enum {
     MOCKVALUETYPE_INTEGER,
     MOCKVALUETYPE_LONG_INTEGER,
     MOCKVALUETYPE_UNSIGNED_LONG_INTEGER,
+    MOCKVALUETYPE_LONG_LONG_INTEGER,
+    MOCKVALUETYPE_UNSIGNED_LONG_LONG_INTEGER,
     MOCKVALUETYPE_DOUBLE,
     MOCKVALUETYPE_STRING,
     MOCKVALUETYPE_POINTER,
@@ -58,6 +61,12 @@ typedef struct SMockValue_c
         unsigned int unsignedIntValue;
         long int longIntValue;
         unsigned long int unsignedLongIntValue;
+#ifdef CPPUTEST_USE_LONG_LONG
+        cpputest_longlong longLongIntValue;
+        cpputest_ulonglong unsignedLongLongIntValue;
+#else
+        char longLongPlaceholder[CPPUTEST_SIZE_OF_FAKE_LONG_LONG_TYPE];
+#endif
         double doubleValue;
         const char* stringValue;
         void* pointerValue;
@@ -77,6 +86,8 @@ struct SMockActualCall_c
     MockActualCall_c* (*withUnsignedIntParameters)(const char* name, unsigned int value);
     MockActualCall_c* (*withLongIntParameters)(const char* name, long int value);
     MockActualCall_c* (*withUnsignedLongIntParameters)(const char* name, unsigned long int value);
+    MockActualCall_c* (*withLongLongIntParameters)(const char* name, cpputest_longlong value);
+    MockActualCall_c* (*withUnsignedLongLongIntParameters)(const char* name, cpputest_ulonglong value);
     MockActualCall_c* (*withDoubleParameters)(const char* name, double value);
     MockActualCall_c* (*withStringParameters)(const char* name, const char* value);
     MockActualCall_c* (*withPointerParameters)(const char* name, void* value);
@@ -98,6 +109,10 @@ struct SMockActualCall_c
     long int (*returnLongIntValueOrDefault)(long int defaultValue);
     unsigned long int (*unsignedLongIntReturnValue)(void);
     unsigned long int (*returnUnsignedLongIntValueOrDefault)(unsigned long int defaultValue);
+    cpputest_longlong (*longLongIntReturnValue)(void);
+    cpputest_longlong (*returnLongLongIntValueOrDefault)(cpputest_longlong defaultValue);
+    cpputest_ulonglong (*unsignedLongLongIntReturnValue)(void);
+    cpputest_ulonglong (*returnUnsignedLongLongIntValueOrDefault)(cpputest_ulonglong defaultValue);
     const char* (*stringReturnValue)(void);
     const char* (*returnStringValueOrDefault)(const char * defaultValue);
     double (*doubleReturnValue)(void);
@@ -118,6 +133,8 @@ struct SMockExpectedCall_c
     MockExpectedCall_c* (*withUnsignedIntParameters)(const char* name, unsigned int value);
     MockExpectedCall_c* (*withLongIntParameters)(const char* name, long int value);
     MockExpectedCall_c* (*withUnsignedLongIntParameters)(const char* name, unsigned long int value);
+    MockExpectedCall_c* (*withLongLongIntParameters)(const char* name, cpputest_longlong value);
+    MockExpectedCall_c* (*withUnsignedLongLongIntParameters)(const char* name, cpputest_ulonglong value);
     MockExpectedCall_c* (*withDoubleParameters)(const char* name, double value);
     MockExpectedCall_c* (*withStringParameters)(const char* name, const char* value);
     MockExpectedCall_c* (*withPointerParameters)(const char* name, void* value);
@@ -134,6 +151,8 @@ struct SMockExpectedCall_c
     MockExpectedCall_c* (*andReturnIntValue)(int value);
     MockExpectedCall_c* (*andReturnLongIntValue)(long int value);
     MockExpectedCall_c* (*andReturnUnsignedLongIntValue)(unsigned long int value);
+    MockExpectedCall_c* (*andReturnLongLongIntValue)(cpputest_longlong value);
+    MockExpectedCall_c* (*andReturnUnsignedLongLongIntValue)(cpputest_ulonglong value);
     MockExpectedCall_c* (*andReturnDoubleValue)(double value);
     MockExpectedCall_c* (*andReturnStringValue)(const char* value);
     MockExpectedCall_c* (*andReturnPointerValue)(void* value);
@@ -165,6 +184,10 @@ struct SMockSupport_c
     long int (*returnLongIntValueOrDefault)(long int defaultValue);
     unsigned long int (*unsignedLongIntReturnValue)(void);
     unsigned long int (*returnUnsignedLongIntValueOrDefault)(unsigned long int defaultValue);
+    cpputest_longlong (*longLongIntReturnValue)(void);
+    cpputest_longlong (*returnLongLongIntValueOrDefault)(cpputest_longlong defaultValue);
+    cpputest_ulonglong (*unsignedLongLongIntReturnValue)(void);
+    cpputest_ulonglong (*returnUnsignedLongLongIntValueOrDefault)(cpputest_ulonglong defaultValue);
     const char* (*stringReturnValue)(void);
     const char* (*returnStringValueOrDefault)(const char * defaultValue);
     double (*doubleReturnValue)(void);

--- a/src/CppUTestExt/MockActualCall.cpp
+++ b/src/CppUTestExt/MockActualCall.cpp
@@ -241,6 +241,40 @@ MockActualCall& MockCheckedActualCall::withLongIntParameter(const SimpleString& 
     return *this;
 }
 
+#ifdef CPPUTEST_USE_LONG_LONG
+
+MockActualCall& MockCheckedActualCall::withUnsignedLongLongIntParameter(const SimpleString& name, cpputest_ulonglong value)
+{
+    MockNamedValue actualParameter(name);
+    actualParameter.setValue(value);
+    checkInputParameter(actualParameter);
+    return *this;
+}
+
+MockActualCall& MockCheckedActualCall::withLongLongIntParameter(const SimpleString& name, cpputest_longlong value)
+{
+    MockNamedValue actualParameter(name);
+    actualParameter.setValue(value);
+    checkInputParameter(actualParameter);
+    return *this;
+}
+
+#else
+
+MockActualCall& MockCheckedActualCall::withUnsignedLongLongIntParameter(const SimpleString&, cpputest_ulonglong)
+{
+    FAIL("Unsigned Long Long type is not supported");
+    return *this;
+}
+
+MockActualCall& MockCheckedActualCall::withLongLongIntParameter(const SimpleString&, cpputest_longlong)
+{
+    FAIL("Long Long type is not supported");
+    return *this;
+}
+
+#endif
+
 MockActualCall& MockCheckedActualCall::withDoubleParameter(const SimpleString& name, double value)
 {
     MockNamedValue actualParameter(name);
@@ -437,6 +471,62 @@ long int MockCheckedActualCall::returnLongIntValueOrDefault(long int default_val
     }
     return returnLongIntValue();
 }
+
+#ifdef CPPUTEST_USE_LONG_LONG
+
+cpputest_ulonglong MockCheckedActualCall::returnUnsignedLongLongIntValue()
+{
+    return returnValue().getUnsignedLongLongIntValue();
+}
+
+cpputest_ulonglong MockCheckedActualCall::returnUnsignedLongLongIntValueOrDefault(cpputest_ulonglong default_value)
+{
+    if (!hasReturnValue()) {
+        return default_value;
+    }
+    return returnUnsignedLongLongIntValue();
+}
+
+cpputest_longlong MockCheckedActualCall::returnLongLongIntValue()
+{
+    return returnValue().getLongLongIntValue();
+}
+
+cpputest_longlong MockCheckedActualCall::returnLongLongIntValueOrDefault(cpputest_longlong default_value)
+{
+    if (!hasReturnValue()) {
+        return default_value;
+    }
+    return returnLongLongIntValue();
+}
+
+#else
+
+cpputest_ulonglong MockCheckedActualCall::returnUnsignedLongLongIntValue()
+{
+    FAIL("Unsigned Long Long type is not supported");
+    return cpputest_ulonglong(0);
+}
+
+cpputest_ulonglong MockCheckedActualCall::returnUnsignedLongLongIntValueOrDefault(cpputest_ulonglong default_value)
+{
+    FAIL("Unsigned Long Long type is not supported");
+    return default_value;
+}
+
+cpputest_longlong MockCheckedActualCall::returnLongLongIntValue()
+{
+    FAIL("Long Long type is not supported");
+    return cpputest_longlong(0);
+}
+
+cpputest_longlong MockCheckedActualCall::returnLongLongIntValueOrDefault(cpputest_longlong default_value)
+{
+    FAIL("Long Long type is not supported");
+    return default_value;
+}
+
+#endif
 
 double MockCheckedActualCall::returnDoubleValue()
 {
@@ -637,6 +727,38 @@ MockActualCall& MockActualCallTrace::withLongIntParameter(const SimpleString& na
     return *this;
 }
 
+#ifdef CPPUTEST_USE_LONG_LONG
+
+MockActualCall& MockActualCallTrace::withUnsignedLongLongIntParameter(const SimpleString& name, cpputest_ulonglong value)
+{
+    addParameterName(name);
+    traceBuffer_ += StringFrom(value) + " " + BracketsFormattedHexStringFrom(value);
+    return *this;
+}
+
+MockActualCall& MockActualCallTrace::withLongLongIntParameter(const SimpleString& name, cpputest_longlong value)
+{
+    addParameterName(name);
+    traceBuffer_ += StringFrom(value) + " " + BracketsFormattedHexStringFrom(value);
+    return *this;
+}
+
+#else
+
+MockActualCall& MockActualCallTrace::withUnsignedLongLongIntParameter(const SimpleString&, cpputest_ulonglong)
+{
+    FAIL("Unsigned Long Long type is not supported");
+    return *this;
+}
+
+MockActualCall& MockActualCallTrace::withLongLongIntParameter(const SimpleString&, cpputest_longlong)
+{
+    FAIL("Long Long type is not supported");
+    return *this;
+}
+
+#endif
+
 MockActualCall& MockActualCallTrace::withDoubleParameter(const SimpleString& name, double value)
 {
     addParameterName(name);
@@ -733,6 +855,56 @@ long int MockActualCallTrace::returnLongIntValueOrDefault(long int)
 {
     return returnLongIntValue();
 }
+
+#ifdef CPPUTEST_USE_LONG_LONG
+
+cpputest_longlong MockActualCallTrace::returnLongLongIntValue()
+{
+    return 0;
+}
+
+cpputest_ulonglong MockActualCallTrace::returnUnsignedLongLongIntValue()
+{
+    return 0;
+}
+
+cpputest_ulonglong MockActualCallTrace::returnUnsignedLongLongIntValueOrDefault(cpputest_ulonglong)
+{
+    return 0;
+}
+
+cpputest_longlong MockActualCallTrace::returnLongLongIntValueOrDefault(cpputest_longlong)
+{
+    return returnLongLongIntValue();
+}
+
+#else
+
+cpputest_longlong MockActualCallTrace::returnLongLongIntValue()
+{
+    FAIL("Long Long type is not supported");
+    return cpputest_longlong(0);
+}
+
+cpputest_ulonglong MockActualCallTrace::returnUnsignedLongLongIntValue()
+{
+    FAIL("Unsigned Long Long type is not supported");
+    return cpputest_ulonglong(0);
+}
+
+cpputest_ulonglong MockActualCallTrace::returnUnsignedLongLongIntValueOrDefault(cpputest_ulonglong)
+{
+    FAIL("Unsigned Long Long type is not supported");
+    return cpputest_ulonglong(0);
+}
+
+cpputest_longlong MockActualCallTrace::returnLongLongIntValueOrDefault(cpputest_longlong)
+{
+    FAIL("Long Long type is not supported");
+    return cpputest_longlong(0);
+}
+
+#endif
 
 bool MockActualCallTrace::returnBoolValue()
 {

--- a/src/CppUTestExt/MockActualCall.cpp
+++ b/src/CppUTestExt/MockActualCall.cpp
@@ -853,7 +853,7 @@ unsigned long int MockActualCallTrace::returnUnsignedLongIntValueOrDefault(unsig
 
 long int MockActualCallTrace::returnLongIntValueOrDefault(long int)
 {
-    return returnLongIntValue();
+    return 0;
 }
 
 #ifdef CPPUTEST_USE_LONG_LONG
@@ -875,7 +875,7 @@ cpputest_ulonglong MockActualCallTrace::returnUnsignedLongLongIntValueOrDefault(
 
 cpputest_longlong MockActualCallTrace::returnLongLongIntValueOrDefault(cpputest_longlong)
 {
-    return returnLongLongIntValue();
+    return 0;
 }
 
 #else

--- a/src/CppUTestExt/MockExpectedCall.cpp
+++ b/src/CppUTestExt/MockExpectedCall.cpp
@@ -125,6 +125,40 @@ MockExpectedCall& MockCheckedExpectedCall::withUnsignedLongIntParameter(const Si
     return *this;
 }
 
+#ifdef CPPUTEST_USE_LONG_LONG
+
+MockExpectedCall& MockCheckedExpectedCall::withLongLongIntParameter(const SimpleString& name, cpputest_longlong value)
+{
+    MockNamedValue* newParameter = new MockExpectedFunctionParameter(name);
+    inputParameters_->add(newParameter);
+    newParameter->setValue(value);
+    return *this;
+}
+
+MockExpectedCall& MockCheckedExpectedCall::withUnsignedLongLongIntParameter(const SimpleString& name, cpputest_ulonglong value)
+{
+    MockNamedValue* newParameter = new MockExpectedFunctionParameter(name);
+    inputParameters_->add(newParameter);
+    newParameter->setValue(value);
+    return *this;
+}
+
+#else
+
+MockExpectedCall& MockCheckedExpectedCall::withLongLongIntParameter(const SimpleString&, cpputest_longlong)
+{
+    FAIL("Long Long type is not supported");
+    return *this;
+}
+
+MockExpectedCall& MockCheckedExpectedCall::withUnsignedLongLongIntParameter(const SimpleString&, cpputest_ulonglong)
+{
+    FAIL("Unsigned Long Long type is not supported");
+    return *this;
+}
+
+#endif
+
 MockExpectedCall& MockCheckedExpectedCall::withDoubleParameter(const SimpleString& name, double value)
 {
     MockNamedValue* newParameter = new MockExpectedFunctionParameter(name);
@@ -466,6 +500,38 @@ MockExpectedCall& MockCheckedExpectedCall::andReturnValue(unsigned long int valu
     returnValue_.setValue(value);
     return *this;
 }
+
+#ifdef CPPUTEST_USE_LONG_LONG
+
+MockExpectedCall& MockCheckedExpectedCall::andReturnValue(cpputest_longlong value)
+{
+    returnValue_.setName("returnValue");
+    returnValue_.setValue(value);
+    return *this;
+}
+
+MockExpectedCall& MockCheckedExpectedCall::andReturnValue(cpputest_ulonglong value)
+{
+    returnValue_.setName("returnValue");
+    returnValue_.setValue(value);
+    return *this;
+}
+
+#else
+
+MockExpectedCall& MockCheckedExpectedCall::andReturnValue(cpputest_longlong)
+{
+    FAIL("Long Long type is not supported");
+    return *this;
+}
+
+MockExpectedCall& MockCheckedExpectedCall::andReturnValue(cpputest_ulonglong)
+{
+    FAIL("Unsigned Long Long type is not supported");
+    return *this;
+}
+
+#endif
 
 MockExpectedCall& MockCheckedExpectedCall::andReturnValue(const char* value)
 {

--- a/src/CppUTestExt/MockNamedValue.cpp
+++ b/src/CppUTestExt/MockNamedValue.cpp
@@ -259,10 +259,10 @@ cpputest_ulonglong MockNamedValue::getUnsignedLongLongIntValue() const
         return value_.unsignedIntValue_;
     else if(type_ == "int" && value_.intValue_ >= 0)
         return (unsigned long long int)value_.intValue_;
-    else if(type_ == "unsigned long int")
-        return value_.unsignedLongIntValue_;
     else if(type_ == "long int" && value_.longIntValue_ >= 0)
         return (unsigned long long int)value_.longIntValue_;
+    else if(type_ == "unsigned long int")
+        return value_.unsignedLongIntValue_;
     else if(type_ == "long long int" && value_.longLongIntValue_ >= 0)
         return (unsigned long long int)value_.longLongIntValue_;
     else

--- a/src/CppUTestExt/MockNamedValue.cpp
+++ b/src/CppUTestExt/MockNamedValue.cpp
@@ -407,7 +407,7 @@ bool MockNamedValue::equals(const MockNamedValue& p) const
     else if ((type_ == "unsigned long long int") && (p.type_ == "long int"))
         return (p.value_.longIntValue_ >= 0) && (value_.unsignedLongLongIntValue_ == (unsigned long long)p.value_.longIntValue_);
     else if ((type_ == "long int") && (p.type_ == "unsigned long long int"))
-        return (value_.longIntValue_ >= 0) && ((unsigned long long)value_.longLongIntValue_ == p.value_.unsignedLongLongIntValue_);
+        return (value_.longIntValue_ >= 0) && ((unsigned long long)value_.longIntValue_ == p.value_.unsignedLongLongIntValue_);
     else if ((type_ == "unsigned long long int") && (p.type_ == "unsigned long int"))
         return value_.unsignedLongLongIntValue_ == p.value_.unsignedLongIntValue_;
     else if ((type_ == "unsigned long int") && (p.type_ == "unsigned long long int"))

--- a/src/CppUTestExt/MockNamedValue.cpp
+++ b/src/CppUTestExt/MockNamedValue.cpp
@@ -249,7 +249,7 @@ cpputest_longlong MockNamedValue::getLongLongIntValue() const
     else
     {
         STRCMP_EQUAL("long long int", type_.asCharString());
-        return value_.longIntValue_;
+        return value_.longLongIntValue_;
     }
 }
 

--- a/src/CppUTestExt/MockNamedValue.cpp
+++ b/src/CppUTestExt/MockNamedValue.cpp
@@ -241,9 +241,9 @@ cpputest_longlong MockNamedValue::getLongLongIntValue() const
     if(type_ == "int")
         return value_.intValue_;
     else if(type_ == "unsigned int")
-        return (long int)value_.unsignedIntValue_;
+        return (long long int)value_.unsignedIntValue_;
     else if(type_ == "long int")
-        return (long long int)value_.longIntValue_;
+        return value_.longIntValue_;
     else if(type_ == "unsigned long int")
         return (long long int)value_.unsignedLongIntValue_;
     else

--- a/src/CppUTestExt/MockNamedValue.cpp
+++ b/src/CppUTestExt/MockNamedValue.cpp
@@ -76,6 +76,34 @@ void MockNamedValue::setValue(unsigned long int value)
     value_.unsignedLongIntValue_ = value;
 }
 
+#ifdef CPPUTEST_USE_LONG_LONG
+
+void MockNamedValue::setValue(cpputest_longlong value)
+{
+    type_ = "long long int";
+    value_.longLongIntValue_ = value;
+}
+
+void MockNamedValue::setValue(cpputest_ulonglong value)
+{
+    type_ = "unsigned long long int";
+    value_.unsignedLongLongIntValue_ = value;
+}
+
+#else
+
+void MockNamedValue::setValue(cpputest_longlong)
+{
+    FAIL("Long Long type is not supported");
+}
+
+void MockNamedValue::setValue(cpputest_ulonglong)
+{
+    FAIL("Unsigned Long Long type is not supported");
+}
+
+#endif
+
 void MockNamedValue::setValue(double value)
 {
     type_ = "double";
@@ -206,6 +234,60 @@ unsigned long int MockNamedValue::getUnsignedLongIntValue() const
     }
 }
 
+#ifdef CPPUTEST_USE_LONG_LONG
+
+cpputest_longlong MockNamedValue::getLongLongIntValue() const
+{
+    if(type_ == "int")
+        return value_.intValue_;
+    else if(type_ == "unsigned int")
+        return (long int)value_.unsignedIntValue_;
+    else if(type_ == "long int")
+        return (long long int)value_.longIntValue_;
+    else if(type_ == "unsigned long int")
+        return (long long int)value_.unsignedLongIntValue_;
+    else
+    {
+        STRCMP_EQUAL("long long int", type_.asCharString());
+        return value_.longIntValue_;
+    }
+}
+
+cpputest_ulonglong MockNamedValue::getUnsignedLongLongIntValue() const
+{
+    if(type_ == "unsigned int")
+        return value_.unsignedIntValue_;
+    else if(type_ == "int" && value_.intValue_ >= 0)
+        return (unsigned long long int)value_.intValue_;
+    else if(type_ == "unsigned long int")
+        return value_.unsignedLongIntValue_;
+    else if(type_ == "long int" && value_.longIntValue_ >= 0)
+        return (unsigned long long int)value_.longIntValue_;
+    else if(type_ == "long long int" && value_.longLongIntValue_ >= 0)
+        return (unsigned long long int)value_.longLongIntValue_;
+    else
+    {
+        STRCMP_EQUAL("unsigned long long int", type_.asCharString());
+        return value_.unsignedLongLongIntValue_;
+    }
+}
+
+#else
+
+cpputest_longlong MockNamedValue::getLongLongIntValue() const
+{
+    FAIL("Long Long type is not supported");
+    return cpputest_longlong(0);
+}
+
+cpputest_ulonglong MockNamedValue::getUnsignedLongLongIntValue() const
+{
+    FAIL("Unsigned Long Long type is not supported");
+    return cpputest_ulonglong(0);
+}
+
+#endif
+
 double MockNamedValue::getDoubleValue() const
 {
     STRCMP_EQUAL("double", type_.asCharString());
@@ -293,6 +375,44 @@ bool MockNamedValue::equals(const MockNamedValue& p) const
         return (value_.longIntValue_ >= 0) && ((unsigned long)value_.longIntValue_ == p.value_.unsignedLongIntValue_);
     else if((type_ == "unsigned long int") && (p.type_ == "long int"))
         return (p.value_.longIntValue_ >= 0) && (value_.unsignedLongIntValue_ == (unsigned long) p.value_.longIntValue_);
+#ifdef CPPUTEST_USE_LONG_LONG
+    else if ((type_ == "long long int") && (p.type_ == "int"))
+        return value_.longLongIntValue_ == p.value_.intValue_;
+    else if ((type_ == "int") && (p.type_ == "long long int"))
+        return value_.intValue_ == p.value_.longLongIntValue_;
+    else if ((type_ == "long long int") && (p.type_ == "long int"))
+        return value_.longLongIntValue_ == p.value_.longIntValue_;
+    else if ((type_ == "long int") && (p.type_ == "long long int"))
+        return value_.longIntValue_ == p.value_.longLongIntValue_;
+    else if ((type_ == "long long int") && (p.type_ == "unsigned int"))
+        return (value_.longLongIntValue_ >= 0) && ((unsigned long long)value_.longLongIntValue_ == p.value_.unsignedIntValue_);
+    else if ((type_ == "unsigned int") && (p.type_ == "long long int"))
+        return (p.value_.longLongIntValue_ >= 0) && (value_.unsignedIntValue_ == (unsigned long long)p.value_.longLongIntValue_);
+    else if ((type_ == "long long int") && (p.type_ == "unsigned long int"))
+        return (value_.longLongIntValue_ >= 0) && ((unsigned long long)value_.longLongIntValue_ == p.value_.unsignedLongIntValue_);
+    else if ((type_ == "unsigned long int") && (p.type_ == "long long int"))
+        return (p.value_.longLongIntValue_ >= 0) && (value_.unsignedLongIntValue_ == (unsigned long long)p.value_.longLongIntValue_);
+    else if ((type_ == "long long int") && (p.type_ == "unsigned long long int"))
+        return (value_.longLongIntValue_ >= 0) && ((unsigned long long)value_.longLongIntValue_ == p.value_.unsignedLongLongIntValue_);
+    else if ((type_ == "unsigned long long int") && (p.type_ == "long long int"))
+        return (p.value_.longLongIntValue_ >= 0) && (value_.unsignedLongLongIntValue_ == (unsigned long long)p.value_.longLongIntValue_);
+    else if ((type_ == "unsigned long long int") && (p.type_ == "int"))
+        return (p.value_.intValue_ >= 0) && (value_.unsignedLongLongIntValue_ == (unsigned long long)p.value_.intValue_);
+    else if ((type_ == "int") && (p.type_ == "unsigned long long int"))
+        return (value_.intValue_ >= 0) && ((unsigned long long)value_.intValue_ == p.value_.unsignedLongLongIntValue_);
+    else if ((type_ == "unsigned long long int") && (p.type_ == "unsigned int"))
+        return value_.unsignedLongLongIntValue_ == p.value_.unsignedIntValue_;
+    else if ((type_ == "unsigned int") && (p.type_ == "unsigned long long int"))
+        return value_.unsignedIntValue_ == p.value_.unsignedLongLongIntValue_;
+    else if ((type_ == "unsigned long long int") && (p.type_ == "long int"))
+        return (p.value_.longIntValue_ >= 0) && (value_.unsignedLongLongIntValue_ == (unsigned long long)p.value_.longIntValue_);
+    else if ((type_ == "long int") && (p.type_ == "unsigned long long int"))
+        return (value_.longIntValue_ >= 0) && ((unsigned long long)value_.longLongIntValue_ == p.value_.unsignedLongLongIntValue_);
+    else if ((type_ == "unsigned long long int") && (p.type_ == "unsigned long int"))
+        return value_.unsignedLongLongIntValue_ == p.value_.unsignedLongIntValue_;
+    else if ((type_ == "unsigned long int") && (p.type_ == "unsigned long long int"))
+        return value_.unsignedLongIntValue_ == p.value_.unsignedLongLongIntValue_;
+#endif
 
     if (type_ != p.type_) return false;
 
@@ -306,6 +426,12 @@ bool MockNamedValue::equals(const MockNamedValue& p) const
         return value_.longIntValue_ == p.value_.longIntValue_;
     else if (type_ == "unsigned long int")
         return value_.unsignedLongIntValue_ == p.value_.unsignedLongIntValue_;
+#ifdef CPPUTEST_USE_LONG_LONG
+    else if (type_ == "long long int")
+        return value_.longLongIntValue_ == p.value_.longLongIntValue_;
+    else if (type_ == "unsigned long long int")
+        return value_.unsignedLongLongIntValue_ == p.value_.unsignedLongLongIntValue_;
+#endif
     else if (type_ == "const char*")
         return SimpleString(value_.stringValue_) == SimpleString(p.value_.stringValue_);
     else if (type_ == "void*")
@@ -352,6 +478,12 @@ SimpleString MockNamedValue::toString() const
         return StringFrom(value_.longIntValue_) + " " + BracketsFormattedHexStringFrom(value_.longIntValue_);
     else if (type_ == "unsigned long int")
         return StringFrom(value_.unsignedLongIntValue_) + " " + BracketsFormattedHexStringFrom(value_.unsignedLongIntValue_);
+#ifdef CPPUTEST_USE_LONG_LONG
+    else if (type_ == "long long int")
+        return StringFrom(value_.longLongIntValue_) + " " + BracketsFormattedHexStringFrom(value_.longLongIntValue_);
+    else if (type_ == "unsigned long long int")
+        return StringFrom(value_.unsignedLongLongIntValue_) + " " + BracketsFormattedHexStringFrom(value_.unsignedLongLongIntValue_);
+#endif
     else if (type_ == "const char*")
         return value_.stringValue_;
     else if (type_ == "void*")

--- a/src/CppUTestExt/MockSupport.cpp
+++ b/src/CppUTestExt/MockSupport.cpp
@@ -558,6 +558,62 @@ unsigned long int MockSupport::unsignedLongIntReturnValue()
     return returnValue().getUnsignedLongIntValue();
 }
 
+#ifdef CPPUTEST_USE_LONG_LONG
+
+cpputest_longlong MockSupport::longLongIntReturnValue()
+{
+    return returnValue().getLongLongIntValue();
+}
+
+cpputest_ulonglong MockSupport::unsignedLongLongIntReturnValue()
+{
+    return returnValue().getUnsignedLongLongIntValue();
+}
+
+cpputest_longlong MockSupport::returnLongLongIntValueOrDefault(cpputest_longlong defaultValue)
+{
+    if (hasReturnValue()) {
+        return longLongIntReturnValue();
+    }
+    return defaultValue;
+}
+
+cpputest_ulonglong MockSupport::returnUnsignedLongLongIntValueOrDefault(cpputest_ulonglong defaultValue)
+{
+    if (hasReturnValue()) {
+        return unsignedLongLongIntReturnValue();
+    }
+    return defaultValue;
+}
+
+#else
+
+cpputest_longlong MockSupport::longLongIntReturnValue()
+{
+    FAIL("Long Long type is not supported");
+    return cpputest_longlong(0);
+}
+
+cpputest_ulonglong MockSupport::unsignedLongLongIntReturnValue()
+{
+    FAIL("Unsigned Long Long type is not supported");
+    return cpputest_ulonglong(0);
+}
+
+cpputest_longlong MockSupport::returnLongLongIntValueOrDefault(cpputest_longlong defaultValue)
+{
+    FAIL("Long Long type is not supported");
+    return defaultValue;
+}
+
+cpputest_ulonglong MockSupport::returnUnsignedLongLongIntValueOrDefault(cpputest_ulonglong defaultValue)
+{
+    FAIL("Unsigned Long Long type is not supported");
+    return defaultValue;
+}
+
+#endif
+
 const char* MockSupport::stringReturnValue()
 {
     return returnValue().getStringValue();

--- a/src/CppUTestExt/MockSupport_c.cpp
+++ b/src/CppUTestExt/MockSupport_c.cpp
@@ -148,6 +148,8 @@ MockExpectedCall_c* withIntParameters_c(const char* name, int value);
 MockExpectedCall_c* withUnsignedIntParameters_c(const char* name, unsigned int value);
 MockExpectedCall_c* withLongIntParameters_c(const char* name, long int value);
 MockExpectedCall_c* withUnsignedLongIntParameters_c(const char* name, unsigned long int value);
+MockExpectedCall_c* withLongLongIntParameters_c(const char* name, cpputest_longlong value);
+MockExpectedCall_c* withUnsignedLongLongIntParameters_c(const char* name, cpputest_ulonglong value);
 MockExpectedCall_c* withDoubleParameters_c(const char* name, double value);
 MockExpectedCall_c* withStringParameters_c(const char* name, const char* value);
 MockExpectedCall_c* withPointerParameters_c(const char* name, void* value);
@@ -163,6 +165,8 @@ MockExpectedCall_c* andReturnIntValue_c(int value);
 MockExpectedCall_c* andReturnUnsignedIntValue_c(unsigned int value);
 MockExpectedCall_c* andReturnLongIntValue_c(long int value);
 MockExpectedCall_c* andReturnUnsignedLongIntValue_c(unsigned long int value);
+MockExpectedCall_c* andReturnLongLongIntValue_c(cpputest_longlong value);
+MockExpectedCall_c* andReturnUnsignedLongLongIntValue_c(cpputest_ulonglong value);
 MockExpectedCall_c* andReturnDoubleValue_c(double value);
 MockExpectedCall_c* andReturnStringValue_c(const char* value);
 MockExpectedCall_c* andReturnPointerValue_c(void* value);
@@ -174,6 +178,8 @@ MockActualCall_c* withActualIntParameters_c(const char* name, int value);
 MockActualCall_c* withActualUnsignedIntParameters_c(const char* name, unsigned int value);
 MockActualCall_c* withActualLongIntParameters_c(const char* name, long int value);
 MockActualCall_c* withActualUnsignedLongIntParameters_c(const char* name, unsigned long int value);
+MockActualCall_c* withActualLongLongIntParameters_c(const char* name, cpputest_longlong value);
+MockActualCall_c* withActualUnsignedLongLongIntParameters_c(const char* name, cpputest_ulonglong value);
 MockActualCall_c* withActualDoubleParameters_c(const char* name, double value);
 MockActualCall_c* withActualStringParameters_c(const char* name, const char* value);
 MockActualCall_c* withActualPointerParameters_c(const char* name, void* value);
@@ -194,6 +200,10 @@ long int longIntReturnValue_c();
 long int returnLongIntValueOrDefault_c(long int defaultValue);
 unsigned long int unsignedLongIntReturnValue_c();
 unsigned long int returnUnsignedLongIntValueOrDefault_c(unsigned long int defaultValue);
+cpputest_longlong longLongIntReturnValue_c();
+cpputest_longlong returnLongLongIntValueOrDefault_c(cpputest_longlong defaultValue);
+cpputest_ulonglong unsignedLongLongIntReturnValue_c();
+cpputest_ulonglong returnUnsignedLongLongIntValueOrDefault_c(cpputest_ulonglong defaultValue);
 const char* stringReturnValue_c();
 const char* returnStringValueOrDefault_c(const char * defaultValue);
 double doubleReturnValue_c();
@@ -238,6 +248,8 @@ static MockExpectedCall_c gExpectedCall = {
         withUnsignedIntParameters_c,
         withLongIntParameters_c,
         withUnsignedLongIntParameters_c,
+        withLongLongIntParameters_c,
+        withUnsignedLongLongIntParameters_c,
         withDoubleParameters_c,
         withStringParameters_c,
         withPointerParameters_c,
@@ -253,6 +265,8 @@ static MockExpectedCall_c gExpectedCall = {
         andReturnIntValue_c,
         andReturnLongIntValue_c,
         andReturnUnsignedLongIntValue_c,
+        andReturnLongLongIntValue_c,
+        andReturnUnsignedLongLongIntValue_c,
         andReturnDoubleValue_c,
         andReturnStringValue_c,
         andReturnPointerValue_c,
@@ -266,6 +280,8 @@ static MockActualCall_c gActualCall = {
         withActualUnsignedIntParameters_c,
         withActualLongIntParameters_c,
         withActualUnsignedLongIntParameters_c,
+        withActualLongLongIntParameters_c,
+        withActualUnsignedLongLongIntParameters_c,
         withActualDoubleParameters_c,
         withActualStringParameters_c,
         withActualPointerParameters_c,
@@ -287,6 +303,10 @@ static MockActualCall_c gActualCall = {
         returnLongIntValueOrDefault_c,
         unsignedLongIntReturnValue_c,
         returnUnsignedLongIntValueOrDefault_c,
+        longLongIntReturnValue_c,
+        returnLongLongIntValueOrDefault_c,
+        unsignedLongLongIntReturnValue_c,
+        returnUnsignedLongLongIntValueOrDefault_c,
         stringReturnValue_c,
         returnStringValueOrDefault_c,
         doubleReturnValue_c,
@@ -317,6 +337,10 @@ static MockSupport_c gMockSupport = {
         returnLongIntValueOrDefault_c,
         unsignedLongIntReturnValue_c,
         returnUnsignedLongIntValueOrDefault_c,
+        longLongIntReturnValue_c,
+        returnLongLongIntValueOrDefault_c,
+        unsignedLongLongIntReturnValue_c,
+        returnUnsignedLongLongIntValueOrDefault_c,
         stringReturnValue_c,
         returnStringValueOrDefault_c,
         doubleReturnValue_c,
@@ -379,6 +403,36 @@ MockExpectedCall_c* withUnsignedLongIntParameters_c(const char* name, unsigned l
     expectedCall = &expectedCall->withParameter(name, value);
     return &gExpectedCall;
 }
+
+#ifdef CPPUTEST_USE_LONG_LONG
+
+MockExpectedCall_c* withLongLongIntParameters_c(const char* name, cpputest_longlong value)
+{
+    expectedCall = &expectedCall->withParameter(name, value);
+    return &gExpectedCall;
+}
+
+MockExpectedCall_c* withUnsignedLongLongIntParameters_c(const char* name, cpputest_ulonglong value)
+{
+    expectedCall = &expectedCall->withParameter(name, value);
+    return &gExpectedCall;
+}
+
+#else
+
+MockExpectedCall_c* withLongLongIntParameters_c(const char*, cpputest_longlong)
+{
+    FAIL("Long Long type is not supported");
+    return &gExpectedCall;
+}
+
+MockExpectedCall_c* withUnsignedLongLongIntParameters_c(const char*, cpputest_ulonglong)
+{
+    FAIL("Unsigned Long Long type is not supported");
+    return &gExpectedCall;
+}
+
+#endif
 
 MockExpectedCall_c* withDoubleParameters_c(const char* name, double value)
 {
@@ -470,6 +524,36 @@ MockExpectedCall_c* andReturnUnsignedLongIntValue_c(unsigned long int value)
     return &gExpectedCall;
 }
 
+#ifdef CPPUTEST_USE_LONG_LONG
+
+MockExpectedCall_c* andReturnLongLongIntValue_c(cpputest_longlong value)
+{
+    expectedCall = &expectedCall->andReturnValue(value);
+    return &gExpectedCall;
+}
+
+MockExpectedCall_c* andReturnUnsignedLongLongIntValue_c(cpputest_ulonglong value)
+{
+    expectedCall = &expectedCall->andReturnValue(value);
+    return &gExpectedCall;
+}
+
+#else
+
+MockExpectedCall_c* andReturnLongLongIntValue_c(cpputest_longlong)
+{
+    FAIL("Long Long type is not supported");
+    return &gExpectedCall;
+}
+
+MockExpectedCall_c* andReturnUnsignedLongLongIntValue_c(cpputest_ulonglong)
+{
+    FAIL("Unsigned Long Long type is not supported");
+    return &gExpectedCall;
+}
+
+#endif
+
 MockExpectedCall_c* andReturnDoubleValue_c(double value)
 {
     expectedCall = &expectedCall->andReturnValue(value);
@@ -523,6 +607,16 @@ static MockValue_c getMockValueCFromNamedValue(const MockNamedValue& namedValue)
         returnValue.type = MOCKVALUETYPE_UNSIGNED_LONG_INTEGER;
         returnValue.value.unsignedLongIntValue = namedValue.getUnsignedLongIntValue();
     }
+#ifdef CPPUTEST_USE_LONG_LONG
+    else if (SimpleString::StrCmp(namedValue.getType().asCharString(), "long long int") == 0) {
+        returnValue.type = MOCKVALUETYPE_LONG_LONG_INTEGER;
+        returnValue.value.longLongIntValue = namedValue.getLongLongIntValue();
+    }
+    else if (SimpleString::StrCmp(namedValue.getType().asCharString(), "unsigned long long int") == 0) {
+        returnValue.type = MOCKVALUETYPE_UNSIGNED_LONG_LONG_INTEGER;
+        returnValue.value.unsignedLongLongIntValue = namedValue.getUnsignedLongLongIntValue();
+    }
+#endif
     else if (SimpleString::StrCmp(namedValue.getType().asCharString(), "double") == 0) {
         returnValue.type = MOCKVALUETYPE_DOUBLE;
         returnValue.value.doubleValue = namedValue.getDoubleValue();
@@ -611,6 +705,36 @@ MockActualCall_c* withActualUnsignedLongIntParameters_c(const char* name, unsign
     actualCall = &actualCall->withParameter(name, value);
     return &gActualCall;
 }
+
+#ifdef CPPUTEST_USE_LONG_LONG
+
+MockActualCall_c* withActualLongLongIntParameters_c(const char* name, cpputest_longlong value)
+{
+    actualCall = &actualCall->withParameter(name, value);
+    return &gActualCall;
+}
+
+MockActualCall_c* withActualUnsignedLongLongIntParameters_c(const char* name, cpputest_ulonglong value)
+{
+    actualCall = &actualCall->withParameter(name, value);
+    return &gActualCall;
+}
+
+#else
+
+MockActualCall_c* withActualLongLongIntParameters_c(const char*, cpputest_longlong)
+{
+    FAIL("Long Long type is not supported");
+    return &gActualCall;
+}
+
+MockActualCall_c* withActualUnsignedLongLongIntParameters_c(const char*, cpputest_ulonglong)
+{
+    FAIL("Unsigned Long Long type is not supported");
+    return &gActualCall;
+}
+
+#endif
 
 MockActualCall_c* withActualDoubleParameters_c(const char* name, double value)
 {
@@ -735,6 +859,62 @@ unsigned long int returnUnsignedLongIntValueOrDefault_c(unsigned long int defaul
     }
     return unsignedLongIntReturnValue_c();
 }
+
+#ifdef CPPUTEST_USE_LONG_LONG
+
+cpputest_longlong longLongIntReturnValue_c()
+{
+    return actualCall->returnLongLongIntValue();
+}
+
+cpputest_longlong returnLongLongIntValueOrDefault_c(cpputest_longlong defaultValue)
+{
+    if (!hasReturnValue_c()) {
+        return defaultValue;
+    }
+    return longLongIntReturnValue_c();
+}
+
+cpputest_ulonglong unsignedLongLongIntReturnValue_c()
+{
+    return actualCall->returnUnsignedLongLongIntValue();
+}
+
+cpputest_ulonglong returnUnsignedLongLongIntValueOrDefault_c(cpputest_ulonglong defaultValue)
+{
+    if (!hasReturnValue_c()) {
+        return defaultValue;
+    }
+    return unsignedLongLongIntReturnValue_c();
+}
+
+#else
+
+cpputest_longlong longLongIntReturnValue_c()
+{
+    FAIL("Long Long type is not supported");
+    return cpputest_longlong(0);
+}
+
+cpputest_longlong returnLongLongIntValueOrDefault_c(cpputest_longlong)
+{
+    FAIL("Long Long type is not supported");
+    return cpputest_longlong(0);
+}
+
+cpputest_ulonglong unsignedLongLongIntReturnValue_c()
+{
+    FAIL("Unsigned Long Long type is not supported");
+    return cpputest_ulonglong(0);
+}
+
+cpputest_ulonglong returnUnsignedLongLongIntValueOrDefault_c(cpputest_ulonglong)
+{
+    FAIL("Unsigned Long Long type is not supported");
+    return cpputest_ulonglong(0);
+}
+
+#endif
 
 const char* stringReturnValue_c()
 {

--- a/tests/CppUTestExt/MockActualCallTest.cpp
+++ b/tests/CppUTestExt/MockActualCallTest.cpp
@@ -161,6 +161,12 @@ TEST(MockCheckedActualCall, MockIgnoredActualCallWorksAsItShould)
     CHECK(1l == actual.returnLongIntValueOrDefault(1l));
     CHECK(0 == actual.returnUnsignedIntValue());
     CHECK(1u == actual.returnUnsignedIntValueOrDefault(1u));
+#ifdef CPPUTEST_USE_LONG_LONG
+    CHECK(0 == actual.returnLongLongIntValue());
+    CHECK(1ll == actual.returnLongLongIntValueOrDefault(1ll));
+    CHECK(0 == actual.returnUnsignedLongLongIntValue());
+    CHECK(1ull == actual.returnUnsignedLongLongIntValueOrDefault(1ull));
+#endif
     DOUBLES_EQUAL(0.0, actual.returnDoubleValue(), 0.0);
     DOUBLES_EQUAL(1.5, actual.returnDoubleValueOrDefault(1.5), 0.0);
     STRCMP_EQUAL("bla", actual.returnStringValueOrDefault("bla"));
@@ -190,6 +196,10 @@ TEST(MockCheckedActualCall, remainderOfMockActualCallTraceWorksAsItShould)
     actual.withUnsignedIntParameter("unsigned_int", (unsigned int) 1);
     actual.withUnsignedLongIntParameter("unsigned_long", (unsigned long)1);
     actual.withLongIntParameter("long_int", (long int) 1);
+#ifdef CPPUTEST_USE_LONG_LONG
+    actual.withLongLongIntParameter("long_long_int", (long long int) 1);
+    actual.withUnsignedLongLongIntParameter("unsigned_long_long_int", (unsigned long long int) 1);
+#endif
     actual.withPointerParameter("pointer", &value);
     actual.withConstPointerParameter("const_pointer", &const_value);
     actual.withFunctionPointerParameter("function_pointer", function_value);
@@ -204,6 +214,10 @@ TEST(MockCheckedActualCall, remainderOfMockActualCallTraceWorksAsItShould)
     expectedString += " unsigned_int:1 (0x1)";
     expectedString += " unsigned_long:1 (0x1)";
     expectedString += " long_int:1 (0x1)";
+#ifdef CPPUTEST_USE_LONG_LONG
+    expectedString += " long_long_int:1 (0x1)";
+    expectedString += " unsigned_long_long_int:1 (0x1)";
+#endif
     expectedString += " pointer:0x";
     expectedString += HexStringFrom(&value);
     expectedString += " const_pointer:0x";
@@ -226,6 +240,12 @@ TEST(MockCheckedActualCall, remainderOfMockActualCallTraceWorksAsItShould)
     CHECK(0 == actual.returnIntValueOrDefault(1));
     CHECK(0 == actual.returnLongIntValue());
     CHECK(0 == actual.returnLongIntValueOrDefault(1l));
+#ifdef CPPUTEST_USE_LONG_LONG
+    CHECK(0 == actual.returnLongLongIntValue());
+    CHECK(0 == actual.returnLongLongIntValueOrDefault(1ll));
+    CHECK(0 == actual.returnUnsignedLongLongIntValue());
+    CHECK(0 == actual.returnUnsignedLongLongIntValueOrDefault(1ull));
+#endif
     CHECK(0 == actual.returnUnsignedIntValue());
     CHECK(0 == actual.returnUnsignedIntValueOrDefault(1u));
     DOUBLES_EQUAL(0.0, actual.returnDoubleValue(), 0.0);

--- a/tests/CppUTestExt/MockExpectedCallTest.cpp
+++ b/tests/CppUTestExt/MockExpectedCallTest.cpp
@@ -227,6 +227,32 @@ TEST(MockExpectedCall, callWithLongIntegerParameter)
     STRCMP_CONTAINS("funcName -> long int paramName: <777 (0x309)>", call->callToString().asCharString());
 }
 
+#ifdef CPPUTEST_USE_LONG_LONG
+
+TEST(MockExpectedCall, callWithUnsignedLongLongIntegerParameter)
+{
+    const SimpleString paramName = "paramName";
+    unsigned long long value = 888;
+    call->withParameter(paramName, value);
+    STRCMP_EQUAL("unsigned long long int", call->getInputParameterType(paramName).asCharString());
+    UNSIGNED_LONGLONGS_EQUAL(value, call->getInputParameter(paramName).getUnsignedLongLongIntValue());
+    CHECK(call->hasInputParameterWithName(paramName));
+    STRCMP_CONTAINS("funcName -> unsigned long long int paramName: <888 (0x378)>", call->callToString().asCharString());
+}
+
+TEST(MockExpectedCall, callWithLongLongIntegerParameter)
+{
+    const SimpleString paramName = "paramName";
+    long long value = 777;
+    call->withParameter(paramName, value);
+    STRCMP_EQUAL("long long int", call->getInputParameterType(paramName).asCharString());
+    LONGLONGS_EQUAL(value, call->getInputParameter(paramName).getLongLongIntValue());
+    CHECK(call->hasInputParameterWithName(paramName));
+    STRCMP_CONTAINS("funcName -> long long int paramName: <777 (0x309)>", call->callToString().asCharString());
+}
+
+#endif
+
 TEST(MockExpectedCall, callWithDoubleParameter)
 {
     const SimpleString paramName = "paramName";
@@ -719,6 +745,10 @@ TEST(MockIgnoredExpectedCall, worksAsItShould)
     ignored.withUnsignedIntParameter("foo", (unsigned int) 1);
     ignored.withLongIntParameter("hey", (long int) 1);
     ignored.withUnsignedLongIntParameter("bah", (unsigned long int) 1);
+#ifdef CPPUTEST_USE_LONG_LONG
+    ignored.withLongLongIntParameter("yo", (long long int) 1);
+    ignored.withUnsignedLongLongIntParameter("grr", (unsigned long long int) 1);
+#endif
     ignored.withDoubleParameter("hah", (double) 1.1f);
     ignored.withStringParameter("goo", "hello");
     ignored.withPointerParameter("pie", (void*) NULLPTR);
@@ -735,6 +765,10 @@ TEST(MockIgnoredExpectedCall, worksAsItShould)
     ignored.andReturnValue((int) 1);
     ignored.andReturnValue((unsigned long int) 1);
     ignored.andReturnValue((long int) 1);
+#ifdef CPPUTEST_USE_LONG_LONG
+    ignored.andReturnValue((unsigned long long int) 1);
+    ignored.andReturnValue((long long int) 1);
+#endif
     ignored.andReturnValue("boo");
     ignored.andReturnValue((void*) NULLPTR);
     ignored.andReturnValue((const void*) NULLPTR);

--- a/tests/CppUTestExt/MockFakeLongLong.cpp
+++ b/tests/CppUTestExt/MockFakeLongLong.cpp
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2007, Michael Feathers, James Grenning and Bas Vodde
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the <organization> nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE EARLIER MENTIONED AUTHORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL <copyright holder> BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "CppUTest/TestHarness.h"
+#include "CppUTest/TestOutput.h"
+#include "CppUTest/TestTestingFixture.h"
+#include "CppUTestExt/MockCheckedActualCall.h"
+#include "CppUTestExt/MockCheckedExpectedCall.h"
+#include "CppUTestExt/MockExpectedCallsList.h"
+#include "CppUTestExt/MockFailure.h"
+#include "MockFailureReporterForTest.h"
+
+#define CHECK_TEST_FAILS_PROPER_WITH_TEXT(text) fixture.checkTestFailsWithProperTestLocation(text, __FILE__, __LINE__)
+
+TEST_GROUP(FakeLongLongs)
+{
+    TestTestingFixture fixture;
+};
+
+#ifndef CPPUTEST_USE_LONG_LONG
+
+static void _actualCallWithFakeLongLongParameter()
+{
+    cpputest_longlong value = {0};
+
+    mock().expectOneCall("foo").withParameter("bar", 0);
+    mock().actualCall("foo").withParameter("bar", value);
+    TestTestingFixture::lineExecutedAfterCheck(); // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
+TEST(FakeLongLongs, ActualCallWithFakeLongLongParameterFAILS)
+{
+    fixture.runTestWithMethod(_actualCallWithFakeLongLongParameter);
+    mock().clear();
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("Long Long type is not supported");
+}
+
+static void _actualCallWithFakeUnsignedLongLongParameter()
+{
+    cpputest_ulonglong value = {0};
+
+    mock().expectOneCall("foo").withParameter("bar", 0);
+    mock().actualCall("foo").withParameter("bar", value);
+    TestTestingFixture::lineExecutedAfterCheck(); // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
+TEST(FakeLongLongs, ActualCallWithFakeUnsignedLongLongParameterFAILS)
+{
+    fixture.runTestWithMethod(_actualCallWithFakeUnsignedLongLongParameter);
+    mock().clear();
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("Unsigned Long Long type is not supported");
+}
+
+static void _actualCallWithFakeLongLongReturn()
+{
+    mock().expectOneCall("foo").andReturnValue(0);
+    mock().actualCall("foo").returnLongLongIntValue();
+    TestTestingFixture::lineExecutedAfterCheck(); // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
+TEST(FakeLongLongs, ActualCallWithFakeLongLongReturnFAILS)
+{
+    fixture.runTestWithMethod(_actualCallWithFakeLongLongReturn);
+    mock().clear();
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("Long Long type is not supported");
+}
+
+static void _actualCallWithFakeUnsignedLongLongReturn()
+{
+    mock().expectOneCall("foo").andReturnValue(0);
+    mock().actualCall("foo").returnUnsignedLongLongIntValue();
+    TestTestingFixture::lineExecutedAfterCheck(); // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
+TEST(FakeLongLongs, ActualCallWithFakeUnsignedLongLongReturnFAILS)
+{
+    fixture.runTestWithMethod(_actualCallWithFakeUnsignedLongLongReturn);
+    mock().clear();
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("Unsigned Long Long type is not supported");
+}
+
+static void _expectOneCallWithFakeLongLongParameter()
+{
+    cpputest_longlong value = {0};
+
+    mock().expectOneCall("foo").withParameter("bar", value);
+    mock().actualCall("foo").withParameter("bar", 0);
+    TestTestingFixture::lineExecutedAfterCheck(); // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
+TEST(FakeLongLongs, ExpectedCallWithFakeLongLongParameterFAILS)
+{
+    fixture.runTestWithMethod(_expectOneCallWithFakeLongLongParameter);
+    mock().clear();
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("Long Long type is not supported");
+}
+
+static void _expectOneCallWithFakeUnsignedLongLongParameter()
+{
+    cpputest_ulonglong value = {0};
+
+    mock().expectOneCall("foo").withParameter("bar", value);
+    mock().actualCall("foo").withParameter("bar", 0);
+    TestTestingFixture::lineExecutedAfterCheck(); // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
+TEST(FakeLongLongs, ExpectedCallWithFakeUnsignedLongLongParameterFAILS)
+{
+    fixture.runTestWithMethod(_expectOneCallWithFakeUnsignedLongLongParameter);
+    mock().clear();
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("Unsigned Long Long type is not supported");
+}
+
+static void _expectOneCallWithFakeLongLongReturn()
+{
+    cpputest_longlong value = {0};
+
+    mock().expectOneCall("foo").andReturnValue(value);
+    mock().actualCall("foo").returnIntValue();
+    TestTestingFixture::lineExecutedAfterCheck(); // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
+TEST(FakeLongLongs, ExpectedCallWithFakeLongLongReturnFAILS)
+{
+    fixture.runTestWithMethod(_expectOneCallWithFakeLongLongReturn);
+    mock().clear();
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("Long Long type is not supported");
+}
+
+static void _expectOneCallWithFakeUnsignedLongLongReturn()
+{
+    cpputest_ulonglong value = {0};
+
+    mock().expectOneCall("foo").andReturnValue(value);
+    mock().actualCall("foo").returnIntValue();
+    TestTestingFixture::lineExecutedAfterCheck(); // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
+TEST(FakeLongLongs, ExpectedCallWithFakeUnsignedLongLongReturnFAILS)
+{
+    fixture.runTestWithMethod(_expectOneCallWithFakeUnsignedLongLongReturn);
+    mock().clear();
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("Unsigned Long Long type is not supported");
+}
+
+#endif

--- a/tests/CppUTestExt/MockParameterTest.cpp
+++ b/tests/CppUTestExt/MockParameterTest.cpp
@@ -62,7 +62,7 @@ TEST(MockParameterTest, expectOneIntegerParameterAndValue)
     mock().checkExpectations();
 }
 
-#ifdef CPPUTEST_USE_LONGLONG
+#ifdef CPPUTEST_USE_LONG_LONG
 
 TEST(MockParameterTest, expectOneUnsignedLongLongIntegerParameterAndValue)
 {

--- a/tests/CppUTestExt/MockParameterTest.cpp
+++ b/tests/CppUTestExt/MockParameterTest.cpp
@@ -96,21 +96,6 @@ TEST(MockParameterTest, mismatchedIntegerTypesIntAndLongAreAllowed)
     mock().checkExpectations();
 }
 
-#ifdef CPPUTEST_USE_LONG_LONG
-
-TEST(MockParameterTest, mismatchedIntegerTypesIntAndLongLongAreAllowed)
-{
-    mock().expectOneCall("foo").withParameter("parameter", (int)1);
-    mock().actualCall("foo").withParameter("parameter", (long long)1);
-
-    mock().expectOneCall("foo").withParameter("parameter", (long long)1);
-    mock().actualCall("foo").withParameter("parameter", (int)1);
-
-    mock().checkExpectations();
-}
-
-#endif
-
 TEST(MockParameterTest, mismatchedIntegerTypesIntAndUnsignedAreAllowed)
 {
     mock().expectOneCall("foo").withParameter("parameter", (int)1);
@@ -133,21 +118,6 @@ TEST(MockParameterTest, mismatchedIntegerTypesIntAndUnsignedLongAreAllowed)
     mock().checkExpectations();
 }
 
-#ifdef CPPUTEST_USE_LONG_LONG
-
-TEST(MockParameterTest, mismatchedIntegerTypesIntAndUnsignedLongLongAreAllowed)
-{
-    mock().expectOneCall("foo").withParameter("parameter", (int)1);
-    mock().actualCall("foo").withParameter("parameter", (unsigned long long)1);
-
-    mock().expectOneCall("foo").withParameter("parameter", (unsigned long long)1);
-    mock().actualCall("foo").withParameter("parameter", (int)1);
-
-    mock().checkExpectations();
-}
-
-#endif
-
 TEST(MockParameterTest, mismatchedIntegerTypesUnsignedAndLongAreAllowed)
 {
     mock().expectOneCall("foo").withParameter("parameter", (unsigned)1);
@@ -158,21 +128,6 @@ TEST(MockParameterTest, mismatchedIntegerTypesUnsignedAndLongAreAllowed)
 
     mock().checkExpectations();
 }
-
-#ifdef CPPUTEST_USE_LONG_LONG
-
-TEST(MockParameterTest, mismatchedIntegerTypesUnsignedAndLongLongAreAllowed)
-{
-    mock().expectOneCall("foo").withParameter("parameter", (unsigned)1);
-    mock().actualCall("foo").withParameter("parameter", (long long)1);
-
-    mock().expectOneCall("foo").withParameter("parameter", (long long)1);
-    mock().actualCall("foo").withParameter("parameter", (unsigned)1);
-
-    mock().checkExpectations();
-}
-
-#endif
 
 TEST(MockParameterTest, mismatchedIntegerTypesUnsignedAndUnsignedLongAreAllowed)
 {
@@ -185,7 +140,51 @@ TEST(MockParameterTest, mismatchedIntegerTypesUnsignedAndUnsignedLongAreAllowed)
     mock().checkExpectations();
 }
 
+TEST(MockParameterTest, mismatchedIntegerTypesLongAndUnsignedLongAreAllowed)
+{
+    mock().expectOneCall("foo").withParameter("parameter", (long)1);
+    mock().actualCall("foo").withParameter("parameter", (unsigned long)1);
+
+    mock().expectOneCall("foo").withParameter("parameter", (unsigned long)1);
+    mock().actualCall("foo").withParameter("parameter", (long)1);
+
+    mock().checkExpectations();
+}
+
 #ifdef CPPUTEST_USE_LONG_LONG
+
+TEST(MockParameterTest, mismatchedIntegerTypesIntAndLongLongAreAllowed)
+{
+    mock().expectOneCall("foo").withParameter("parameter", (int)1);
+    mock().actualCall("foo").withParameter("parameter", (long long)1);
+
+    mock().expectOneCall("foo").withParameter("parameter", (long long)1);
+    mock().actualCall("foo").withParameter("parameter", (int)1);
+
+    mock().checkExpectations();
+}
+
+TEST(MockParameterTest, mismatchedIntegerTypesIntAndUnsignedLongLongAreAllowed)
+{
+    mock().expectOneCall("foo").withParameter("parameter", (int)1);
+    mock().actualCall("foo").withParameter("parameter", (unsigned long long)1);
+
+    mock().expectOneCall("foo").withParameter("parameter", (unsigned long long)1);
+    mock().actualCall("foo").withParameter("parameter", (int)1);
+
+    mock().checkExpectations();
+}
+
+TEST(MockParameterTest, mismatchedIntegerTypesUnsignedAndLongLongAreAllowed)
+{
+    mock().expectOneCall("foo").withParameter("parameter", (unsigned)1);
+    mock().actualCall("foo").withParameter("parameter", (long long)1);
+
+    mock().expectOneCall("foo").withParameter("parameter", (long long)1);
+    mock().actualCall("foo").withParameter("parameter", (unsigned)1);
+
+    mock().checkExpectations();
+}
 
 TEST(MockParameterTest, mismatchedIntegerTypesUnsignedAndUnsignedLongLongAreAllowed)
 {
@@ -219,21 +218,6 @@ TEST(MockParameterTest, mismatchedIntegerTypesLongAndLongLongAreAllowed)
 
     mock().checkExpectations();
 }
-
-#endif
-
-TEST(MockParameterTest, mismatchedIntegerTypesLongAndUnsignedLongAreAllowed)
-{
-    mock().expectOneCall("foo").withParameter("parameter", (long)1);
-    mock().actualCall("foo").withParameter("parameter", (unsigned long)1);
-
-    mock().expectOneCall("foo").withParameter("parameter", (unsigned long)1);
-    mock().actualCall("foo").withParameter("parameter", (long)1);
-
-    mock().checkExpectations();
-}
-
-#ifdef CPPUTEST_USE_LONG_LONG
 
 TEST(MockParameterTest, mismatchedIntegerTypesLongAndUnsignedLongLongAreAllowed)
 {

--- a/tests/CppUTestExt/MockParameterTest.cpp
+++ b/tests/CppUTestExt/MockParameterTest.cpp
@@ -62,6 +62,29 @@ TEST(MockParameterTest, expectOneIntegerParameterAndValue)
     mock().checkExpectations();
 }
 
+#ifdef CPPUTEST_USE_LONGLONG
+
+TEST(MockParameterTest, expectOneUnsignedLongLongIntegerParameterAndValue)
+{
+    unsigned long long value = 0xFFFFAAAAFFFFAAAA;
+    mock().expectOneCall("foo").withParameter("parameter", value);
+    mock().actualCall("foo").withParameter("parameter", value);
+
+    mock().checkExpectations();
+}
+
+TEST(MockParameterTest, expectOneLongLongIntegerParameterAndValue)
+{
+    long long value = 0x7FFFAAAAFFFFAAAA;
+
+    mock().expectOneCall("foo").withParameter("parameter", value);
+    mock().actualCall("foo").withParameter("parameter", value);
+
+    mock().checkExpectations();
+}
+
+#endif
+
 TEST(MockParameterTest, mismatchedIntegerTypesIntAndLongAreAllowed)
 {
     mock().expectOneCall("foo").withParameter("parameter", (int)1);
@@ -72,6 +95,21 @@ TEST(MockParameterTest, mismatchedIntegerTypesIntAndLongAreAllowed)
 
     mock().checkExpectations();
 }
+
+#ifdef CPPUTEST_USE_LONG_LONG
+
+TEST(MockParameterTest, mismatchedIntegerTypesIntAndLongLongAreAllowed)
+{
+    mock().expectOneCall("foo").withParameter("parameter", (int)1);
+    mock().actualCall("foo").withParameter("parameter", (long long)1);
+
+    mock().expectOneCall("foo").withParameter("parameter", (long long)1);
+    mock().actualCall("foo").withParameter("parameter", (int)1);
+
+    mock().checkExpectations();
+}
+
+#endif
 
 TEST(MockParameterTest, mismatchedIntegerTypesIntAndUnsignedAreAllowed)
 {
@@ -95,6 +133,21 @@ TEST(MockParameterTest, mismatchedIntegerTypesIntAndUnsignedLongAreAllowed)
     mock().checkExpectations();
 }
 
+#ifdef CPPUTEST_USE_LONG_LONG
+
+TEST(MockParameterTest, mismatchedIntegerTypesIntAndUnsignedLongLongAreAllowed)
+{
+    mock().expectOneCall("foo").withParameter("parameter", (int)1);
+    mock().actualCall("foo").withParameter("parameter", (unsigned long long)1);
+
+    mock().expectOneCall("foo").withParameter("parameter", (unsigned long long)1);
+    mock().actualCall("foo").withParameter("parameter", (int)1);
+
+    mock().checkExpectations();
+}
+
+#endif
+
 TEST(MockParameterTest, mismatchedIntegerTypesUnsignedAndLongAreAllowed)
 {
     mock().expectOneCall("foo").withParameter("parameter", (unsigned)1);
@@ -105,6 +158,21 @@ TEST(MockParameterTest, mismatchedIntegerTypesUnsignedAndLongAreAllowed)
 
     mock().checkExpectations();
 }
+
+#ifdef CPPUTEST_USE_LONG_LONG
+
+TEST(MockParameterTest, mismatchedIntegerTypesUnsignedAndLongLongAreAllowed)
+{
+    mock().expectOneCall("foo").withParameter("parameter", (unsigned)1);
+    mock().actualCall("foo").withParameter("parameter", (long long)1);
+
+    mock().expectOneCall("foo").withParameter("parameter", (long long)1);
+    mock().actualCall("foo").withParameter("parameter", (unsigned)1);
+
+    mock().checkExpectations();
+}
+
+#endif
 
 TEST(MockParameterTest, mismatchedIntegerTypesUnsignedAndUnsignedLongAreAllowed)
 {
@@ -117,6 +185,43 @@ TEST(MockParameterTest, mismatchedIntegerTypesUnsignedAndUnsignedLongAreAllowed)
     mock().checkExpectations();
 }
 
+#ifdef CPPUTEST_USE_LONG_LONG
+
+TEST(MockParameterTest, mismatchedIntegerTypesUnsignedAndUnsignedLongLongAreAllowed)
+{
+    mock().expectOneCall("foo").withParameter("parameter", (unsigned)1);
+    mock().actualCall("foo").withParameter("parameter", (unsigned long long)1);
+
+    mock().expectOneCall("foo").withParameter("parameter", (unsigned long long)1);
+    mock().actualCall("foo").withParameter("parameter", (unsigned)1);
+
+    mock().checkExpectations();
+}
+
+TEST(MockParameterTest, mismatchedIntegerTypesUnsignedLongAndUnsignedLongLongAreAllowed)
+{
+    mock().expectOneCall("foo").withParameter("parameter", (unsigned long)1);
+    mock().actualCall("foo").withParameter("parameter", (unsigned long long)1);
+
+    mock().expectOneCall("foo").withParameter("parameter", (unsigned long long)1);
+    mock().actualCall("foo").withParameter("parameter", (unsigned long)1);
+
+    mock().checkExpectations();
+}
+
+TEST(MockParameterTest, mismatchedIntegerTypesLongAndLongLongAreAllowed)
+{
+    mock().expectOneCall("foo").withParameter("parameter", (long)1);
+    mock().actualCall("foo").withParameter("parameter", (long long)1);
+
+    mock().expectOneCall("foo").withParameter("parameter", (long long)1);
+    mock().actualCall("foo").withParameter("parameter", (long)1);
+
+    mock().checkExpectations();
+}
+
+#endif
+
 TEST(MockParameterTest, mismatchedIntegerTypesLongAndUnsignedLongAreAllowed)
 {
     mock().expectOneCall("foo").withParameter("parameter", (long)1);
@@ -127,6 +232,43 @@ TEST(MockParameterTest, mismatchedIntegerTypesLongAndUnsignedLongAreAllowed)
 
     mock().checkExpectations();
 }
+
+#ifdef CPPUTEST_USE_LONG_LONG
+
+TEST(MockParameterTest, mismatchedIntegerTypesLongAndUnsignedLongLongAreAllowed)
+{
+    mock().expectOneCall("foo").withParameter("parameter", (long)1);
+    mock().actualCall("foo").withParameter("parameter", (unsigned long long)1);
+
+    mock().expectOneCall("foo").withParameter("parameter", (unsigned long long)1);
+    mock().actualCall("foo").withParameter("parameter", (long)1);
+
+    mock().checkExpectations();
+}
+
+TEST(MockParameterTest, mismatchedIntegerTypesUnsignedLongAndLongLongAreAllowed)
+{
+    mock().expectOneCall("foo").withParameter("parameter", (unsigned long)1);
+    mock().actualCall("foo").withParameter("parameter", (long long)1);
+
+    mock().expectOneCall("foo").withParameter("parameter", (long long)1);
+    mock().actualCall("foo").withParameter("parameter", (unsigned long)1);
+
+    mock().checkExpectations();
+}
+
+TEST(MockParameterTest, mismatchedIntegerTypesLongLongAndUnsignedLongLongAreAllowed)
+{
+    mock().expectOneCall("foo").withParameter("parameter", (long long)1);
+    mock().actualCall("foo").withParameter("parameter", (unsigned long long)1);
+
+    mock().expectOneCall("foo").withParameter("parameter", (unsigned long long)1);
+    mock().actualCall("foo").withParameter("parameter", (long long)1);
+
+    mock().checkExpectations();
+}
+
+#endif
 
 TEST(MockParameterTest, longAndUnsignedLongWithSameBitRepresentationShouldNotBeTreatedAsEqual)
 {
@@ -712,6 +854,10 @@ TEST(MockParameterTest, ignoreOtherCallsIgnoresWithAllKindsOfParameters)
            .withParameter("bar", 1u)
            .withParameter("foo", 1l)
            .withParameter("hey", 1ul)
+#ifdef CPPUTEST_USE_LONG_LONG
+           .withParameter("ick", 1ll)
+           .withParameter("grr", 1ull)
+#endif
            .withParameter("duh", 1.0)
            .withParameter("yoo", (const void*) NULLPTR)
            .withParameter("func", (void(*)()) NULLPTR)

--- a/tests/CppUTestExt/MockReturnValueTest.cpp
+++ b/tests/CppUTestExt/MockReturnValueTest.cpp
@@ -27,6 +27,7 @@
 
 #include "CppUTest/TestHarness.h"
 #include "MockFailureReporterForTest.h"
+#include <climits>
 
 TEST_GROUP(MockReturnValueTest)
 {
@@ -104,6 +105,87 @@ TEST(MockReturnValueTest, UnsignedIntReturnValueCanBeRetrievedAsUnsignedLongInt)
     mock().expectOneCall("foo").andReturnValue(expected_value);
     UNSIGNED_LONGS_EQUAL(expected_value, mock().actualCall("foo").returnValue().getUnsignedLongIntValue());
 }
+
+#ifdef CPPUTEST_USE_LONG_LONG
+
+TEST(MockReturnValueTest, PositiveIntReturnValueCanBeRetrievedAsUnsignedLongLongInt)
+{
+    int expected_value = 7;
+    mock().expectOneCall("foo").andReturnValue(expected_value);
+    UNSIGNED_LONGLONGS_EQUAL(expected_value, mock().actualCall("foo").returnValue().getUnsignedLongLongIntValue());
+}
+
+TEST(MockReturnValueTest, PositiveLongIntReturnValueCanBeRetrievedAsUnsignedLongLongInt)
+{
+    long int expected_value = 7;
+    mock().expectOneCall("foo").andReturnValue(expected_value);
+    UNSIGNED_LONGLONGS_EQUAL(expected_value, mock().actualCall("foo").returnValue().getUnsignedLongLongIntValue());
+}
+
+TEST(MockReturnValueTest, PositiveLongLongIntReturnValueCanBeRetrievedAsUnsignedLongLongInt)
+{
+    long long int expected_value = 7;
+    mock().expectOneCall("foo").andReturnValue(expected_value);
+    UNSIGNED_LONGLONGS_EQUAL(expected_value, mock().actualCall("foo").returnValue().getUnsignedLongLongIntValue());
+}
+
+TEST(MockReturnValueTest, UnsignedIntReturnValueCanBeRetrievedAsUnsignedLongLongInt)
+{
+    unsigned int expected_value = 7;
+    mock().expectOneCall("foo").andReturnValue(expected_value);
+    UNSIGNED_LONGLONGS_EQUAL(expected_value, mock().actualCall("foo").returnValue().getUnsignedLongLongIntValue());
+}
+
+TEST(MockReturnValueTest, UnsignedLongIntReturnValueCanBeRetrievedAsUnsignedLongLongInt)
+{
+    unsigned long int expected_value = 7;
+    mock().expectOneCall("foo").andReturnValue(expected_value);
+    UNSIGNED_LONGLONGS_EQUAL(expected_value, mock().actualCall("foo").returnValue().getUnsignedLongLongIntValue());
+}
+
+TEST(MockReturnValueTest, UnsignedLongLongIntReturnValueCanBeRetrieved)
+{
+    unsigned long long int expected_value = ULLONG_MAX;
+    mock().expectOneCall("foo").andReturnValue(expected_value);
+    UNSIGNED_LONGLONGS_EQUAL(expected_value, mock().actualCall("foo").returnValue().getUnsignedLongLongIntValue());
+}
+
+TEST(MockReturnValueTest, PositiveIntReturnValueCanBeRetrievedAsLongLongInt)
+{
+    int expected_value = 7;
+    mock().expectOneCall("foo").andReturnValue(expected_value);
+    LONGLONGS_EQUAL(expected_value, mock().actualCall("foo").returnValue().getLongLongIntValue());
+}
+
+TEST(MockReturnValueTest, PositiveLongIntReturnValueCanBeRetrievedAsLongLongInt)
+{
+    long int expected_value = 7;
+    mock().expectOneCall("foo").andReturnValue(expected_value);
+    LONGLONGS_EQUAL(expected_value, mock().actualCall("foo").returnValue().getLongLongIntValue());
+}
+
+TEST(MockReturnValueTest, UnsignedIntReturnValueCanBeRetrievedAsLongLongInt)
+{
+    unsigned int expected_value = 7;
+    mock().expectOneCall("foo").andReturnValue(expected_value);
+    LONGLONGS_EQUAL(expected_value, mock().actualCall("foo").returnValue().getLongLongIntValue());
+}
+
+TEST(MockReturnValueTest, UnsignedLongIntReturnValueCanBeRetrievedAsLongLongInt)
+{
+    unsigned long int expected_value = 7;
+    mock().expectOneCall("foo").andReturnValue(expected_value);
+    LONGLONGS_EQUAL(expected_value, mock().actualCall("foo").returnValue().getLongLongIntValue());
+}
+
+TEST(MockReturnValueTest, LongLongIntReturnValueCanBeRetrieved)
+{
+    long long int expected_value = LLONG_MAX;
+    mock().expectOneCall("foo").andReturnValue(expected_value);
+    LONGLONGS_EQUAL(expected_value, mock().actualCall("foo").returnValue().getLongLongIntValue());
+}
+
+#endif
 
 TEST(MockReturnValueTest, UnsignedIntegerReturnValueSetsDifferentValues)
 {
@@ -201,6 +283,44 @@ TEST(MockReturnValueTest, WhenNoLongIntegerReturnValueIsExpectedButThereIsADefau
     LONGS_EQUAL(default_return_value, mock().actualCall("foo").returnLongIntValueOrDefault(default_return_value));
     LONGS_EQUAL(default_return_value, mock().returnLongIntValueOrDefault(default_return_value));
 }
+
+#ifdef CPPUTEST_USE_LONG_LONG
+
+TEST(MockReturnValueTest, WhenAUnsignedLongLongIntegerReturnValueIsExpectedAndAlsoThereIsADefaultShouldlIgnoreTheDefault)
+{
+    unsigned long long int default_return_value = ULLONG_MAX;
+    unsigned long long int expected_return_value = default_return_value - 1;
+    mock().expectOneCall("foo").andReturnValue(expected_return_value);
+    LONGS_EQUAL(expected_return_value, mock().actualCall("foo").returnUnsignedLongLongIntValueOrDefault(default_return_value));
+    LONGS_EQUAL(expected_return_value, mock().returnUnsignedLongLongIntValueOrDefault(default_return_value));
+}
+
+TEST(MockReturnValueTest, WhenNoUnsignedLongLongIntegerReturnValueIsExpectedButThereIsADefaultShouldlUseTheDefaultValue)
+{
+    unsigned long long int default_return_value = ULLONG_MAX;
+    mock().expectOneCall("foo");
+    LONGS_EQUAL(default_return_value, mock().actualCall("foo").returnUnsignedLongLongIntValueOrDefault(default_return_value));
+    LONGS_EQUAL(default_return_value, mock().returnUnsignedLongLongIntValueOrDefault(default_return_value));
+}
+
+TEST(MockReturnValueTest, WhenALongLongIntegerReturnValueIsExpectedAndAlsoThereIsADefaultShouldlIgnoreTheDefault)
+{
+    long long int default_return_value = LLONG_MAX;
+    long long int expected_return_value = default_return_value - 1;
+    mock().expectOneCall("foo").andReturnValue(expected_return_value);
+    LONGS_EQUAL(expected_return_value, mock().actualCall("foo").returnLongLongIntValueOrDefault(default_return_value));
+    LONGS_EQUAL(expected_return_value, mock().returnLongLongIntValueOrDefault(default_return_value));
+}
+
+TEST(MockReturnValueTest, WhenNoLongLongIntegerReturnValueIsExpectedButThereIsADefaultShouldlUseTheDefaultValue)
+{
+    long long int default_return_value = LLONG_MAX;
+    mock().expectOneCall("foo");
+    LONGS_EQUAL(default_return_value, mock().actualCall("foo").returnLongLongIntValueOrDefault(default_return_value));
+    LONGS_EQUAL(default_return_value, mock().returnLongLongIntValueOrDefault(default_return_value));
+}
+
+#endif
 
 TEST(MockReturnValueTest, WhenABooleanReturnValueIsExpectedAndAlsoThereIsADefaultShouldlIgnoreTheDefault)
 {
@@ -397,6 +517,90 @@ TEST(MockReturnValueTest, UnsignedLongIntegerReturnValueSetsDifferentValuesWhile
     LONGS_EQUAL(another_ret_value, mock().actualCall("foo").withParameter("p1", 1).returnValue().getUnsignedLongIntValue());
     LONGS_EQUAL(another_ret_value, mock().returnValue().getUnsignedLongIntValue());
 }
+
+#ifdef CPPUTEST_USE_LONG_LONG
+
+TEST(MockReturnValueTest, LongLongIntegerReturnValue)
+{
+    long long int expected_value = 7;
+    mock().expectOneCall("foo").andReturnValue(expected_value);
+
+    MockActualCall& actual_call = mock().actualCall("foo");
+    LONGLONGS_EQUAL(expected_value, actual_call.returnValue().getLongLongIntValue());
+    LONGLONGS_EQUAL(expected_value, actual_call.returnLongLongIntValue());
+    LONGLONGS_EQUAL(expected_value, mock().returnValue().getLongLongIntValue());
+    LONGLONGS_EQUAL(expected_value, mock().longLongIntReturnValue());
+}
+
+TEST(MockReturnValueTest, LongLongIntegerReturnValueSetsDifferentValues)
+{
+    long long int expected_value = 1;
+    long long int another_expected_value = 2;
+
+    mock().expectOneCall("foo").andReturnValue(expected_value);
+    mock().expectOneCall("foo").andReturnValue(another_expected_value);
+
+    LONGLONGS_EQUAL(expected_value, mock().actualCall("foo").returnValue().getLongLongIntValue());
+    LONGLONGS_EQUAL(expected_value, mock().returnValue().getLongLongIntValue());
+    LONGLONGS_EQUAL(another_expected_value, mock().actualCall("foo").returnValue().getLongLongIntValue());
+    LONGLONGS_EQUAL(another_expected_value, mock().returnValue().getLongLongIntValue());
+}
+
+TEST(MockReturnValueTest, LongLongIntegerReturnValueSetsDifferentValuesWhileParametersAreIgnored)
+{
+    long long int ret_value = 1;
+    long long int another_ret_value = 2;
+
+    mock().expectOneCall("foo").withParameter("p1", 1).ignoreOtherParameters().andReturnValue(ret_value);
+    mock().expectOneCall("foo").withParameter("p1", 1).ignoreOtherParameters().andReturnValue(another_ret_value);
+
+    LONGLONGS_EQUAL(ret_value, mock().actualCall("foo").withParameter("p1", 1).returnValue().getLongLongIntValue());
+    LONGLONGS_EQUAL(ret_value, mock().returnValue().getLongLongIntValue());
+    LONGLONGS_EQUAL(another_ret_value, mock().actualCall("foo").withParameter("p1", 1).returnValue().getLongLongIntValue());
+    LONGLONGS_EQUAL(another_ret_value, mock().returnValue().getLongLongIntValue());
+}
+
+TEST(MockReturnValueTest, UnsignedLongLongIntegerReturnValue)
+{
+    unsigned long long int expected_value = 7;
+    mock().expectOneCall("foo").andReturnValue(expected_value);
+
+    MockActualCall& actual_call = mock().actualCall("foo");
+    UNSIGNED_LONGLONGS_EQUAL(expected_value, actual_call.returnValue().getUnsignedLongLongIntValue());
+    UNSIGNED_LONGLONGS_EQUAL(expected_value, actual_call.returnUnsignedLongLongIntValue());
+    UNSIGNED_LONGLONGS_EQUAL(expected_value, mock().returnValue().getUnsignedLongLongIntValue());
+    UNSIGNED_LONGLONGS_EQUAL(expected_value, mock().unsignedLongLongIntReturnValue());
+}
+
+TEST(MockReturnValueTest, UnsignedLongLongIntegerReturnValueSetsDifferentValues)
+{
+    unsigned long long int expected_value = 1;
+    unsigned long long int another_expected_value = 2;
+
+    mock().expectOneCall("foo").andReturnValue(expected_value);
+    mock().expectOneCall("foo").andReturnValue(another_expected_value);
+
+    UNSIGNED_LONGLONGS_EQUAL(expected_value, mock().actualCall("foo").returnValue().getUnsignedLongLongIntValue());
+    UNSIGNED_LONGLONGS_EQUAL(expected_value, mock().returnValue().getUnsignedLongLongIntValue());
+    UNSIGNED_LONGLONGS_EQUAL(another_expected_value, mock().actualCall("foo").returnValue().getUnsignedLongLongIntValue());
+    UNSIGNED_LONGLONGS_EQUAL(another_expected_value, mock().returnValue().getUnsignedLongLongIntValue());
+}
+
+TEST(MockReturnValueTest, UnsignedLongLongIntegerReturnValueSetsDifferentValuesWhileParametersAreIgnored)
+{
+    unsigned long long int ret_value = 1;
+    unsigned long long int another_ret_value = 2;
+
+    mock().expectOneCall("foo").withParameter("p1", 1).ignoreOtherParameters().andReturnValue(ret_value);
+    mock().expectOneCall("foo").withParameter("p1", 1).ignoreOtherParameters().andReturnValue(another_ret_value);
+
+    UNSIGNED_LONGLONGS_EQUAL(ret_value, mock().actualCall("foo").withParameter("p1", 1).returnValue().getUnsignedLongLongIntValue());
+    UNSIGNED_LONGLONGS_EQUAL(ret_value, mock().returnValue().getUnsignedLongLongIntValue());
+    UNSIGNED_LONGLONGS_EQUAL(another_ret_value, mock().actualCall("foo").withParameter("p1", 1).returnValue().getUnsignedLongLongIntValue());
+    UNSIGNED_LONGLONGS_EQUAL(another_ret_value, mock().returnValue().getUnsignedLongLongIntValue());
+}
+
+#endif
 
 TEST(MockReturnValueTest, MatchingReturnValueOnWhileSignature)
 {

--- a/tests/CppUTestExt/MockReturnValueTest.cpp
+++ b/tests/CppUTestExt/MockReturnValueTest.cpp
@@ -27,7 +27,6 @@
 
 #include "CppUTest/TestHarness.h"
 #include "MockFailureReporterForTest.h"
-#include <climits>
 
 TEST_GROUP(MockReturnValueTest)
 {

--- a/tests/CppUTestExt/MockSupport_cTest.cpp
+++ b/tests/CppUTestExt/MockSupport_cTest.cpp
@@ -154,6 +154,22 @@ TEST(MockSupport_c, unsignedLongIntParameter)
     mock_c()->actualCall("foo")->withUnsignedLongIntParameters("p", 1);
 }
 
+#ifdef CPPUTEST_USE_LONG_LONG
+
+TEST(MockSupport_c, longLongIntParameter)
+{
+    mock_c()->expectOneCall("foo")->withLongLongIntParameters("p", 1);
+    mock_c()->actualCall("foo")->withLongLongIntParameters("p", 1);
+}
+
+TEST(MockSupport_c, unsignedLongLongIntParameter)
+{
+    mock_c()->expectOneCall("foo")->withUnsignedLongLongIntParameters("p", 1);
+    mock_c()->actualCall("foo")->withUnsignedLongLongIntParameters("p", 1);
+}
+
+#endif
+
 TEST(MockSupport_c, memoryBufferParameter)
 {
     const unsigned char mem_buffer[] = { 1, 2, 3};
@@ -333,6 +349,62 @@ TEST(MockSupport_c, whenNoReturnValueIsGivenReturnUnsignedLongIntValueOrDefaultS
     LONGS_EQUAL(defaultValue, mock_c()->actualCall("foo")->returnUnsignedLongIntValueOrDefault(defaultValue));
     LONGS_EQUAL(defaultValue, mock_c()->returnUnsignedLongIntValueOrDefault(defaultValue));
 }
+
+#ifdef CPPUTEST_USE_LONG_LONG
+
+TEST(MockSupport_c, returnLongLongIntValue)
+{
+    long long int expected_value = -10L;
+    mock_c()->expectOneCall("boo")->andReturnLongLongIntValue(expected_value);
+    LONGLONGS_EQUAL(expected_value, mock_c()->actualCall("boo")->longLongIntReturnValue());
+    LONGLONGS_EQUAL(expected_value, mock_c()->longLongIntReturnValue());
+    LONGLONGS_EQUAL(MOCKVALUETYPE_LONG_LONG_INTEGER, mock_c()->returnValue().type);
+}
+
+TEST(MockSupport_c, whenReturnValueIsGivenReturnLongLongIntValueOrDefaultShouldIgnoreTheDefault)
+{
+    long long int defaultValue = -10L;
+    long long int expectedValue = defaultValue - 1L;
+    mock_c()->expectOneCall("foo")->andReturnLongLongIntValue(expectedValue);
+    LONGLONGS_EQUAL(expectedValue, mock_c()->actualCall("foo")->returnLongLongIntValueOrDefault(defaultValue));
+    LONGLONGS_EQUAL(expectedValue, mock_c()->returnLongLongIntValueOrDefault(defaultValue));
+}
+
+TEST(MockSupport_c, whenNoReturnValueIsGivenReturnLongLongIntValueOrDefaultShouldlUseTheDefaultValue)
+{
+    long long int defaultValue = -10L;
+    mock_c()->expectOneCall("foo");
+    LONGLONGS_EQUAL(defaultValue, mock_c()->actualCall("foo")->returnLongLongIntValueOrDefault(defaultValue));
+    LONGLONGS_EQUAL(defaultValue, mock_c()->returnLongLongIntValueOrDefault(defaultValue));
+}
+
+TEST(MockSupport_c, returnUnsignedLongLongIntValue)
+{
+    unsigned long long int expected_value = 10;
+    mock_c()->expectOneCall("boo")->andReturnUnsignedLongLongIntValue(expected_value);
+    UNSIGNED_LONGLONGS_EQUAL(expected_value, mock_c()->actualCall("boo")->unsignedLongLongIntReturnValue());
+    UNSIGNED_LONGLONGS_EQUAL(expected_value, mock_c()->unsignedLongLongIntReturnValue());
+    UNSIGNED_LONGLONGS_EQUAL(MOCKVALUETYPE_UNSIGNED_LONG_LONG_INTEGER, mock_c()->returnValue().type);
+}
+
+TEST(MockSupport_c, whenReturnValueIsGivenReturnUnsignedLongLongIntValueOrDefaultShouldIgnoreTheDefault)
+{
+    unsigned long long int defaultValue = 10L;
+    unsigned long long int expectedValue = defaultValue + 1L;
+    mock_c()->expectOneCall("foo")->andReturnUnsignedLongLongIntValue(expectedValue);
+    UNSIGNED_LONGLONGS_EQUAL(expectedValue, mock_c()->actualCall("foo")->returnUnsignedLongLongIntValueOrDefault(defaultValue));
+    UNSIGNED_LONGLONGS_EQUAL(expectedValue, mock_c()->returnUnsignedLongLongIntValueOrDefault(defaultValue));
+}
+
+TEST(MockSupport_c, whenNoReturnValueIsGivenReturnUnsignedLongLongIntValueOrDefaultShouldlUseTheDefaultValue)
+{
+    unsigned long long int defaultValue = 10L;
+    mock_c()->expectOneCall("foo");
+    UNSIGNED_LONGLONGS_EQUAL(defaultValue, mock_c()->actualCall("foo")->returnUnsignedLongLongIntValueOrDefault(defaultValue));
+    UNSIGNED_LONGLONGS_EQUAL(defaultValue, mock_c()->returnUnsignedLongLongIntValueOrDefault(defaultValue));
+}
+
+#endif
 
 TEST(MockSupport_c, returnStringValue)
 {

--- a/tests/CppUTestExt/MockSupport_cTestCFile.c
+++ b/tests/CppUTestExt/MockSupport_cTestCFile.c
@@ -53,6 +53,11 @@ void all_mock_support_c_calls(void)
             withUnsignedIntParameters("unsigned", 1)->
             withLongIntParameters("long int", (long int) -1)->
             withUnsignedLongIntParameters("unsigned long int", (unsigned long int) 1)->
+#ifdef CPPUTEST_USE_LONG_LONG
+            withLongLongIntParameters("long long int", (long long int) -1)->
+            withUnsignedLongLongIntParameters("unsigned long long int", (unsigned long long int) 1)->
+#endif
+
             withDoubleParameters("double", 1.0)->
             withStringParameters("string", "string")->
             withPointerParameters("pointer", (void*) 1)->
@@ -66,6 +71,10 @@ void all_mock_support_c_calls(void)
             withUnsignedIntParameters("unsigned", 1)->
             withLongIntParameters("long int", (long int) -1)->
             withUnsignedLongIntParameters("unsigned long int", (unsigned long int) 1)->
+#ifdef CPPUTEST_USE_LONG_LONG
+            withLongLongIntParameters("long long int", (long long int) -1)->
+            withUnsignedLongLongIntParameters("unsigned long long int", (unsigned long long int) 1)->
+#endif
             withDoubleParameters("double", 1.0)->
             withStringParameters("string", "string")->
             withPointerParameters("pointer", (void*) 1)->
@@ -111,6 +120,16 @@ void all_mock_support_c_calls(void)
     mock_c()->expectOneCall("boo3")->andReturnUnsignedLongIntValue(1);
     mock_c()->actualCall("boo3")->unsignedLongIntReturnValue();
     mock_c()->unsignedLongIntReturnValue();
+
+#ifdef CPPUTEST_USE_LONG_LONG
+    mock_c()->expectOneCall("mgrgrgr1")->andReturnLongLongIntValue(1);
+    mock_c()->actualCall("mgrgrgr1")->longLongIntReturnValue();
+    mock_c()->longLongIntReturnValue();
+
+    mock_c()->expectOneCall("mgrgrgr2")->andReturnUnsignedLongLongIntValue(1);
+    mock_c()->actualCall("mgrgrgr2")->unsignedLongLongIntReturnValue();
+    mock_c()->unsignedLongLongIntReturnValue();
+#endif
 
     mock_c()->expectOneCall("boo4")->andReturnDoubleValue(1.0);
     mock_c()->actualCall("boo4")->doubleReturnValue();
@@ -168,6 +187,10 @@ void all_mock_support_c_calls(void)
     mock_c()->returnUnsignedIntValueOrDefault(1);
     mock_c()->returnLongIntValueOrDefault(-1L);
     mock_c()->returnUnsignedLongIntValueOrDefault(1L);
+#ifdef CPPUTEST_USE_LONG_LONG
+    mock_c()->returnLongLongIntValueOrDefault(-1LL);
+    mock_c()->returnUnsignedLongLongIntValueOrDefault(1ULL);
+#endif
     mock_c()->returnStringValueOrDefault("");
     mock_c()->returnDoubleValueOrDefault(0.01);
     mock_c()->returnPointerValueOrDefault(0);


### PR DESCRIPTION
When testing code that needs to work on both 64-bit platforms and 32-bit
platforms, the long integer may not guarantee 64bits of width on the
32-bit platform. This makes testing calls which take and return 64bit
values difficult, as the test framework can't handle these natively.

Add support for long long integers, so that test code can natively
handle these larger values.

Signed-off-by: Jacob Keller <jacob.e.keller@intel.com>