### PR TITLE
Enable cmake buildtime discover tests for CppUTest clients.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,6 +141,10 @@ if(PkgHelpers_AVAILABLE)
     DESTINATION ${LIB_INSTALL_DIR}/CppUTest/cmake )
   install(EXPORT CppUTestTargets
     DESTINATION ${LIB_INSTALL_DIR}/CppUTest/cmake)
+  install(FILES  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Scripts/CppUTestBuildTimeDiscoverTests.cmake
+    DESTINATION ${LIB_INSTALL_DIR}/CppUTest/cmake/Scripts)
+  install(FILES  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/CppUTestBuildTimeDiscoverTests.cmake
+    DESTINATION ${LIB_INSTALL_DIR}/CppUTest/cmake/Modules)
   configure_package_config_file(CppUTestConfig.cmake.build.in
     ${CMAKE_CURRENT_BINARY_DIR}/CppUTestConfig.cmake
     INSTALL_DESTINATION ${CMAKE_CURRENT_BINARY_DIR}

--- a/CppUTestConfig.cmake.install.in
+++ b/CppUTestConfig.cmake.install.in
@@ -3,5 +3,6 @@
 set_and_check(CppUTest_INCLUDE_DIRS "@PACKAGE_INCLUDE_INSTALL_DIR@")
 include("${CMAKE_CURRENT_LIST_DIR}/CppUTestTargets.cmake")
 set(CppUTest_LIBRARIES CppUTest CppUTestExt)
+include("${CMAKE_CURRENT_LIST_DIR}/Modules/CppUTestBuildTimeDiscoverTests.cmake")
 
 check_required_components(CppUTest)

--- a/cmake/Modules/CppUTestBuildTimeDiscoverTests.cmake
+++ b/cmake/Modules/CppUTestBuildTimeDiscoverTests.cmake
@@ -1,9 +1,19 @@
 # Create target to discover tests
 function (cpputest_buildtime_discover_tests EXECUTABLE)
-    add_custom_command (TARGET ${EXECUTABLE}
-			POST_BUILD
-			COMMAND ${CMAKE_COMMAND} -DTESTS_DETAILED:BOOL=${TESTS_DETAILED} -DEXECUTABLE=${EXECUTABLE} -P ${PROJECT_SOURCE_DIR}/cmake/Scripts/CppUTestBuildTimeDiscoverTests.cmake
-			WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-			COMMENT "Discovering Tests in ${EXECUTABLE}"
-			VERBATIM)
+  # The path to the discover script depends on execution mode:
+  # - internal (building CppUTest it self).
+  # - imported (installed, imported, and executed by a client of the CppUTest lib)
+  if (PROJECT_NAME STREQUAL "CppUTest") # internal - (path is relative to source dir)
+    SET(DISCOVER_SCRIPT ${PROJECT_SOURCE_DIR}/cmake/Scripts/CppUTestBuildTimeDiscoverTests.cmake)
+  else (PROJECT_NAME STREQUAL "CppUTest") # Installed (path is relative to install directory)
+    SET(DISCOVER_SCRIPT ${CppUTest_DIR}/Scripts/CppUTestBuildTimeDiscoverTests.cmake)
+  endif (PROJECT_NAME STREQUAL "CppUTest")
+
+  add_custom_command (TARGET ${EXECUTABLE}
+    POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -DTESTS_DETAILED:BOOL=${TESTS_DETAILED} -DEXECUTABLE=$<TARGET_FILE:${EXECUTABLE}> -P ${DISCOVER_SCRIPT}
+    VERBATIM
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    COMMENT "Discovering Tests in ${EXECUTABLE}"
+    VERBATIM)
 endfunction ()

--- a/src/CppUTest/CMakeLists.txt
+++ b/src/CppUTest/CMakeLists.txt
@@ -31,7 +31,7 @@ endif(CPP_PLATFORM)
 target_include_directories(CppUTest
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../include>
-        $<INSTALL_INTERFACE:include/CppUTest>
+        $<INSTALL_INTERFACE:include>
 )
 
 set(CppUTest_headers

--- a/src/CppUTestExt/CMakeLists.txt
+++ b/src/CppUTestExt/CMakeLists.txt
@@ -40,6 +40,14 @@ set(CppUTestExt_headers
 
 add_library(CppUTestExt STATIC ${CppUTestExt_src} ${CppUTestExt_headers})
 target_link_libraries(CppUTestExt ${CPPUNIT_EXTERNAL_LIBRARIES})
+
+#[[Arrange for the include directory to be added to the include paths of any CMake target depending on CppUTestExt.]]
+target_include_directories(CppUTestExt
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../include>
+        $<INSTALL_INTERFACE:include>
+)
+
 set_target_properties(CppUTestExt PROPERTIES
     PUBLIC_HEADER "${CppUTestExt_headers}")
 install(TARGETS CppUTestExt


### PR DESCRIPTION
This PR enables CppUTest lib clients to use the CMake `cpputest_buildtime_discover_tests()` function with the benefit of the CMake generated project/solution that autodiscovers tests.
 
To use buildtime discover on your tests add the following to your test project CMakeLists.txt

```cmake
cpputest_buildtime_discover_tests(<TestName>)
```

## Preconditions
1. CppUTest is configure using CMake, build and installed
2. CMake based test project

## Example
A CMake base test project with a top level `CMakeLists.txt` that includes:

```cmake
include(CTest)
enable_testing()
FIND_PACKAGE(CppUTest REQUIRED CONFIG)
```
An implementation that you want to test e.g. `src/CMakeLists.txt`:
```cmake
add_library(MyModule  MyModule.c)
``` 
And a  test e.g. `tests/CMakeLists.txt` with discovery added :
```cmake
add_executable(TestMyModule TestMyModule.cpp)
target_link_libraries(TestMyModule MyModule CppUTestExt CppUTestRunner)
cpputest_buildtime_discover_tests(TestMyModule)

```



