### PR TITLE
JUnit output: Encode special chars in XML Text

### DIFF
--- a/include/CppUTest/JUnitTestOutput.h
+++ b/include/CppUTest/JUnitTestOutput.h
@@ -71,6 +71,7 @@ protected:
     virtual void writeTestSuiteSummary();
     virtual void writeProperties();
     virtual void writeTestCases();
+    virtual SimpleString encodeXmlText(const SimpleString& textbody);
     virtual void writeFailure(JUnitTestCaseResultNode* node);
     virtual void writeFileEnding();
 

--- a/src/CppUTest/JUnitTestOutput.cpp
+++ b/src/CppUTest/JUnitTestOutput.cpp
@@ -237,7 +237,7 @@ void JUnitTestOutput::writeFailure(JUnitTestCaseResultNode* node)
             "<failure message=\"%s:%d: %s\" type=\"AssertionFailedError\">\n",
             node->failure_->getFileName().asCharString(),
             node->failure_->getFailureLineNumber(),
-	    encodeXmlText(node->failure_->getMessage()).asCharString());
+            encodeXmlText(node->failure_->getMessage()).asCharString());
     writeToFile(buf.asCharString());
     writeToFile("</failure>\n");
 }

--- a/src/CppUTest/JUnitTestOutput.cpp
+++ b/src/CppUTest/JUnitTestOutput.cpp
@@ -190,6 +190,17 @@ void JUnitTestOutput::writeProperties()
     writeToFile("</properties>\n");
 }
 
+SimpleString JUnitTestOutput::encodeXmlText(const SimpleString& textbody)
+{
+    SimpleString buf = textbody.asCharString();
+    buf.replace("&", "&amp;");
+    buf.replace("\"", "&quot;");
+    buf.replace("<", "&lt;");
+    buf.replace(">", "&gt;");
+    buf.replace("\n", "{newline}");
+    return buf;
+}
+
 void JUnitTestOutput::writeTestCases()
 {
     JUnitTestCaseResultNode* cur = impl_->results_.head_;
@@ -222,23 +233,21 @@ void JUnitTestOutput::writeTestCases()
 
 void JUnitTestOutput::writeFailure(JUnitTestCaseResultNode* node)
 {
-    SimpleString message = node->failure_->getMessage().asCharString();
-    message.replace('"', '\'');
-    message.replace('<', '[');
-    message.replace('>', ']');
-    message.replace("&", "&amp;");
-    message.replace("\n", "{newline}");
     SimpleString buf = StringFromFormat(
             "<failure message=\"%s:%d: %s\" type=\"AssertionFailedError\">\n",
             node->failure_->getFileName().asCharString(),
-            node->failure_->getFailureLineNumber(), message.asCharString());
+            node->failure_->getFailureLineNumber(),
+	    encodeXmlText(node->failure_->getMessage()).asCharString());
     writeToFile(buf.asCharString());
     writeToFile("</failure>\n");
 }
 
+
 void JUnitTestOutput::writeFileEnding()
 {
-    writeToFile("<system-out>"); writeToFile(impl_->stdOutput_); writeToFile("</system-out>\n");
+    writeToFile("<system-out>");
+    writeToFile(encodeXmlText(impl_->stdOutput_));
+    writeToFile("</system-out>\n");
     writeToFile("<system-err></system-err>\n");
     writeToFile("</testsuite>\n");
 }

--- a/src/CppUTest/SimpleString.cpp
+++ b/src/CppUTest/SimpleString.cpp
@@ -263,7 +263,7 @@ void SimpleString::replace(const char* to, const char* with)
 {
     size_t c = count(to);
     if (c == 0) {
-	return;
+        return;
     }
     size_t len = size();
     size_t tolen = StrLen(to);

--- a/src/CppUTest/SimpleString.cpp
+++ b/src/CppUTest/SimpleString.cpp
@@ -262,6 +262,9 @@ void SimpleString::replace(char to, char with)
 void SimpleString::replace(const char* to, const char* with)
 {
     size_t c = count(to);
+    if (c == 0) {
+	return;
+    }
     size_t len = size();
     size_t tolen = StrLen(to);
     size_t withlen = StrLen(with);

--- a/tests/CppUTest/JUnitOutputTest.cpp
+++ b/tests/CppUTest/JUnitOutputTest.cpp
@@ -510,7 +510,7 @@ TEST(JUnitOutputTest, testFailureWithLessThanAndGreaterThanInsideIt)
 
     outputFile = fileSystem.file("cpputest_testGroupWithFailingTest.xml");
 
-    STRCMP_EQUAL("<failure message=\"thisfile:10: Test [failed]\" type=\"AssertionFailedError\">\n", outputFile->line(6));
+    STRCMP_EQUAL("<failure message=\"thisfile:10: Test &lt;failed&gt;\" type=\"AssertionFailedError\">\n", outputFile->line(6));
 }
 
 TEST(JUnitOutputTest, testFailureWithQuotesInIt)
@@ -522,7 +522,7 @@ TEST(JUnitOutputTest, testFailureWithQuotesInIt)
 
     outputFile = fileSystem.file("cpputest_testGroupWithFailingTest.xml");
 
-    STRCMP_EQUAL("<failure message=\"thisfile:10: Test 'failed'\" type=\"AssertionFailedError\">\n", outputFile->line(6));
+    STRCMP_EQUAL("<failure message=\"thisfile:10: Test &quot;failed&quot;\" type=\"AssertionFailedError\">\n", outputFile->line(6));
 }
 
 TEST(JUnitOutputTest, testFailureWithNewlineInIt)
@@ -547,6 +547,18 @@ TEST(JUnitOutputTest, testFailureWithDifferentFileAndLine)
     outputFile = fileSystem.file("cpputest_testGroupWithFailingTest.xml");
 
     STRCMP_EQUAL("<failure message=\"importantFile:999: Test failed\" type=\"AssertionFailedError\">\n", outputFile->line(6));
+}
+
+TEST(JUnitOutputTest, testFailureWithAmpersandsAndLessThan)
+{
+    testCaseRunner->start()
+            .withGroup("testGroupWithFailingTest")
+                .withTest("FailingTestName").thatFails("&object1 < &object2", "importantFile", 999)
+            .end();
+
+    outputFile = fileSystem.file("cpputest_testGroupWithFailingTest.xml");
+
+    STRCMP_EQUAL("<failure message=\"importantFile:999: &amp;object1 &lt; &amp;object2\" type=\"AssertionFailedError\">\n", outputFile->line(6));
 }
 
 TEST(JUnitOutputTest, testFailureWithAmpersands)
@@ -723,4 +735,15 @@ TEST(JUnitOutputTest, UTPRINTOutputInJUnitOutput)
 
     outputFile = fileSystem.file("cpputest_groupname.xml");
     STRCMP_EQUAL("<system-out>someoutput</system-out>\n", outputFile->lineFromTheBack(3));
+}
+
+TEST(JUnitOutputTest, UTPRINTOutputInJUnitOutputWithSpecials)
+{
+    testCaseRunner->start()
+            .withGroup("groupname")
+            .withTest("testname").thatPrints("The <rain> in \"Spain\"\nGoes \\mainly\\ down the Dr&in\n")
+            .end();
+
+    outputFile = fileSystem.file("cpputest_groupname.xml");
+    STRCMP_EQUAL("<system-out>The &lt;rain&gt; in &quot;Spain&quot;{newline}Goes \\mainly\\ down the Dr&amp;in{newline}</system-out>\n", outputFile->lineFromTheBack(3));
 }


### PR DESCRIPTION
This change extends escaping of XML special characters to text blocks as well
as attributes.  It also changes the mapping to use standard escape encoding:

	"   &quot;
	<   &lt;
	>   &gt;
	&   &amp;

This change maintains the historic behavior of mapping newlines to "{newline}"
in the XML text. We're not sure whether this is optimal for Bamboo and Jenkins,
although our experience to date is it's better then emitting the raw newlines
or mapping newlines to spaces.

This implementation is expensive, calling SimpleString::replace() repeatedly
over the same string.  The cost was mitigated by modifying the replace() method
to exit quickly if the pattern is not found.