### PR TITLE
Empty expression warnings fixed

### DIFF
--- a/include/CppUTest/MemoryLeakWarningPlugin.h
+++ b/include/CppUTest/MemoryLeakWarningPlugin.h
@@ -31,8 +31,8 @@
 #include "TestPlugin.h"
 #include "MemoryLeakDetectorNewMacros.h"
 
-#define IGNORE_ALL_LEAKS_IN_TEST() MemoryLeakWarningPlugin::getFirstPlugin()->ignoreAllLeaksInTest();
-#define EXPECT_N_LEAKS(n)          MemoryLeakWarningPlugin::getFirstPlugin()->expectLeaksInTest(n);
+#define IGNORE_ALL_LEAKS_IN_TEST() MemoryLeakWarningPlugin::getFirstPlugin()->ignoreAllLeaksInTest()
+#define EXPECT_N_LEAKS(n)          MemoryLeakWarningPlugin::getFirstPlugin()->expectLeaksInTest(n)
 
 extern void crash_on_allocation_number(unsigned alloc_number);
 

--- a/include/CppUTest/TestPlugin.h
+++ b/include/CppUTest/TestPlugin.h
@@ -98,7 +98,7 @@ public:
     };
 };
 
-#define UT_PTR_SET(a, b) { CppUTestStore( (void**)&a ); a = b; }
+#define UT_PTR_SET(a, b) do { CppUTestStore( (void**)&a ); a = b; } while(0)
 
 ///////////// Null Plugin
 

--- a/include/CppUTest/UtestMacros.h
+++ b/include/CppUTest/UtestMacros.h
@@ -117,10 +117,10 @@
   CHECK_FALSE_LOCATION(condition, "CHECK_FALSE", #condition, text, __FILE__, __LINE__)
 
 #define CHECK_TRUE_LOCATION(condition, checkString, conditionString, text, file, line)\
-  { UtestShell::getCurrent()->assertTrue((condition), checkString, conditionString, text, file, line); }
+  do { UtestShell::getCurrent()->assertTrue((condition), checkString, conditionString, text, file, line); } while(0)
 
 #define CHECK_FALSE_LOCATION(condition, checkString, conditionString, text, file, line)\
-  { UtestShell::getCurrent()->assertTrue(!(condition), checkString, conditionString, text, file, line); }
+  do { UtestShell::getCurrent()->assertTrue(!(condition), checkString, conditionString, text, file, line); } while(0)
 
 //This check needs the operator!=(), and a StringFrom(YourType) function
 #define CHECK_EQUAL(expected, actual)\
@@ -130,7 +130,7 @@
   CHECK_EQUAL_LOCATION(expected, actual, text, __FILE__, __LINE__)
 
 #define CHECK_EQUAL_LOCATION(expected, actual, text, file, line)\
-  { if ((expected) != (actual)) { \
+  do { if ((expected) != (actual)) { \
       if ((actual) != (actual)) \
       	  UtestShell::getCurrent()->print("WARNING:\n\tThe \"Actual Parameter\" parameter is evaluated multiple times resulting in different values.\n\tThus the value in the error message is probably incorrect.", file, line); \
       if ((expected) != (expected)) \
@@ -140,7 +140,7 @@
   else \
   { \
     UtestShell::getCurrent()->assertLongsEqual((long)0, (long)0, NULLPTR, file, line); \
-  } }
+  } } while(0)
 
 #define CHECK_COMPARE(first, relop, second)\
   CHECK_COMPARE_TEXT(first, relop, second, NULLPTR)
@@ -149,12 +149,12 @@
   CHECK_COMPARE_LOCATION(first, relop, second, text, __FILE__, __LINE__)
 
 #define CHECK_COMPARE_LOCATION(first, relop, second, text, file, line)\
- { SimpleString conditionString;\
-   conditionString += StringFrom(first); conditionString += " ";\
-   conditionString += #relop; conditionString += " ";\
-   conditionString += StringFrom(second);\
-   UtestShell::getCurrent()->assertCompare((first) relop (second), "CHECK_COMPARE", conditionString.asCharString(), text, __FILE__, __LINE__);\
- }
+ do { SimpleString conditionString;\
+      conditionString += StringFrom(first); conditionString += " ";\
+      conditionString += #relop; conditionString += " ";\
+      conditionString += StringFrom(second);\
+      UtestShell::getCurrent()->assertCompare((first) relop (second), "CHECK_COMPARE", conditionString.asCharString(), text, __FILE__, __LINE__);\
+ } while(0)
 
 //This check checks for char* string equality using strcmp.
 //This makes up for the fact that CHECK_EQUAL only compares the pointers to char*'s
@@ -165,7 +165,7 @@
   STRCMP_EQUAL_LOCATION(expected, actual, text, __FILE__, __LINE__)
 
 #define STRCMP_EQUAL_LOCATION(expected, actual, text, file, line)\
-  { UtestShell::getCurrent()->assertCstrEqual(expected, actual, text, file, line); }
+  do { UtestShell::getCurrent()->assertCstrEqual(expected, actual, text, file, line); } while(0)
 
 #define STRNCMP_EQUAL(expected, actual, length)\
   STRNCMP_EQUAL_LOCATION(expected, actual, length, NULLPTR, __FILE__, __LINE__)
@@ -174,7 +174,7 @@
   STRNCMP_EQUAL_LOCATION(expected, actual, length, text, __FILE__, __LINE__)
 
 #define STRNCMP_EQUAL_LOCATION(expected, actual, length, text, file, line)\
-  { UtestShell::getCurrent()->assertCstrNEqual(expected, actual, length, text, file, line); }
+  do { UtestShell::getCurrent()->assertCstrNEqual(expected, actual, length, text, file, line); } while(0)
 
 #define STRCMP_NOCASE_EQUAL(expected, actual)\
   STRCMP_NOCASE_EQUAL_LOCATION(expected, actual, NULLPTR, __FILE__, __LINE__)
@@ -183,7 +183,7 @@
   STRCMP_NOCASE_EQUAL_LOCATION(expected, actual, text, __FILE__, __LINE__)
 
 #define STRCMP_NOCASE_EQUAL_LOCATION(expected, actual, text, file, line)\
-  { UtestShell::getCurrent()->assertCstrNoCaseEqual(expected, actual, text, file, line); }
+  do { UtestShell::getCurrent()->assertCstrNoCaseEqual(expected, actual, text, file, line); } while(0)
 
 #define STRCMP_CONTAINS(expected, actual)\
   STRCMP_CONTAINS_LOCATION(expected, actual, NULLPTR, __FILE__, __LINE__)
@@ -192,7 +192,7 @@
   STRCMP_CONTAINS_LOCATION(expected, actual, text, __FILE__, __LINE__)
 
 #define STRCMP_CONTAINS_LOCATION(expected, actual, text, file, line)\
-  { UtestShell::getCurrent()->assertCstrContains(expected, actual, text, file, line); }
+  do { UtestShell::getCurrent()->assertCstrContains(expected, actual, text, file, line); } while(0)
 
 #define STRCMP_NOCASE_CONTAINS(expected, actual)\
   STRCMP_NOCASE_CONTAINS_LOCATION(expected, actual, NULLPTR, __FILE__, __LINE__)
@@ -201,7 +201,7 @@
   STRCMP_NOCASE_CONTAINS_LOCATION(expected, actual, text, __FILE__, __LINE__)
 
 #define STRCMP_NOCASE_CONTAINS_LOCATION(expected, actual, text, file, line)\
-  { UtestShell::getCurrent()->assertCstrNoCaseContains(expected, actual, text, file, line); }
+  do { UtestShell::getCurrent()->assertCstrNoCaseContains(expected, actual, text, file, line); } while(0)
 
 //Check two long integers for equality
 #define LONGS_EQUAL(expected, actual)\
@@ -217,10 +217,10 @@
   UNSIGNED_LONGS_EQUAL_LOCATION((expected), (actual), text, __FILE__, __LINE__)
 
 #define LONGS_EQUAL_LOCATION(expected, actual, text, file, line)\
-  { UtestShell::getCurrent()->assertLongsEqual((long)expected, (long)actual, text, file, line); }
+  do { UtestShell::getCurrent()->assertLongsEqual((long)expected, (long)actual, text, file, line); } while(0)
 
 #define UNSIGNED_LONGS_EQUAL_LOCATION(expected, actual, text, file, line)\
-  { UtestShell::getCurrent()->assertUnsignedLongsEqual((unsigned long)expected, (unsigned long)actual, text, file, line); }
+  do { UtestShell::getCurrent()->assertUnsignedLongsEqual((unsigned long)expected, (unsigned long)actual, text, file, line); } while(0)
 
 #define LONGLONGS_EQUAL(expected, actual)\
   LONGLONGS_EQUAL_LOCATION(expected, actual, NULLPTR, __FILE__, __LINE__)
@@ -235,10 +235,10 @@
   UNSIGNED_LONGLONGS_EQUAL_LOCATION(expected, actual, text, __FILE__, __LINE__)
 
 #define LONGLONGS_EQUAL_LOCATION(expected, actual, text, file, line)\
-        { UtestShell::getCurrent()->assertLongLongsEqual((long long)expected, (long long)actual, text, file, line); }
+        do { UtestShell::getCurrent()->assertLongLongsEqual((long long)expected, (long long)actual, text, file, line); } while(0)
 
 #define UNSIGNED_LONGLONGS_EQUAL_LOCATION(expected, actual, text, file, line)\
-        { UtestShell::getCurrent()->assertUnsignedLongLongsEqual((unsigned long long)expected, (unsigned long long)actual, text, file, line); }
+        do { UtestShell::getCurrent()->assertUnsignedLongLongsEqual((unsigned long long)expected, (unsigned long long)actual, text, file, line); } while(0)
 
 #define BYTES_EQUAL(expected, actual)\
     LONGS_EQUAL((expected) & 0xff,(actual) & 0xff)
@@ -250,13 +250,13 @@
     SIGNED_BYTES_EQUAL_LOCATION(expected, actual, __FILE__, __LINE__)
 
 #define SIGNED_BYTES_EQUAL_LOCATION(expected, actual, file, line) \
-       { UtestShell::getCurrent()->assertSignedBytesEqual(expected, actual, NULLPTR, file, line); }
+       do { UtestShell::getCurrent()->assertSignedBytesEqual(expected, actual, NULLPTR, file, line); } while(0)
 
 #define SIGNED_BYTES_EQUAL_TEXT(expected, actual, text)\
     SIGNED_BYTES_EQUAL_TEXT_LOCATION(expected, actual, text, __FILE__, __LINE__)
 
 #define SIGNED_BYTES_EQUAL_TEXT_LOCATION(expected, actual, text, file, line) \
-        { UtestShell::getCurrent()->assertSignedBytesEqual(expected, actual, text, file, line); }
+        do { UtestShell::getCurrent()->assertSignedBytesEqual(expected, actual, text, file, line); } while(0)
 
 #define POINTERS_EQUAL(expected, actual)\
     POINTERS_EQUAL_LOCATION((expected), (actual), NULLPTR, __FILE__, __LINE__)
@@ -265,7 +265,7 @@
     POINTERS_EQUAL_LOCATION((expected), (actual), text, __FILE__, __LINE__)
 
 #define POINTERS_EQUAL_LOCATION(expected, actual, text, file, line)\
-  { UtestShell::getCurrent()->assertPointersEqual((const void *)expected, (const void *)actual, text, file, line); }
+  do { UtestShell::getCurrent()->assertPointersEqual((const void *)expected, (const void *)actual, text, file, line); } while(0)
 
 #define FUNCTIONPOINTERS_EQUAL(expected, actual)\
     FUNCTIONPOINTERS_EQUAL_LOCATION((expected), (actual), NULLPTR, __FILE__, __LINE__)
@@ -274,7 +274,7 @@
     FUNCTIONPOINTERS_EQUAL_LOCATION((expected), (actual), text, __FILE__, __LINE__)
 
 #define FUNCTIONPOINTERS_EQUAL_LOCATION(expected, actual, text, file, line)\
-  { UtestShell::getCurrent()->assertFunctionPointersEqual((void (*)())expected, (void (*)())actual, text, file, line); }
+  do { UtestShell::getCurrent()->assertFunctionPointersEqual((void (*)())expected, (void (*)())actual, text, file, line); } while(0)
 
 //Check two doubles for equality within a tolerance threshold
 #define DOUBLES_EQUAL(expected, actual, threshold)\
@@ -284,7 +284,7 @@
   DOUBLES_EQUAL_LOCATION(expected, actual, threshold, text, __FILE__, __LINE__)
 
 #define DOUBLES_EQUAL_LOCATION(expected, actual, threshold, text, file, line)\
-  { UtestShell::getCurrent()->assertDoublesEqual(expected, actual, threshold, text, file, line); }
+  do { UtestShell::getCurrent()->assertDoublesEqual(expected, actual, threshold, text, file, line); } while(0)
 
 #define MEMCMP_EQUAL(expected, actual, size)\
   MEMCMP_EQUAL_LOCATION(expected, actual, size, NULLPTR, __FILE__, __LINE__)
@@ -293,7 +293,7 @@
   MEMCMP_EQUAL_LOCATION(expected, actual, size, text, __FILE__, __LINE__)
 
 #define MEMCMP_EQUAL_LOCATION(expected, actual, size, text, file, line)\
-  { UtestShell::getCurrent()->assertBinaryEqual(expected, actual, size, text, file, line); }
+  do { UtestShell::getCurrent()->assertBinaryEqual(expected, actual, size, text, file, line); } while(0)
 
 #define BITS_EQUAL(expected, actual, mask)\
   BITS_LOCATION(expected, actual, mask, NULLPTR, __FILE__, __LINE__)
@@ -302,7 +302,7 @@
   BITS_LOCATION(expected, actual, mask, text, __FILE__, __LINE__)
 
 #define BITS_LOCATION(expected, actual, mask, text, file, line)\
-  { UtestShell::getCurrent()->assertBitsEqual(expected, actual, mask, sizeof(actual), text, file, line); }
+  do { UtestShell::getCurrent()->assertBitsEqual(expected, actual, mask, sizeof(actual), text, file, line); } while(0)
 
 #define ENUMS_EQUAL_INT(expected, actual)\
   ENUMS_EQUAL_TYPE(int, expected, actual)
@@ -317,7 +317,7 @@
   ENUMS_EQUAL_TYPE_LOCATION(underlying_type, expected, actual, text, __FILE__, __LINE__)
 
 #define ENUMS_EQUAL_TYPE_LOCATION(underlying_type, expected, actual, text, file, line)\
-  { underlying_type expected_underlying_value = (underlying_type)(expected); \
+  do { underlying_type expected_underlying_value = (underlying_type)(expected); \
     underlying_type actual_underlying_value = (underlying_type)(actual); \
     if (expected_underlying_value != actual_underlying_value) { \
       UtestShell::getCurrent()->assertEquals(true, StringFrom(expected_underlying_value).asCharString(), StringFrom(actual_underlying_value).asCharString(), text, file, line); \
@@ -326,7 +326,7 @@
     { \
       UtestShell::getCurrent()->assertLongsEqual((long)0, long(0), NULLPTR, file, line); \
     } \
-  }
+  } while(0)
 
 //Fail if you get to this macro
 //The macro FAIL may already be taken, so allow FAIL_TEST too
@@ -335,27 +335,27 @@
   FAIL_LOCATION(text, __FILE__,__LINE__)
 
 #define FAIL_LOCATION(text, file, line)\
-  { UtestShell::getCurrent()->fail(text,  file, line); }
+  do { UtestShell::getCurrent()->fail(text,  file, line); } while(0)
 #endif
 
 #define FAIL_TEST(text)\
   FAIL_TEST_LOCATION(text, __FILE__,__LINE__)
 
 #define FAIL_TEST_LOCATION(text, file,line)\
-  { UtestShell::getCurrent()->fail(text, file, line); }
+  do { UtestShell::getCurrent()->fail(text, file, line); } while(0)
 
 #define TEST_EXIT\
-  { UtestShell::getCurrent()->exitTest(); }
+  do { UtestShell::getCurrent()->exitTest(); } while(0)
 
 #define UT_PRINT_LOCATION(text, file, line) \
-   { UtestShell::getCurrent()->print(text, file, line); }
+  do { UtestShell::getCurrent()->print(text, file, line); } while(0)
 
 #define UT_PRINT(text) \
    UT_PRINT_LOCATION(text, __FILE__, __LINE__)
 
 #if CPPUTEST_USE_STD_CPP_LIB
 #define CHECK_THROWS(expected, expression) \
-    { \
+    do { \
     SimpleString failure_msg("expected to throw "#expected "\nbut threw nothing"); \
     bool caught_expected = false; \
     try { \
@@ -371,10 +371,10 @@
     else { \
         UtestShell::getCurrent()->countCheck(); \
     } \
-    }
+    } while(0)
 #endif /* CPPUTEST_USE_STD_CPP_LIB */
 
-#define UT_CRASH() { UtestShell::crash(); }
+#define UT_CRASH() do { UtestShell::crash(); } while(0)
 #define RUN_ALL_TESTS(ac, av) CommandLineTestRunner::RunAllTests(ac, av)
 
 #endif /*D_UTestMacros_h*/

--- a/src/CppUTest/JUnitTestOutput.cpp
+++ b/src/CppUTest/JUnitTestOutput.cpp
@@ -92,7 +92,6 @@ void JUnitTestOutput::resetTestGroupResult()
     JUnitTestCaseResultNode* cur = impl_->results_.head_;
     while (cur) {
         JUnitTestCaseResultNode* tmp = cur->next_;
-        ;
         delete cur->failure_;
         delete cur;
         cur = tmp;

--- a/src/CppUTest/MemoryLeakWarningPlugin.cpp
+++ b/src/CppUTest/MemoryLeakWarningPlugin.cpp
@@ -128,7 +128,7 @@ void cpputest_free_location_with_leak_detection(void* buffer, const char* file, 
 #undef new
 
 #if CPPUTEST_USE_STD_CPP_LIB
-#define UT_THROW_BAD_ALLOC_WHEN_NULL(memory) if (memory == NULLPTR) throw std::bad_alloc();
+#define UT_THROW_BAD_ALLOC_WHEN_NULL(memory) if (memory == NULLPTR) throw std::bad_alloc()
 #else
 #define UT_THROW_BAD_ALLOC_WHEN_NULL(memory)
 #endif

--- a/src/CppUTest/TestFailure.cpp
+++ b/src/CppUTest/TestFailure.cpp
@@ -387,5 +387,5 @@ FeatureUnsupportedFailure::FeatureUnsupportedFailure(UtestShell* test, const cha
 {
     message_ = createUserText(text);
 
-    message_ += StringFromFormat("The feature \"%s\" is not supported in this environment or with the feature set selected when building the library.", featureName.asCharString());;
+    message_ += StringFromFormat("The feature \"%s\" is not supported in this environment or with the feature set selected when building the library.", featureName.asCharString());
 }

--- a/src/CppUTest/TestTestingFixture.cpp
+++ b/src/CppUTest/TestTestingFixture.cpp
@@ -43,6 +43,6 @@ void TestTestingFixture::checkTestFailsWithProperTestLocation(const char* text, 
   STRCMP_CONTAINS_LOCATION(text, output_->getOutput().asCharString(), "", file, line);
 
   if (lineOfCodeExecutedAfterCheck)
-    FAIL_LOCATION("The test should jump/throw on failure and not execute the next line. However, the next line was executed.", file, line)
+    FAIL_LOCATION("The test should jump/throw on failure and not execute the next line. However, the next line was executed.", file, line);
 }
 

--- a/src/CppUTestExt/MockActualCall.cpp
+++ b/src/CppUTestExt/MockActualCall.cpp
@@ -386,7 +386,7 @@ void MockCheckedActualCall::checkExpectations()
     }
 
     if (potentiallyMatchingExpectations_.hasFinalizedMatchingExpectations())
-        FAIL("Actual call is in progress, but there are finalized matching expectations when checking expectations. This cannot happen.") // LCOV_EXCL_LINE
+        FAIL("Actual call is in progress, but there are finalized matching expectations when checking expectations. This cannot happen."); // LCOV_EXCL_LINE
 
     matchingExpectation_ = potentiallyMatchingExpectations_.removeFirstMatchingExpectation();
     if (matchingExpectation_) {

--- a/tests/CppUTest/SetPluginTest.cpp
+++ b/tests/CppUTest/SetPluginTest.cpp
@@ -77,7 +77,6 @@ public:
 TEST(SetPointerPluginTest, installTwoFunctionPointer)
 {
     FunctionPointerUtestShell *tst = new FunctionPointerUtestShell();
-    ;
 
     fp1 = orig_func1;
     fp2 = orig_func2;

--- a/tests/CppUTest/SimpleStringTest.cpp
+++ b/tests/CppUTest/SimpleStringTest.cpp
@@ -610,17 +610,17 @@ TEST(SimpleString, StringFromFormatpointer)
     //this is not a great test. but %p is odd on mingw and even more odd on Solaris.
     SimpleString h1 = StringFromFormat("%p", (void*) 1);
     if (h1.size() == 3)
-        STRCMP_EQUAL("0x1", h1.asCharString())
+        STRCMP_EQUAL("0x1", h1.asCharString());
     else if (h1.size() == 8)
-        STRCMP_EQUAL("00000001", h1.asCharString())
+        STRCMP_EQUAL("00000001", h1.asCharString());
     else if (h1.size() == 9)
-        STRCMP_EQUAL("0000:0001", h1.asCharString())
+        STRCMP_EQUAL("0000:0001", h1.asCharString());
     else if (h1.size() == 16)
-        STRCMP_EQUAL("0000000000000001", h1.asCharString())
+        STRCMP_EQUAL("0000000000000001", h1.asCharString());
     else if (h1.size() == 1)
-        STRCMP_EQUAL("1", h1.asCharString())
+        STRCMP_EQUAL("1", h1.asCharString());
     else
-        FAIL("Off %p behavior")
+        FAIL("Off %p behavior");
 }
 
 TEST(SimpleString, StringFromFormatLarge)

--- a/tests/CppUTest/TestHarness_cTest.cpp
+++ b/tests/CppUTest/TestHarness_cTest.cpp
@@ -98,7 +98,7 @@ TEST(TestHarness_c, checkBool)
     fixture->runAllTests();
     fixture->assertPrintContains("expected <true>\n	but was  <false>");
     fixture->assertPrintContains("arness_c");
-    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
+    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
 static void _failBoolTextMethod()
@@ -116,7 +116,7 @@ TEST(TestHarness_c, checkBoolText)
     fixture->assertPrintContains("expected <true>\n	but was  <false>");
     fixture->assertPrintContains("arness_c");
     fixture->assertPrintContains("Message: BoolTestText");
-    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
+    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
 static void _failIntMethod()
@@ -132,7 +132,7 @@ TEST(TestHarness_c, checkInt)
     fixture->runAllTests();
     fixture->assertPrintContains("expected <1 (0x1)>\n	but was  <2 (0x2)>");
     fixture->assertPrintContains("arness_c");
-    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
+    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
 static void _failIntTextMethod()
@@ -149,7 +149,7 @@ TEST(TestHarness_c, checkIntText)
     fixture->assertPrintContains("expected <1 (0x1)>\n	but was  <2 (0x2)>");
     fixture->assertPrintContains("arness_c");
     fixture->assertPrintContains("Message: IntTestText");
-    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
+    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
 static void _failUnsignedIntMethod()
@@ -165,7 +165,7 @@ TEST(TestHarness_c, checkUnsignedInt)
     fixture->runAllTests();
     fixture->assertPrintContains("expected <1 (0x1)>\n	but was  <2 (0x2)>");
     fixture->assertPrintContains("arness_c");
-    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
+    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
 static void _failUnsignedIntTextMethod()
@@ -182,7 +182,7 @@ TEST(TestHarness_c, checkUnsignedIntText)
     fixture->assertPrintContains("expected <1 (0x1)>\n	but was  <2 (0x2)>");
     fixture->assertPrintContains("arness_c");
     fixture->assertPrintContains("Message: UnsignedIntTestText");
-    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
+    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
 static void _failLongIntMethod()
@@ -198,7 +198,7 @@ TEST(TestHarness_c, checkLongInt)
     fixture->runAllTests();
     fixture->assertPrintContains("expected <1 (0x1)>\n	but was  <2 (0x2)>");
     fixture->assertPrintContains("arness_c");
-    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
+    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
 static void _failLongIntTextMethod()
@@ -215,7 +215,7 @@ TEST(TestHarness_c, checkLongIntText)
     fixture->assertPrintContains("expected <1 (0x1)>\n	but was  <2 (0x2)>");
     fixture->assertPrintContains("arness_c");
     fixture->assertPrintContains("Message: LongIntTestText");
-    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
+    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
 static void _failUnsignedLongIntMethod()
@@ -231,7 +231,7 @@ TEST(TestHarness_c, checkUnsignedLongInt)
     fixture->runAllTests();
     fixture->assertPrintContains("expected <1 (0x1)>\n	but was  <2 (0x2)>");
     fixture->assertPrintContains("arness_c");
-    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
+    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
 static void _failUnsignedLongIntTextMethod()
@@ -248,7 +248,7 @@ TEST(TestHarness_c, checkUnsignedLongIntText)
     fixture->assertPrintContains("expected <1 (0x1)>\n	but was  <2 (0x2)>");
     fixture->assertPrintContains("arness_c");
     fixture->assertPrintContains("Message: UnsignedLongIntTestText");
-    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
+    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
 #ifdef CPPUTEST_USE_LONG_LONG
@@ -266,7 +266,7 @@ TEST(TestHarness_c, checkLongLongInt)
     fixture->runAllTests();
     fixture->assertPrintContains("expected <1 (0x1)>\n	but was  <2 (0x2)>");
     fixture->assertPrintContains("arness_c");
-    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
+    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
 static void _failLongLongIntTextMethod()
@@ -283,7 +283,7 @@ TEST(TestHarness_c, checkLongLongIntText)
     fixture->assertPrintContains("expected <1 (0x1)>\n	but was  <2 (0x2)>");
     fixture->assertPrintContains("arness_c");
     fixture->assertPrintContains("Message: LongLongTestText");
-    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
+    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
 static void _failUnsignedLongLongIntMethod()
@@ -299,7 +299,7 @@ TEST(TestHarness_c, checkUnsignedLongLongInt)
     fixture->runAllTests();
     fixture->assertPrintContains("expected <1 (0x1)>\n	but was  <2 (0x2)>");
     fixture->assertPrintContains("arness_c");
-    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
+    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
 static void _failUnsignedLongLongIntTextMethod()
@@ -316,7 +316,7 @@ TEST(TestHarness_c, checkUnsignedLongLongIntText)
     fixture->assertPrintContains("expected <1 (0x1)>\n	but was  <2 (0x2)>");
     fixture->assertPrintContains("arness_c");
     fixture->assertPrintContains("Message: UnsignedLongLongTestText");
-    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
+    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
 #else
@@ -392,7 +392,7 @@ TEST(TestHarness_c, checkReal)
     fixture->runAllTests();
     fixture->assertPrintContains("expected <1>\n	but was  <2>");
     fixture->assertPrintContains("arness_c");
-    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
+    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
 static void _failRealTextMethod()
@@ -409,7 +409,7 @@ TEST(TestHarness_c, checkRealText)
     fixture->assertPrintContains("expected <1>\n	but was  <2>");
     fixture->assertPrintContains("arness_c");
     fixture->assertPrintContains("Message: RealTestText");
-    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
+    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
 static void _failCharMethod()
@@ -425,7 +425,7 @@ TEST(TestHarness_c, checkChar)
     fixture->runAllTests();
     fixture->assertPrintContains("expected <a>\n	but was  <c>");
     fixture->assertPrintContains("arness_c");
-    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
+    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
 static void _failCharTextMethod()
@@ -442,7 +442,7 @@ TEST(TestHarness_c, checkCharText)
     fixture->assertPrintContains("expected <a>\n	but was  <c>");
     fixture->assertPrintContains("arness_c");
     fixture->assertPrintContains("Message: CharTestText");
-    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
+    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
 static void _failUnsignedByteMethod()
@@ -458,7 +458,7 @@ TEST(TestHarness_c, checkUnsignedByte)
     fixture->runAllTests();
     fixture->assertPrintContains("expected <254>\n	but was  <253>");
     fixture->assertPrintContains("arness_c");
-    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
+    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
 static void _failUnsignedByteTextMethod()
@@ -475,7 +475,7 @@ TEST(TestHarness_c, checkUnsignedByteText)
     fixture->assertPrintContains("expected <254>\n	but was  <253>");
     fixture->assertPrintContains("arness_c");
     fixture->assertPrintContains("Message: UnsignedByteTestText");
-    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
+    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
 static void _failSignedByteMethod()
@@ -491,7 +491,7 @@ TEST(TestHarness_c, checkSignedByte)
     fixture->runAllTests();
     fixture->assertPrintContains("expected <-3>\n	but was  <-5>");
     fixture->assertPrintContains("arness_c");
-    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
+    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
 static void _failSignedByteTextMethod()
@@ -508,7 +508,7 @@ TEST(TestHarness_c, checkSignedByteText)
     fixture->assertPrintContains("expected <-3>\n	but was  <-5>");
     fixture->assertPrintContains("arness_c");
     fixture->assertPrintContains("Message: SignedByteTestText");
-    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
+    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
 static void _failStringMethod()
@@ -526,7 +526,7 @@ TEST(TestHarness_c, checkString)
     StringEqualFailure failure(UtestShell::getCurrent(), "file", 1, "Hello", "Hello World", "");
     fixture->assertPrintContains(failure.getMessage());
     fixture->assertPrintContains("arness_c");
-    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
+    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
 static void _failStringTextMethod()
@@ -545,7 +545,7 @@ TEST(TestHarness_c, checkStringText)
     fixture->assertPrintContains(failure.getMessage());
     fixture->assertPrintContains("arness_c");
     fixture->assertPrintContains("Message: StringTestText");
-    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
+    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
 static void _failPointerMethod()
@@ -561,7 +561,7 @@ TEST(TestHarness_c, checkPointer)
     fixture->runAllTests();
     fixture->assertPrintContains("expected <0x0>\n	but was  <0x1>");
     fixture->assertPrintContains("arness_c");
-    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
+    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
 static void _failPointerTextMethod()
@@ -578,7 +578,7 @@ TEST(TestHarness_c, checkPointerText)
     fixture->assertPrintContains("expected <0x0>\n	but was  <0x1>");
     fixture->assertPrintContains("arness_c");
     fixture->assertPrintContains("Message: PointerTestText");
-    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
+    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
 static void _failBitsMethod()
@@ -594,7 +594,7 @@ TEST(TestHarness_c, checkBits)
     fixture->runAllTests();
     fixture->assertPrintContains("expected <00000000 00000001>\n\tbut was  <00000000 00000011>");
     fixture->assertPrintContains("arness_c");
-    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
+    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
 static void _failBitsTextMethod()
@@ -611,7 +611,7 @@ TEST(TestHarness_c, checkBitsText)
     fixture->assertPrintContains("expected <00000000 00000001>\n\tbut was  <00000000 00000011>");
     fixture->assertPrintContains("arness_c");
     fixture->assertPrintContains("Message: BitsTestText");
-    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
+    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
 static void _failTextMethod()
@@ -626,7 +626,7 @@ TEST(TestHarness_c, checkFailText)
     fixture->runAllTests();
     fixture->assertPrintContains("Booo");
     fixture->assertPrintContains("arness_c");
-    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
+    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
 static void _failMethod()
@@ -641,7 +641,7 @@ TEST(TestHarness_c, checkFail)
     fixture->runAllTests();
     LONGS_EQUAL(1, fixture->getFailureCount());
     fixture->assertPrintContains("arness_c");
-    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
+    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
 static void _CheckMethod()
@@ -656,7 +656,7 @@ TEST(TestHarness_c, checkCheck)
     fixture->setTestFunction(_CheckMethod);
     fixture->runAllTests();
     LONGS_EQUAL(1, fixture->getFailureCount());
-    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
+    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
 static void _CheckTextMethod()
@@ -672,7 +672,7 @@ TEST(TestHarness_c, checkCheckText)
     fixture->runAllTests();
     LONGS_EQUAL(1, fixture->getFailureCount());
     fixture->assertPrintContains("Message: CheckTestText");
-    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled)
+    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
 #if CPPUTEST_USE_MEM_LEAK_DETECTION
@@ -728,7 +728,7 @@ TEST(TestHarness_c, cpputest_strdup)
 {
     char * mem = cpputest_strdup("0123456789");
     CHECK(NULLPTR != mem);
-    STRCMP_EQUAL("0123456789", mem)
+    STRCMP_EQUAL("0123456789", mem);
     cpputest_free(mem);
 }
 
@@ -736,7 +736,7 @@ TEST(TestHarness_c, cpputest_strndup)
 {
     char * mem = cpputest_strndup("0123456789", 3);
     CHECK(NULLPTR != mem);
-    STRCMP_EQUAL("012", mem)
+    STRCMP_EQUAL("012", mem);
     cpputest_free(mem);
 }
 

--- a/tests/CppUTest/TestUTestMacro.cpp
+++ b/tests/CppUTest/TestUTestMacro.cpp
@@ -68,11 +68,11 @@ TEST(UnitTestMacros, FAILWillPrintTheFileThatItFailed)
 
 TEST(UnitTestMacros, FAILBehavesAsAProperMacro)
 {
-    if (false) FAIL("")
-    else CHECK(true)
+    if (false) FAIL("");
+    else CHECK(true);
 
-    if (true) CHECK(true)
-    else FAIL("")
+    if (true) CHECK(true);
+    else FAIL("");
 }
 
 IGNORE_TEST(UnitTestMacros, FAILworksInAnIgnoredTest)
@@ -95,8 +95,8 @@ TEST(UnitTestMacros, TestUNSIGNED_LONGS_EQUAL)
 
 TEST(UnitTestMacros, UNSIGNED_LONGS_EQUALBehavesAsProperMacro)
 {
-    if (false) UNSIGNED_LONGS_EQUAL(1, 0)
-    else UNSIGNED_LONGS_EQUAL(1, 1)
+    if (false) UNSIGNED_LONGS_EQUAL(1, 0);
+    else UNSIGNED_LONGS_EQUAL(1, 1);
 }
 
 IGNORE_TEST(UnitTestMacros, UNSIGNED_LONGS_EQUALWorksInAnIgnoredTest)
@@ -119,8 +119,8 @@ TEST(UnitTestMacros, TestUNSIGNED_LONGS_EQUAL_TEXT)
 
 TEST(UnitTestMacros, UNSIGNED_LONGS_EQUAL_TEXTBehavesAsProperMacro)
 {
-    if (false) UNSIGNED_LONGS_EQUAL_TEXT(1, 0, "Failed because it failed")
-    else UNSIGNED_LONGS_EQUAL_TEXT(1, 1, "Failed because it failed")
+    if (false) UNSIGNED_LONGS_EQUAL_TEXT(1, 0, "Failed because it failed");
+    else UNSIGNED_LONGS_EQUAL_TEXT(1, 1, "Failed because it failed");
 }
 
 IGNORE_TEST(UnitTestMacros, UNSIGNED_LONGS_EQUAL_TEXTWorksInAnIgnoredTest)
@@ -145,8 +145,8 @@ TEST(UnitTestMacros, TestLONGLONGS_EQUAL)
 
 TEST(UnitTestMacros, LONGLONGS_EQUALBehavesAsProperMacro)
 {
-    if (false) LONGLONGS_EQUAL(1, 0)
-    else LONGLONGS_EQUAL(1, 1)
+    if (false) LONGLONGS_EQUAL(1, 0);
+    else LONGLONGS_EQUAL(1, 1);
 }
 
 IGNORE_TEST(UnitTestMacros, LONGLONGS_EQUALWorksInAnIgnoredTest)
@@ -169,8 +169,8 @@ TEST(UnitTestMacros, TestLONGLONGS_EQUAL_TEXT)
 
 TEST(UnitTestMacros, LONGLONGS_EQUAL_TEXTBehavesAsProperMacro)
 {
-    if (false) LONGLONGS_EQUAL_TEXT(1, 0, "Failed because it failed")
-    else LONGLONGS_EQUAL_TEXT(1, 1, "Failed because it failed")
+    if (false) LONGLONGS_EQUAL_TEXT(1, 0, "Failed because it failed");
+    else LONGLONGS_EQUAL_TEXT(1, 1, "Failed because it failed");
 }
 
 IGNORE_TEST(UnitTestMacros, LONGLONGS_EQUAL_TEXTWorksInAnIgnoredTest)
@@ -193,8 +193,8 @@ TEST(UnitTestMacros, TestUNSIGNED_LONGLONGS_EQUAL)
 
 TEST(UnitTestMacros, UNSIGNED_LONGLONGS_EQUALBehavesAsProperMacro)
 {
-    if (false) UNSIGNED_LONGLONGS_EQUAL(1, 0)
-    else UNSIGNED_LONGLONGS_EQUAL(1, 1)
+    if (false) UNSIGNED_LONGLONGS_EQUAL(1, 0);
+    else UNSIGNED_LONGLONGS_EQUAL(1, 1);
 }
 
 IGNORE_TEST(UnitTestMacros, UNSIGNED_LONGLONGS_EQUALWorksInAnIgnoredTest)
@@ -217,8 +217,8 @@ TEST(UnitTestMacros, TestUNSIGNED_LONGLONGS_EQUAL_TEXT)
 
 TEST(UnitTestMacros, UNSIGNED_LONGLONGS_EQUAL_TEXTBehavesAsProperMacro)
 {
-    if (false) UNSIGNED_LONGLONGS_EQUAL_TEXT(1, 0, "Failed because it failed")
-    else UNSIGNED_LONGLONGS_EQUAL_TEXT(1, 1, "Failed because it failed")
+    if (false) UNSIGNED_LONGLONGS_EQUAL_TEXT(1, 0, "Failed because it failed");
+    else UNSIGNED_LONGLONGS_EQUAL_TEXT(1, 1, "Failed because it failed");
 }
 
 IGNORE_TEST(UnitTestMacros, UNSIGNED_LONGLONGS_EQUAL_TEXTWorksInAnIgnoredTest)
@@ -266,8 +266,8 @@ TEST(UnitTestMacros, FailureWithCHECK)
 
 TEST(UnitTestMacros, CHECKBehavesAsProperMacro)
 {
-    if (false) CHECK(false)
-    else CHECK(true)
+    if (false) CHECK(false);
+    else CHECK(true);
 }
 
 IGNORE_TEST(UnitTestMacros, CHECKWorksInAnIgnoredTest)
@@ -290,8 +290,8 @@ TEST(UnitTestMacros, FailureWithCHECK_TEXT)
 
 TEST(UnitTestMacros, CHECK_TEXTBehavesAsProperMacro)
 {
-    if (false) CHECK_TEXT(false, "false")
-    else CHECK_TEXT(true, "true")
+    if (false) CHECK_TEXT(false, "false");
+    else CHECK_TEXT(true, "true");
 }
 
 IGNORE_TEST(UnitTestMacros, CHECK_TEXTWorksInAnIgnoredTest)
@@ -313,13 +313,13 @@ TEST(UnitTestMacros, FailureWithCHECK_TRUE)
 
 TEST(UnitTestMacros, CHECK_TRUEBehavesAsProperMacro)
 {
-    if (false) CHECK_TRUE(false)
-    else CHECK_TRUE(true)
+    if (false) CHECK_TRUE(false);
+    else CHECK_TRUE(true);
 }
 
 IGNORE_TEST(UnitTestMacros, CHECK_TRUEWorksInAnIgnoredTest)
 {
-    CHECK_TRUE(false) // LCOV_EXCL_LINE
+    CHECK_TRUE(false); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
 static void _failingTestMethodWithCHECK_TRUE_TEXT()
@@ -337,13 +337,13 @@ TEST(UnitTestMacros, FailureWithCHECK_TRUE_TEXT)
 
 TEST(UnitTestMacros, CHECK_TRUE_TEXTBehavesAsProperMacro)
 {
-    if (false) CHECK_TRUE_TEXT(false, "Failed because it failed")
-    else CHECK_TRUE_TEXT(true, "Failed because it failed")
+    if (false) CHECK_TRUE_TEXT(false, "Failed because it failed");
+    else CHECK_TRUE_TEXT(true, "Failed because it failed");
 }
 
 IGNORE_TEST(UnitTestMacros, CHECK_TRUE_TEXTWorksInAnIgnoredTest)
 {
-    CHECK_TRUE_TEXT(false, "Failed because it failed") // LCOV_EXCL_LINE
+    CHECK_TRUE_TEXT(false, "Failed because it failed"); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
 static void _failingTestMethodWithCHECK_FALSE()
@@ -360,13 +360,13 @@ TEST(UnitTestMacros, FailureWithCHECK_FALSE)
 
 TEST(UnitTestMacros, CHECK_FALSEBehavesAsProperMacro)
 {
-    if (false) CHECK_FALSE(true)
-    else CHECK_FALSE(false)
+    if (false) CHECK_FALSE(true);
+    else CHECK_FALSE(false);
 }
 
 IGNORE_TEST(UnitTestMacros, CHECK_FALSEWorksInAnIgnoredTest)
 {
-    CHECK_FALSE(true) // LCOV_EXCL_LINE
+    CHECK_FALSE(true); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
 static void _failingTestMethodWithCHECK_FALSE_TEXT()
@@ -384,13 +384,13 @@ TEST(UnitTestMacros, FailureWithCHECK_FALSE_TEXT)
 
 TEST(UnitTestMacros, CHECK_FALSE_TEXTBehavesAsProperMacro)
 {
-    if (false) CHECK_FALSE_TEXT(true, "Failed because it failed")
-    else CHECK_FALSE_TEXT(false, "Failed because it failed")
+    if (false) CHECK_FALSE_TEXT(true, "Failed because it failed");
+    else CHECK_FALSE_TEXT(false, "Failed because it failed");
 }
 
 IGNORE_TEST(UnitTestMacros, CHECK_FALSE_TEXTWorksInAnIgnoredTest)
 {
-    CHECK_FALSE_TEXT(true, "Failed because it failed") // LCOV_EXCL_LINE
+    CHECK_FALSE_TEXT(true, "Failed because it failed"); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
 static void _failingTestMethodWithCHECK_EQUAL()
@@ -421,13 +421,13 @@ TEST(UnitTestMacros, FailureWithCHECK_COMPARE)
 
 TEST(UnitTestMacros, CHECK_COMPAREBehavesAsProperMacro)
 {
-    if (false) CHECK_COMPARE(1, >, 2)
-    else CHECK_COMPARE(1, <, 2)
+    if (false) CHECK_COMPARE(1, >, 2);
+    else CHECK_COMPARE(1, <, 2);
 }
 
 IGNORE_TEST(UnitTestMacros, CHECK_COMPAREWorksInAnIgnoredTest)
 {
-  CHECK_COMPARE(1, >, 2) // LCOV_EXCL_LINE
+  CHECK_COMPARE(1, >, 2); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
 static void _failingTestMethodWithCHECK_COMPARE_TEXT()
@@ -446,13 +446,13 @@ TEST(UnitTestMacros, FailureWithCHECK_COMPARE_TEXT)
 
 TEST(UnitTestMacros, CHECK_COMPARE_TEXTBehavesAsProperMacro)
 {
-  if (false) CHECK_COMPARE_TEXT(1, >, 2, "1 bigger than 2")
-  else CHECK_COMPARE_TEXT(1, <, 2, "1 smaller than 2")
+  if (false) CHECK_COMPARE_TEXT(1, >, 2, "1 bigger than 2");
+  else CHECK_COMPARE_TEXT(1, <, 2, "1 smaller than 2");
 }
 
 IGNORE_TEST(UnitTestMacros, CHECK_COMPARE_TEXTWorksInAnIgnoredTest)
 {
-  CHECK_COMPARE_TEXT(1, >, 2, "1 smaller than 2") // LCOV_EXCL_LINE
+  CHECK_COMPARE_TEXT(1, >, 2, "1 smaller than 2"); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
 static int countInCountingMethod;
@@ -515,13 +515,13 @@ TEST(UnitTestMacros, failing_CHECK_EQUAL_withParamatersThatDontChangeWillNotGive
 
 TEST(UnitTestMacros, CHECK_EQUALBehavesAsProperMacro)
 {
-    if (false) CHECK_EQUAL(1, 2)
-    else CHECK_EQUAL(1, 1)
+    if (false) CHECK_EQUAL(1, 2);
+    else CHECK_EQUAL(1, 1);
 }
 
 IGNORE_TEST(UnitTestMacros, CHECK_EQUALWorksInAnIgnoredTest)
 {
-    CHECK_EQUAL(1, 2) // LCOV_EXCL_LINE
+    CHECK_EQUAL(1, 2); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
 static void _failingTestMethodWithCHECK_EQUAL_TEXT()
@@ -540,13 +540,13 @@ TEST(UnitTestMacros, FailureWithCHECK_EQUAL_TEXT)
 
 TEST(UnitTestMacros, CHECK_EQUAL_TEXTBehavesAsProperMacro)
 {
-    if (false) CHECK_EQUAL_TEXT(1, 2, "Failed because it failed")
-    else CHECK_EQUAL_TEXT(1, 1, "Failed because it failed")
+    if (false) CHECK_EQUAL_TEXT(1, 2, "Failed because it failed");
+    else CHECK_EQUAL_TEXT(1, 1, "Failed because it failed");
 }
 
 IGNORE_TEST(UnitTestMacros, CHECK_EQUAL_TEXTWorksInAnIgnoredTest)
 {
-    CHECK_EQUAL_TEXT(1, 2, "Failed because it failed") // LCOV_EXCL_LINE
+    CHECK_EQUAL_TEXT(1, 2, "Failed because it failed"); // LCOV_EXCL_LINE;
 } // LCOV_EXCL_LINE
 
 static void _failingTestMethodWithLONGS_EQUAL()
@@ -581,13 +581,13 @@ TEST(UnitTestMacros, FailureWithLONGS_EQUALShowsSymbolicParameters)
 
 TEST(UnitTestMacros, LONGS_EQUALBehavesAsProperMacro)
 {
-    if (false) LONGS_EQUAL(1, 2)
-    else LONGS_EQUAL(10, 10)
+    if (false) LONGS_EQUAL(1, 2);
+    else LONGS_EQUAL(10, 10);
 }
 
 IGNORE_TEST(UnitTestMacros, LONGS_EQUALWorksInAnIgnoredTest)
 {
-    LONGS_EQUAL(11, 22) // LCOV_EXCL_LINE
+    LONGS_EQUAL(11, 22); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
 static void _failingTestMethodWithLONGS_EQUAL_TEXT()
@@ -606,13 +606,13 @@ TEST(UnitTestMacros, FailureWithLONGS_EQUALS_TEXT)
 
 TEST(UnitTestMacros, LONGS_EQUAL_TEXTBehavesAsProperMacro)
 {
-    if (false) LONGS_EQUAL_TEXT(1, 2, "Failed because it failed")
-    else LONGS_EQUAL_TEXT(10, 10, "Failed because it failed")
+    if (false) LONGS_EQUAL_TEXT(1, 2, "Failed because it failed");
+    else LONGS_EQUAL_TEXT(10, 10, "Failed because it failed");
 }
 
 IGNORE_TEST(UnitTestMacros, LONGS_EQUAL_TEXTWorksInAnIgnoredTest)
 {
-    LONGS_EQUAL_TEXT(11, 22, "Failed because it failed") // LCOV_EXCL_LINE
+    LONGS_EQUAL_TEXT(11, 22, "Failed because it failed"); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
 static void _failingTestMethodWithBYTES_EQUAL()
@@ -630,13 +630,13 @@ TEST(UnitTestMacros, FailureWithBYTES_EQUAL)
 
 TEST(UnitTestMacros, BYTES_EQUALBehavesAsProperMacro)
 {
-    if (false) BYTES_EQUAL('a', 'b')
-    else BYTES_EQUAL('c', 'c')
+    if (false) BYTES_EQUAL('a', 'b');
+    else BYTES_EQUAL('c', 'c');
 }
 
 IGNORE_TEST(UnitTestMacros, BYTES_EQUALWorksInAnIgnoredTest)
 {
-    BYTES_EQUAL('q', 'w') // LCOV_EXCL_LINE
+    BYTES_EQUAL('q', 'w'); // LCOV_EXCL_LINE;
 } // LCOV_EXCL_LINE
 
 static void _failingTestMethodWithBYTES_EQUAL_TEXT()
@@ -655,13 +655,13 @@ TEST(UnitTestMacros, FailureWithBYTES_EQUAL_TEXT)
 
 TEST(UnitTestMacros, BYTES_EQUAL_TEXTBehavesAsProperMacro)
 {
-    if (false) BYTES_EQUAL_TEXT('a', 'b', "Failed because it failed")
-    else BYTES_EQUAL_TEXT('c', 'c', "Failed because it failed")
+    if (false) BYTES_EQUAL_TEXT('a', 'b', "Failed because it failed");
+    else BYTES_EQUAL_TEXT('c', 'c', "Failed because it failed");
 }
 
 IGNORE_TEST(UnitTestMacros, BYTES_EQUAL_TEXTWorksInAnIgnoredTest)
 {
-    BYTES_EQUAL_TEXT('q', 'w', "Failed because it failed") // LCOV_EXCL_LINE
+    BYTES_EQUAL_TEXT('q', 'w', "Failed because it failed"); // LCOV_EXCL_LINE;
 } // LCOV_EXCL_LINE
 
 static void _failingTestMethodWithSIGNED_BYTES_EQUAL()
@@ -684,13 +684,13 @@ TEST(UnitTestMacros, FailureWithSIGNED_BYTES_EQUAL)
 
 TEST(UnitTestMacros, CHARS_EQUALBehavesAsProperMacro)
 {
-    if (false) SIGNED_BYTES_EQUAL(-1, -2)
-    else SIGNED_BYTES_EQUAL(-3, -3)
+    if (false) SIGNED_BYTES_EQUAL(-1, -2);
+    else SIGNED_BYTES_EQUAL(-3, -3);
 }
 
 IGNORE_TEST(UnitTestMacros, CHARS_EQUALWorksInAnIgnoredTest)
 {
-    SIGNED_BYTES_EQUAL(-7, 19) // LCOV_EXCL_LINE
+    SIGNED_BYTES_EQUAL(-7, 19); // LCOV_EXCL_LINE;
 } // LCOV_EXCL_LINE
 
 static void _failingTestMethodWithSIGNED_BYTES_EQUAL_TEXT()
@@ -709,13 +709,13 @@ TEST(UnitTestMacros, FailureWithSIGNED_BYTES_EQUAL_TEXT)
 
 TEST(UnitTestMacros, CHARS_EQUAL_TEXTBehavesAsProperMacro)
 {
-    if (false) SIGNED_BYTES_EQUAL_TEXT(-1, -2, "Failed because it failed")
-    else SIGNED_BYTES_EQUAL_TEXT(-3, -3, "Failed because it failed")
+    if (false) SIGNED_BYTES_EQUAL_TEXT(-1, -2, "Failed because it failed");
+    else SIGNED_BYTES_EQUAL_TEXT(-3, -3, "Failed because it failed");
 }
 
 IGNORE_TEST(UnitTestMacros, SIGNED_BYTES_EQUAL_TEXTWorksInAnIgnoredTest)
 {
-    SIGNED_BYTES_EQUAL_TEXT(-7, 19, "Failed because it failed") // LCOV_EXCL_LINE
+    SIGNED_BYTES_EQUAL_TEXT(-7, 19, "Failed because it failed"); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
 static void _failingTestMethodWithPOINTERS_EQUAL()
@@ -733,13 +733,13 @@ TEST(UnitTestMacros, FailureWithPOINTERS_EQUAL)
 
 TEST(UnitTestMacros, POINTERS_EQUALBehavesAsProperMacro)
 {
-    if (false) POINTERS_EQUAL(NULLPTR, to_void_pointer(0xbeefbeef))
-    else POINTERS_EQUAL(to_void_pointer(0xdeadbeef), to_void_pointer(0xdeadbeef))
+    if (false) POINTERS_EQUAL(NULLPTR, to_void_pointer(0xbeefbeef));
+    else POINTERS_EQUAL(to_void_pointer(0xdeadbeef), to_void_pointer(0xdeadbeef));
 }
 
 IGNORE_TEST(UnitTestMacros, POINTERS_EQUALWorksInAnIgnoredTest)
 {
-    POINTERS_EQUAL((void*) 0xbeef, (void*) 0xdead) // LCOV_EXCL_LINE
+    POINTERS_EQUAL((void*) 0xbeef, (void*) 0xdead); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
 static void _failingTestMethodWithPOINTERS_EQUAL_TEXT()
@@ -758,13 +758,13 @@ TEST(UnitTestMacros, FailureWithPOINTERS_EQUAL_TEXT)
 
 TEST(UnitTestMacros, POINTERS_EQUAL_TEXTBehavesAsProperMacro)
 {
-    if (false) POINTERS_EQUAL_TEXT(NULLPTR, to_void_pointer(0xbeefbeef), "Failed because it failed")
-    else POINTERS_EQUAL_TEXT(to_void_pointer(0xdeadbeef), to_void_pointer(0xdeadbeef), "Failed because it failed")
+    if (false) POINTERS_EQUAL_TEXT(NULLPTR, to_void_pointer(0xbeefbeef), "Failed because it failed");
+    else POINTERS_EQUAL_TEXT(to_void_pointer(0xdeadbeef), to_void_pointer(0xdeadbeef), "Failed because it failed");
 }
 
 IGNORE_TEST(UnitTestMacros, POINTERS_EQUAL_TEXTWorksInAnIgnoredTest)
 {
-    POINTERS_EQUAL_TEXT((void*) 0xbeef, (void*) 0xdead, "Failed because it failed") // LCOV_EXCL_LINE
+    POINTERS_EQUAL_TEXT((void*) 0xbeef, (void*) 0xdead, "Failed because it failed"); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
 
@@ -783,13 +783,13 @@ TEST(UnitTestMacros, FailureWithFUNCTIONPOINTERS_EQUAL)
 
 TEST(UnitTestMacros, FUNCTIONPOINTERS_EQUALBehavesAsProperMacro)
 {
-    if (false) FUNCTIONPOINTERS_EQUAL(NULLPTR, to_func_pointer(0xbeefbeef))
-    else FUNCTIONPOINTERS_EQUAL(to_func_pointer(0xdeadbeef), to_func_pointer(0xdeadbeef))
+    if (false) FUNCTIONPOINTERS_EQUAL(NULLPTR, to_func_pointer(0xbeefbeef));
+    else FUNCTIONPOINTERS_EQUAL(to_func_pointer(0xdeadbeef), to_func_pointer(0xdeadbeef));
 }
 
 IGNORE_TEST(UnitTestMacros, FUNCTIONPOINTERS_EQUALWorksInAnIgnoredTest)
 {
-    FUNCTIONPOINTERS_EQUAL((void (*)())0xbeef, (void (*)())0xdead) // LCOV_EXCL_LINE
+    FUNCTIONPOINTERS_EQUAL((void (*)())0xbeef, (void (*)())0xdead); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
 static void _failingTestMethodWithFUNCTIONPOINTERS_EQUAL_TEXT()
@@ -808,13 +808,13 @@ TEST(UnitTestMacros, FailureWithFUNCTIONPOINTERS_EQUAL_TEXT)
 
 TEST(UnitTestMacros, FUNCTIONPOINTERS_EQUAL_TEXTBehavesAsProperMacro)
 {
-    if (false) FUNCTIONPOINTERS_EQUAL_TEXT(NULLPTR, to_func_pointer(0xbeefbeef), "Failed because it failed")
-    else FUNCTIONPOINTERS_EQUAL_TEXT(to_func_pointer(0xdeadbeef), to_func_pointer(0xdeadbeef), "Failed because it failed")
+    if (false) FUNCTIONPOINTERS_EQUAL_TEXT(NULLPTR, to_func_pointer(0xbeefbeef), "Failed because it failed");
+    else FUNCTIONPOINTERS_EQUAL_TEXT(to_func_pointer(0xdeadbeef), to_func_pointer(0xdeadbeef), "Failed because it failed");
 }
 
 IGNORE_TEST(UnitTestMacros, FUNCTIONPOINTERS_EQUAL_TEXTWorksInAnIgnoredTest)
 {
-    FUNCTIONPOINTERS_EQUAL_TEXT((void (*)())0xbeef, (void (*)())0xdead, "Failed because it failed") // LCOV_EXCL_LINE
+    FUNCTIONPOINTERS_EQUAL_TEXT((void (*)())0xbeef, (void (*)())0xdead, "Failed because it failed"); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
 
@@ -836,13 +836,13 @@ TEST(UnitTestMacros, FailureWithDOUBLES_EQUAL)
 
 TEST(UnitTestMacros, DOUBLES_EQUALBehavesAsProperMacro)
 {
-    if (false) DOUBLES_EQUAL(0.0, 1.1, 0.0005)
-    else DOUBLES_EQUAL(0.1, 0.2, 0.2)
+    if (false) DOUBLES_EQUAL(0.0, 1.1, 0.0005);
+    else DOUBLES_EQUAL(0.1, 0.2, 0.2);
 }
 
 IGNORE_TEST(UnitTestMacros, DOUBLES_EQUALWorksInAnIgnoredTest)
 {
-    DOUBLES_EQUAL(100.0, 0.0, 0.2) // LCOV_EXCL_LINE
+    DOUBLES_EQUAL(100.0, 0.0, 0.2); // LCOV_EXCL_LINE;
 } // LCOV_EXCL_LINE
 
 static void _failingTestMethodWithDOUBLES_EQUAL_TEXT()
@@ -862,13 +862,13 @@ TEST(UnitTestMacros, FailureWithDOUBLES_EQUAL_TEXT)
 
 TEST(UnitTestMacros, DOUBLES_EQUAL_TEXTBehavesAsProperMacro)
 {
-    if (false) DOUBLES_EQUAL_TEXT(0.0, 1.1, 0.0005, "Failed because it failed")
-    else DOUBLES_EQUAL_TEXT(0.1, 0.2, 0.2, "Failed because it failed")
+    if (false) DOUBLES_EQUAL_TEXT(0.0, 1.1, 0.0005, "Failed because it failed");
+    else DOUBLES_EQUAL_TEXT(0.1, 0.2, 0.2, "Failed because it failed");
 }
 
 IGNORE_TEST(UnitTestMacros, DOUBLES_EQUAL_TEXTWorksInAnIgnoredTest)
 {
-    DOUBLES_EQUAL_TEXT(100.0, 0.0, 0.2, "Failed because it failed") // LCOV_EXCL_LINE
+    DOUBLES_EQUAL_TEXT(100.0, 0.0, 0.2, "Failed because it failed"); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
 static bool lineOfCodeExecutedAfterCheck = false;
@@ -949,8 +949,8 @@ TEST(UnitTestMacros, allMacrosFromFunctionThatReturnsAValue)
 
 TEST(UnitTestMacros, MEMCMP_EQUALBehavesAsAProperMacro)
 {
-    if (false) MEMCMP_EQUAL("TEST", "test", 5)
-    else MEMCMP_EQUAL("TEST", "TEST", 5)
+    if (false) MEMCMP_EQUAL("TEST", "test", 5);
+    else MEMCMP_EQUAL("TEST", "TEST", 5);
 }
 
 IGNORE_TEST(UnitTestMacros, MEMCMP_EQUALWorksInAnIgnoredTest)
@@ -1031,8 +1031,8 @@ TEST(UnitTestMacros, FailureWithMEMCMP_EQUAL_TEXT)
 
 TEST(UnitTestMacros, MEMCMP_EQUAL_TEXTBehavesAsAProperMacro)
 {
-    if (false) MEMCMP_EQUAL_TEXT("TEST", "test", 5, "Failed because it failed")
-    else MEMCMP_EQUAL_TEXT("TEST", "TEST", 5, "Failed because it failed")
+    if (false) MEMCMP_EQUAL_TEXT("TEST", "test", 5, "Failed because it failed");
+    else MEMCMP_EQUAL_TEXT("TEST", "TEST", 5, "Failed because it failed");
 }
 
 IGNORE_TEST(UnitTestMacros, MEMCMP_EQUAL_TEXTWorksInAnIgnoredTest)
@@ -1042,8 +1042,8 @@ IGNORE_TEST(UnitTestMacros, MEMCMP_EQUAL_TEXTWorksInAnIgnoredTest)
 
 TEST(UnitTestMacros, BITS_EQUALBehavesAsAProperMacro)
 {
-    if (false) BITS_EQUAL(0x00, 0xFF, 0xFF)
-    else BITS_EQUAL(0x00, 0x00, 0xFF)
+    if (false) BITS_EQUAL(0x00, 0xFF, 0xFF);
+    else BITS_EQUAL(0x00, 0x00, 0xFF);
 }
 
 IGNORE_TEST(UnitTestMacros, BITS_EQUALWorksInAnIgnoredTest)
@@ -1085,8 +1085,8 @@ TEST(UnitTestMacros, FailureWithBITS_EQUAL_TEXT)
 
 TEST(UnitTestMacros, BITS_EQUAL_TEXTBehavesAsAProperMacro)
 {
-    if (false) BITS_EQUAL_TEXT(0x00, 0xFF, 0xFF, "Failed because it failed")
-    else BITS_EQUAL_TEXT(0x00, 0x00, 0xFF, "Failed because it failed")
+    if (false) BITS_EQUAL_TEXT(0x00, 0xFF, 0xFF, "Failed because it failed");
+    else BITS_EQUAL_TEXT(0x00, 0x00, 0xFF, "Failed because it failed");
 }
 
 IGNORE_TEST(UnitTestMacros, BITS_EQUAL_TEXTWorksInAnIgnoredTest)
@@ -1114,8 +1114,8 @@ TEST(UnitTestMacros, TestENUMS_EQUAL_INTWithScopedIntEnum)
 
 TEST(UnitTestMacros, ENUMS_EQUAL_INTWithScopedIntEnumBehavesAsProperMacro)
 {
-    if (false) ENUMS_EQUAL_INT(ScopedIntEnum::B, ScopedIntEnum::A)
-    else ENUMS_EQUAL_INT(ScopedIntEnum::B, ScopedIntEnum::B)
+    if (false) ENUMS_EQUAL_INT(ScopedIntEnum::B, ScopedIntEnum::A);
+    else ENUMS_EQUAL_INT(ScopedIntEnum::B, ScopedIntEnum::B);
 }
 
 IGNORE_TEST(UnitTestMacros, ENUMS_EQUAL_INTWithScopedIntEnumWorksInAnIgnoredTest)
@@ -1138,8 +1138,8 @@ TEST(UnitTestMacros, TestENUMS_EQUAL_INT_TEXTWithScopedIntEnum)
 
 TEST(UnitTestMacros, ENUMS_EQUAL_INT_TEXTWithScopedIntEnumBehavesAsProperMacro)
 {
-    if (false) ENUMS_EQUAL_INT_TEXT(ScopedIntEnum::B, ScopedIntEnum::A, "Failed because it failed")
-    else ENUMS_EQUAL_INT_TEXT(ScopedIntEnum::B, ScopedIntEnum::B, "Failed because it failed")
+    if (false) ENUMS_EQUAL_INT_TEXT(ScopedIntEnum::B, ScopedIntEnum::A, "Failed because it failed");
+    else ENUMS_EQUAL_INT_TEXT(ScopedIntEnum::B, ScopedIntEnum::B, "Failed because it failed");
 }
 
 IGNORE_TEST(UnitTestMacros, ENUMS_EQUAL_EQUAL_INT_TEXTWithScopedIntEnumWorksInAnIgnoredTest)
@@ -1166,8 +1166,8 @@ TEST(UnitTestMacros, TestENUMS_EQUAL_TYPEWithScopedLongEnum)
 
 TEST(UnitTestMacros, ENUMS_EQUAL_TYPEWithScopedLongEnumBehavesAsProperMacro)
 {
-    if (false) ENUMS_EQUAL_TYPE(long, ScopedLongEnum::B, ScopedLongEnum::A)
-    else ENUMS_EQUAL_TYPE(long, ScopedLongEnum::B, ScopedLongEnum::B)
+    if (false) ENUMS_EQUAL_TYPE(long, ScopedLongEnum::B, ScopedLongEnum::A);
+    else ENUMS_EQUAL_TYPE(long, ScopedLongEnum::B, ScopedLongEnum::B);
 }
 
 IGNORE_TEST(UnitTestMacros, ENUMS_EQUAL_TYPEWithScopedLongEnumWorksInAnIgnoredTest)
@@ -1190,8 +1190,8 @@ TEST(UnitTestMacros, TestENUMS_EQUAL_TYPE_TEXTWithScopedLongEnum)
 
 TEST(UnitTestMacros, ENUMS_EQUAL_TYPE_TEXTWithScopedLongEnumBehavesAsProperMacro)
 {
-    if (false) ENUMS_EQUAL_TYPE_TEXT(long, ScopedLongEnum::B, ScopedLongEnum::A, "Failed because it failed")
-    else ENUMS_EQUAL_TYPE_TEXT(long, ScopedLongEnum::B, ScopedLongEnum::B, "Failed because it failed")
+    if (false) ENUMS_EQUAL_TYPE_TEXT(long, ScopedLongEnum::B, ScopedLongEnum::A, "Failed because it failed");
+    else ENUMS_EQUAL_TYPE_TEXT(long, ScopedLongEnum::B, ScopedLongEnum::B, "Failed because it failed");
 }
 
 IGNORE_TEST(UnitTestMacros, ENUMS_EQUAL_EQUAL_TYPE_TEXTWithScopedLongEnumWorksInAnIgnoredTest)
@@ -1220,8 +1220,8 @@ TEST(UnitTestMacros, TestENUMS_EQUAL_INTWithUnscopedEnum)
 
 TEST(UnitTestMacros, ENUMS_EQUAL_INTWithUnscopedEnumBehavesAsProperMacro)
 {
-    if (false) ENUMS_EQUAL_INT(UNSCOPED_ENUM_B, UNSCOPED_ENUM_A)
-    else ENUMS_EQUAL_INT(UNSCOPED_ENUM_B, UNSCOPED_ENUM_B)
+    if (false) ENUMS_EQUAL_INT(UNSCOPED_ENUM_B, UNSCOPED_ENUM_A);
+    else ENUMS_EQUAL_INT(UNSCOPED_ENUM_B, UNSCOPED_ENUM_B);
 }
 
 IGNORE_TEST(UnitTestMacros, ENUMS_EQUAL_INTWithUnscopedEnumWorksInAnIgnoredTest)
@@ -1244,8 +1244,8 @@ TEST(UnitTestMacros, TestENUMS_EQUAL_INT_TEXTWithUnscopedEnum)
 
 TEST(UnitTestMacros, ENUMS_EQUAL_INT_TEXTWithUnscopedEnumBehavesAsProperMacro)
 {
-    if (false) ENUMS_EQUAL_INT_TEXT(UNSCOPED_ENUM_B, UNSCOPED_ENUM_A, "Failed because it failed")
-    else ENUMS_EQUAL_INT_TEXT(UNSCOPED_ENUM_B, UNSCOPED_ENUM_B, "Failed because it failed")
+    if (false) ENUMS_EQUAL_INT_TEXT(UNSCOPED_ENUM_B, UNSCOPED_ENUM_A, "Failed because it failed");
+    else ENUMS_EQUAL_INT_TEXT(UNSCOPED_ENUM_B, UNSCOPED_ENUM_B, "Failed because it failed");
 }
 
 IGNORE_TEST(UnitTestMacros, ENUMS_EQUAL_EQUAL_INT_TEXTWithUnscopedEnumWorksInAnIgnoredTest)

--- a/tests/CppUTest/TestUTestStringMacro.cpp
+++ b/tests/CppUTest/TestUTestStringMacro.cpp
@@ -172,13 +172,13 @@ TEST(UnitTestStringMacros, FailureWithSTRCMP_EQUAL)
 
 TEST(UnitTestStringMacros, STRCMP_EQUALBehavesAsProperMacro)
 {
-    if (false) STRCMP_EQUAL("1", "2")
-    else STRCMP_EQUAL("1", "1")
+    if (false) STRCMP_EQUAL("1", "2");
+    else STRCMP_EQUAL("1", "1");
 }
 
 IGNORE_TEST(UnitTestStringMacros, STRCMP_EQUALWorksInAnIgnoredTest)
 {
-    STRCMP_EQUAL("Hello", "World") // LCOV_EXCL_LINE
+    STRCMP_EQUAL("Hello", "World"); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
 static void _failingTestMethodWithSTRCMP_EQUAL_TEXT()
@@ -197,13 +197,13 @@ TEST(UnitTestStringMacros, FailureWithSTRCMP_EQUAL_TEXT)
 
 TEST(UnitTestStringMacros, STRCMP_EQUAL_TEXTBehavesAsProperMacro)
 {
-    if (false) STRCMP_EQUAL_TEXT("1", "2", "Failed because it failed")
-    else STRCMP_EQUAL_TEXT("1", "1", "Failed because it failed")
+    if (false) STRCMP_EQUAL_TEXT("1", "2", "Failed because it failed");
+    else STRCMP_EQUAL_TEXT("1", "1", "Failed because it failed");
 }
 
 IGNORE_TEST(UnitTestStringMacros, STRCMP_EQUAL_TEXTWorksInAnIgnoredTest)
 {
-    STRCMP_EQUAL_TEXT("Hello", "World", "Failed because it failed") // LCOV_EXCL_LINE
+    STRCMP_EQUAL_TEXT("Hello", "World", "Failed because it failed"); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
 static void _failingTestMethodWithSTRNCMP_EQUAL()
@@ -221,13 +221,13 @@ TEST(UnitTestStringMacros, FailureWithSTRNCMP_EQUAL)
 
 TEST(UnitTestStringMacros, STRNCMP_EQUALBehavesAsProperMacro)
 {
-    if (false) STRNCMP_EQUAL("1", "2", 1)
-    else STRNCMP_EQUAL("1", "1", 1)
+    if (false) STRNCMP_EQUAL("1", "2", 1);
+    else STRNCMP_EQUAL("1", "1", 1);
 }
 
 IGNORE_TEST(UnitTestStringMacros, STRNCMP_EQUALWorksInAnIgnoredTest)
 {
-    STRNCMP_EQUAL("Hello", "World", 3) // LCOV_EXCL_LINE
+    STRNCMP_EQUAL("Hello", "World", 3); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
 static void _failingTestMethodWithSTRNCMP_EQUAL_TEXT()
@@ -246,13 +246,13 @@ TEST(UnitTestStringMacros, FailureWithSTRNCMP_EQUAL_TEXT)
 
 TEST(UnitTestStringMacros, STRNCMP_EQUAL_TEXTBehavesAsProperMacro)
 {
-    if (false) STRNCMP_EQUAL_TEXT("1", "2", 1, "Failed because it failed")
-    else STRNCMP_EQUAL_TEXT("1", "1", 1, "Failed because it failed")
+    if (false) STRNCMP_EQUAL_TEXT("1", "2", 1, "Failed because it failed");
+    else STRNCMP_EQUAL_TEXT("1", "1", 1, "Failed because it failed");
 }
 
 IGNORE_TEST(UnitTestStringMacros, STRNCMP_EQUAL_TEXTWorksInAnIgnoredTest)
 {
-    STRNCMP_EQUAL_TEXT("Hello", "World", 3, "Failed because it failed") // LCOV_EXCL_LINE
+    STRNCMP_EQUAL_TEXT("Hello", "World", 3, "Failed because it failed"); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
 static void _failingTestMethodWithSTRCMP_NOCASE_EQUAL()
@@ -270,13 +270,13 @@ TEST(UnitTestStringMacros, FailureWithSTRCMP_NOCASE_EQUAL)
 
 TEST(UnitTestStringMacros, STRCMP_NOCASE_EQUALBehavesAsProperMacro)
 {
-    if (false) STRCMP_NOCASE_EQUAL("1", "2")
-    else STRCMP_NOCASE_EQUAL("1", "1")
+    if (false) STRCMP_NOCASE_EQUAL("1", "2");
+    else STRCMP_NOCASE_EQUAL("1", "1");
 }
 
 IGNORE_TEST(UnitTestStringMacros, STRCMP_NOCASE_EQUALWorksInAnIgnoredTest)
 {
-    STRCMP_NOCASE_EQUAL("Hello", "World") // LCOV_EXCL_LINE
+    STRCMP_NOCASE_EQUAL("Hello", "World"); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
 static void _failingTestMethodWithSTRCMP_NOCASE_EQUAL_TEXT()
@@ -295,13 +295,13 @@ TEST(UnitTestStringMacros, FailureWithSTRCMP_NOCASE_EQUAL_TEXT)
 
 TEST(UnitTestStringMacros, STRCMP_NOCASE_EQUAL_TEXTBehavesAsProperMacro)
 {
-    if (false) STRCMP_NOCASE_EQUAL_TEXT("1", "2", "Failed because it failed")
-    else STRCMP_NOCASE_EQUAL_TEXT("1", "1", "Failed because it failed")
+    if (false) STRCMP_NOCASE_EQUAL_TEXT("1", "2", "Failed because it failed");
+    else STRCMP_NOCASE_EQUAL_TEXT("1", "1", "Failed because it failed");
 }
 
 IGNORE_TEST(UnitTestStringMacros, STRCMP_NOCASE_EQUAL_TEXTWorksInAnIgnoredTest)
 {
-    STRCMP_NOCASE_EQUAL_TEXT("Hello", "World", "Failed because it failed") // LCOV_EXCL_LINE
+    STRCMP_NOCASE_EQUAL_TEXT("Hello", "World", "Failed because it failed"); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
 static void _failingTestMethodWithSTRCMP_CONTAINS()
@@ -319,13 +319,13 @@ TEST(UnitTestStringMacros, FailureWithSTRCMP_CONTAINS)
 
 TEST(UnitTestStringMacros, STRCMP_CONTAINSBehavesAsProperMacro)
 {
-    if (false) STRCMP_CONTAINS("1", "2")
-    else STRCMP_CONTAINS("1", "1")
+    if (false) STRCMP_CONTAINS("1", "2");
+    else STRCMP_CONTAINS("1", "1");
 }
 
 IGNORE_TEST(UnitTestStringMacros, STRCMP_CONTAINSWorksInAnIgnoredTest)
 {
-    STRCMP_CONTAINS("Hello", "World") // LCOV_EXCL_LINE
+    STRCMP_CONTAINS("Hello", "World"); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
 static void _failingTestMethodWithSTRCMP_CONTAINS_TEXT()
@@ -344,13 +344,13 @@ TEST(UnitTestStringMacros, FailureWithSTRCMP_CONTAINS_TEXT)
 
 TEST(UnitTestStringMacros, STRCMP_CONTAINS_TEXTBehavesAsProperMacro)
 {
-    if (false) STRCMP_CONTAINS_TEXT("1", "2", "Failed because it failed")
-    else STRCMP_CONTAINS_TEXT("1", "1", "Failed because it failed")
+    if (false) STRCMP_CONTAINS_TEXT("1", "2", "Failed because it failed");
+    else STRCMP_CONTAINS_TEXT("1", "1", "Failed because it failed");
 }
 
 IGNORE_TEST(UnitTestStringMacros, STRCMP_CONTAINS_TEXTWorksInAnIgnoredTest)
 {
-    STRCMP_CONTAINS_TEXT("Hello", "World", "Failed because it failed") // LCOV_EXCL_LINE
+    STRCMP_CONTAINS_TEXT("Hello", "World", "Failed because it failed"); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
 static void _failingTestMethodWithSTRCMP_NOCASE_CONTAINS()
@@ -368,13 +368,13 @@ TEST(UnitTestStringMacros, FailureWithSTRCMP_NOCASE_CONTAINS)
 
 TEST(UnitTestStringMacros, STRCMP_NOCASE_CONTAINSBehavesAsProperMacro)
 {
-    if (false) STRCMP_NOCASE_CONTAINS("never", "executed")
-    else STRCMP_NOCASE_CONTAINS("hello", "HELLO WORLD")
+    if (false) STRCMP_NOCASE_CONTAINS("never", "executed");
+    else STRCMP_NOCASE_CONTAINS("hello", "HELLO WORLD");
 }
 
 IGNORE_TEST(UnitTestStringMacros, STRCMP_NO_CASE_CONTAINSWorksInAnIgnoredTest)
 {
-    STRCMP_NOCASE_CONTAINS("Hello", "World") // LCOV_EXCL_LINE
+    STRCMP_NOCASE_CONTAINS("Hello", "World"); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
 static void _failingTestMethodWithSTRCMP_NOCASE_CONTAINS_TEXT()
@@ -393,13 +393,13 @@ TEST(UnitTestStringMacros, FailureWithSTRCMP_NOCASE_CONTAINS_TEXT)
 
 TEST(UnitTestStringMacros, STRCMP_NOCASE_CONTAINS_TEXTBehavesAsProperMacro)
 {
-    if (false) STRCMP_NOCASE_CONTAINS_TEXT("never", "executed", "Failed because it failed")
-    else STRCMP_NOCASE_CONTAINS_TEXT("hello", "HELLO WORLD", "Failed because it failed")
+    if (false) STRCMP_NOCASE_CONTAINS_TEXT("never", "executed", "Failed because it failed");
+    else STRCMP_NOCASE_CONTAINS_TEXT("hello", "HELLO WORLD", "Failed because it failed");
 }
 
 IGNORE_TEST(UnitTestStringMacros, STRCMP_NO_CASE_CONTAINS_TEXTWorksInAnIgnoredTest)
 {
-    STRCMP_NOCASE_CONTAINS_TEXT("Hello", "World", "Failed because it failed") // LCOV_EXCL_LINE
+    STRCMP_NOCASE_CONTAINS_TEXT("Hello", "World", "Failed because it failed"); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
 TEST(UnitTestStringMacros, NFirstCharsComparison)

--- a/tests/CppUTestExt/CodeMemoryReporterTest.cpp
+++ b/tests/CppUTestExt/CodeMemoryReporterTest.cpp
@@ -30,8 +30,8 @@
 #include "CppUTestExt/MemoryReportAllocator.h"
 #include "CppUTestExt/CodeMemoryReportFormatter.h"
 
-#define TESTOUTPUT_EQUAL(a) STRCMP_EQUAL_LOCATION(a, testOutput.getOutput().asCharString(), "", __FILE__, __LINE__);
-#define TESTOUTPUT_CONTAINS(a) STRCMP_CONTAINS_LOCATION(a, testOutput.getOutput().asCharString(), "", __FILE__, __LINE__);
+#define TESTOUTPUT_EQUAL(a) STRCMP_EQUAL_LOCATION(a, testOutput.getOutput().asCharString(), "", __FILE__, __LINE__)
+#define TESTOUTPUT_CONTAINS(a) STRCMP_CONTAINS_LOCATION(a, testOutput.getOutput().asCharString(), "", __FILE__, __LINE__)
 
 TEST_GROUP(CodeMemoryReportFormatter)
 {

--- a/tests/CppUTestExt/MemoryReportFormatterTest.cpp
+++ b/tests/CppUTestExt/MemoryReportFormatterTest.cpp
@@ -30,7 +30,7 @@
 #include "CppUTestExt/MemoryReportAllocator.h"
 #include "CppUTestExt/MemoryReportFormatter.h"
 
-#define TESTOUTPUT_EQUAL(a) STRCMP_EQUAL_LOCATION(a, testOutput.getOutput().asCharString(), "", __FILE__, __LINE__);
+#define TESTOUTPUT_EQUAL(a) STRCMP_EQUAL_LOCATION(a, testOutput.getOutput().asCharString(), "", __FILE__, __LINE__)
 
 TEST_GROUP(NormalMemoryReportFormatter)
 {

--- a/tests/CppUTestExt/MemoryReporterPluginTest.cpp
+++ b/tests/CppUTestExt/MemoryReporterPluginTest.cpp
@@ -178,8 +178,8 @@ TEST(MemoryReporterPlugin, preTestActionReportsTest)
 
 TEST(MemoryReporterPlugin, postTestActionReportsTest)
 {
-    mock("formatter").expectOneCall("report_test_end").withParameter("result", result).withParameter("test", test);;
-    mock("formatter").expectOneCall("report_testgroup_end").withParameter("result", result).withParameter("test", test);;
+    mock("formatter").expectOneCall("report_test_end").withParameter("result", result).withParameter("test", test);
+    mock("formatter").expectOneCall("report_testgroup_end").withParameter("result", result).withParameter("test", test);
 
     reporter->postTestAction(*test, *result);
 }

--- a/tests/CppUTestExt/MockCallTest.cpp
+++ b/tests/CppUTestExt/MockCallTest.cpp
@@ -301,7 +301,7 @@ TEST(MockCallTest, ignoreOtherCallsExceptForTheExpectedOne)
 {
     mock().expectOneCall("foo");
     mock().ignoreOtherCalls();
-    mock().actualCall("bar").withParameter("foo", 1);;
+    mock().actualCall("bar").withParameter("foo", 1);
 
     mock().clear();
 }
@@ -392,7 +392,7 @@ TEST(MockCallTest, OnObjectIgnored_InitialMatchDiscarded)
 
     mock().expectOneCall("boo");
     mock().expectOneCall("boo").withBoolParameter("p", true);
-    mock().actualCall("boo").onObject(objectPtr2).withBoolParameter("p", true);;
+    mock().actualCall("boo").onObject(objectPtr2).withBoolParameter("p", true);
     mock().actualCall("boo").onObject(objectPtr1);
 }
 

--- a/tests/CppUTestExt/MockParameterTest.cpp
+++ b/tests/CppUTestExt/MockParameterTest.cpp
@@ -616,7 +616,7 @@ TEST(MockParameterTest, newCallStartsWhileNotAllParametersWerePassed)
 
     mock().expectOneCall("foo").withParameter("p1", 1);
     mock().actualCall("foo");
-    mock().actualCall("foo").withParameter("p1", 1);;
+    mock().actualCall("foo").withParameter("p1", 1);
 
     CHECK_EXPECTED_MOCK_FAILURE(expectedFailure);
 }

--- a/tests/CppUTestExt/MockPluginTest.cpp
+++ b/tests/CppUTestExt/MockPluginTest.cpp
@@ -65,7 +65,7 @@ TEST(MockPlugin, checkExpectationsAndClearAtEnd)
 
     plugin.postTestAction(*test, *result);
 
-    STRCMP_CONTAINS(expectedFailure.getMessage().asCharString(), output.getOutput().asCharString())
+    STRCMP_CONTAINS(expectedFailure.getMessage().asCharString(), output.getOutput().asCharString());
     LONGS_EQUAL(0, mock().expectedCallsLeft());
     CHECK_NO_MOCK_FAILURE();
 }
@@ -83,7 +83,7 @@ TEST(MockPlugin, checkExpectationsWorksAlsoWithHierachicalObjects)
 
     plugin.postTestAction(*test, *result);
 
-    STRCMP_CONTAINS(expectedFailure.getMessage().asCharString(), output.getOutput().asCharString())
+    STRCMP_CONTAINS(expectedFailure.getMessage().asCharString(), output.getOutput().asCharString());
     CHECK_NO_MOCK_FAILURE();
 }
 


### PR DESCRIPTION
Empty expression warnings fixed (#1206).

Together with #1205 this concludes the Clang 8 support.