### PR TITLE
0️⃣ add suffixes to floating point literals

### DIFF
--- a/include/CppUTestExt/MockCheckedActualCall.h
+++ b/include/CppUTestExt/MockCheckedActualCall.h
@@ -274,7 +274,7 @@ public:
     virtual unsigned int returnUnsignedIntValue() _override { return 0; }
     virtual unsigned int returnUnsignedIntValueOrDefault(unsigned int value) _override { return value; }
 
-    virtual double returnDoubleValue() _override { return 0.0; }
+    virtual double returnDoubleValue() _override { return (double)0.0L; }
     virtual double returnDoubleValueOrDefault(double value) _override { return value; }
 
     virtual const char * returnStringValue() _override { return ""; }

--- a/src/CppUTestExt/MockActualCall.cpp
+++ b/src/CppUTestExt/MockActualCall.cpp
@@ -923,7 +923,7 @@ int MockActualCallTrace::returnIntValue()
 
 double MockActualCallTrace::returnDoubleValue()
 {
-    return 0.0;
+    return (double)0.0L;
 }
 
 double MockActualCallTrace::returnDoubleValueOrDefault(double)

--- a/src/CppUTestExt/MockNamedValue.cpp
+++ b/src/CppUTestExt/MockNamedValue.cpp
@@ -31,7 +31,7 @@
 
 
 MockNamedValueComparatorsAndCopiersRepository* MockNamedValue::defaultRepository_ = NULLPTR;
-const double MockNamedValue::defaultDoubleTolerance = 0.005;
+const double MockNamedValue::defaultDoubleTolerance = (double)0.005L;
 
 void MockNamedValue::setDefaultComparatorsAndCopiersRepository(MockNamedValueComparatorsAndCopiersRepository* repository)
 {

--- a/src/Platforms/Gcc/UtestPlatform.cpp
+++ b/src/Platforms/Gcc/UtestPlatform.cpp
@@ -179,7 +179,7 @@ static long TimeInMillisImplementation()
     struct timeval tv;
     struct timezone tz;
     gettimeofday(&tv, &tz);
-    return (tv.tv_sec * 1000) + (long)((double)tv.tv_usec * 0.001);
+    return (tv.tv_sec * 1000) + (long)((double)tv.tv_usec * (double)0.001L);
 }
 
 static const char* TimeStringImplementation()

--- a/src/Platforms/Symbian/UtestPlatform.cpp
+++ b/src/Platforms/Symbian/UtestPlatform.cpp
@@ -71,7 +71,7 @@ static long TimeInMillisImplementation() {
     struct timeval tv;
     struct timezone tz;
     ::gettimeofday(&tv, &tz);
-    return (tv.tv_sec * 1000) + (long)(tv.tv_usec * 0.001);
+    return (tv.tv_sec * 1000) + (long)(tv.tv_usec * (double)0.001L);
 }
 
 long (*GetPlatformSpecificTimeInMillis)() = TimeInMillisImplementation;


### PR DESCRIPTION
To enable compiling with `-Werror=unsuffixed-float-constants`, add some
suffixes to double literal constants.

Without using gnu extensions, there's no suffix available for double
literals, so instead use the suffix for `long double`, `L`, and cast to
explicit `double`. This should result in generated code equivalent to
using a double literal, even if precision loss occurs (it doesn't in
these cases though, and implicit conversion should be equivalent, but
just to be sure).