### PR TITLE
Fix issue where GreenHills is not fully compatible with "override" specifier

### DIFF
--- a/include/CppUTest/CppUTestConfig.h
+++ b/include/CppUTest/CppUTestConfig.h
@@ -268,8 +268,16 @@ typedef struct cpputest_ulonglong cpputest_ulonglong;
 
 /* Visual C++ 10.0+ (2010+) supports the override keyword, but doesn't define the C++ version as C++11 */
 #if defined(__cplusplus) && ((__cplusplus >= 201103L) || (defined(_MSC_VER) && (_MSC_VER >= 1600)))
+#if !defined(__ghs__)
 #define CPPUTEST_COMPILER_FULLY_SUPPORTS_CXX11
 #define _override override
+#else
+/* GreenHills is not compatible with other compilers with regards to where
+ * it expects the override specifier to be on methods that return function
+ * pointers. Given this, it is easiest to not use the override specifier.
+ */
+#define _override
+#endif
 #define NULLPTR nullptr
 #else
 #define _override

--- a/include/CppUTestExt/MockCheckedActualCall.h
+++ b/include/CppUTestExt/MockCheckedActualCall.h
@@ -92,8 +92,8 @@ public:
     virtual void * returnPointerValue() _override;
     virtual void * returnPointerValueOrDefault(void *) _override;
 
-    virtual void (*returnFunctionPointerValue())() _override;
-    virtual void (*returnFunctionPointerValueOrDefault(void (*)()))() _override;
+    virtual void (*returnFunctionPointerValue() _override )();
+    virtual void (*returnFunctionPointerValueOrDefault(void (*)()) _override )();
 
     virtual MockActualCall& onObject(const void* objectPtr) _override;
 
@@ -213,8 +213,8 @@ public:
     virtual const void * returnConstPointerValue() _override;
     virtual const void * returnConstPointerValueOrDefault(const void * default_value) _override;
 
-    virtual void (*returnFunctionPointerValue())() _override;
-    virtual void (*returnFunctionPointerValueOrDefault(void (*)()))() _override;
+    virtual void (*returnFunctionPointerValue() _override )();
+    virtual void (*returnFunctionPointerValueOrDefault(void (*)()) _override )();
 
     virtual MockActualCall& onObject(const void* objectPtr) _override;
 
@@ -286,8 +286,8 @@ public:
     virtual const void * returnConstPointerValue() _override { return NULLPTR; }
     virtual const void * returnConstPointerValueOrDefault(const void * value) _override { return value; }
 
-    virtual void (*returnFunctionPointerValue())() _override { return NULLPTR; }
-    virtual void (*returnFunctionPointerValueOrDefault(void (*value)()))() _override { return value; }
+    virtual void (*returnFunctionPointerValue() _override )() { return NULLPTR; }
+    virtual void (*returnFunctionPointerValueOrDefault(void (*value)()) _override )() { return value; }
 
     virtual MockActualCall& onObject(const void* ) _override { return *this; }
 

--- a/include/CppUTestExt/MockCheckedActualCall.h
+++ b/include/CppUTestExt/MockCheckedActualCall.h
@@ -92,8 +92,8 @@ public:
     virtual void * returnPointerValue() _override;
     virtual void * returnPointerValueOrDefault(void *) _override;
 
-    virtual void (*returnFunctionPointerValue() _override )();
-    virtual void (*returnFunctionPointerValueOrDefault(void (*)()) _override )();
+    virtual void (*returnFunctionPointerValue())() _override;
+    virtual void (*returnFunctionPointerValueOrDefault(void (*)()))() _override;
 
     virtual MockActualCall& onObject(const void* objectPtr) _override;
 
@@ -213,8 +213,8 @@ public:
     virtual const void * returnConstPointerValue() _override;
     virtual const void * returnConstPointerValueOrDefault(const void * default_value) _override;
 
-    virtual void (*returnFunctionPointerValue() _override )();
-    virtual void (*returnFunctionPointerValueOrDefault(void (*)()) _override )();
+    virtual void (*returnFunctionPointerValue())() _override;
+    virtual void (*returnFunctionPointerValueOrDefault(void (*)()))() _override;
 
     virtual MockActualCall& onObject(const void* objectPtr) _override;
 
@@ -286,8 +286,8 @@ public:
     virtual const void * returnConstPointerValue() _override { return NULLPTR; }
     virtual const void * returnConstPointerValueOrDefault(const void * value) _override { return value; }
 
-    virtual void (*returnFunctionPointerValue() _override )() { return NULLPTR; }
-    virtual void (*returnFunctionPointerValueOrDefault(void (*value)()) _override )() { return value; }
+    virtual void (*returnFunctionPointerValue())() _override { return NULLPTR; }
+    virtual void (*returnFunctionPointerValueOrDefault(void (*value)()))() _override { return value; }
 
     virtual MockActualCall& onObject(const void* ) _override { return *this; }
 


### PR DESCRIPTION
GreenHills is sensitive to the location of the "override" specifier on methods that return function pointers. This fix was tested with Visual Studio 2017 and GreenHills 7.1.4 on ColdFire.

An example of the error previously produced follows:
```
[  6%] Building CXX object src/CppUTestExt/CMakeFiles/CppUTestExt.dir/MockSupportPlugin.cpp.o
"N:/cpputest/include/CppUTestExt/MockCheckedActualCall.h", line 216: error #65:
          expected a ";"
      virtual void (*returnFunctionPointerValue())() _override;
```
Interestingly, GreenHills did compile with the following placement of override:
```
virtual void (*returnFunctionPointerValue() _override )();
```
but that broke Visual Studio leading me to avoid use of "override" on GreenHills.
