### PR TITLE
In README: CPPUTEST_HOME variable prefixed with a $

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ You can also use CMake, which also works for Windows Visual Studio.
 
 Then to get started, you'll need to do the following:
 * Add the include path to the Makefile. Something like:
-    * CPPFLAGS += -I(CPPUTEST_HOME)/include
+    * CPPFLAGS += -I$(CPPUTEST_HOME)/include
 * Add the memory leak macros to your Makefile (needed for additional debug info!). Something like:
     * CXXFLAGS += -include $(CPPUTEST_HOME)/include/CppUTest/MemoryLeakDetectorNewMacros.h
     * CFLAGS += -include $(CPPUTEST_HOME)/include/CppUTest/MemoryLeakDetectorMallocMacros.h


### PR DESCRIPTION
The CPPUTEST_HOME variable to be added to CPPFLAGS perhaps needs to be prefixed with a $ to work in a Makefile.