### PR TITLE
Added support for setting tolerance for doubles in mock

### DIFF
--- a/include/CppUTestExt/MockCheckedExpectedCall.h
+++ b/include/CppUTestExt/MockCheckedExpectedCall.h
@@ -50,6 +50,7 @@ public:
     virtual MockExpectedCall& withLongLongIntParameter(const SimpleString& name, cpputest_longlong value) _override;
     virtual MockExpectedCall& withUnsignedLongLongIntParameter(const SimpleString& name, cpputest_ulonglong value) _override;
     virtual MockExpectedCall& withDoubleParameter(const SimpleString& name, double value) _override;
+    virtual MockExpectedCall& withDoubleParameter(const SimpleString& name, double value, double tolerance) _override;
     virtual MockExpectedCall& withStringParameter(const SimpleString& name, const char* value) _override;
     virtual MockExpectedCall& withPointerParameter(const SimpleString& name, void* value) _override;
     virtual MockExpectedCall& withConstPointerParameter(const SimpleString& name, const void* value) _override;
@@ -160,6 +161,7 @@ public:
     virtual MockExpectedCall& withLongLongIntParameter(const SimpleString&, cpputest_longlong) _override { return *this; }
     virtual MockExpectedCall& withUnsignedLongLongIntParameter(const SimpleString&, cpputest_ulonglong) _override { return *this; }
     virtual MockExpectedCall& withDoubleParameter(const SimpleString&, double) _override { return *this; }
+    virtual MockExpectedCall& withDoubleParameter(const SimpleString&, double, double) _override { return *this; }
     virtual MockExpectedCall& withStringParameter(const SimpleString&, const char*) _override { return *this; }
     virtual MockExpectedCall& withPointerParameter(const SimpleString& , void*) _override { return *this; }
     virtual MockExpectedCall& withConstPointerParameter(const SimpleString& , const void*) _override { return *this; }

--- a/include/CppUTestExt/MockExpectedCall.h
+++ b/include/CppUTestExt/MockExpectedCall.h
@@ -51,6 +51,7 @@ public:
     MockExpectedCall& withParameter(const SimpleString& name, cpputest_longlong value) { return withLongLongIntParameter(name, value); }
     MockExpectedCall& withParameter(const SimpleString& name, cpputest_ulonglong value) { return withUnsignedLongLongIntParameter(name, value); }
     MockExpectedCall& withParameter(const SimpleString& name, double value) { return withDoubleParameter(name, value); }
+    MockExpectedCall& withParameter(const SimpleString& name, double value, double tolerance) { return withDoubleParameter(name, value, tolerance); }
     MockExpectedCall& withParameter(const SimpleString& name, const char* value) { return withStringParameter(name, value); }
     MockExpectedCall& withParameter(const SimpleString& name, void* value) { return withPointerParameter(name, value); }
     MockExpectedCall& withParameter(const SimpleString& name, const void* value) { return withConstPointerParameter(name, value); }
@@ -69,6 +70,7 @@ public:
     virtual MockExpectedCall& withLongLongIntParameter(const SimpleString& name, cpputest_longlong value)=0;
     virtual MockExpectedCall& withUnsignedLongLongIntParameter(const SimpleString& name, cpputest_ulonglong value)=0;
     virtual MockExpectedCall& withDoubleParameter(const SimpleString& name, double value)=0;
+    virtual MockExpectedCall& withDoubleParameter(const SimpleString& name, double value, double tolerance)=0;
     virtual MockExpectedCall& withStringParameter(const SimpleString& name, const char* value)=0;
     virtual MockExpectedCall& withPointerParameter(const SimpleString& name, void* value)=0;
     virtual MockExpectedCall& withFunctionPointerParameter(const SimpleString& name, void (*value)())=0;

--- a/include/CppUTestExt/MockNamedValue.h
+++ b/include/CppUTestExt/MockNamedValue.h
@@ -112,6 +112,7 @@ public:
     virtual void setValue(cpputest_longlong value);
     virtual void setValue(cpputest_ulonglong value);
     virtual void setValue(double value);
+    virtual void setValue(double value, double tolerance);
     virtual void setValue(void* value);
     virtual void setValue(const void* value);
     virtual void setValue(void (*value)());
@@ -139,6 +140,7 @@ public:
     virtual cpputest_longlong getLongLongIntValue() const;
     virtual cpputest_ulonglong getUnsignedLongLongIntValue() const;
     virtual double getDoubleValue() const;
+    virtual double getDoubleTolerance() const;
     virtual const char* getStringValue() const;
     virtual void* getPointerValue() const;
     virtual const void* getConstPointerValue() const;
@@ -153,6 +155,8 @@ public:
     virtual MockNamedValueCopier* getCopier() const;
 
     static void setDefaultComparatorsAndCopiersRepository(MockNamedValueComparatorsAndCopiersRepository* repository);
+
+    static const double defaultDoubleTolerance;
 private:
     SimpleString name_;
     SimpleString type_;
@@ -168,7 +172,10 @@ private:
 #else
         char longLongPlaceholder_[CPPUTEST_SIZE_OF_FAKE_LONG_LONG_TYPE];
 #endif
-        double doubleValue_;
+        struct {
+            double value;
+            double tolerance;
+        } doubleValue_;
         const char* stringValue_;
         void* pointerValue_;
         const void* constPointerValue_;

--- a/include/CppUTestExt/MockSupport_c.h
+++ b/include/CppUTestExt/MockSupport_c.h
@@ -136,6 +136,7 @@ struct SMockExpectedCall_c
     MockExpectedCall_c* (*withLongLongIntParameters)(const char* name, cpputest_longlong value);
     MockExpectedCall_c* (*withUnsignedLongLongIntParameters)(const char* name, cpputest_ulonglong value);
     MockExpectedCall_c* (*withDoubleParameters)(const char* name, double value);
+    MockExpectedCall_c* (*withDoubleParametersAndTolerance)(const char* name, double value, double tolerance);
     MockExpectedCall_c* (*withStringParameters)(const char* name, const char* value);
     MockExpectedCall_c* (*withPointerParameters)(const char* name, void* value);
     MockExpectedCall_c* (*withConstPointerParameters)(const char* name, const void* value);

--- a/src/CppUTestExt/MockExpectedCall.cpp
+++ b/src/CppUTestExt/MockExpectedCall.cpp
@@ -167,6 +167,14 @@ MockExpectedCall& MockCheckedExpectedCall::withDoubleParameter(const SimpleStrin
     return *this;
 }
 
+MockExpectedCall& MockCheckedExpectedCall::withDoubleParameter(const SimpleString& name, double value, double tolerance)
+{
+    MockNamedValue* newParameter = new MockExpectedFunctionParameter(name);
+    inputParameters_->add(newParameter);
+    newParameter->setValue(value, tolerance);
+    return *this;
+}
+
 MockExpectedCall& MockCheckedExpectedCall::withStringParameter(const SimpleString& name, const char* value)
 {
     MockNamedValue* newParameter = new MockExpectedFunctionParameter(name);

--- a/src/CppUTestExt/MockNamedValue.cpp
+++ b/src/CppUTestExt/MockNamedValue.cpp
@@ -31,6 +31,7 @@
 
 
 MockNamedValueComparatorsAndCopiersRepository* MockNamedValue::defaultRepository_ = NULLPTR;
+const double MockNamedValue::defaultDoubleTolerance = 0.005;
 
 void MockNamedValue::setDefaultComparatorsAndCopiersRepository(MockNamedValueComparatorsAndCopiersRepository* repository)
 {
@@ -106,8 +107,14 @@ void MockNamedValue::setValue(cpputest_ulonglong)
 
 void MockNamedValue::setValue(double value)
 {
+    setValue(value, defaultDoubleTolerance);
+}
+
+void MockNamedValue::setValue(double value, double tolerance)
+{
     type_ = "double";
-    value_.doubleValue_ = value;
+    value_.doubleValue_.value = value;
+    value_.doubleValue_.tolerance = tolerance;
 }
 
 void MockNamedValue::setValue(void* value)
@@ -291,7 +298,13 @@ cpputest_ulonglong MockNamedValue::getUnsignedLongLongIntValue() const
 double MockNamedValue::getDoubleValue() const
 {
     STRCMP_EQUAL("double", type_.asCharString());
-    return value_.doubleValue_;
+    return value_.doubleValue_.value;
+}
+
+double MockNamedValue::getDoubleTolerance() const
+{
+    STRCMP_EQUAL("double", type_.asCharString());
+    return value_.doubleValue_.tolerance;
 }
 
 const char* MockNamedValue::getStringValue() const
@@ -441,7 +454,7 @@ bool MockNamedValue::equals(const MockNamedValue& p) const
     else if (type_ == "void (*)()")
         return value_.functionPointerValue_ == p.value_.functionPointerValue_;
     else if (type_ == "double")
-        return (doubles_equal(value_.doubleValue_, p.value_.doubleValue_, 0.005));
+        return (doubles_equal(value_.doubleValue_.value, p.value_.doubleValue_.value, value_.doubleValue_.tolerance));
     else if (type_ == "const unsigned char*")
     {
         if (size_ != p.size_) {
@@ -493,7 +506,7 @@ SimpleString MockNamedValue::toString() const
     else if (type_ == "const void*")
         return StringFrom(value_.constPointerValue_);
     else if (type_ == "double")
-        return StringFrom(value_.doubleValue_);
+        return StringFrom(value_.doubleValue_.value);
     else if (type_ == "const unsigned char*")
         return StringFromBinaryWithSizeOrNull(value_.memoryBufferValue_, size_);
 

--- a/src/CppUTestExt/MockSupport_c.cpp
+++ b/src/CppUTestExt/MockSupport_c.cpp
@@ -151,6 +151,7 @@ MockExpectedCall_c* withUnsignedLongIntParameters_c(const char* name, unsigned l
 MockExpectedCall_c* withLongLongIntParameters_c(const char* name, cpputest_longlong value);
 MockExpectedCall_c* withUnsignedLongLongIntParameters_c(const char* name, cpputest_ulonglong value);
 MockExpectedCall_c* withDoubleParameters_c(const char* name, double value);
+MockExpectedCall_c* withDoubleParametersAndTolerance_c(const char* name, double value, double tolerance);
 MockExpectedCall_c* withStringParameters_c(const char* name, const char* value);
 MockExpectedCall_c* withPointerParameters_c(const char* name, void* value);
 MockExpectedCall_c* withConstPointerParameters_c(const char* name, const void* value);
@@ -251,6 +252,7 @@ static MockExpectedCall_c gExpectedCall = {
         withLongLongIntParameters_c,
         withUnsignedLongLongIntParameters_c,
         withDoubleParameters_c,
+        withDoubleParametersAndTolerance_c,
         withStringParameters_c,
         withPointerParameters_c,
         withConstPointerParameters_c,
@@ -437,6 +439,12 @@ MockExpectedCall_c* withUnsignedLongLongIntParameters_c(const char*, cpputest_ul
 MockExpectedCall_c* withDoubleParameters_c(const char* name, double value)
 {
     expectedCall = &expectedCall->withParameter(name, value);
+    return &gExpectedCall;
+}
+
+MockExpectedCall_c* withDoubleParametersAndTolerance_c(const char* name, double value, double tolerance)
+{
+    expectedCall = &expectedCall->withParameter(name, value, tolerance);
     return &gExpectedCall;
 }
 

--- a/tests/CppUTestExt/MockExpectedCallTest.cpp
+++ b/tests/CppUTestExt/MockExpectedCallTest.cpp
@@ -259,7 +259,19 @@ TEST(MockExpectedCall, callWithDoubleParameter)
     double value = 1.2;
     call->withParameter(paramName, value);
     STRCMP_EQUAL("double", call->getInputParameterType(paramName).asCharString());
-    DOUBLES_EQUAL(value, call->getInputParameter(paramName).getDoubleValue(), 0.05);
+    DOUBLES_EQUAL(value, call->getInputParameter(paramName).getDoubleValue(), 0.0);
+    STRCMP_CONTAINS("funcName -> double paramName: <1.2>", call->callToString().asCharString());
+}
+
+TEST(MockExpectedCall, callWithDoubleParameterAndTolerance)
+{
+    const SimpleString paramName = "paramName";
+    double value = 1.2;
+    double tolerance = 0.2;
+    call->withParameter(paramName, value, tolerance);
+    STRCMP_EQUAL("double", call->getInputParameterType(paramName).asCharString());
+    DOUBLES_EQUAL(value, call->getInputParameter(paramName).getDoubleValue(), 0.0);
+    DOUBLES_EQUAL(tolerance, call->getInputParameter(paramName).getDoubleTolerance(), 0.0);
     STRCMP_CONTAINS("funcName -> double paramName: <1.2>", call->callToString().asCharString());
 }
 
@@ -750,6 +762,7 @@ TEST(MockIgnoredExpectedCall, worksAsItShould)
     ignored.withUnsignedLongLongIntParameter("grr", (unsigned long long int) 1);
 #endif
     ignored.withDoubleParameter("hah", (double) 1.1f);
+    ignored.withDoubleParameter("gah", 2.1, 0.3);
     ignored.withStringParameter("goo", "hello");
     ignored.withPointerParameter("pie", (void*) NULLPTR);
     ignored.withConstPointerParameter("woo", (const void*) NULLPTR);

--- a/tests/CppUTestExt/MockNamedValueTest.cpp
+++ b/tests/CppUTestExt/MockNamedValueTest.cpp
@@ -27,7 +27,6 @@
 
 #include "CppUTest/TestHarness.h"
 #include "CppUTestExt/MockNamedValue.h"
-#include <cfloat>
 
 TEST_GROUP(ComparatorsAndCopiersRepository)
 {

--- a/tests/CppUTestExt/MockNamedValueTest.cpp
+++ b/tests/CppUTestExt/MockNamedValueTest.cpp
@@ -27,6 +27,7 @@
 
 #include "CppUTest/TestHarness.h"
 #include "CppUTestExt/MockNamedValue.h"
+#include <cfloat>
 
 TEST_GROUP(ComparatorsAndCopiersRepository)
 {
@@ -110,15 +111,15 @@ TEST_GROUP(MockNamedValue)
 TEST(MockNamedValue, DefaultToleranceUsedWhenNoToleranceGiven)
 {
   value->setValue(0.2);
-  CHECK_EQUAL(MockNamedValue::defaultDoubleTolerance, value->getDoubleTolerance());
+  DOUBLES_EQUAL(MockNamedValue::defaultDoubleTolerance, value->getDoubleTolerance(), 0.0);
 }
 
 TEST(MockNamedValue, GivenToleranceUsed)
 {
   value->setValue(0.2, 3.2);
   STRCMP_EQUAL("double", value->getType().asCharString());
-  CHECK_EQUAL(0.2, value->getDoubleValue());
-  CHECK_EQUAL(3.2, value->getDoubleTolerance());
+  DOUBLES_EQUAL(0.2, value->getDoubleValue(), 0.0);
+  DOUBLES_EQUAL(3.2, value->getDoubleTolerance(), 0.0);
 }
 
 TEST(MockNamedValue, DoublesEqualIfWithinTolerance)

--- a/tests/CppUTestExt/MockNamedValueTest.cpp
+++ b/tests/CppUTestExt/MockNamedValueTest.cpp
@@ -80,7 +80,7 @@ TEST(ComparatorsAndCopiersRepository, InstallComparatorsAndCopiersFromRepository
   MyCopier copier;
   MockNamedValueComparatorsAndCopiersRepository source;
   MockNamedValueComparatorsAndCopiersRepository target;
-	
+
   source.installCopier("MyType", copier);
   source.installComparator("MyType", comparator);
   
@@ -93,3 +93,49 @@ TEST(ComparatorsAndCopiersRepository, InstallComparatorsAndCopiersFromRepository
   target.clear();
 }
 
+TEST_GROUP(MockNamedValue)
+{
+  MockNamedValue * value;
+  void setup()
+  {
+    value = new MockNamedValue("param");
+  }
+
+  void teardown()
+  {
+    delete value;
+  }
+};
+
+TEST(MockNamedValue, DefaultToleranceUsedWhenNoToleranceGiven)
+{
+  value->setValue(0.2);
+  CHECK_EQUAL(MockNamedValue::defaultDoubleTolerance, value->getDoubleTolerance());
+}
+
+TEST(MockNamedValue, GivenToleranceUsed)
+{
+  value->setValue(0.2, 3.2);
+  STRCMP_EQUAL("double", value->getType().asCharString());
+  CHECK_EQUAL(0.2, value->getDoubleValue());
+  CHECK_EQUAL(3.2, value->getDoubleTolerance());
+}
+
+TEST(MockNamedValue, DoublesEqualIfWithinTolerance)
+{
+  value->setValue(5.0, 0.4);
+  MockNamedValue other("param2");
+  other.setValue(5.3);
+
+  CHECK_TRUE(value->equals(other));
+}
+
+
+TEST(MockNamedValue, DoublesNotEqualIfOutsideTolerance)
+{
+  value->setValue(5.0, 0.4);
+  MockNamedValue other("param2");
+  other.setValue(5.5);
+
+  CHECK_FALSE(value->equals(other));
+}

--- a/tests/CppUTestExt/MockParameterTest.cpp
+++ b/tests/CppUTestExt/MockParameterTest.cpp
@@ -294,6 +294,31 @@ TEST(MockParameterTest, expectOneDoubleParameterAndValue)
     mock().checkExpectations();
 }
 
+TEST(MockParameterTest, expectOneDoubleParameterAndValueAndTolerance)
+{
+    mock( ).expectOneCall("foo").withParameter("parameter", 100.0, 5.0);
+    mock( ).actualCall("foo").withParameter("parameter", 96.0);
+
+    mock( ).checkExpectations();
+}
+
+TEST(MockParameterTest, doubleParameterNotEqualIfOutsideTolerance)
+{
+    MockFailureReporterInstaller failureReporterInstaller;
+
+    MockExpectedCallsListForTest expectations;
+    expectations.addFunction("foo")->withParameter("parameter", 100.0);
+    MockNamedValue parameter("parameter");
+    parameter.setValue(106.0);
+    MockUnexpectedInputParameterFailure expectedFailure(mockFailureTest(), "foo", parameter, expectations);
+
+    mock( ).expectOneCall("foo").withParameter("parameter", 100.0, 5.0);
+    mock( ).actualCall("foo").withParameter("parameter", 106.0);
+
+    CHECK_EXPECTED_MOCK_FAILURE(expectedFailure);
+}
+
+
 TEST(MockParameterTest, expectOneStringParameterAndValue)
 {
     mock().expectOneCall("foo").withParameter("parameter", "string");

--- a/tests/CppUTestExt/MockSupport_cTest.cpp
+++ b/tests/CppUTestExt/MockSupport_cTest.cpp
@@ -154,6 +154,12 @@ TEST(MockSupport_c, unsignedLongIntParameter)
     mock_c()->actualCall("foo")->withUnsignedLongIntParameters("p", 1);
 }
 
+TEST(MockSupport_c, doubleParameterWithTolerance)
+{
+    mock_c( )->expectOneCall("foo")->withDoubleParametersAndTolerance("p", 2.0, 0.2);
+    mock_c( )->actualCall("foo")->withDoubleParameters("p", 1.9);
+}
+
 #ifdef CPPUTEST_USE_LONG_LONG
 
 TEST(MockSupport_c, longLongIntParameter)

--- a/tests/CppUTestExt/MockSupport_cTestCFile.c
+++ b/tests/CppUTestExt/MockSupport_cTestCFile.c
@@ -59,6 +59,7 @@ void all_mock_support_c_calls(void)
 #endif
 
             withDoubleParameters("double", 1.0)->
+            withDoubleParametersAndTolerance("doubleWithTolerance", 1.0, 1.0)->
             withStringParameters("string", "string")->
             withPointerParameters("pointer", (void*) 1)->
             withConstPointerParameters("constpointer", (const void*) 1)->
@@ -76,6 +77,7 @@ void all_mock_support_c_calls(void)
             withUnsignedLongLongIntParameters("unsigned long long int", (unsigned long long int) 1)->
 #endif
             withDoubleParameters("double", 1.0)->
+            withDoubleParameters("doubleWithTolerance", 0.0 )->
             withStringParameters("string", "string")->
             withPointerParameters("pointer", (void*) 1)->
             withConstPointerParameters("constpointer", (const void*) 1)->


### PR DESCRIPTION
Added overloaded methods for withParameter and withDoubleParameter which takes a tolerance as well as the expected value for doubles