### PR TITLE
Shuffle test execution order with -s

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,10 @@ missing
 test-driver
 platforms/iar/settings
 cpputest_*.xml
+generated/
+*.deps/
+*.dirstamp
+*.trs
 
 #IAR automatically generated files
 *.dep

--- a/include/CppUTest/CommandLineArguments.h
+++ b/include/CppUTest/CommandLineArguments.h
@@ -47,6 +47,7 @@ public:
     bool isListingTestGroupAndCaseNames() const;
     bool isRunIgnored() const;
     int getRepeatCount() const;
+    unsigned int getShuffle() const;
     const TestFilter* getGroupFilters() const;
     const TestFilter* getNameFilters() const;
     bool isJUnitOutput() const;
@@ -72,6 +73,7 @@ private:
     bool listTestGroupAndCaseNames_;
     bool runIgnored_;
     int repeat_;
+    unsigned int shuffle_; // 0: shuffling disabled, 1: random seed, other values: specific random seed
     TestFilter* groupFilters_;
     TestFilter* nameFilters_;
     OutputType outputType_;
@@ -79,6 +81,7 @@ private:
 
     SimpleString getParameterField(int ac, const char *const *av, int& i, const SimpleString& parameterName);
     void SetRepeatCount(int ac, const char *const *av, int& index);
+    void SetShuffle(int ac, const char *const *av, int& index);
     void AddGroupFilter(int ac, const char *const *av, int& index);
     void AddStrictGroupFilter(int ac, const char *const *av, int& index);
     void AddExcludeGroupFilter(int ac, const char *const *av, int& index);

--- a/include/CppUTest/StandardCLibrary.h
+++ b/include/CppUTest/StandardCLibrary.h
@@ -15,6 +15,8 @@
 #ifdef __cplusplus
  #if CPPUTEST_USE_STD_CPP_LIB
   #include <cstdlib>
+  #include <vector>
+  #include <algorithm>
  #endif
 #endif
 

--- a/include/CppUTest/TestOutput.h
+++ b/include/CppUTest/TestOutput.h
@@ -58,6 +58,7 @@ public:
 
     virtual void verbose();
     virtual void color();
+    virtual void setShuffleSeed(unsigned int);
     virtual void printBuffer(const char*)=0;
     virtual void print(const char*);
     virtual void print(long);
@@ -91,6 +92,7 @@ protected:
     int dotCount_;
     bool verbose_;
     bool color_;
+    unsigned int shuffleSeed_;
     const char* progressIndication_;
 
     static WorkingEnvironment workingEnvironment_;

--- a/include/CppUTest/TestRegistry.h
+++ b/include/CppUTest/TestRegistry.h
@@ -50,6 +50,7 @@ public:
     virtual void unDoLastAddTest();
     virtual int countTests();
     virtual void runAllTests(TestResult& result);
+    virtual void shuffleRunOrder();
     virtual void listTestGroupNames(TestResult& result);
     virtual void listTestGroupAndCaseNames(TestResult& result);
     virtual void setNameFilters(const TestFilter* filters);

--- a/include/CppUTest/TestResult.h
+++ b/include/CppUTest/TestResult.h
@@ -57,6 +57,7 @@ public:
     virtual void countCheck();
     virtual void countFilteredOut();
     virtual void countIgnored();
+    virtual void setShuffleSeed(unsigned int);
     virtual void addFailure(const TestFailure& failure);
     virtual void print(const char* text);
 
@@ -84,6 +85,10 @@ public:
     {
         return failureCount_;
     }
+    unsigned int getShuffleSeed() const
+    {
+        return shuffleSeed_;
+    }
 
     long getTotalExecutionTime() const;
     void setTotalExecutionTime(long exTime);
@@ -99,6 +104,7 @@ private:
     int failureCount_;
     int filteredOutCount_;
     int ignoredCount_;
+    unsigned int shuffleSeed_;
     long totalExecutionTime_;
     long timeStarted_;
     long currentTestTimeStarted_;

--- a/src/CppUTest/CommandLineArguments.cpp
+++ b/src/CppUTest/CommandLineArguments.cpp
@@ -30,7 +30,7 @@
 #include "CppUTest/PlatformSpecificFunctions.h"
 
 CommandLineArguments::CommandLineArguments(int ac, const char *const *av) :
-    ac_(ac), av_(av), verbose_(false), color_(false), runTestsAsSeperateProcess_(false), listTestGroupNames_(false), listTestGroupAndCaseNames_(false), runIgnored_(false), repeat_(1), groupFilters_(NULLPTR), nameFilters_(NULLPTR), outputType_(OUTPUT_ECLIPSE)
+    ac_(ac), av_(av), verbose_(false), color_(false), runTestsAsSeperateProcess_(false), listTestGroupNames_(false), listTestGroupAndCaseNames_(false), runIgnored_(false), repeat_(1), shuffle_(0), groupFilters_(NULLPTR), nameFilters_(NULLPTR), outputType_(OUTPUT_ECLIPSE)
 {
 }
 
@@ -69,6 +69,7 @@ bool CommandLineArguments::parse(TestPlugin* plugin)
         else if (argument.startsWith("-sn")) AddStrictNameFilter(ac_, av_, i);
         else if (argument.startsWith("-xn")) AddExcludeNameFilter(ac_, av_, i);
         else if (argument.startsWith("-xsn")) AddExcludeStrictNameFilter(ac_, av_, i);
+        else if (argument.startsWith("-s")) SetShuffle(ac_, av_, i);
         else if (argument.startsWith("TEST(")) AddTestToRunBasedOnVerboseOutput(ac_, av_, i, "TEST(");
         else if (argument.startsWith("IGNORE_TEST(")) AddTestToRunBasedOnVerboseOutput(ac_, av_, i, "IGNORE_TEST(");
         else if (argument.startsWith("-o")) correctParameters = SetOutputType(ac_, av_, i);
@@ -85,7 +86,7 @@ bool CommandLineArguments::parse(TestPlugin* plugin)
 
 const char* CommandLineArguments::usage() const
 {
-    return "usage [-v] [-c] [-p] [-lg] [-ln] [-ri] [-r#] [-g|sg|xg|xsg groupName]... [-n|sn|xn|xsn testName]... [\"TEST(groupName, testName)\"]... [-o{normal, junit, teamcity}] [-k packageName]\n";
+    return "usage [-v] [-c] [-p] [-lg] [-ln] [-ri] [-r#] [-g|sg|xg|xsg groupName]... [-n|sn|xn|xsn testName]... [-s [randomizerSeed]] [\"TEST(groupName, testName)\"]... [-o{normal, junit, teamcity}] [-k packageName]\n";
 }
 
 bool CommandLineArguments::isVerbose() const
@@ -124,6 +125,11 @@ int CommandLineArguments::getRepeatCount() const
     return repeat_;
 }
 
+unsigned int CommandLineArguments::getShuffle() const
+{
+    return shuffle_;
+}
+
 const TestFilter* CommandLineArguments::getGroupFilters() const
 {
     return groupFilters_;
@@ -147,6 +153,21 @@ void CommandLineArguments::SetRepeatCount(int ac, const char *const *av, int& i)
 
     if (0 == repeat_) repeat_ = 2;
 
+}
+
+void CommandLineArguments::SetShuffle(int ac, const char * const *av, int& i)
+{
+    shuffle_ = 1;
+    SimpleString shuffleParameter(av[i]);
+    if (shuffleParameter.size() > 2) {
+        shuffle_ = SimpleString::AtoI(av[i] + 2);
+    } else if (i + 1 < ac) {
+        const int parsed = SimpleString::AtoI(av[i + 1]);
+        if (parsed != 0) {
+            i++;
+            shuffle_ = parsed;
+        }
+    }
 }
 
 SimpleString CommandLineArguments::getParameterField(int ac, const char * const *av, int& i, const SimpleString& parameterName)

--- a/src/CppUTest/TestOutput.cpp
+++ b/src/CppUTest/TestOutput.cpp
@@ -45,7 +45,7 @@ TestOutput::WorkingEnvironment TestOutput::getWorkingEnvironment()
 
 
 TestOutput::TestOutput() :
-    dotCount_(0), verbose_(false), color_(false), progressIndication_(".")
+    dotCount_(0), verbose_(false), color_(false), shuffleSeed_(0), progressIndication_(".")
 {
 }
 
@@ -61,6 +61,11 @@ void TestOutput::verbose()
 void TestOutput::color()
 {
     color_ = true;
+}
+
+void TestOutput::setShuffleSeed(unsigned int shuffleSeed)
+{
+    shuffleSeed_ = shuffleSeed;
 }
 
 void TestOutput::print(const char* str)
@@ -162,6 +167,9 @@ void TestOutput::printTestsEnded(const TestResult& result)
     print(" checks, ");
     print(result.getIgnoredCount());
     print(" ignored, ");
+    if (shuffleSeed_ != 0) {
+         printf("0x%08X seed, ", shuffleSeed_);
+    }
     print(result.getFilteredOutCount());
     print(" filtered out, ");
     print(result.getTotalExecutionTime());

--- a/src/CppUTest/TestRegistry.cpp
+++ b/src/CppUTest/TestRegistry.cpp
@@ -227,6 +227,23 @@ UtestShell* TestRegistry::getFirstTest()
     return tests_;
 }
 
+void TestRegistry::shuffleRunOrder()
+{
+    std::vector<UtestShell *> tests;
+    for (UtestShell *test = tests_; test != NULL; test = test->getNext()) {
+        tests.push_back(test);
+    }
+    std::random_shuffle(tests.begin(), tests.end());
+
+    // Store shuffled vector back to linked list
+    UtestShell *prev = NULL;
+    for (size_t i = 0; i < tests.size(); ++i)
+    {
+        prev = tests[i]->addTest(prev);
+    }
+    tests_ = prev;
+}
+
 UtestShell* TestRegistry::getTestWithNext(UtestShell* test)
 {
     UtestShell* current = tests_;

--- a/src/CppUTest/TestResult.cpp
+++ b/src/CppUTest/TestResult.cpp
@@ -32,7 +32,7 @@
 #include "CppUTest/PlatformSpecificFunctions.h"
 
 TestResult::TestResult(TestOutput& p) :
-    output_(p), testCount_(0), runCount_(0), checkCount_(0), failureCount_(0), filteredOutCount_(0), ignoredCount_(0), totalExecutionTime_(0), timeStarted_(0), currentTestTimeStarted_(0),
+    output_(p), testCount_(0), runCount_(0), checkCount_(0), failureCount_(0), filteredOutCount_(0), ignoredCount_(0), shuffleSeed_(0), totalExecutionTime_(0), timeStarted_(0), currentTestTimeStarted_(0),
             currentTestTotalExecutionTime_(0), currentGroupTimeStarted_(0), currentGroupTotalExecutionTime_(0)
 {
 }
@@ -75,6 +75,10 @@ void TestResult::addFailure(const TestFailure& failure)
 {
     output_.printFailure(failure);
     failureCount_++;
+}
+void TestResult::setShuffleSeed(unsigned int shuffleSeed)
+{
+    shuffleSeed_ = shuffleSeed;
 }
 
 void TestResult::countTest()


### PR DESCRIPTION
Shuffling is off by default.

-s enables shuffling with random seed derived from current time.

The seed is printed before executing tests. A specific test execution
order can be reproduced by setting the seed explicitly with -s <seed>.

Seed values 0 and 1 are reserved values and cannot be set.

If -v (verbose) is enabled, the seed is also printed after test
execution. This might be useful in case tests produce console output
which could cause the seed printed at the beginning to be lost.

Test order is reshuffled between repeats (-r).