### PR TITLE
cpputest: kill example test with memset

### DIFF
--- a/examples/AllTests/HelloTest.cpp
+++ b/examples/AllTests/HelloTest.cpp
@@ -27,6 +27,7 @@
 
 #include "hello.h"
 
+#include <cstring>
 #include <stdio.h>
 #include <stdarg.h>
 #include "CppUTest/TestHarness.h"
@@ -49,6 +50,7 @@ void setup()
 }
 void teardown()
 {
+    memset(buffer, 0, sizeof(*buffer));
     delete buffer;
 }
 };

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -11,7 +11,8 @@ endif
 
 #--- Inputs ----#
 COMPONENT_NAME = CppUTestExamples
-CPPUTEST_HOME = ..
+CPPUTEST_BUILD = ..
+CPPUTEST_HOME := ..
 
 CPPUTEST_USE_EXTENSIONS = Y
 CPP_PLATFORM = Gcc
@@ -31,6 +32,6 @@ INCLUDE_DIRS =\
   ApplicationLib\
   $(CPPUTEST_HOME)/include\
 
-include $(CPPUTEST_HOME)/build/MakefileWorker.mk
+include $(CPPUTEST_BUILD)/build/MakefileWorker.mk
 
 


### PR DESCRIPTION
This breaks badly if building with
```
./autogen.sh
./configure --prefix=/home/jesse/cpputest
make
make install
cd examples
make CPPUTEST_HOME=/home/jesse/cpputest
```