### PR TITLE
Fix missing class member function override specifiers

### DIFF
--- a/include/CppUTest/TestOutput.h
+++ b/include/CppUTest/TestOutput.h
@@ -178,24 +178,24 @@ public:
     CompositeTestOutput();
     virtual ~CompositeTestOutput();
 
-    virtual void printTestsStarted();
-    virtual void printTestsEnded(const TestResult& result);
+    virtual void printTestsStarted() _override;
+    virtual void printTestsEnded(const TestResult& result) _override;
 
-    virtual void printCurrentTestStarted(const UtestShell& test);
-    virtual void printCurrentTestEnded(const TestResult& res);
-    virtual void printCurrentGroupStarted(const UtestShell& test);
-    virtual void printCurrentGroupEnded(const TestResult& res);
+    virtual void printCurrentTestStarted(const UtestShell& test) _override;
+    virtual void printCurrentTestEnded(const TestResult& res) _override;
+    virtual void printCurrentGroupStarted(const UtestShell& test) _override;
+    virtual void printCurrentGroupEnded(const TestResult& res) _override;
 
-    virtual void verbose();
-    virtual void color();
-    virtual void printBuffer(const char*);
-    virtual void print(const char*);
-    virtual void print(long);
-    virtual void printDouble(double);
-    virtual void printFailure(const TestFailure& failure);
-    virtual void setProgressIndicator(const char*);
+    virtual void verbose() _override;
+    virtual void color() _override;
+    virtual void printBuffer(const char*) _override;
+    virtual void print(const char*) _override;
+    virtual void print(long) _override;
+    virtual void printDouble(double) _override;
+    virtual void printFailure(const TestFailure& failure) _override;
+    virtual void setProgressIndicator(const char*) _override;
 
-    virtual void flush();
+    virtual void flush() _override;
 
 protected:
     CompositeTestOutput(const TestOutput&);

--- a/include/CppUTest/Utest.h
+++ b/include/CppUTest/Utest.h
@@ -207,7 +207,7 @@ public:
                 tear), testFunction_(NULLPTR)
     {
     }
-    Utest* createTest() { return new ExecFunctionTest(this); }
+    Utest* createTest() _override { return new ExecFunctionTest(this); }
     virtual ~ExecFunctionTestShell();
 };
 

--- a/include/CppUTest/UtestMacros.h
+++ b/include/CppUTest/UtestMacros.h
@@ -62,7 +62,7 @@
   \
   class TEST_##testGroup##_##testName##_Test : public TEST_GROUP_##CppUTestGroup##testGroup \
 { public: TEST_##testGroup##_##testName##_Test () : TEST_GROUP_##CppUTestGroup##testGroup () {} \
-       void testBody(); }; \
+       void testBody() _override; }; \
   class TEST_##testGroup##_##testName##_TestShell : public UtestShell { \
       virtual Utest* createTest() _override { return new TEST_##testGroup##_##testName##_Test; } \
   } TEST_##testGroup##_##testName##_TestShell_instance; \
@@ -76,7 +76,7 @@
   \
   class IGNORE##testGroup##_##testName##_Test : public TEST_GROUP_##CppUTestGroup##testGroup \
 { public: IGNORE##testGroup##_##testName##_Test () : TEST_GROUP_##CppUTestGroup##testGroup () {} \
-  public: void testBody (); }; \
+  public: void testBody() _override; }; \
   class IGNORE##testGroup##_##testName##_TestShell : public IgnoredUtestShell { \
       virtual Utest* createTest() _override { return new IGNORE##testGroup##_##testName##_Test; } \
   } IGNORE##testGroup##_##testName##_TestShell_instance; \


### PR DESCRIPTION
This fixes a handful of pedantic compiler and static analysis warnings.