### PR TITLE
Fix: avoid using std::nullptr_t with ARM C++11 compiler

### DIFF
--- a/include/CppUTest/SimpleString.h
+++ b/include/CppUTest/SimpleString.h
@@ -174,7 +174,11 @@ SimpleString BracketsFormattedHexStringFrom(cpputest_ulonglong value);
 SimpleString BracketsFormattedHexStringFrom(signed char value);
 SimpleString BracketsFormattedHexString(SimpleString hexString);
 
-#if __cplusplus > 199711L
+/*
+ * ARM compiler has only partial support for C++11.
+ * Specifically std::nullptr_t is not officially supported
+ */
+#if __cplusplus > 199711L && !defined __arm__
 SimpleString StringFrom(const std::nullptr_t value);
 #endif
 

--- a/src/CppUTest/SimpleString.cpp
+++ b/src/CppUTest/SimpleString.cpp
@@ -540,7 +540,11 @@ SimpleString BracketsFormattedHexString(SimpleString hexString)
     return SimpleString("(0x") + hexString + ")" ;
 }
 
-#if __cplusplus > 199711L
+/*
+ * ARM compiler has only partial support for C++11.
+ * Specifically std::nullptr_t is not officially supported
+ */
+#if __cplusplus > 199711L && !defined __arm__
 SimpleString StringFrom(const std::nullptr_t __attribute__((unused)) value)
 {
     return "(null)";


### PR DESCRIPTION
Fixes issue #1173 