### PR TITLE
add StringFrom for std::nullptr_t values

### DIFF
--- a/include/CppUTest/SimpleString.h
+++ b/include/CppUTest/SimpleString.h
@@ -174,7 +174,9 @@ SimpleString BracketsFormattedHexStringFrom(cpputest_ulonglong value);
 SimpleString BracketsFormattedHexStringFrom(signed char value);
 SimpleString BracketsFormattedHexString(SimpleString hexString);
 
-
+#if __cplusplus > 199711L
+SimpleString StringFrom(const std::nullptr_t value);
+#endif
 
 #if CPPUTEST_USE_STD_CPP_LIB
 

--- a/src/CppUTest/SimpleString.cpp
+++ b/src/CppUTest/SimpleString.cpp
@@ -540,6 +540,12 @@ SimpleString BracketsFormattedHexString(SimpleString hexString)
     return SimpleString("(0x") + hexString + ")" ;
 }
 
+#if __cplusplus > 199711L
+SimpleString StringFrom(const std::nullptr_t __attribute__((unused)) value)
+{
+    return "(null)";
+}
+#endif
 
 #ifdef CPPUTEST_USE_LONG_LONG
 

--- a/tests/CppUTest/SimpleStringTest.cpp
+++ b/tests/CppUTest/SimpleStringTest.cpp
@@ -577,8 +577,6 @@ TEST(SimpleString, nullptr_type)
 {
     SimpleString s(StringFrom(nullptr));
     STRCMP_EQUAL("(null)", s.asCharString());
-
-    CHECK_EQUAL(nullptr, (nullptr_t)0);
 }
 #endif
 

--- a/tests/CppUTest/SimpleStringTest.cpp
+++ b/tests/CppUTest/SimpleStringTest.cpp
@@ -572,6 +572,16 @@ TEST(SimpleString, Sizes)
     STRCMP_EQUAL("10", StringFrom((int) size).asCharString());
 }
 
+#if __cplusplus > 199711L
+TEST(SimpleString, nullptr_type)
+{
+    SimpleString s(StringFrom(nullptr));
+    STRCMP_EQUAL("(null)", s.asCharString());
+
+    CHECK_EQUAL(nullptr, (nullptr_t)0);
+}
+#endif
+
 TEST(SimpleString, HexStrings)
 {
     STRCMP_EQUAL("f3", HexStringFrom((signed char)-13).asCharString());


### PR DESCRIPTION
In C++11, the nullptr_t type was introduced, and in some projects NULL
is defined as nullptr. In this case, the C++ compiler will produce
warnings when trying to convert NULL to a string, because it is
ambiguous which conversion is used.

  test.cpp:89:2: error: call to 'StringFrom' is ambiguous
        CHECK_EQUAL(NULL, actual);
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  /usr/local/include/CppUTest/UtestMacros.h:127:3: note: expanded from macro 'CHECK_EQUAL'
    CHECK_EQUAL_LOCATION(expected, actual, NULL, __FILE__, __LINE__)
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  /usr/local/include/CppUTest/UtestMacros.h:138:52: note: expanded from macro 'CHECK_EQUAL_LOCATION'
        UtestShell::getCurrent()->assertEquals(true, StringFrom(expected).asCharString(), StringFrom(actual).asCharString(), text, file, line); \
                                                     ^~~~~~~~~~
  /usr/local/include/CppUTest/SimpleString.h:138:14: note: candidate function
  SimpleString StringFrom(const void* value);
               ^
  /usr/local/include/CppUTest/SimpleString.h:139:14: note: candidate function
  SimpleString StringFrom(void (*value)());
               ^
  /usr/local/include/CppUTest/SimpleString.h:141:14: note: candidate function
  SimpleString StringFrom(const char *value);
               ^
  /usr/local/include/CppUTest/SimpleString.h:137:14: note: candidate function
  SimpleString StringFrom(bool value);
               ^
  /usr/local/include/CppUTest/SimpleString.h:157:14: note: candidate function
  SimpleString StringFrom(const SimpleString& other);
               ^
  /usr/local/include/CppUTest/SimpleString.h:171:14: note: candidate function
  SimpleString StringFrom(const std::string& other);

These warnings can be resolved by providing a StringFrom which takes the
nullptr_t as the argument, avoiding the need for conversions at all.

According to the C++ standard, the define __cplusplus is set to a value greater
than 199711L when C++ 11 is supported. Thus, we'll check this when implementing
the function, in order to allow building on older C++ standards.

Additionally, avoid a compiler warning due to the expected unused parameter in
the implementation of StringFrom.

Signed-off-by: Jacob Keller <jacob.e.keller@intel.com>