### PR TITLE
Added missed header files when cpputest is being installed as external project though cmake

### DIFF
--- a/src/CppUTest/CMakeLists.txt
+++ b/src/CppUTest/CMakeLists.txt
@@ -60,6 +60,8 @@ set(CppUTest_headers
         ${CppUTestRootDirectory}/include/CppUTest/MemoryLeakWarningPlugin.h
         ${CppUTestRootDirectory}/include/CppUTest/TestHarness_c.h
         ${CppUTestRootDirectory}/include/CppUTest/UtestMacros.h
+        ${CppUTestRootDirectory}/include/CppUTest/Shuffle.h
+        ${CppUTestRootDirectory}/include/CppUTest/SimpleMutex.h
 )
 
 if (WIN32)


### PR DESCRIPTION
Added Shuffle.h and SimpleMutex.h in the list of headers to be installed in CMakeLists.txt.