### PR TITLE
IAR: Add support to redirect file writes to stdout.

### DIFF
--- a/src/Platforms/Iar/UtestPlatform.cpp
+++ b/src/Platforms/Iar/UtestPlatform.cpp
@@ -125,15 +125,18 @@ int (*PlatformSpecificVSNprintf)(char *str, size_t size, const char* format, va_
 
 static PlatformSpecificFile PlatformSpecificFOpenImplementation(const char* filename, const char* flag)
 {
+    static int fileNo = 0;   // Count the files so different files can be differenciated.
     (void)filename;
     (void)flag;
-    return 0;
+    fileNo++;
+    return (void*)fileNo;   // Return the file handle number.
 }
 
 static void PlatformSpecificFPutsImplementation(const char* str, PlatformSpecificFile file)
 {
     (void)str;
     (void)file;
+    printf("FILE%d:%s",(int)file, str);   // Print the text to stdout preceeded by the characters "FILE<fileNo>".
 }
 
 static void PlatformSpecificFCloseImplementation(PlatformSpecificFile file)


### PR DESCRIPTION
Ad the possibility to output strings that are normally written to a file to stdout. This makes it possible to generate JUnit XML output with the IAR simulator or even real HW. All FPuts are redirected to stdout and prepended with "FILEx" where x is an incrementing number. This makes it possible to separate the output later to different files.
Small caveat: All FPuts must be terminated with a newline character and should not contain newline characters except for the terminating one.