### PR TITLE
Remove floating point support for GreenHills compiler on the Coldfire processor

### DIFF
--- a/include/CppUTest/CppUTestConfig.h
+++ b/include/CppUTest/CppUTestConfig.h
@@ -169,10 +169,13 @@
 
 /*
  * Handling of IEEE754 floating point exceptions via fenv.h
- * Works on non-Visual C++ compilers and Visual C++ 2008 and newer
+ * Predominantly works on non-Visual C++ compilers and Visual C++ 2008 and newer
  */
 
-#if CPPUTEST_USE_STD_C_LIB && (!defined(_MSC_VER) || (_MSC_VER >= 1800)) && (!defined(__APPLE__))
+#if CPPUTEST_USE_STD_C_LIB && \
+  (!defined(_MSC_VER) || (_MSC_VER >= 1800)) && \
+  (!defined(__APPLE__)) && \
+  (!defined(__ghs__) || !defined(__ColdFire__))
 #define CPPUTEST_HAVE_FENV
 #if defined(__WATCOMC__) || defined(__ARMEL__) || defined(__m68k__)
 #define CPPUTEST_FENV_IS_WORKING_PROPERLY 0


### PR DESCRIPTION
Here is an excerpt from "MULTI Compiler 2017.1 Release Notes for Embedded 68K/ColdFire":
Changes in fenv.h:
The fenv.h header file no longer defines the floating-point exception macros
FE_DIVBYZERO, FE_INEXACT, FE_INVALID, FE_OVERFLOW, and FE_UNDERFLOW.
In addition, the FE_ALL_EXCEPT macro is now defined as 0. This change more
clearly indicates the compiler's lack of support for floating-point exceptions.