### PR TITLE
Add package to JUnit report file name

### DIFF
--- a/include/CppUTest/JUnitTestOutput.h
+++ b/include/CppUTest/JUnitTestOutput.h
@@ -72,9 +72,9 @@ protected:
     virtual void writeProperties();
     virtual void writeTestCases();
     virtual SimpleString encodeXmlText(const SimpleString& textbody);
+    virtual SimpleString encodeFileName(const SimpleString& fileName);
     virtual void writeFailure(JUnitTestCaseResultNode* node);
     virtual void writeFileEnding();
-
 };
 
 #endif

--- a/src/CppUTest/JUnitTestOutput.cpp
+++ b/src/CppUTest/JUnitTestOutput.cpp
@@ -151,8 +151,24 @@ void JUnitTestOutput::printCurrentTestStarted(const UtestShell& test)
 SimpleString JUnitTestOutput::createFileName(const SimpleString& group)
 {
     SimpleString fileName = "cpputest_";
+    if (!impl_->package_.isEmpty()) {
+        fileName += impl_->package_;
+        fileName += "_";
+    }
     fileName += group;
+
+    // special character list based on: https://en.wikipedia.org/wiki/Filename
     fileName.replace('/', '_');
+    fileName.replace('\\', '_');
+    fileName.replace('?', '_');
+    fileName.replace('%', '_');
+    fileName.replace('*', '_');
+    fileName.replace(':', '_');
+    fileName.replace('|', '_');
+    fileName.replace('"', '_');
+    fileName.replace('<', '_');
+    fileName.replace('>', '_');
+
     fileName += ".xml";
     return fileName;
 }
@@ -208,7 +224,7 @@ void JUnitTestOutput::writeTestCases()
         SimpleString buf = StringFromFormat(
                 "<testcase classname=\"%s%s%s\" name=\"%s\" assertions=\"%d\" time=\"%d.%03d\" file=\"%s\" line=\"%d\">\n",
                 impl_->package_.asCharString(),
-                impl_->package_.isEmpty() == true ? "" : ".",
+                impl_->package_.isEmpty() ? "" : ".",
                 impl_->results_.group_.asCharString(),
                 cur->name_.asCharString(),
                 cur->checkCount_ - impl_->results_.totalCheckCount_,

--- a/src/CppUTest/JUnitTestOutput.cpp
+++ b/src/CppUTest/JUnitTestOutput.cpp
@@ -156,21 +156,19 @@ SimpleString JUnitTestOutput::createFileName(const SimpleString& group)
         fileName += "_";
     }
     fileName += group;
+    return encodeFileName(fileName) + ".xml";
+}
 
+SimpleString JUnitTestOutput::encodeFileName(const SimpleString& fileName)
+{
     // special character list based on: https://en.wikipedia.org/wiki/Filename
-    fileName.replace('/', '_');
-    fileName.replace('\\', '_');
-    fileName.replace('?', '_');
-    fileName.replace('%', '_');
-    fileName.replace('*', '_');
-    fileName.replace(':', '_');
-    fileName.replace('|', '_');
-    fileName.replace('"', '_');
-    fileName.replace('<', '_');
-    fileName.replace('>', '_');
+    static const char* const forbiddenCharacters = "/\\?%*:|\"<>";
 
-    fileName += ".xml";
-    return fileName;
+    SimpleString result = fileName;
+    for (const char* sym = forbiddenCharacters; *sym; ++sym) {
+        result.replace(*sym, '_');
+    }
+    return result;
 }
 
 void JUnitTestOutput::setPackageName(const SimpleString& package)

--- a/tests/CppUTest/JUnitOutputTest.cpp
+++ b/tests/CppUTest/JUnitOutputTest.cpp
@@ -42,7 +42,7 @@ class FileForJUnitOutputTests
 
 public:
 
-    FileForJUnitOutputTests(SimpleString filename, FileForJUnitOutputTests* next) :
+    FileForJUnitOutputTests(const SimpleString& filename, FileForJUnitOutputTests* next) :
         name_(filename), isOpen_(true), next_(next) {}
 
     FileForJUnitOutputTests* nextFile()
@@ -162,7 +162,7 @@ class JUnitTestOutputTestRunner
 
 public:
 
-    JUnitTestOutputTestRunner(TestResult result) :
+    explicit JUnitTestOutputTestRunner(const TestResult& result) :
         result_(result), currentGroupName_(NULLPTR), currentTest_(NULLPTR), firstTestInGroup_(true), timeTheTestTakes_(0), numberOfChecksInTest_(0), testFailure_(NULLPTR)
     {
         millisTime = 0;
@@ -363,6 +363,16 @@ TEST(JUnitOutputTest, withOneTestGroupAndOneTestOnlyWriteToOneFile)
 
     LONGS_EQUAL(1, fileSystem.amountOfFiles());
     CHECK(fileSystem.fileExists("cpputest_groupname.xml"));
+}
+
+TEST(JUnitOutputTest, withReservedCharactersInPackageOrTestGroupUsesUnderscoresForFileName)
+{
+    junitOutput->setPackageName("p/a\\c?k%a*g:e|n\"a<m>e.");
+    testCaseRunner->start()
+                  .withGroup("g/r\\o?u%p*n:a|m\"e<h>ere").withTest("testname")
+                  .end();
+
+    CHECK(fileSystem.fileExists("cpputest_p_a_c_k_a_g_e_n_a_m_e._g_r_o_u_p_n_a_m_e_h_ere.xml"));
 }
 
 TEST(JUnitOutputTest, withOneTestGroupAndOneTestOutputsValidXMLFiles)
@@ -634,7 +644,7 @@ TEST(JUnitOutputTest, TestCaseBlockWithAPackageName)
             .withGroup("groupname").withTest("testname")
             .end();
 
-    outputFile = fileSystem.file("cpputest_groupname.xml");
+    outputFile = fileSystem.file("cpputest_packagename_groupname.xml");
 
     STRCMP_EQUAL("<testcase classname=\"packagename.groupname\" name=\"testname\" assertions=\"0\" time=\"0.000\" file=\"file\" line=\"1\">\n", outputFile->line(5));
     STRCMP_EQUAL("</testcase>\n", outputFile->line(6));
@@ -647,7 +657,7 @@ TEST(JUnitOutputTest, TestCaseBlockForIgnoredTest)
       .withGroup("groupname").withIgnoredTest("testname")
       .end();
 
-   outputFile = fileSystem.file("cpputest_groupname.xml");
+   outputFile = fileSystem.file("cpputest_packagename_groupname.xml");
 
    STRCMP_EQUAL("<testcase classname=\"packagename.groupname\" name=\"testname\" assertions=\"0\" time=\"0.000\" file=\"file\" line=\"1\">\n", outputFile->line(5));
    STRCMP_EQUAL("<skipped />\n", outputFile->line(6));
@@ -662,7 +672,7 @@ TEST(JUnitOutputTest, TestCaseWithTestLocation)
             .withTest("testname").inFile("MySource.c").onLine(159)
             .end();
 
-    outputFile = fileSystem.file("cpputest_groupname.xml");
+    outputFile = fileSystem.file("cpputest_packagename_groupname.xml");
 
     STRCMP_EQUAL("<testcase classname=\"packagename.groupname\" name=\"testname\" assertions=\"0\" time=\"0.000\" file=\"MySource.c\" line=\"159\">\n", outputFile->line(5));
 }
@@ -690,7 +700,7 @@ TEST(JUnitOutputTest, TestCaseBlockWithAssertions)
             .thatHasChecks(24)
             .end();
 
-    outputFile = fileSystem.file("cpputest_groupname.xml");
+    outputFile = fileSystem.file("cpputest_packagename_groupname.xml");
 
     STRCMP_EQUAL("<testcase classname=\"packagename.groupname\" name=\"testname\" assertions=\"24\" time=\"0.000\" file=\"file\" line=\"1\">\n", outputFile->line(5));
 }


### PR DESCRIPTION
If JUnit package is set, add it to the report file name.
Slightly expand list of special characters not allowed in file names
as package is provided via command line.

Closes #1256 