### PR TITLE
Fix for inconsistent-missing-destructor-override warning

### DIFF
--- a/cmake/Modules/CppUTestWarningFlags.cmake
+++ b/cmake/Modules/CppUTestWarningFlags.cmake
@@ -69,6 +69,7 @@ else (MSVC)
            Wno-c++98-compat
            Wno-c++98-compat-pedantic
            Wno-c++14-compat
+           Wno-inconsistent-missing-destructor-override
            )
     endif (C++11)
 


### PR DESCRIPTION
Disables the `no-inconsistent-missing-destructor-override`, which fail the clang builds atm.

This follows the [C++ Core Guidelines (C.128)](http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rh-override) which recommend _not_ to add `override` to dtors.