### PR TITLE
Support Microsoft UWP platform by extending VisualCppTimeInMillis().

### DIFF
--- a/src/Platforms/VisualCpp/UtestPlatform.cpp
+++ b/src/Platforms/VisualCpp/UtestPlatform.cpp
@@ -83,7 +83,7 @@ static long VisualCppTimeInMillis()
 	{
 		LARGE_INTEGER now;
 		QueryPerformanceCounter(&now);
-		return (now.QuadPart * 1000) / s_frequency.QuadPart;
+		return (long)((now.QuadPart * 1000) / s_frequency.QuadPart);
 	} 
 	else 
 	{
@@ -93,7 +93,7 @@ static long VisualCppTimeInMillis()
 		#if !defined(_WIN32_WINNT) || !defined(_WIN32_WINNT_VISTA) || (_WIN32_WINNT < _WIN32_WINNT_VISTA)
 			return GetTickCount();
 		#else
-			return GetTickCount64();
+			return (long)GetTickCount64();
 		#endif
 	#endif
 	}

--- a/src/Platforms/VisualCpp/UtestPlatform.cpp
+++ b/src/Platforms/VisualCpp/UtestPlatform.cpp
@@ -77,7 +77,26 @@ TestOutput::WorkingEnvironment PlatformSpecificGetWorkingEnvironment()
 
 static long VisualCppTimeInMillis()
 {
-    return timeGetTime();
+	static LARGE_INTEGER s_frequency;
+	static const BOOL s_use_qpc = QueryPerformanceFrequency(&s_frequency);
+	if (s_use_qpc)
+	{
+		LARGE_INTEGER now;
+		QueryPerformanceCounter(&now);
+		return (now.QuadPart * 1000) / s_frequency.QuadPart;
+	} 
+	else 
+	{
+	#ifdef TIMERR_NOERROR
+		return timeGetTime();
+	#else
+		#if !defined(_WIN32_WINNT) || !defined(_WIN32_WINNT_VISTA) || (_WIN32_WINNT < _WIN32_WINNT_VISTA)
+			return GetTickCount();
+		#else
+			return GetTickCount64();
+		#endif
+	#endif
+	}
 }
 
 long (*GetPlatformSpecificTimeInMillis)() = VisualCppTimeInMillis;


### PR DESCRIPTION
Support Microsoft UWP platform by providing an alternative timer function in ```VisualCppTimeInMillis()``` due to absence of ```timeGetTime()``` API in UWP.

```TIMERR_NOERROR``` can be used to detect presence of timeGetTime() API.

UWP supports ```QueryPerformanceFrequency()/QueryPerformanceCounter()``` API which can be used for time calculation and this API is available on all Windows versions, so the proposal is to use this implementation for Windows platform in general and fallback to ```timeGetTime()``` or ```GetTickCount``` in case ```QueryPerformanceFrequency()``` fails due to some unknown reason.

```timeGetTime()``` also suffers from lower time resolution  which can be avoided by new implementation too.