### PR TITLE
Add newline to end of JUnit output files.

### DIFF
--- a/src/CppUTest/JUnitTestOutput.cpp
+++ b/src/CppUTest/JUnitTestOutput.cpp
@@ -240,7 +240,7 @@ void JUnitTestOutput::writeFileEnding()
 {
     writeToFile("<system-out>"); writeToFile(impl_->stdOutput_); writeToFile("</system-out>\n");
     writeToFile("<system-err></system-err>\n");
-    writeToFile("</testsuite>");
+    writeToFile("</testsuite>\n");
 }
 
 void JUnitTestOutput::writeTestGroupToFile()

--- a/tests/CppUTest/JUnitOutputTest.cpp
+++ b/tests/CppUTest/JUnitOutputTest.cpp
@@ -383,7 +383,7 @@ TEST(JUnitOutputTest, withOneTestGroupAndOneTestOutputsTestSuiteStartAndEndBlock
 
     outputFile = fileSystem.file("cpputest_groupname.xml");
     STRCMP_EQUAL("<testsuite errors=\"0\" failures=\"0\" hostname=\"localhost\" name=\"groupname\" tests=\"1\" time=\"0.000\" timestamp=\"1978-10-03T00:00:00\">\n", outputFile->line(2));
-    STRCMP_EQUAL("</testsuite>", outputFile->lineFromTheBack(1));
+    STRCMP_EQUAL("</testsuite>\n", outputFile->lineFromTheBack(1));
 }
 
 TEST(JUnitOutputTest, withOneTestGroupAndOneTestFileShouldContainAnEmptyPropertiesBlock)


### PR DESCRIPTION
Add a newline at the end of each JUnit output file so the file ends with a newline character.