### PR TITLE
Extension attribute replaced

### DIFF
--- a/src/CppUTest/SimpleString.cpp
+++ b/src/CppUTest/SimpleString.cpp
@@ -562,8 +562,9 @@ SimpleString BracketsFormattedHexString(SimpleString hexString)
  * Specifically nullptr_t is not officially supported
  */
 #if __cplusplus > 199711L && !defined __arm__
-SimpleString StringFrom(const nullptr_t __attribute__((unused)) value)
+SimpleString StringFrom(const nullptr_t value)
 {
+    (void) value;
     return "(null)";
 }
 #endif


### PR DESCRIPTION
Replaces the GNU `__attribute__((unused))` with a simple cast to void which should be portable on all systems.