### PR TITLE
[cmake] add support for Conan, a C++ package manager

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,15 @@ set(CppUTest_version_minor 8)
 # 3.1 is needed for target_sources
 cmake_minimum_required(VERSION 3.1)
 
+###############
+# Conan support
+###############
+if (EXISTS "${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
+    include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+    message(STATUS "conan_basic_setup()")
+    conan_basic_setup()
+endif()
+
 # Check for functions before setting a lot of stuff
 include(CheckFunctionExists)
 set (CMAKE_REQUIRED_INCLUDES "unistd.h")


### PR DESCRIPTION
It would be a nice feature to be friendly with Conan.
It allows to propagate easily flags for:
- C++ language standard
- ABI (ABI incompatibility between GCC version)
- runtime libraries with Visual Studio
- and so on...

@bryceschober is kindly managing a repository to host the conan recipe for CppUTest.
While trying to set up a CI on AppVeyor, he met a lot of link issues related to runtime incompatibility (https://github.com/bryceschober/conan-cpputest/issues/5).
```
C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.14.26428\bin\HostX86\x86\link.exe /ERRORREPORT:QUEUE /OUT:"C:\projects\conan-cpputest\test_package\build\39d1509292314c21074b4137bae955683dd6acf9\bin\example.exe" /INCREMENTAL:NO /NOLOGO /LIBPATH:C:/Users/appveyor/.conan/data/CppUTest/master/bryceschober/testing/package/ea63b9b23f301d1bee2b08a4f9d864eda3d538a3/lib /LIBPATH:C:/Users/appveyor/.conan/data/CppUTest/master/bryceschober/testing/package/ea63b9b23f301d1bee2b08a4f9d864eda3d538a3/lib/Release /LIBPATH:"C:\Tools\vcpkg\installed\x86-windows\lib" /LIBPATH:"C:\Tools\vcpkg\installed\x86-windows\lib\manual-link" CppUTest.lib CppUTestExt.lib winmm.lib kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdlg32.lib advapi32.lib "C:\Tools\vcpkg\installed\x86-windows\lib\*.lib" /MANIFEST /MANIFESTUAC:"level='asInvoker' uiAccess='false'" /manifest:embed /PDB:"C:/projects/conan-cpputest/test_package/build/39d1509292314c21074b4137bae955683dd6acf9/bin/example.pdb" /SUBSYSTEM:CONSOLE /TLBID:1 /DYNAMICBASE /NXCOMPAT /IMPLIB:"C:/projects/conan-cpputest/test_package/build/39d1509292314c21074b4137bae955683dd6acf9/lib/example.lib" /MACHINE:X86 /SAFESEH  /machine:X86 example.dir\Release\example.obj
     3>CppUTest.lib(Utest.obj) : error LNK2038: mismatch detected for 'RuntimeLibrary': value 'MD_DynamicRelease' doesn't match value 'MT_StaticRelease' in example.obj [C:\projects\conan-cpputest\test_package\build\39d1509292314c21074b4137bae955683dd6acf9\example.vcxproj]
     3>CppUTest.lib(MemoryLeakWarningPlugin.obj) : error LNK2038: mismatch detected for 'RuntimeLibrary': value 'MD_DynamicRelease' doesn't match value 'MT_StaticRelease' in example.obj [C:\projects\conan-cpputest\test_package\build\39d1509292314c21074b4137bae955683dd6acf9\example.vcxproj]
```
It appeared that conan set up correctly the flags in `CONAN_LINK_RUNTIME` but they were ignored by CMakeLists.txt from CppUTest. While building the test package (with CMakeLists.txt using `conan_basic_setup()`), it sets up the good flags but then the example object file conflicts at the link time with CppUTest.lib.

This pull request would solve the above issue.