### PR TITLE
Travis image update and C++98 compat warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: cpp
 
-dist: trusty
+dist: bionic
 
 matrix:
     include:

--- a/scripts/travis_ci_build.sh
+++ b/scripts/travis_ci_build.sh
@@ -34,8 +34,14 @@ if [ "x$BUILD" = "xautotools" ]; then
 fi
 
 if [ "x$BUILD" = "xcmake" ]; then
+    BUILD_ARGS=("-DWERROR=ON" "-DC++11=${CPP11}")
+
+    if [ "x$CPP11" = "xOFF" ]; then
+        BUILD_ARGS+=("-DCMAKE_CXX_STANDARD=98")
+    fi
+
     cmake --version
-    cmake -DWERROR=ON -DC++11=${CPP11} ..
+    cmake "${BUILD_ARGS[@]}" ..
     make
     ctest -V
 fi


### PR DESCRIPTION
Travis updated to the latest bionic image.

This caused the non-C++11 CMake clang build to fail because of  warnings:

* -Wc++98-compat
* -Wc++98-compat-pedantic
* -Winconsistent-missing-destructor-override

Since all three are only disabled with `C++11=ON` it failed to compile on clang with C++11 disabled.

While it makes sense to disable the last one somehow, I'm not that sure about the C++98 compat.

Other options:

1. Disable the C++98 warnings only for clang
1. Set C++98/03 explicitly

