### PR TITLE
Signedness corrected

### DIFF
--- a/include/CppUTest/Shuffle.h
+++ b/include/CppUTest/Shuffle.h
@@ -46,16 +46,15 @@ static inline int rand_(void) // rand_func_t
 // "Durstenfeld shuffle" according to Wikipedia
 static inline void shuffle_list(rand_func_t rand_func, size_t numElems, void* listToShuffleInPlace[])
 {
-    if( numElems > 0 )
+    if( numElems == 0 ) return;
+
+    for (size_t i = numElems - 1; i >= 1; --i)
     {
-        for (size_t i = numElems - 1; i >= 1; --i)
-        {
-            const size_t j = ((size_t)rand_func()) % (i + 1); // distribution biased by modulo, but good enough for shuffling
-            void* e1 = listToShuffleInPlace[j];
-            void* e2 = listToShuffleInPlace[i];
-            listToShuffleInPlace[i] = e1;
-            listToShuffleInPlace[j] = e2;
-        }
+        const size_t j = ((size_t)rand_func()) % (i + 1); // distribution biased by modulo, but good enough for shuffling
+        void* e1 = listToShuffleInPlace[j];
+        void* e2 = listToShuffleInPlace[i];
+        listToShuffleInPlace[i] = e1;
+        listToShuffleInPlace[j] = e2;
     }
 }
 

--- a/include/CppUTest/Shuffle.h
+++ b/include/CppUTest/Shuffle.h
@@ -44,11 +44,11 @@ static inline int rand_(void) // rand_func_t
 }
 
 // "Durstenfeld shuffle" according to Wikipedia
-static inline void shuffle_list(rand_func_t rand_func, int numElems, void* listToShuffleInPlace[])
+static inline void shuffle_list(rand_func_t rand_func, size_t numElems, void* listToShuffleInPlace[])
 {
-    for (int i = numElems - 1; i >= 1; --i)
+    for (size_t i = numElems - 1; i >= 1; --i)
     {
-        int j = rand_func() % (i + 1); // distribution biased by modulo, but good enough for shuffling
+        const size_t j = (size_t) rand_func() % (i + 1); // distribution biased by modulo, but good enough for shuffling
         void* e1 = listToShuffleInPlace[j];
         void* e2 = listToShuffleInPlace[i];
         listToShuffleInPlace[i] = e1;

--- a/include/CppUTest/Shuffle.h
+++ b/include/CppUTest/Shuffle.h
@@ -46,13 +46,16 @@ static inline int rand_(void) // rand_func_t
 // "Durstenfeld shuffle" according to Wikipedia
 static inline void shuffle_list(rand_func_t rand_func, size_t numElems, void* listToShuffleInPlace[])
 {
-    for (size_t i = numElems - 1; i >= 1; --i)
+    if( numElems > 0 )
     {
-        const size_t j = (size_t) rand_func() % (i + 1); // distribution biased by modulo, but good enough for shuffling
-        void* e1 = listToShuffleInPlace[j];
-        void* e2 = listToShuffleInPlace[i];
-        listToShuffleInPlace[i] = e1;
-        listToShuffleInPlace[j] = e2;
+        for (size_t i = numElems - 1; i >= 1; --i)
+        {
+            const size_t j = ((size_t)rand_func()) % (i + 1); // distribution biased by modulo, but good enough for shuffling
+            void* e1 = listToShuffleInPlace[j];
+            void* e2 = listToShuffleInPlace[i];
+            listToShuffleInPlace[i] = e1;
+            listToShuffleInPlace[j] = e2;
+        }
     }
 }
 

--- a/include/CppUTest/TestRegistry.h
+++ b/include/CppUTest/TestRegistry.h
@@ -33,6 +33,7 @@
 #ifndef D_TestRegistry_h
 #define D_TestRegistry_h
 
+#include <stddef.h>
 #include "SimpleString.h"
 #include "TestFilter.h"
 #include "Shuffle.h"
@@ -49,7 +50,7 @@ public:
 
     virtual void addTest(UtestShell *test);
     virtual void unDoLastAddTest();
-    virtual int countTests();
+    virtual size_t countTests();
     virtual void runAllTests(TestResult& result);
     virtual void shuffleRunOrder(rand_func_t);
     virtual void listTestGroupNames(TestResult& result);

--- a/include/CppUTest/TestRegistry.h
+++ b/include/CppUTest/TestRegistry.h
@@ -33,7 +33,7 @@
 #ifndef D_TestRegistry_h
 #define D_TestRegistry_h
 
-#include <stddef.h>
+#include "StandardCLibrary.h"
 #include "SimpleString.h"
 #include "TestFilter.h"
 #include "Shuffle.h"

--- a/include/CppUTest/Utest.h
+++ b/include/CppUTest/Utest.h
@@ -93,7 +93,7 @@ public:
 
     virtual UtestShell* addTest(UtestShell* test);
     virtual UtestShell *getNext() const;
-    virtual int countTests();
+    virtual size_t countTests();
 
     bool shouldRun(const TestFilter* groupFilters, const TestFilter* nameFilters) const;
     const SimpleString getName() const;

--- a/src/CppUTest/TestRegistry.cpp
+++ b/src/CppUTest/TestRegistry.cpp
@@ -128,7 +128,7 @@ bool TestRegistry::endOfGroup(UtestShell* test)
     return (!test || !test->getNext() || test->getGroup() != test->getNext()->getGroup());
 }
 
-int TestRegistry::countTests()
+size_t TestRegistry::countTests()
 {
     return tests_ ? tests_->countTests() : 0;
 }
@@ -234,11 +234,11 @@ void TestRegistry::shuffleRunOrder(rand_func_t rand_func)
     {
         return;
     }
-    int numTests = getFirstTest()->countTests();
+    const size_t numTests = getFirstTest()->countTests();
     typedef UtestShell* listElem;
     listElem* tests = new listElem[numTests];
     UtestShell *test = getFirstTest();
-    for (int testsIdx = 0; testsIdx < numTests; ++testsIdx)
+    for (size_t testsIdx = 0; testsIdx < numTests; ++testsIdx)
     {
         tests[testsIdx] = test;
         test = test->getNext();
@@ -247,7 +247,7 @@ void TestRegistry::shuffleRunOrder(rand_func_t rand_func)
 
     // Store shuffled list back to linked list
     UtestShell *prev = NULLPTR;
-    for (int i = 0; i < numTests; ++i)
+    for (size_t i = 0; i < numTests; ++i)
     {
         prev = tests[numTests - 1 - i]->addTest(prev);
     }

--- a/src/CppUTest/Utest.cpp
+++ b/src/CppUTest/Utest.cpp
@@ -227,7 +227,7 @@ UtestShell* UtestShell::addTest(UtestShell *test)
     return this;
 }
 
-int UtestShell::countTests()
+size_t UtestShell::countTests()
 {
     return next_ ? next_->countTests() + 1 : 1;
 }


### PR DESCRIPTION
Signedness correction (reported by clang 8).

@basvodde isn't `size_t` a better choice here anyway? Neither test count nor `shuffle_list()` parameter should become `< 1`.