### PR TITLE
Deprecated travis option removed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: cpp
 
 dist: trusty
-sudo: false
 
 matrix:
     include:


### PR DESCRIPTION
Due the current Linux infrastructure migration the `sudo: false` option has been deprecated. Please visit the [announcement](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration) for more details.