### PR TITLE
include string.h in StandardCLibrary.h

### DIFF
--- a/include/CppUTest/StandardCLibrary.h
+++ b/include/CppUTest/StandardCLibrary.h
@@ -27,6 +27,11 @@
 /* Needed for some detection of long long and 64 bit */
 #include <limits.h>
 
+/* Needed to ensure that string.h is included prior to strdup redefinition */
+#ifdef CPPUTEST_HAVE_STRING_H
+#include <string.h>
+#endif
+
 #else
 
 #ifdef __KERNEL__


### PR DESCRIPTION
If memory leak detection for C code is enabled, the header file
MemoryLeakDetectorMallocMacros.h is included by the command line prior
to any of the raw source code for an object.

In this case, if CPPUTEST_HAVE_STRDUP is defined, the strdup function
will be redefined using a macro.

If the source code happens to include <string.h> or <cstring>, this will
happen *after* the memory leak detection header is included on the
command line.

Because of this, strdup will have already been redefined, and will then
result in compiler warnings similar to the following:

/usr/include/string.h:166:37: error: expected identifier before string constant
 extern char *strdup (const char *__s)
				     ^
/usr/include/string.h:166:37: error: expected ‘,’ or ‘...’ before string constant
In file included from <command-line>:
.../include/CppUTest/MemoryLeakDetectorMallocMacros.h:62:21: error: conflicting declaration of C function ‘char* cpputest_strdup_location(const char*, int)’
 #define strdup(str) cpputest_strdup_location(str, __FILE__, __LINE__)
		     ^~~~~~~~~~~~~~~~~~~~~~~~
.../include/CppUTest/MemoryLeakDetectorMallocMacros.h:55:14: note: previous declaration ‘char* cpputest_strdup_location(const char*, const char*, int)’
 extern char* cpputest_strdup_location(const char* str, const char* file, int line);
	      ^~~~~~~~~~~~~~~~~~~~~~~~

This happens because the "strdup (const char *__s) is converted by the
macro.

To fix this, <string.h> must be included prior to the setup of memory
leak detection.

Modify StandardCLibrary.h to include <string.h> if CPPUTEST_HAVE_STRING_H
is defined. This fixes the error and allows proper usage of the leak
detection strdup implementation.

Signed-off-by: Jacob Keller <jacob.e.keller@intel.com>