### PR TITLE
State Need For Manual "build directory" In ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,11 @@ Building from source (unix-based, cygwin, MacOSX):
 
 * Download latest version
 * autogen.sh
-* configure
-* make
-* make check
-* You can use "make install" if you want to install CppUTest system-wide
+* make a build directory and change to it `mkdir a_build_dir && cd a_build_dir`
+* configure `../configure`
+* `make`
+* `make check`
+* You can use `make install` if you want to install CppUTest system-wide
 
 You can also use CMake, which also works for Windows Visual Studio.
 


### PR DESCRIPTION
The present ReadMe Getting Started instructions do not indicate that a new build directory needs to be created by the user.  autoget.sh should be run in the root of the project, whereas the configure command needs to be run in a sub-directory.  Expand the instructions to show creating and navigating to a build directory and then markup commands.