### PR TITLE
Fix #1219 copy on expect with output parameter returning

### DIFF
--- a/include/CppUTestExt/MockCheckedExpectedCall.h
+++ b/include/CppUTestExt/MockCheckedExpectedCall.h
@@ -79,7 +79,7 @@ public:
     virtual MockExpectedCall& onObject(void* objectPtr) _override;
 
     virtual MockNamedValue getInputParameter(const SimpleString& name);
-    virtual MockNamedValue getOutputParameter(const SimpleString& name);
+    virtual MockNamedValue* getOutputParameter(const SimpleString& name);
     virtual SimpleString getInputParameterType(const SimpleString& name);
     virtual SimpleString getInputParameterValueString(const SimpleString& name);
 

--- a/include/CppUTestExt/MockNamedValue.h
+++ b/include/CppUTestExt/MockNamedValue.h
@@ -104,6 +104,8 @@ public:
     DEFAULT_COPY_CONSTRUCTOR(MockNamedValue)
     virtual ~MockNamedValue();
 
+    virtual void copyValue(const void* value, size_t size);
+
     virtual void setValue(bool value);
     virtual void setValue(int value);
     virtual void setValue(unsigned int value);
@@ -185,6 +187,7 @@ private:
         void* objectPointerValue_;
         const void* outputPointerValue_;
     } value_;
+    uint8_t* membuf_;
     size_t size_;
     MockNamedValueComparator* comparator_;
     MockNamedValueCopier* copier_;

--- a/include/CppUTestExt/MockNamedValue.h
+++ b/include/CppUTestExt/MockNamedValue.h
@@ -187,7 +187,7 @@ private:
         void* objectPointerValue_;
         const void* outputPointerValue_;
     } value_;
-    uint8_t* membuf_;
+    char * membuf_;
     size_t size_;
     MockNamedValueComparator* comparator_;
     MockNamedValueCopier* copier_;

--- a/src/CppUTestExt/MockExpectedCall.cpp
+++ b/src/CppUTestExt/MockExpectedCall.cpp
@@ -227,8 +227,7 @@ MockExpectedCall& MockCheckedExpectedCall::withOutputParameterReturning(const Si
 {
     MockNamedValue* newParameter = new MockExpectedFunctionParameter(name);
     outputParameters_->add(newParameter);
-    newParameter->setValue(value);
-    newParameter->setSize(size);
+    newParameter->copyValue(value, size);
     return *this;
 }
 
@@ -264,10 +263,9 @@ MockNamedValue MockCheckedExpectedCall::getInputParameter(const SimpleString& na
     return (p) ? *p : MockNamedValue("");
 }
 
-MockNamedValue MockCheckedExpectedCall::getOutputParameter(const SimpleString& name)
+MockNamedValue* MockCheckedExpectedCall::getOutputParameter(const SimpleString& name)
 {
-    MockNamedValue * p = outputParameters_->getValueByName(name);
-    return (p) ? *p : MockNamedValue("");
+    return outputParameters_->getValueByName(name);
 }
 
 bool MockCheckedExpectedCall::areParametersMatchingActualCall()

--- a/src/CppUTestExt/MockNamedValue.cpp
+++ b/src/CppUTestExt/MockNamedValue.cpp
@@ -38,13 +38,17 @@ void MockNamedValue::setDefaultComparatorsAndCopiersRepository(MockNamedValueCom
     defaultRepository_ = repository;
 }
 
-MockNamedValue::MockNamedValue(const SimpleString& name) : name_(name), type_("int"), size_(0), comparator_(NULLPTR), copier_(NULLPTR)
+MockNamedValue::MockNamedValue(const SimpleString& name) : name_(name), type_("int"), membuf_(NULL), size_(0), comparator_(NULLPTR), copier_(NULLPTR)
 {
     value_.intValue_ = 0;
 }
 
 MockNamedValue::~MockNamedValue()
 {
+    if ( (membuf_ != NULL)) {
+	delete [] membuf_;
+	membuf_ = NULL;
+    }
 }
 
 void MockNamedValue::setValue(bool value)
@@ -127,6 +131,17 @@ void MockNamedValue::setValue(const void* value)
 {
     type_ = "const void*";
     value_.constPointerValue_ = value;
+}
+
+void MockNamedValue::copyValue(const void* value, size_t size)
+{
+	type_ = "const void*";
+	if (membuf_ == NULL) {
+		membuf_ = new uint8_t[size];
+	}
+	memcpy(membuf_, value, size);
+	value_.constPointerValue_ = (const void*) membuf_;
+	size_ = size;
 }
 
 void MockNamedValue::setValue(void (*value)())

--- a/src/CppUTestExt/MockNamedValue.cpp
+++ b/src/CppUTestExt/MockNamedValue.cpp
@@ -137,7 +137,7 @@ void MockNamedValue::copyValue(const void* value, size_t size)
 {
 	type_ = "const void*";
 	if (membuf_ == NULL) {
-		membuf_ = new uint8_t[size];
+		membuf_ = new char[size];
 	}
 	memcpy(membuf_, value, size);
 	value_.constPointerValue_ = (const void*) membuf_;

--- a/tests/CppUTestExt/MockParameterTest.cpp
+++ b/tests/CppUTestExt/MockParameterTest.cpp
@@ -634,6 +634,27 @@ TEST(MockParameterTest, outputParameterSucceeds)
     mock().checkExpectations();
 }
 
+TEST(MockParameterTest, outputParameterIsCopiedOnExpect)
+{
+    int param = 1;
+    int retval = 2;
+
+    /*
+       The mock method .withOutputParameterReturning() should copied
+       on .expectOneCall(), but is actually dereference on
+       .actualCall(). This will allow the memory pointed to by
+       .withOutputParameterReturning() to be changed between calls.
+    */
+
+    mock().expectOneCall("function").withOutputParameterReturning("parameterName", &retval, sizeof(retval));
+    retval = 7;
+
+    mock().actualCall("function").withOutputParameter("parameterName", &param);
+    CHECK_EQUAL(param, 2); // Check fails !!!
+
+    mock().checkExpectations();
+}
+
 TEST(MockParameterTest, noActualCallForOutputParameter)
 {
     MockFailureReporterInstaller failureReporterInstaller;
@@ -904,4 +925,3 @@ TEST(MockParameterTest, expectMultipleMultipleCallsWithParameters)
 
     mock().checkExpectations();
 }
-


### PR DESCRIPTION
This fixes #1219.
On expect .withOutputParameterReturning() store content of
output parameter.