### PR TITLE
Correcting Example in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ TEST_GROUP(ClassName)
   {
     delete className;
   }
-}
+};
 
 TEST(ClassName, Create)
 {


### PR DESCRIPTION
"Example Test" is missing semicolon after TEST_GROUP. Adding semicolon to example.