### PR TITLE
Add _TEXT assertions to C-Interface

### DIFF
--- a/include/CppUTest/TestHarness_c.h
+++ b/include/CppUTest/TestHarness_c.h
@@ -37,46 +37,88 @@
 #include "CppUTestConfig.h"
 
 #define CHECK_EQUAL_C_BOOL(expected,actual) \
-  CHECK_EQUAL_C_BOOL_LOCATION(expected,actual,__FILE__,__LINE__)
+  CHECK_EQUAL_C_BOOL_LOCATION(expected,actual,NULL,__FILE__,__LINE__)
+
+#define CHECK_EQUAL_C_BOOL_TEXT(expected,actual,text) \
+  CHECK_EQUAL_C_BOOL_LOCATION(expected,actual,text,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_INT(expected,actual) \
-  CHECK_EQUAL_C_INT_LOCATION(expected,actual,__FILE__,__LINE__)
+  CHECK_EQUAL_C_INT_LOCATION(expected,actual,NULL,__FILE__,__LINE__)
+
+#define CHECK_EQUAL_C_INT_TEXT(expected,actual,text) \
+  CHECK_EQUAL_C_INT_LOCATION(expected,actual,text,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_UINT(expected,actual) \
-  CHECK_EQUAL_C_UINT_LOCATION(expected,actual,__FILE__,__LINE__)
+  CHECK_EQUAL_C_UINT_LOCATION(expected,actual,NULL,__FILE__,__LINE__)
+
+#define CHECK_EQUAL_C_UINT_TEXT(expected,actual,text) \
+  CHECK_EQUAL_C_UINT_LOCATION(expected,actual,text,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_LONG(expected,actual) \
-  CHECK_EQUAL_C_LONG_LOCATION(expected,actual,__FILE__,__LINE__)
+  CHECK_EQUAL_C_LONG_LOCATION(expected,actual,NULL,__FILE__,__LINE__)
+
+#define CHECK_EQUAL_C_LONG_TEXT(expected,actual,text) \
+  CHECK_EQUAL_C_LONG_LOCATION(expected,actual,text,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_ULONG(expected,actual) \
-  CHECK_EQUAL_C_ULONG_LOCATION(expected,actual,__FILE__,__LINE__)
+  CHECK_EQUAL_C_ULONG_LOCATION(expected,actual,NULL,__FILE__,__LINE__)
+
+#define CHECK_EQUAL_C_ULONG_TEXT(expected,actual,text) \
+  CHECK_EQUAL_C_ULONG_LOCATION(expected,actual,text,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_LONGLONG(expected,actual) \
-  CHECK_EQUAL_C_LONGLONG_LOCATION(expected,actual,__FILE__,__LINE__)
+  CHECK_EQUAL_C_LONGLONG_LOCATION(expected,actual,NULL,__FILE__,__LINE__)
+
+#define CHECK_EQUAL_C_LONGLONG_TEXT(expected,actual,text) \
+  CHECK_EQUAL_C_LONGLONG_LOCATION(expected,actual,text,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_ULONGLONG(expected,actual) \
-  CHECK_EQUAL_C_ULONGLONG_LOCATION(expected,actual,__FILE__,__LINE__)
+  CHECK_EQUAL_C_ULONGLONG_LOCATION(expected,actual,NULL,__FILE__,__LINE__)
+
+#define CHECK_EQUAL_C_ULONGLONG_TEXT(expected,actual,text) \
+  CHECK_EQUAL_C_ULONGLONG_LOCATION(expected,actual,text,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_REAL(expected,actual,threshold) \
-  CHECK_EQUAL_C_REAL_LOCATION(expected,actual,threshold,__FILE__,__LINE__)
+  CHECK_EQUAL_C_REAL_LOCATION(expected,actual,threshold,NULL,__FILE__,__LINE__)
+
+#define CHECK_EQUAL_C_REAL_TEXT(expected,actual,threshold,text) \
+  CHECK_EQUAL_C_REAL_LOCATION(expected,actual,threshold,text,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_CHAR(expected,actual) \
-  CHECK_EQUAL_C_CHAR_LOCATION(expected,actual,__FILE__,__LINE__)
+  CHECK_EQUAL_C_CHAR_LOCATION(expected,actual,NULL,__FILE__,__LINE__)
+
+#define CHECK_EQUAL_C_CHAR_TEXT(expected,actual,text) \
+  CHECK_EQUAL_C_CHAR_LOCATION(expected,actual,text,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_UBYTE(expected,actual) \
-  CHECK_EQUAL_C_UBYTE_LOCATION(expected,actual,__FILE__,__LINE__)
+  CHECK_EQUAL_C_UBYTE_LOCATION(expected,actual,NULL,__FILE__,__LINE__)
+
+#define CHECK_EQUAL_C_UBYTE_TEXT(expected,actual,text) \
+  CHECK_EQUAL_C_UBYTE_LOCATION(expected,actual,text,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_SBYTE(expected,actual) \
-  CHECK_EQUAL_C_SBYTE_LOCATION(expected,actual,__FILE__,__LINE__)
+  CHECK_EQUAL_C_SBYTE_LOCATION(expected,actual,NULL,__FILE__,__LINE__)
+
+#define CHECK_EQUAL_C_SBYTE_TEXT(expected,actual,text) \
+  CHECK_EQUAL_C_SBYTE_LOCATION(expected,actual,text,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_STRING(expected,actual) \
-  CHECK_EQUAL_C_STRING_LOCATION(expected,actual,__FILE__,__LINE__)
+  CHECK_EQUAL_C_STRING_LOCATION(expected,actual,NULL,__FILE__,__LINE__)
+
+#define CHECK_EQUAL_C_STRING_TEXT(expected,actual,text) \
+  CHECK_EQUAL_C_STRING_LOCATION(expected,actual,text,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_POINTER(expected,actual) \
-  CHECK_EQUAL_C_POINTER_LOCATION(expected,actual,__FILE__,__LINE__)
+  CHECK_EQUAL_C_POINTER_LOCATION(expected,actual,NULL,__FILE__,__LINE__)
 
-#define CHECK_EQUAL_C_BITS(expected, actual, mask)\
-  CHECK_EQUAL_C_BITS_LOCATION(expected, actual, mask, sizeof(actual), __FILE__, __LINE__)
+#define CHECK_EQUAL_C_POINTER_TEXT(expected,actual,text) \
+  CHECK_EQUAL_C_POINTER_LOCATION(expected,actual,text,__FILE__,__LINE__)
+
+#define CHECK_EQUAL_C_BITS(expected, actual, mask) \
+  CHECK_EQUAL_C_BITS_LOCATION(expected, actual, mask, sizeof(actual), NULL, __FILE__, __LINE__)
+
+#define CHECK_EQUAL_C_BITS_TEXT(expected, actual, mask, text) \
+  CHECK_EQUAL_C_BITS_LOCATION(expected, actual, mask, sizeof(actual), text, __FILE__, __LINE__)
 
 #define FAIL_TEXT_C(text) \
   FAIL_TEXT_C_LOCATION(text,__FILE__,__LINE__)
@@ -85,8 +127,10 @@
   FAIL_C_LOCATION(__FILE__,__LINE__)
 
 #define CHECK_C(condition) \
-  CHECK_C_LOCATION(condition, #condition, __FILE__,__LINE__)
+  CHECK_C_LOCATION(condition, #condition, NULL, __FILE__,__LINE__)
 
+#define CHECK_C_TEXT(condition, text) \
+  CHECK_C_LOCATION(condition, #condition, text, __FILE__, __LINE__)
 
 /******************************************************************************
  *
@@ -149,38 +193,38 @@ extern "C"
 
 /* CHECKS that can be used from C code */
 extern void CHECK_EQUAL_C_BOOL_LOCATION(int expected, int actual,
-        const char* fileName, int lineNumber);
+        const char* text, const char* fileName, int lineNumber);
 extern void CHECK_EQUAL_C_INT_LOCATION(int expected, int actual,
-        const char* fileName, int lineNumber);
+        const char* text, const char* fileName, int lineNumber);
 extern void CHECK_EQUAL_C_UINT_LOCATION(unsigned int expected, unsigned int actual,
-        const char* fileName, int lineNumber);
+        const char* text, const char* fileName, int lineNumber);
 extern void CHECK_EQUAL_C_LONG_LOCATION(long expected, long actual,
-        const char* fileName, int lineNumber);
+        const char* text, const char* fileName, int lineNumber);
 extern void CHECK_EQUAL_C_ULONG_LOCATION(unsigned long expected, unsigned long actual,
-        const char* fileName, int lineNumber);
+        const char* text, const char* fileName, int lineNumber);
 extern void CHECK_EQUAL_C_LONGLONG_LOCATION(cpputest_longlong expected, cpputest_longlong actual,
-        const char* fileName, int lineNumber);
+        const char* text, const char* fileName, int lineNumber);
 extern void CHECK_EQUAL_C_ULONGLONG_LOCATION(cpputest_ulonglong expected, cpputest_ulonglong actual,
-        const char* fileName, int lineNumber);
+        const char* text, const char* fileName, int lineNumber);
 extern void CHECK_EQUAL_C_REAL_LOCATION(double expected, double actual,
-        double threshold, const char* fileName, int lineNumber);
+        double threshold, const char* text, const char* fileName, int lineNumber);
 extern void CHECK_EQUAL_C_CHAR_LOCATION(char expected, char actual,
-        const char* fileName, int lineNumber);
+        const char* text, const char* fileName, int lineNumber);
 extern void CHECK_EQUAL_C_UBYTE_LOCATION(unsigned char expected, unsigned char actual, 
-        const char* fileName, int lineNumber);
+        const char* text, const char* fileName, int lineNumber);
 extern void CHECK_EQUAL_C_SBYTE_LOCATION(signed char expected, signed char actual, 
-        const char* fileName, int lineNumber);
+        const char* text, const char* fileName, int lineNumber);
 extern void CHECK_EQUAL_C_STRING_LOCATION(const char* expected,
-        const char* actual, const char* fileName, int lineNumber);
+        const char* actual, const char* text, const char* fileName, int lineNumber);
 extern void CHECK_EQUAL_C_POINTER_LOCATION(const void* expected,
-        const void* actual, const char* fileName, int lineNumber);
+        const void* actual, const char* text, const char* fileName, int lineNumber);
 extern void CHECK_EQUAL_C_BITS_LOCATION(unsigned int expected, unsigned int actual,
-        unsigned int mask, size_t size, const char* fileName, int lineNumber);
+        unsigned int mask, size_t size, const char* text, const char* fileName, int lineNumber);
 extern void FAIL_TEXT_C_LOCATION(const char* text, const char* fileName,
         int lineNumber);
 extern void FAIL_C_LOCATION(const char* fileName, int lineNumber);
 extern void CHECK_C_LOCATION(int condition, const char* conditionString,
-        const char* fileName, int lineNumber);
+        const char* text, const char* fileName, int lineNumber);
 
 extern void* cpputest_malloc(size_t size);
 extern char* cpputest_strdup(const char* str);

--- a/include/CppUTest/TestHarness_c.h
+++ b/include/CppUTest/TestHarness_c.h
@@ -37,85 +37,85 @@
 #include "CppUTestConfig.h"
 
 #define CHECK_EQUAL_C_BOOL(expected,actual) \
-  CHECK_EQUAL_C_BOOL_LOCATION(expected,actual,NULL,__FILE__,__LINE__)
+  CHECK_EQUAL_C_BOOL_LOCATION(expected,actual,NULLPTR,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_BOOL_TEXT(expected,actual,text) \
   CHECK_EQUAL_C_BOOL_LOCATION(expected,actual,text,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_INT(expected,actual) \
-  CHECK_EQUAL_C_INT_LOCATION(expected,actual,NULL,__FILE__,__LINE__)
+  CHECK_EQUAL_C_INT_LOCATION(expected,actual,NULLPTR,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_INT_TEXT(expected,actual,text) \
   CHECK_EQUAL_C_INT_LOCATION(expected,actual,text,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_UINT(expected,actual) \
-  CHECK_EQUAL_C_UINT_LOCATION(expected,actual,NULL,__FILE__,__LINE__)
+  CHECK_EQUAL_C_UINT_LOCATION(expected,actual,NULLPTR,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_UINT_TEXT(expected,actual,text) \
   CHECK_EQUAL_C_UINT_LOCATION(expected,actual,text,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_LONG(expected,actual) \
-  CHECK_EQUAL_C_LONG_LOCATION(expected,actual,NULL,__FILE__,__LINE__)
+  CHECK_EQUAL_C_LONG_LOCATION(expected,actual,NULLPTR,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_LONG_TEXT(expected,actual,text) \
   CHECK_EQUAL_C_LONG_LOCATION(expected,actual,text,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_ULONG(expected,actual) \
-  CHECK_EQUAL_C_ULONG_LOCATION(expected,actual,NULL,__FILE__,__LINE__)
+  CHECK_EQUAL_C_ULONG_LOCATION(expected,actual,NULLPTR,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_ULONG_TEXT(expected,actual,text) \
   CHECK_EQUAL_C_ULONG_LOCATION(expected,actual,text,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_LONGLONG(expected,actual) \
-  CHECK_EQUAL_C_LONGLONG_LOCATION(expected,actual,NULL,__FILE__,__LINE__)
+  CHECK_EQUAL_C_LONGLONG_LOCATION(expected,actual,NULLPTR,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_LONGLONG_TEXT(expected,actual,text) \
   CHECK_EQUAL_C_LONGLONG_LOCATION(expected,actual,text,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_ULONGLONG(expected,actual) \
-  CHECK_EQUAL_C_ULONGLONG_LOCATION(expected,actual,NULL,__FILE__,__LINE__)
+  CHECK_EQUAL_C_ULONGLONG_LOCATION(expected,actual,NULLPTR,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_ULONGLONG_TEXT(expected,actual,text) \
   CHECK_EQUAL_C_ULONGLONG_LOCATION(expected,actual,text,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_REAL(expected,actual,threshold) \
-  CHECK_EQUAL_C_REAL_LOCATION(expected,actual,threshold,NULL,__FILE__,__LINE__)
+  CHECK_EQUAL_C_REAL_LOCATION(expected,actual,threshold,NULLPTR,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_REAL_TEXT(expected,actual,threshold,text) \
   CHECK_EQUAL_C_REAL_LOCATION(expected,actual,threshold,text,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_CHAR(expected,actual) \
-  CHECK_EQUAL_C_CHAR_LOCATION(expected,actual,NULL,__FILE__,__LINE__)
+  CHECK_EQUAL_C_CHAR_LOCATION(expected,actual,NULLPTR,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_CHAR_TEXT(expected,actual,text) \
   CHECK_EQUAL_C_CHAR_LOCATION(expected,actual,text,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_UBYTE(expected,actual) \
-  CHECK_EQUAL_C_UBYTE_LOCATION(expected,actual,NULL,__FILE__,__LINE__)
+  CHECK_EQUAL_C_UBYTE_LOCATION(expected,actual,NULLPTR,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_UBYTE_TEXT(expected,actual,text) \
   CHECK_EQUAL_C_UBYTE_LOCATION(expected,actual,text,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_SBYTE(expected,actual) \
-  CHECK_EQUAL_C_SBYTE_LOCATION(expected,actual,NULL,__FILE__,__LINE__)
+  CHECK_EQUAL_C_SBYTE_LOCATION(expected,actual,NULLPTR,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_SBYTE_TEXT(expected,actual,text) \
   CHECK_EQUAL_C_SBYTE_LOCATION(expected,actual,text,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_STRING(expected,actual) \
-  CHECK_EQUAL_C_STRING_LOCATION(expected,actual,NULL,__FILE__,__LINE__)
+  CHECK_EQUAL_C_STRING_LOCATION(expected,actual,NULLPTR,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_STRING_TEXT(expected,actual,text) \
   CHECK_EQUAL_C_STRING_LOCATION(expected,actual,text,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_POINTER(expected,actual) \
-  CHECK_EQUAL_C_POINTER_LOCATION(expected,actual,NULL,__FILE__,__LINE__)
+  CHECK_EQUAL_C_POINTER_LOCATION(expected,actual,NULLPTR,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_POINTER_TEXT(expected,actual,text) \
   CHECK_EQUAL_C_POINTER_LOCATION(expected,actual,text,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_BITS(expected, actual, mask) \
-  CHECK_EQUAL_C_BITS_LOCATION(expected, actual, mask, sizeof(actual), NULL, __FILE__, __LINE__)
+  CHECK_EQUAL_C_BITS_LOCATION(expected, actual, mask, sizeof(actual), NULLPTR, __FILE__, __LINE__)
 
 #define CHECK_EQUAL_C_BITS_TEXT(expected, actual, mask, text) \
   CHECK_EQUAL_C_BITS_LOCATION(expected, actual, mask, sizeof(actual), text, __FILE__, __LINE__)

--- a/include/CppUTest/TestHarness_c.h
+++ b/include/CppUTest/TestHarness_c.h
@@ -127,7 +127,7 @@
   FAIL_C_LOCATION(__FILE__,__LINE__)
 
 #define CHECK_C(condition) \
-  CHECK_C_LOCATION(condition, #condition, NULL, __FILE__,__LINE__)
+  CHECK_C_LOCATION(condition, #condition, NULLPTR, __FILE__,__LINE__)
 
 #define CHECK_C_TEXT(condition, text) \
   CHECK_C_LOCATION(condition, #condition, text, __FILE__, __LINE__)

--- a/src/CppUTest/TestHarness_c.cpp
+++ b/src/CppUTest/TestHarness_c.cpp
@@ -34,74 +34,74 @@
 extern "C"
 {
 
-void CHECK_EQUAL_C_BOOL_LOCATION(int expected, int actual, const char* fileName, int lineNumber)
+void CHECK_EQUAL_C_BOOL_LOCATION(int expected, int actual, const char* text, const char* fileName, int lineNumber)
 {
-    UtestShell::getCurrent()->assertEquals(!!expected != !!actual, expected ? "true" : "false", actual ? "true" : "false", NULLPTR, fileName, lineNumber, TestTerminatorWithoutExceptions());
+    UtestShell::getCurrent()->assertEquals(!!expected != !!actual, expected ? "true" : "false", actual ? "true" : "false", text, fileName, lineNumber, TestTerminatorWithoutExceptions());
 }
 
-void CHECK_EQUAL_C_INT_LOCATION(int expected, int actual, const char* fileName, int lineNumber)
+void CHECK_EQUAL_C_INT_LOCATION(int expected, int actual, const char* text, const char* fileName, int lineNumber)
 {
-    UtestShell::getCurrent()->assertLongsEqual((long)expected, (long)actual, NULLPTR, fileName, lineNumber, TestTerminatorWithoutExceptions());
+    UtestShell::getCurrent()->assertLongsEqual((long)expected, (long)actual, text, fileName, lineNumber, TestTerminatorWithoutExceptions());
 }
 
-void CHECK_EQUAL_C_UINT_LOCATION(unsigned int expected, unsigned int actual, const char* fileName, int lineNumber)
+void CHECK_EQUAL_C_UINT_LOCATION(unsigned int expected, unsigned int actual, const char* text, const char* fileName, int lineNumber)
 {
-    UtestShell::getCurrent()->assertUnsignedLongsEqual((unsigned long)expected, (unsigned long)actual, NULLPTR, fileName, lineNumber, TestTerminatorWithoutExceptions());
+    UtestShell::getCurrent()->assertUnsignedLongsEqual((unsigned long)expected, (unsigned long)actual, text, fileName, lineNumber, TestTerminatorWithoutExceptions());
 }
 
-void CHECK_EQUAL_C_LONG_LOCATION(long expected, long actual, const char* fileName, int lineNumber)
+void CHECK_EQUAL_C_LONG_LOCATION(long expected, long actual, const char* text, const char* fileName, int lineNumber)
 {
-    UtestShell::getCurrent()->assertLongsEqual(expected, actual, NULLPTR, fileName, lineNumber, TestTerminatorWithoutExceptions());
+    UtestShell::getCurrent()->assertLongsEqual(expected, actual, text, fileName, lineNumber, TestTerminatorWithoutExceptions());
 }
 
-void CHECK_EQUAL_C_ULONG_LOCATION(unsigned long expected, unsigned long actual, const char* fileName, int lineNumber)
+void CHECK_EQUAL_C_ULONG_LOCATION(unsigned long expected, unsigned long actual, const char* text, const char* fileName, int lineNumber)
 {
-    UtestShell::getCurrent()->assertUnsignedLongsEqual(expected, actual, NULLPTR, fileName, lineNumber, TestTerminatorWithoutExceptions());
+    UtestShell::getCurrent()->assertUnsignedLongsEqual(expected, actual, text, fileName, lineNumber, TestTerminatorWithoutExceptions());
 }
 
-void CHECK_EQUAL_C_LONGLONG_LOCATION(cpputest_longlong expected, cpputest_longlong actual, const char* fileName, int lineNumber)
+void CHECK_EQUAL_C_LONGLONG_LOCATION(cpputest_longlong expected, cpputest_longlong actual, const char* text, const char* fileName, int lineNumber)
 {
-    UtestShell::getCurrent()->assertLongLongsEqual(expected, actual, NULLPTR, fileName, lineNumber, TestTerminatorWithoutExceptions());
+    UtestShell::getCurrent()->assertLongLongsEqual(expected, actual, text, fileName, lineNumber, TestTerminatorWithoutExceptions());
 }
 
-void CHECK_EQUAL_C_ULONGLONG_LOCATION(cpputest_ulonglong expected, cpputest_ulonglong actual, const char* fileName, int lineNumber)
+void CHECK_EQUAL_C_ULONGLONG_LOCATION(cpputest_ulonglong expected, cpputest_ulonglong actual, const char* text, const char* fileName, int lineNumber)
 {
-    UtestShell::getCurrent()->assertUnsignedLongLongsEqual(expected, actual, NULLPTR, fileName, lineNumber, TestTerminatorWithoutExceptions());
+    UtestShell::getCurrent()->assertUnsignedLongLongsEqual(expected, actual, text, fileName, lineNumber, TestTerminatorWithoutExceptions());
 }
 
-void CHECK_EQUAL_C_REAL_LOCATION(double expected, double actual, double threshold, const char* fileName, int lineNumber)
+void CHECK_EQUAL_C_REAL_LOCATION(double expected, double actual, double threshold, const char* text, const char* fileName, int lineNumber)
 {
-    UtestShell::getCurrent()->assertDoublesEqual(expected, actual, threshold, NULLPTR, fileName, lineNumber, TestTerminatorWithoutExceptions());
+    UtestShell::getCurrent()->assertDoublesEqual(expected, actual, threshold, text, fileName, lineNumber, TestTerminatorWithoutExceptions());
 }
 
-void CHECK_EQUAL_C_CHAR_LOCATION(char expected, char actual, const char* fileName, int lineNumber)
+void CHECK_EQUAL_C_CHAR_LOCATION(char expected, char actual, const char* text, const char* fileName, int lineNumber)
 {
-    UtestShell::getCurrent()->assertEquals(((expected) != (actual)), StringFrom(expected).asCharString(), StringFrom(actual).asCharString(), NULLPTR, fileName, lineNumber, TestTerminatorWithoutExceptions());
+    UtestShell::getCurrent()->assertEquals(((expected) != (actual)), StringFrom(expected).asCharString(), StringFrom(actual).asCharString(), text, fileName, lineNumber, TestTerminatorWithoutExceptions());
 }
 
-extern void CHECK_EQUAL_C_UBYTE_LOCATION(unsigned char expected, unsigned char actual, const char* fileName, int lineNumber)\
+extern void CHECK_EQUAL_C_UBYTE_LOCATION(unsigned char expected, unsigned char actual, const char* text, const char* fileName, int lineNumber)\
 {
-    UtestShell::getCurrent()->assertEquals(((expected) != (actual)),StringFrom((int)expected).asCharString(), StringFrom((int) actual).asCharString(), NULLPTR, fileName, lineNumber, TestTerminatorWithoutExceptions());
+    UtestShell::getCurrent()->assertEquals(((expected) != (actual)),StringFrom((int)expected).asCharString(), StringFrom((int) actual).asCharString(), text, fileName, lineNumber, TestTerminatorWithoutExceptions());
 }
 
-void CHECK_EQUAL_C_SBYTE_LOCATION(char signed expected, signed char actual, const char* fileName, int lineNumber)
+void CHECK_EQUAL_C_SBYTE_LOCATION(char signed expected, signed char actual, const char* text, const char* fileName, int lineNumber)
 {
-    UtestShell::getCurrent()->assertEquals(((expected) != (actual)),StringFrom((int)expected).asCharString(), StringFrom((int) actual).asCharString(), NULLPTR, fileName, lineNumber, TestTerminatorWithoutExceptions());
+    UtestShell::getCurrent()->assertEquals(((expected) != (actual)),StringFrom((int)expected).asCharString(), StringFrom((int) actual).asCharString(), text, fileName, lineNumber, TestTerminatorWithoutExceptions());
 }
 
-void CHECK_EQUAL_C_STRING_LOCATION(const char* expected, const char* actual, const char* fileName, int lineNumber)
+void CHECK_EQUAL_C_STRING_LOCATION(const char* expected, const char* actual, const char* text, const char* fileName, int lineNumber)
 {
-    UtestShell::getCurrent()->assertCstrEqual(expected, actual, NULLPTR, fileName, lineNumber, TestTerminatorWithoutExceptions());
+    UtestShell::getCurrent()->assertCstrEqual(expected, actual, text, fileName, lineNumber, TestTerminatorWithoutExceptions());
 }
 
-void CHECK_EQUAL_C_POINTER_LOCATION(const void* expected, const void* actual, const char* fileName, int lineNumber)
+void CHECK_EQUAL_C_POINTER_LOCATION(const void* expected, const void* actual, const char* text, const char* fileName, int lineNumber)
 {
-    UtestShell::getCurrent()->assertPointersEqual(expected, actual, NULLPTR, fileName, lineNumber, TestTerminatorWithoutExceptions());
+    UtestShell::getCurrent()->assertPointersEqual(expected, actual, text, fileName, lineNumber, TestTerminatorWithoutExceptions());
 }
 
-extern void CHECK_EQUAL_C_BITS_LOCATION(unsigned int expected, unsigned int actual, unsigned int mask, size_t size, const char* fileName, int lineNumber)
+extern void CHECK_EQUAL_C_BITS_LOCATION(unsigned int expected, unsigned int actual, unsigned int mask, size_t size, const char* text, const char* fileName, int lineNumber)
 {
-    UtestShell::getCurrent()->assertBitsEqual(expected, actual, mask, size, NULLPTR, fileName, lineNumber, TestTerminatorWithoutExceptions());
+    UtestShell::getCurrent()->assertBitsEqual(expected, actual, mask, size, text, fileName, lineNumber, TestTerminatorWithoutExceptions());
 }
 
 void FAIL_TEXT_C_LOCATION(const char* text, const char* fileName, int lineNumber)
@@ -114,9 +114,9 @@ void FAIL_C_LOCATION(const char* fileName, int lineNumber)
     UtestShell::getCurrent()->fail("",  fileName, lineNumber, TestTerminatorWithoutExceptions());
 } // LCOV_EXCL_LINE
 
-void CHECK_C_LOCATION(int condition, const char* conditionString, const char* fileName, int lineNumber)
+void CHECK_C_LOCATION(int condition, const char* conditionString, const char* text, const char* fileName, int lineNumber)
 {
-    UtestShell::getCurrent()->assertTrue(condition != 0, "CHECK_C", conditionString, NULLPTR, fileName, lineNumber, TestTerminatorWithoutExceptions());
+    UtestShell::getCurrent()->assertTrue(condition != 0, "CHECK_C", conditionString, text, fileName, lineNumber, TestTerminatorWithoutExceptions());
 }
 
 enum { NO_COUNTDOWN = -1, OUT_OF_MEMORRY = 0 };

--- a/tests/CppUTest/TestHarness_cTest.cpp
+++ b/tests/CppUTest/TestHarness_cTest.cpp
@@ -101,6 +101,24 @@ TEST(TestHarness_c, checkBool)
     CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
 }
 
+static void _failBoolTextMethod()
+{
+    HasTheDestructorBeenCalledChecker checker;
+    CHECK_EQUAL_C_BOOL_TEXT(1, 0, "BoolTestText");
+} // LCOV_EXCL_LINE
+
+TEST(TestHarness_c, checkBoolText)
+{
+    CHECK_EQUAL_C_BOOL_TEXT(1, 1, "Text");
+    CHECK_EQUAL_C_BOOL_TEXT(1, 2, "Text");
+    fixture->setTestFunction(_failBoolTextMethod);
+    fixture->runAllTests();
+    fixture->assertPrintContains("expected <true>\n	but was  <false>");
+    fixture->assertPrintContains("arness_c");
+    fixture->assertPrintContains("Message: BoolTestText");
+    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
+}
+
 static void _failIntMethod()
 {
     HasTheDestructorBeenCalledChecker checker;
@@ -114,6 +132,23 @@ TEST(TestHarness_c, checkInt)
     fixture->runAllTests();
     fixture->assertPrintContains("expected <1 (0x1)>\n	but was  <2 (0x2)>");
     fixture->assertPrintContains("arness_c");
+    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
+}
+
+static void _failIntTextMethod()
+{
+    HasTheDestructorBeenCalledChecker checker;
+    CHECK_EQUAL_C_INT_TEXT(1, 2, "IntTestText");
+} // LCOV_EXCL_LINE
+
+TEST(TestHarness_c, checkIntText)
+{
+    CHECK_EQUAL_C_INT_TEXT(2, 2, "Text");
+    fixture->setTestFunction(_failIntTextMethod);
+    fixture->runAllTests();
+    fixture->assertPrintContains("expected <1 (0x1)>\n	but was  <2 (0x2)>");
+    fixture->assertPrintContains("arness_c");
+    fixture->assertPrintContains("Message: IntTestText");
     CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
 }
 
@@ -133,6 +168,23 @@ TEST(TestHarness_c, checkUnsignedInt)
     CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
 }
 
+static void _failUnsignedIntTextMethod()
+{
+    HasTheDestructorBeenCalledChecker checker;
+    CHECK_EQUAL_C_UINT_TEXT(1, 2, "UnsignedIntTestText");
+} // LCOV_EXCL_LINE
+
+TEST(TestHarness_c, checkUnsignedIntText)
+{
+    CHECK_EQUAL_C_UINT_TEXT(2, 2, "Text");
+    fixture->setTestFunction(_failUnsignedIntTextMethod);
+    fixture->runAllTests();
+    fixture->assertPrintContains("expected <1 (0x1)>\n	but was  <2 (0x2)>");
+    fixture->assertPrintContains("arness_c");
+    fixture->assertPrintContains("Message: UnsignedIntTestText");
+    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
+}
+
 static void _failLongIntMethod()
 {
     HasTheDestructorBeenCalledChecker checker;
@@ -149,6 +201,23 @@ TEST(TestHarness_c, checkLongInt)
     CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
 }
 
+static void _failLongIntTextMethod()
+{
+    HasTheDestructorBeenCalledChecker checker;
+    CHECK_EQUAL_C_LONG_TEXT(1, 2, "LongIntTestText");
+} // LCOV_EXCL_LINE
+
+TEST(TestHarness_c, checkLongIntText)
+{
+    CHECK_EQUAL_C_LONG_TEXT(2, 2, "Text");
+    fixture->setTestFunction(_failLongIntTextMethod);
+    fixture->runAllTests();
+    fixture->assertPrintContains("expected <1 (0x1)>\n	but was  <2 (0x2)>");
+    fixture->assertPrintContains("arness_c");
+    fixture->assertPrintContains("Message: LongIntTestText");
+    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
+}
+
 static void _failUnsignedLongIntMethod()
 {
     HasTheDestructorBeenCalledChecker checker;
@@ -162,6 +231,23 @@ TEST(TestHarness_c, checkUnsignedLongInt)
     fixture->runAllTests();
     fixture->assertPrintContains("expected <1 (0x1)>\n	but was  <2 (0x2)>");
     fixture->assertPrintContains("arness_c");
+    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
+}
+
+static void _failUnsignedLongIntTextMethod()
+{
+    HasTheDestructorBeenCalledChecker checker;
+    CHECK_EQUAL_C_ULONG_TEXT(1, 2, "UnsignedLongIntTestText");
+} // LCOV_EXCL_LINE
+
+TEST(TestHarness_c, checkUnsignedLongIntText)
+{
+    CHECK_EQUAL_C_ULONG_TEXT(2, 2, "Text");
+    fixture->setTestFunction(_failUnsignedLongIntTextMethod);
+    fixture->runAllTests();
+    fixture->assertPrintContains("expected <1 (0x1)>\n	but was  <2 (0x2)>");
+    fixture->assertPrintContains("arness_c");
+    fixture->assertPrintContains("Message: UnsignedLongIntTestText");
     CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
 }
 
@@ -183,6 +269,23 @@ TEST(TestHarness_c, checkLongLongInt)
     CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
 }
 
+static void _failLongLongIntTextMethod()
+{
+    HasTheDestructorBeenCalledChecker checker;
+    CHECK_EQUAL_C_LONGLONG_TEXT(1, 2, "LongLongTestText");
+} // LCOV_EXCL_LINE
+
+TEST(TestHarness_c, checkLongLongIntText)
+{
+    CHECK_EQUAL_C_LONGLONG_TEXT(2, 2, "Text");
+    fixture->setTestFunction(_failLongLongIntTextMethod);
+    fixture->runAllTests();
+    fixture->assertPrintContains("expected <1 (0x1)>\n	but was  <2 (0x2)>");
+    fixture->assertPrintContains("arness_c");
+    fixture->assertPrintContains("Message: LongLongTestText");
+    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
+}
+
 static void _failUnsignedLongLongIntMethod()
 {
     HasTheDestructorBeenCalledChecker checker;
@@ -196,6 +299,23 @@ TEST(TestHarness_c, checkUnsignedLongLongInt)
     fixture->runAllTests();
     fixture->assertPrintContains("expected <1 (0x1)>\n	but was  <2 (0x2)>");
     fixture->assertPrintContains("arness_c");
+    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
+}
+
+static void _failUnsignedLongLongIntTextMethod()
+{
+    HasTheDestructorBeenCalledChecker checker;
+    CHECK_EQUAL_C_ULONGLONG_TEXT(1, 2, "UnsignedLongLongTestText");
+} // LCOV_EXCL_LINE
+
+TEST(TestHarness_c, checkUnsignedLongLongIntText)
+{
+    CHECK_EQUAL_C_ULONGLONG_TEXT(2, 2, "Text");
+    fixture->setTestFunction(_failUnsignedLongLongIntTextMethod);
+    fixture->runAllTests();
+    fixture->assertPrintContains("expected <1 (0x1)>\n	but was  <2 (0x2)>");
+    fixture->assertPrintContains("arness_c");
+    fixture->assertPrintContains("Message: UnsignedLongLongTestText");
     CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
 }
 
@@ -215,6 +335,20 @@ TEST(TestHarness_c, checkLongLongInt)
     fixture->assertPrintContains("arness_c");
 }
 
+static void _failLongLongIntTextMethod()
+{
+    cpputest_longlong dummy_longlong;
+    CHECK_EQUAL_C_LONGLONG_TEXT(dummy_longlong, dummy_longlong);
+} // LCOV_EXCL_LINE
+
+TEST(TestHarness_c, checkLongLongIntText)
+{
+    fixture->setTestFunction(_failLongLongIntTextMethod);
+    fixture->runAllTests();
+    fixture->assertPrintContains("is not supported");
+    fixture->assertPrintContains("arness_c");
+}
+
 static void _failUnsignedLongLongIntMethod()
 {
     cpputest_ulonglong dummy_ulonglong;
@@ -224,6 +358,20 @@ static void _failUnsignedLongLongIntMethod()
 TEST(TestHarness_c, checkUnsignedLongLongInt)
 {
     fixture->setTestFunction(_failUnsignedLongLongIntMethod);
+    fixture->runAllTests();
+    fixture->assertPrintContains("is not supported");
+    fixture->assertPrintContains("arness_c");
+}
+
+static void _failUnsignedLongLongIntTextMethod()
+{
+    cpputest_ulonglong dummy_ulonglong;
+    CHECK_EQUAL_C_ULONGLONG_TEXT(dummy_ulonglong, dummy_ulonglong);
+} // LCOV_EXCL_LINE
+
+TEST(TestHarness_c, checkUnsignedLongLongIntText)
+{
+    fixture->setTestFunction(_failUnsignedLongLongIntTextMethod);
     fixture->runAllTests();
     fixture->assertPrintContains("is not supported");
     fixture->assertPrintContains("arness_c");
@@ -247,6 +395,23 @@ TEST(TestHarness_c, checkReal)
     CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
 }
 
+static void _failRealTextMethod()
+{
+    HasTheDestructorBeenCalledChecker checker;
+    CHECK_EQUAL_C_REAL_TEXT(1.0, 2.0, 0.5, "RealTestText");
+} // LCOV_EXCL_LINE
+
+TEST(TestHarness_c, checkRealText)
+{
+    CHECK_EQUAL_C_REAL_TEXT(1.0, 1.1, 0.5, "Text");
+    fixture->setTestFunction(_failRealTextMethod);
+    fixture->runAllTests();
+    fixture->assertPrintContains("expected <1>\n	but was  <2>");
+    fixture->assertPrintContains("arness_c");
+    fixture->assertPrintContains("Message: RealTestText");
+    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
+}
+
 static void _failCharMethod()
 {
     HasTheDestructorBeenCalledChecker checker;
@@ -260,6 +425,23 @@ TEST(TestHarness_c, checkChar)
     fixture->runAllTests();
     fixture->assertPrintContains("expected <a>\n	but was  <c>");
     fixture->assertPrintContains("arness_c");
+    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
+}
+
+static void _failCharTextMethod()
+{
+    HasTheDestructorBeenCalledChecker checker;
+    CHECK_EQUAL_C_CHAR_TEXT('a', 'c', "CharTestText");
+}
+
+TEST(TestHarness_c, checkCharText)
+{
+    CHECK_EQUAL_C_CHAR_TEXT('a', 'a', "Text");
+    fixture->setTestFunction(_failCharTextMethod);
+    fixture->runAllTests();
+    fixture->assertPrintContains("expected <a>\n	but was  <c>");
+    fixture->assertPrintContains("arness_c");
+    fixture->assertPrintContains("Message: CharTestText");
     CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
 }
 
@@ -279,6 +461,23 @@ TEST(TestHarness_c, checkUnsignedByte)
     CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
 }
 
+static void _failUnsignedByteTextMethod()
+{
+    HasTheDestructorBeenCalledChecker checker;
+    CHECK_EQUAL_C_UBYTE_TEXT(254, 253, "UnsignedByteTestText");
+}
+
+TEST(TestHarness_c, checkUnsignedByteText)
+{
+    CHECK_EQUAL_C_UBYTE_TEXT(254, 254, "Text");
+    fixture->setTestFunction(_failUnsignedByteTextMethod);
+    fixture->runAllTests();
+    fixture->assertPrintContains("expected <254>\n	but was  <253>");
+    fixture->assertPrintContains("arness_c");
+    fixture->assertPrintContains("Message: UnsignedByteTestText");
+    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
+}
+
 static void _failSignedByteMethod()
 {
     HasTheDestructorBeenCalledChecker checker;
@@ -292,6 +491,23 @@ TEST(TestHarness_c, checkSignedByte)
     fixture->runAllTests();
     fixture->assertPrintContains("expected <-3>\n	but was  <-5>");
     fixture->assertPrintContains("arness_c");
+    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
+}
+
+static void _failSignedByteTextMethod()
+{
+    HasTheDestructorBeenCalledChecker checker;
+    CHECK_EQUAL_C_SBYTE_TEXT(-3, -5, "SignedByteTestText");
+}
+
+TEST(TestHarness_c, checkSignedByteText)
+{
+    CHECK_EQUAL_C_SBYTE_TEXT(-3, -3, "Text");
+    fixture->setTestFunction(_failSignedByteTextMethod);
+    fixture->runAllTests();
+    fixture->assertPrintContains("expected <-3>\n	but was  <-5>");
+    fixture->assertPrintContains("arness_c");
+    fixture->assertPrintContains("Message: SignedByteTestText");
     CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
 }
 
@@ -313,6 +529,25 @@ TEST(TestHarness_c, checkString)
     CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
 }
 
+static void _failStringTextMethod()
+{
+    HasTheDestructorBeenCalledChecker checker;
+    CHECK_EQUAL_C_STRING_TEXT("Hello", "Hello World", "StringTestText");
+} // LCOV_EXCL_LINE
+
+TEST(TestHarness_c, checkStringText)
+{
+    CHECK_EQUAL_C_STRING_TEXT("Hello", "Hello", "Text");
+    fixture->setTestFunction(_failStringTextMethod);
+    fixture->runAllTests();
+
+    StringEqualFailure failure(UtestShell::getCurrent(), "file", 1, "Hello", "Hello World", "");
+    fixture->assertPrintContains(failure.getMessage());
+    fixture->assertPrintContains("arness_c");
+    fixture->assertPrintContains("Message: StringTestText");
+    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
+}
+
 static void _failPointerMethod()
 {
     HasTheDestructorBeenCalledChecker checker;
@@ -329,6 +564,23 @@ TEST(TestHarness_c, checkPointer)
     CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
 }
 
+static void _failPointerTextMethod()
+{
+    HasTheDestructorBeenCalledChecker checker;
+    CHECK_EQUAL_C_POINTER_TEXT(NULLPTR, (void *)0x1, "PointerTestText");
+}
+
+TEST(TestHarness_c, checkPointerText)
+{
+    CHECK_EQUAL_C_POINTER_TEXT(NULLPTR, NULLPTR, "Text");
+    fixture->setTestFunction(_failPointerTextMethod);
+    fixture->runAllTests();
+    fixture->assertPrintContains("expected <0x0>\n	but was  <0x1>");
+    fixture->assertPrintContains("arness_c");
+    fixture->assertPrintContains("Message: PointerTestText");
+    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
+}
+
 static void _failBitsMethod()
 {
     HasTheDestructorBeenCalledChecker checker;
@@ -337,11 +589,28 @@ static void _failBitsMethod()
 
 TEST(TestHarness_c, checkBits)
 {
-    CHECK_EQUAL_C_POINTER(NULLPTR, NULLPTR);
+    CHECK_EQUAL_C_BITS(0xABCD, (unsigned short)0xABCD, 0xFFFF);
     fixture->setTestFunction(_failBitsMethod);
     fixture->runAllTests();
     fixture->assertPrintContains("expected <00000000 00000001>\n\tbut was  <00000000 00000011>");
     fixture->assertPrintContains("arness_c");
+    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
+}
+
+static void _failBitsTextMethod()
+{
+    HasTheDestructorBeenCalledChecker checker;
+    CHECK_EQUAL_C_BITS_TEXT(0x0001, (unsigned short)0x0003, 0xFFFF, "BitsTestText");
+}
+
+TEST(TestHarness_c, checkBitsText)
+{
+    CHECK_EQUAL_C_BITS_TEXT(0xABCD, (unsigned short)0xABCD, 0xFFFF, "Text");
+    fixture->setTestFunction(_failBitsTextMethod);
+    fixture->runAllTests();
+    fixture->assertPrintContains("expected <00000000 00000001>\n\tbut was  <00000000 00000011>");
+    fixture->assertPrintContains("arness_c");
+    fixture->assertPrintContains("Message: BitsTestText");
     CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
 }
 
@@ -387,6 +656,22 @@ TEST(TestHarness_c, checkCheck)
     fixture->setTestFunction(_CheckMethod);
     fixture->runAllTests();
     LONGS_EQUAL(1, fixture->getFailureCount());
+    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
+}
+
+static void _CheckTextMethod()
+{
+    HasTheDestructorBeenCalledChecker checker;
+    CHECK_C_TEXT(false, "CheckTestText");
+} // LCOV_EXCL_LINE
+
+TEST(TestHarness_c, checkCheckText)
+{
+    CHECK_C_TEXT(true, "Text");
+    fixture->setTestFunction(_CheckTextMethod);
+    fixture->runAllTests();
+    LONGS_EQUAL(1, fixture->getFailureCount());
+    fixture->assertPrintContains("Message: CheckTestText");
     CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
 }
 


### PR DESCRIPTION
Adds for all C-Interface assertions a <assertion>_TEXT macro variant using the existing functionality.