### PR TITLE
nullptr is defined in Std namespace

### DIFF
--- a/include/CppUTest/SimpleString.h
+++ b/include/CppUTest/SimpleString.h
@@ -180,7 +180,7 @@ SimpleString BracketsFormattedHexString(SimpleString hexString);
  * Specifically nullptr_t is not officially supported
  */
 #if __cplusplus > 199711L && !defined __arm__
-SimpleString StringFrom(const nullptr_t value);
+SimpleString StringFrom(const std::nullptr_t value);
 #endif
 
 #if CPPUTEST_USE_STD_CPP_LIB


### PR DESCRIPTION
Not 100% sure if this is really necessary, but I had some problems compiling without the std so I thought it might do no harm