### PR TITLE
Gcc 5 c++14-compat warning  - std check

### DIFF
--- a/include/CppUTest/MemoryLeakDetectorNewMacros.h
+++ b/include/CppUTest/MemoryLeakDetectorNewMacros.h
@@ -60,8 +60,10 @@
     void operator delete[](void* mem, const char* file, int line) UT_NOTHROW;
     void operator delete(void* mem) UT_NOTHROW;
     void operator delete[](void* mem) UT_NOTHROW;
+#if __cplusplus >= 201402L
     void operator delete (void* mem, size_t size) UT_NOTHROW;
     void operator delete[] (void* mem, size_t size) UT_NOTHROW;
+#endif
 
 #endif
 

--- a/src/CppUTest/MemoryLeakWarningPlugin.cpp
+++ b/src/CppUTest/MemoryLeakWarningPlugin.cpp
@@ -319,10 +319,12 @@ void operator delete(void* mem, const char*, int) UT_NOTHROW
     operator_delete_fptr(mem);
 }
 
+#if __cplusplus >= 201402L
 void operator delete (void* mem, size_t) UT_NOTHROW
 {
     operator_delete_fptr(mem);
 }
+#endif
 
 void* operator new[](size_t size) UT_THROW(std::bad_alloc)
 {
@@ -344,10 +346,12 @@ void operator delete[](void* mem, const char*, int) UT_NOTHROW
      operator_delete_array_fptr(mem);
 }
 
+#if __cplusplus >= 201402L
 void operator delete[] (void* mem, size_t) UT_NOTHROW
 {
      operator_delete_array_fptr(mem);
 }
+#endif
 
 #if CPPUTEST_USE_STD_CPP_LIB
 

--- a/tests/CppUTest/MemoryOperatorOverloadTest.cpp
+++ b/tests/CppUTest/MemoryOperatorOverloadTest.cpp
@@ -38,6 +38,7 @@ TEST(BasicBehavior, deleteInvalidatesMemory)
     CHECK(*memory != 0xAD);
 }
 
+#if __cplusplus >= 201402L
 TEST(BasicBehavior, DeleteWithSizeParameterWorks)
 {
     char* charMemory = new char;
@@ -45,7 +46,7 @@ TEST(BasicBehavior, DeleteWithSizeParameterWorks)
     ::operator delete(charMemory, sizeof(char));
     ::operator delete[](charArrayMemory, sizeof(char)* 10);
 }
-
+#endif
 
 static void deleteUnallocatedMemory()
 {


### PR DESCRIPTION
Another approach to #991 by including these operators only when compiling C++14 or newer. This version does not depend on any build system.