### PR TITLE
Added namespace directive to fix compilation error under MinGW-w64.

### DIFF
--- a/src/CppUTest/SimpleString.cpp
+++ b/src/CppUTest/SimpleString.cpp
@@ -562,7 +562,7 @@ SimpleString BracketsFormattedHexString(SimpleString hexString)
  * Specifically nullptr_t is not officially supported
  */
 #if __cplusplus > 199711L && !defined __arm__
-SimpleString StringFrom(const nullptr_t value)
+SimpleString StringFrom(const std::nullptr_t value)
 {
     (void) value;
     return "(null)";


### PR DESCRIPTION
This fixes compiling cpputest with CMake and MinGW-w64.

The compilation used to fail with:
```
src/CppUTest/CMakeFiles/CppUTest.dir/SimpleString.cpp.obj
C:\git\tdd\cpputest\src\CppUTest\SimpleString.cpp:565:31: error:
'nullptr_t' does not name a type
 SimpleString StringFrom(const nullptr_t value)
                               ^~~~~~~~~
C:\git\tdd\cpputest\src\CppUTest\SimpleString.cpp:565:31: note: 'nullptr_t'
is defined in header '<cstddef>'; did you forget to '#include <cstddef>'?
C:\git\tdd\cpputest\src\CppUTest\SimpleString.cpp:32:1:
+#include <cstddef>

C:\git\tdd\cpputest\src\CppUTest\SimpleString.cpp:565:31:
 SimpleString StringFrom(const nullptr_t value)
                               ^~~~~~~~~
C:\git\tdd\cpputest\src\CppUTest\SimpleString.cpp:565:14: error:
redefinition of 'SimpleString StringFrom(int)'
 SimpleString StringFrom(const nullptr_t value)
              ^~~~~~~~~~
```