### PR TITLE
Return non-zero for command line errors

### DIFF
--- a/src/CppUTest/CommandLineTestRunner.cpp
+++ b/src/CppUTest/CommandLineTestRunner.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2007, Michael Feathers, James Grenning and Bas Vodde
+ * Copyright (c) 2019, Nokia
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -73,7 +74,7 @@ CommandLineTestRunner::~CommandLineTestRunner()
 
 int CommandLineTestRunner::runAllTestsMain()
 {
-    int testResult = 0;
+    int testResult = 1;
 
     SetPointerPlugin pPlugin(DEF_PLUGIN_SET_POINTER);
     registry_->installPlugin(&pPlugin);

--- a/src/CppUTest/CommandLineTestRunner.cpp
+++ b/src/CppUTest/CommandLineTestRunner.cpp
@@ -73,7 +73,7 @@ CommandLineTestRunner::~CommandLineTestRunner()
 
 int CommandLineTestRunner::runAllTestsMain()
 {
-    int testResult = -1;
+    int testResult = 1;
 
     SetPointerPlugin pPlugin(DEF_PLUGIN_SET_POINTER);
     registry_->installPlugin(&pPlugin);

--- a/src/CppUTest/CommandLineTestRunner.cpp
+++ b/src/CppUTest/CommandLineTestRunner.cpp
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2007, Michael Feathers, James Grenning and Bas Vodde
- * Copyright (c) 2019, Nokia
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -74,7 +73,7 @@ CommandLineTestRunner::~CommandLineTestRunner()
 
 int CommandLineTestRunner::runAllTestsMain()
 {
-    int testResult = 1;
+    int testResult = -1;
 
     SetPointerPlugin pPlugin(DEF_PLUGIN_SET_POINTER);
     registry_->installPlugin(&pPlugin);

--- a/tests/CppUTest/CommandLineTestRunnerTest.cpp
+++ b/tests/CppUTest/CommandLineTestRunnerTest.cpp
@@ -139,14 +139,14 @@ TEST(CommandLineTestRunner, NoPluginsAreInstalledAtTheEndOfARunWhenTheArgumentsA
 
 }
 
-TEST(CommandLineTestRunner, ReturnsNegativeWhenTheArgumentsAreInvalid)
+TEST(CommandLineTestRunner, ReturnsOneWhenTheArgumentsAreInvalid)
 {
     const char* argv[] = { "tests.exe", "-some-invalid=parameter" };
 
     CommandLineTestRunnerWithStringBufferOutput commandLineTestRunner(2, argv, &registry);
     int returned = commandLineTestRunner.runAllTestsMain();
 
-    CHECK_COMPARE(returned, <, 0);
+    LONGS_EQUAL(1, returned);
 }
 
 TEST(CommandLineTestRunner, ReturnsZeroWhenNoErrors)

--- a/tests/CppUTest/CommandLineTestRunnerTest.cpp
+++ b/tests/CppUTest/CommandLineTestRunnerTest.cpp
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2007, Michael Feathers, James Grenning and Bas Vodde
- * Copyright (c) 2019, Nokia
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -140,14 +139,14 @@ TEST(CommandLineTestRunner, NoPluginsAreInstalledAtTheEndOfARunWhenTheArgumentsA
 
 }
 
-TEST(CommandLineTestRunner, ReturnsNonZeroWhenTheArgumentsAreInvalid)
+TEST(CommandLineTestRunner, ReturnsNegativeWhenTheArgumentsAreInvalid)
 {
-    const char* argv[] = { "tests.exe", "-fdskjnfkds"};
+    const char* argv[] = { "tests.exe", "-some-invalid=parameter" };
 
     CommandLineTestRunnerWithStringBufferOutput commandLineTestRunner(2, argv, &registry);
     int returned = commandLineTestRunner.runAllTestsMain();
 
-    CHECK_TRUE(0 != returned);
+    CHECK_COMPARE(returned, <, 0);
 }
 
 TEST(CommandLineTestRunner, ReturnsZeroWhenNoErrors)
@@ -155,6 +154,16 @@ TEST(CommandLineTestRunner, ReturnsZeroWhenNoErrors)
     const char* argv[] = { "tests.exe" };
 
     CommandLineTestRunnerWithStringBufferOutput commandLineTestRunner(1, argv, &registry);
+    int returned = commandLineTestRunner.runAllTestsMain();
+
+    LONGS_EQUAL(0, returned);
+}
+
+TEST(CommandLineTestRunner, ReturnsZeroWhenNoTestsMatchProvidedFilter)
+{
+    const char* argv[] = { "tests.exe", "-g", "NoSuchGroup"};
+
+    CommandLineTestRunnerWithStringBufferOutput commandLineTestRunner(3, argv, &registry);
     int returned = commandLineTestRunner.runAllTestsMain();
 
     LONGS_EQUAL(0, returned);

--- a/tests/CppUTest/CommandLineTestRunnerTest.cpp
+++ b/tests/CppUTest/CommandLineTestRunnerTest.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2007, Michael Feathers, James Grenning and Bas Vodde
+ * Copyright (c) 2019, Nokia
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -137,6 +138,26 @@ TEST(CommandLineTestRunner, NoPluginsAreInstalledAtTheEndOfARunWhenTheArgumentsA
 
     LONGS_EQUAL(0, registry.countPlugins());
 
+}
+
+TEST(CommandLineTestRunner, ReturnsNonZeroWhenTheArgumentsAreInvalid)
+{
+    const char* argv[] = { "tests.exe", "-fdskjnfkds"};
+
+    CommandLineTestRunnerWithStringBufferOutput commandLineTestRunner(2, argv, &registry);
+    int returned = commandLineTestRunner.runAllTestsMain();
+
+    CHECK_TRUE(0 != returned);
+}
+
+TEST(CommandLineTestRunner, ReturnsZeroWhenNoErrors)
+{
+    const char* argv[] = { "tests.exe" };
+
+    CommandLineTestRunnerWithStringBufferOutput commandLineTestRunner(1, argv, &registry);
+    int returned = commandLineTestRunner.runAllTestsMain();
+
+    LONGS_EQUAL(0, returned);
 }
 
 TEST(CommandLineTestRunner, TeamcityOutputEnabled)


### PR DESCRIPTION
If command line arguments parsing fails, return non-zero from CommandLineTestRunner::RunAllTests.

Fixes #1243 