### PR TITLE
Allow nullpointers in Memory comparer when comparison size is zero

### DIFF
--- a/src/CppUTest/Utest.cpp
+++ b/src/CppUTest/Utest.cpp
@@ -486,6 +486,7 @@ void UtestShell::assertDoublesEqual(double expected, double actual, double thres
 void UtestShell::assertBinaryEqual(const void *expected, const void *actual, size_t length, const char* text, const char *fileName, int lineNumber, const TestTerminator& testTerminator)
 {
     getTestResult()->countCheck();
+	if (length == 0) return;
     if (actual == NULLPTR && expected == NULLPTR) return;
     if (actual == NULLPTR || expected == NULLPTR)
         failWith(BinaryEqualFailure(this, fileName, lineNumber, (const unsigned char *) expected, (const unsigned char *) actual, length, text), testTerminator);

--- a/tests/CppUTest/TestUTestMacro.cpp
+++ b/tests/CppUTest/TestUTestMacro.cpp
@@ -1011,6 +1011,18 @@ TEST(UnitTestMacros, MEMCMP_EQUALNullExpectedNullActual)
     MEMCMP_EQUAL(NULLPTR, NULLPTR, 1024);
 }
 
+TEST(UnitTestMacros, MEMCMP_EQUALNullPointerIgnoredInExpectationWhenSize0)
+{
+	unsigned char actualData[] = { 0x00, 0x01, 0x03, 0x03 };
+	MEMCMP_EQUAL(NULLPTR, actualData, 0);
+}
+
+TEST(UnitTestMacros, MEMCMP_EQUALNullPointerIgnoredInActualWhenSize0)
+{
+	unsigned char expectedData[] = { 0x00, 0x01, 0x02, 0x03 };
+	MEMCMP_EQUAL(expectedData, NULLPTR, 0);
+}
+
 static void _failingTestMethodWithMEMCMP_EQUAL_TEXT()
 {
     unsigned char expectedData[] = { 0x00, 0x01, 0x02, 0x03 };


### PR DESCRIPTION
This Pull request ignores nullpointers when comparing between memory regions with size 0