### PR TITLE
Force line endings to fix libtoolize error.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,3 +13,8 @@
 *.mak text eol=crlf
 *.vcproj text eol=crlf
 *.vcxproj text eol=crlf
+
+
+*.sh -crlf
+*.ac -crlf
+*.am -crlf


### PR DESCRIPTION
Fixes : "AC_CONFIG_MACRO_DIR([m4]) conflicts with ACLOCAL_AFLAGS=-I m4" error.

This was required for `autoreconf -i` for WSL Ubuntu 18.04