### PR TITLE
Add scoped enum support

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ The failure of one of these macros causes the current test to immediately exit
 * BYTES_EQUAL(expected, actual) - Compares two numbers, eight bits wide
 * POINTERS_EQUAL(expected, actual) - Compares two const void *
 * DOUBLES_EQUAL(expected, actual, tolerance) - Compares two doubles within some tolerance
+* ENUMS_EQUAL_INT(excepted, actual) - Compares two enums which their underlying type is int
+* ENUMS_EQUAL_TYPE(underlying_type, excepted, actual) - Compares two enums which they have the same underlying type
 * FAIL(text) - always fails
 * TEST_EXIT - Exit the test without failure - useful for contract testing (implementing an assert fake)
 

--- a/include/CppUTest/UtestMacros.h
+++ b/include/CppUTest/UtestMacros.h
@@ -304,6 +304,30 @@
 #define BITS_LOCATION(expected, actual, mask, text, file, line)\
   { UtestShell::getCurrent()->assertBitsEqual(expected, actual, mask, sizeof(actual), text, file, line); }
 
+#define ENUMS_EQUAL_INT(expected, actual)\
+  ENUMS_EQUAL_TYPE(int, expected, actual)
+
+#define ENUMS_EQUAL_INT_TEXT(expected, actual, text)\
+  ENUMS_EQUAL_TYPE_TEXT(int, expected, actual, text)
+
+#define ENUMS_EQUAL_TYPE(underlying_type, expected, actual)\
+  ENUMS_EQUAL_TYPE_LOCATION(underlying_type, expected, actual, NULLPTR, __FILE__, __LINE__)
+
+#define ENUMS_EQUAL_TYPE_TEXT(underlying_type, expected, actual, text)\
+  ENUMS_EQUAL_TYPE_LOCATION(underlying_type, expected, actual, text, __FILE__, __LINE__)
+
+#define ENUMS_EQUAL_TYPE_LOCATION(underlying_type, expected, actual, text, file, line)\
+  { underlying_type expected_underlying_value = (underlying_type)(expected); \
+    underlying_type actual_underlying_value = (underlying_type)(actual); \
+    if (expected_underlying_value != actual_underlying_value) { \
+      UtestShell::getCurrent()->assertEquals(true, StringFrom(expected_underlying_value).asCharString(), StringFrom(actual_underlying_value).asCharString(), text, file, line); \
+    } \
+    else \
+    { \
+      UtestShell::getCurrent()->assertLongsEqual((long)0, long(0), NULLPTR, file, line); \
+    } \
+  }
+
 //Fail if you get to this macro
 //The macro FAIL may already be taken, so allow FAIL_TEST too
 #ifndef FAIL

--- a/tests/CppUTest/TestUTestMacro.cpp
+++ b/tests/CppUTest/TestUTestMacro.cpp
@@ -1094,6 +1094,165 @@ IGNORE_TEST(UnitTestMacros, BITS_EQUAL_TEXTWorksInAnIgnoredTest)
     BITS_EQUAL_TEXT(0x00, 0xFF, 0xFF, "Failed because it failed"); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
+#if defined(__cplusplus) && __cplusplus >= 201103L
+enum class ScopedIntEnum {
+    A, B
+};
+
+static void _ENUMS_EQUAL_INTWithScopedIntEnumTestMethod()
+{
+    ENUMS_EQUAL_INT(ScopedIntEnum::B, ScopedIntEnum::B);
+    ENUMS_EQUAL_INT(ScopedIntEnum::B, ScopedIntEnum::A);
+} // LCOV_EXCL_LINE
+
+TEST(UnitTestMacros, TestENUMS_EQUAL_INTWithScopedIntEnum)
+{
+    fixture.runTestWithMethod(_ENUMS_EQUAL_INTWithScopedIntEnumTestMethod);
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <1>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <0>");
+}
+
+TEST(UnitTestMacros, ENUMS_EQUAL_INTWithScopedIntEnumBehavesAsProperMacro)
+{
+    if (false) ENUMS_EQUAL_INT(ScopedIntEnum::B, ScopedIntEnum::A)
+    else ENUMS_EQUAL_INT(ScopedIntEnum::B, ScopedIntEnum::B)
+}
+
+IGNORE_TEST(UnitTestMacros, ENUMS_EQUAL_INTWithScopedIntEnumWorksInAnIgnoredTest)
+{
+    ENUMS_EQUAL_INT(ScopedIntEnum::B, ScopedIntEnum::A); // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
+static void _ENUMS_EQUAL_INT_TEXTWithScopedIntEnumTestMethod()
+{
+    ENUMS_EQUAL_INT_TEXT(ScopedIntEnum::B, ScopedIntEnum::A, "Failed because it failed");
+} // LCOV_EXCL_LINE
+
+TEST(UnitTestMacros, TestENUMS_EQUAL_INT_TEXTWithScopedIntEnum)
+{
+    fixture.runTestWithMethod(_ENUMS_EQUAL_INT_TEXTWithScopedIntEnumTestMethod);
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <1>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <0>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("Failed because it failed");
+}
+
+TEST(UnitTestMacros, ENUMS_EQUAL_INT_TEXTWithScopedIntEnumBehavesAsProperMacro)
+{
+    if (false) ENUMS_EQUAL_INT_TEXT(ScopedIntEnum::B, ScopedIntEnum::A, "Failed because it failed")
+    else ENUMS_EQUAL_INT_TEXT(ScopedIntEnum::B, ScopedIntEnum::B, "Failed because it failed")
+}
+
+IGNORE_TEST(UnitTestMacros, ENUMS_EQUAL_EQUAL_INT_TEXTWithScopedIntEnumWorksInAnIgnoredTest)
+{
+    ENUMS_EQUAL_INT_TEXT(ScopedIntEnum::B, ScopedIntEnum::A, "Failed because it failed"); // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
+enum class ScopedLongEnum : long {
+    A, B
+};
+
+static void _ENUMS_EQUAL_TYPEWithScopedLongEnumTestMethod()
+{
+    ENUMS_EQUAL_TYPE(long, ScopedLongEnum::B, ScopedLongEnum::B);
+    ENUMS_EQUAL_TYPE(long, ScopedLongEnum::B, ScopedLongEnum::A);
+} // LCOV_EXCL_LINE
+
+TEST(UnitTestMacros, TestENUMS_EQUAL_TYPEWithScopedLongEnum)
+{
+    fixture.runTestWithMethod(_ENUMS_EQUAL_TYPEWithScopedLongEnumTestMethod);
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <1>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <0>");
+}
+
+TEST(UnitTestMacros, ENUMS_EQUAL_TYPEWithScopedLongEnumBehavesAsProperMacro)
+{
+    if (false) ENUMS_EQUAL_TYPE(long, ScopedLongEnum::B, ScopedLongEnum::A)
+    else ENUMS_EQUAL_TYPE(long, ScopedLongEnum::B, ScopedLongEnum::B)
+}
+
+IGNORE_TEST(UnitTestMacros, ENUMS_EQUAL_TYPEWithScopedLongEnumWorksInAnIgnoredTest)
+{
+    ENUMS_EQUAL_TYPE(long, ScopedLongEnum::B, ScopedLongEnum::A); // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
+static void _ENUMS_EQUAL_TYPE_TEXTWithScopedLongEnumTestMethod()
+{
+    ENUMS_EQUAL_TYPE_TEXT(long, ScopedLongEnum::B, ScopedLongEnum::A, "Failed because it failed");
+} // LCOV_EXCL_LINE
+
+TEST(UnitTestMacros, TestENUMS_EQUAL_TYPE_TEXTWithScopedLongEnum)
+{
+    fixture.runTestWithMethod(_ENUMS_EQUAL_TYPE_TEXTWithScopedLongEnumTestMethod);
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <1>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <0>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("Failed because it failed");
+}
+
+TEST(UnitTestMacros, ENUMS_EQUAL_TYPE_TEXTWithScopedLongEnumBehavesAsProperMacro)
+{
+    if (false) ENUMS_EQUAL_TYPE_TEXT(long, ScopedLongEnum::B, ScopedLongEnum::A, "Failed because it failed")
+    else ENUMS_EQUAL_TYPE_TEXT(long, ScopedLongEnum::B, ScopedLongEnum::B, "Failed because it failed")
+}
+
+IGNORE_TEST(UnitTestMacros, ENUMS_EQUAL_EQUAL_TYPE_TEXTWithScopedLongEnumWorksInAnIgnoredTest)
+{
+    ENUMS_EQUAL_TYPE_TEXT(long, ScopedLongEnum::B, ScopedLongEnum::A, "Failed because it failed"); // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
+#endif
+
+enum UnscopedEnum {
+    UNSCOPED_ENUM_A, UNSCOPED_ENUM_B
+};
+
+static void _ENUMS_EQUAL_INTWithUnscopedEnumTestMethod()
+{
+    ENUMS_EQUAL_INT(UNSCOPED_ENUM_B, UNSCOPED_ENUM_B);
+    ENUMS_EQUAL_INT(UNSCOPED_ENUM_B, UNSCOPED_ENUM_A);
+} // LCOV_EXCL_LINE
+
+TEST(UnitTestMacros, TestENUMS_EQUAL_INTWithUnscopedEnum)
+{
+    fixture.runTestWithMethod(_ENUMS_EQUAL_INTWithUnscopedEnumTestMethod);
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <1>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <0>");
+}
+
+TEST(UnitTestMacros, ENUMS_EQUAL_INTWithUnscopedEnumBehavesAsProperMacro)
+{
+    if (false) ENUMS_EQUAL_INT(UNSCOPED_ENUM_B, UNSCOPED_ENUM_A)
+    else ENUMS_EQUAL_INT(UNSCOPED_ENUM_B, UNSCOPED_ENUM_B)
+}
+
+IGNORE_TEST(UnitTestMacros, ENUMS_EQUAL_INTWithUnscopedEnumWorksInAnIgnoredTest)
+{
+    ENUMS_EQUAL_INT(UNSCOPED_ENUM_B, UNSCOPED_ENUM_A); // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
+static void _ENUMS_EQUAL_INT_TEXTWithUnscopedEnumTestMethod()
+{
+    ENUMS_EQUAL_INT_TEXT(UNSCOPED_ENUM_B, UNSCOPED_ENUM_A, "Failed because it failed");
+} // LCOV_EXCL_LINE
+
+TEST(UnitTestMacros, TestENUMS_EQUAL_INT_TEXTWithUnscopedEnum)
+{
+    fixture.runTestWithMethod(_ENUMS_EQUAL_INT_TEXTWithUnscopedEnumTestMethod);
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <1>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <0>");
+    CHECK_TEST_FAILS_PROPER_WITH_TEXT("Failed because it failed");
+}
+
+TEST(UnitTestMacros, ENUMS_EQUAL_INT_TEXTWithUnscopedEnumBehavesAsProperMacro)
+{
+    if (false) ENUMS_EQUAL_INT_TEXT(UNSCOPED_ENUM_B, UNSCOPED_ENUM_A, "Failed because it failed")
+    else ENUMS_EQUAL_INT_TEXT(UNSCOPED_ENUM_B, UNSCOPED_ENUM_B, "Failed because it failed")
+}
+
+IGNORE_TEST(UnitTestMacros, ENUMS_EQUAL_EQUAL_INT_TEXTWithUnscopedEnumWorksInAnIgnoredTest)
+{
+    ENUMS_EQUAL_INT_TEXT(UNSCOPED_ENUM_B, UNSCOPED_ENUM_A, "Failed because it failed"); // LCOV_EXCL_LINE
+} // LCOV_EXCL_LINE
+
 #if CPPUTEST_USE_STD_CPP_LIB
 static void _failingTestMethod_NoThrowWithCHECK_THROWS()
 {


### PR DESCRIPTION
Scoped enumerations from C++11 are no implicit
conversions from their values to integral types.

Add two assertion macros.

ENUMS_EQUAL_INT(excepted, actual)
  Compares two enums which their underlying type is int

ENUMS_EQUAL_TYPE(underlying_type, excepted, actual)
  Compares two enums which they have the same underlying type