### PR TITLE
Print error result and return 1 for zero run tests

### DIFF
--- a/include/CppUTest/TestResult.h
+++ b/include/CppUTest/TestResult.h
@@ -41,7 +41,7 @@ class UtestShell;
 class TestResult
 {
 public:
-    TestResult(TestOutput&);
+    explicit TestResult(TestOutput&);
     DEFAULT_COPY_CONSTRUCTOR(TestResult)
     virtual ~TestResult();
 
@@ -59,6 +59,8 @@ public:
     virtual void countIgnored();
     virtual void addFailure(const TestFailure& failure);
     virtual void print(const char* text);
+
+    virtual void clear();
 
     int getTestCount() const
     {
@@ -83,6 +85,11 @@ public:
     int getFailureCount() const
     {
         return failureCount_;
+    }
+
+    bool isSuccess() const
+    {
+        return getFailureCount() == 0 && getRunCount() > 0;
     }
 
     long getTotalExecutionTime() const;

--- a/src/CppUTest/CommandLineTestRunner.cpp
+++ b/src/CppUTest/CommandLineTestRunner.cpp
@@ -113,8 +113,9 @@ int CommandLineTestRunner::runAllTests()
 {
     initializeTestRun();
     int loopCount = 0;
-    int failureCount = 0;
-    int repeat_ = arguments_->getRepeatCount();
+    int failedTestCount = 0;
+    int successCount = 0;
+    int repeatCount = arguments_->getRepeatCount();
 
     if (arguments_->isListingTestGroupNames())
     {
@@ -139,17 +140,21 @@ int CommandLineTestRunner::runAllTests()
         output_->print("\n");
         srand(seed);
     }
-    while (loopCount++ < repeat_) {
+    while (loopCount++ < repeatCount) {
         if (shuffleEnabled)
         {
             registry_->shuffleRunOrder(rand_);
         }
-        output_->printTestRun(loopCount, repeat_);
+        output_->printTestRun(loopCount, repeatCount);
         TestResult tr(*output_);
         registry_->runAllTests(tr);
-        failureCount += tr.getFailureCount();
+        failedTestCount += tr.getFailureCount();
+        if (tr.isSuccess()) successCount++;
     }
-    return failureCount;
+    if (failedTestCount != 0)
+        return failedTestCount;
+    else
+        return successCount != repeatCount;
 }
 
 TestOutput* CommandLineTestRunner::createTeamCityOutput()

--- a/src/CppUTest/TestOutput.cpp
+++ b/src/CppUTest/TestOutput.cpp
@@ -145,14 +145,19 @@ void TestOutput::printCurrentGroupEnded(const TestResult& /*res*/)
 void TestOutput::printTestsEnded(const TestResult& result)
 {
     print("\n");
-    const bool anyTestFailed = result.getFailureCount() > 0;
-    if (anyTestFailed) {
+    const bool isFailure = !result.isSuccess();
+    if (isFailure) {
         if (color_) {
             print("\033[31;1m");
         }
         print("Errors (");
-        print(result.getFailureCount());
-        print(" failures, ");
+        const int failureCount = result.getFailureCount();
+        if (failureCount > 0) {
+            print(failureCount);
+            print(" failures, ");
+        }
+        else if (result.getRunCount() == 0)
+            print("ran nothing, ");
     }
     else {
         if (color_) {
@@ -170,7 +175,7 @@ void TestOutput::printTestsEnded(const TestResult& result)
     print(" ignored, ");
     print(result.getFilteredOutCount());
     print(" filtered out, ");
-    if (shuffleSeed_ != SHUFFLE_DISABLED && (verbose_ || anyTestFailed)) {
+    if (shuffleSeed_ != SHUFFLE_DISABLED && (verbose_ || isFailure)) {
         print("shuffle seed was: ");
         print(shuffleSeed_);
         print(", ");

--- a/src/CppUTest/TestResult.cpp
+++ b/src/CppUTest/TestResult.cpp
@@ -41,6 +41,22 @@ TestResult::~TestResult()
 {
 }
 
+void TestResult::clear()
+{
+    testCount_ = 0;
+    runCount_ = 0;
+    checkCount_ = 0;
+    failureCount_ = 0;
+    filteredOutCount_ = 0;
+    ignoredCount_ = 0;
+    totalExecutionTime_ = 0;
+    timeStarted_ = 0;
+    currentTestTimeStarted_ = 0;
+    currentTestTotalExecutionTime_ = 0;
+    currentGroupTimeStarted_ = 0;
+    currentGroupTotalExecutionTime_ = 0;
+}
+
 void TestResult::currentGroupStarted(UtestShell* test)
 {
     output_.printCurrentGroupStarted(*test);

--- a/src/Platforms/Gcc/UtestPlatform.cpp
+++ b/src/Platforms/Gcc/UtestPlatform.cpp
@@ -76,29 +76,34 @@ static int PlatformSpecificWaitPidImplementation(int, int*, int)
 
 static void GccPlatformSpecificRunTestInASeperateProcess(UtestShell* shell, TestPlugin* plugin, TestResult* result)
 {
-    pid_t cpid, w;
+    const pid_t syscallError = -1;
+    pid_t cpid;
+    pid_t w;
     int status;
 
     cpid = PlatformSpecificFork();
 
-    if (cpid == -1) {
+    if (cpid == syscallError) {
         result->addFailure(TestFailure(shell, "Call to fork() failed"));
         return;
     }
 
     if (cpid == 0) {            /* Code executed by child */
-        shell->runOneTestInCurrentProcess(plugin, *result);   // LCOV_EXCL_LINE
-        _exit(result->getFailureCount());                     // LCOV_EXCL_LINE
+        TestResult childResult(*result);                          // LCOV_EXCL_LINE
+        childResult.clear();                                      // LCOV_EXCL_LINE
+        shell->runOneTestInCurrentProcess(plugin, childResult);   // LCOV_EXCL_LINE
+        _exit(!childResult.isSuccess());                          // LCOV_EXCL_LINE
     } else {                    /* Code executed by parent */
+        result->countRun();
         do {
             w = PlatformSpecificWaitPid(cpid, &status, WUNTRACED);
-            if (w == -1) {
-                if(EINTR ==errno) continue; /* OS X debugger */
+            if (w == syscallError) {
+                if(EINTR == errno) continue; /* OS X debugger */
                 result->addFailure(TestFailure(shell, "Call to waitpid() failed"));
                 return;
             }
 
-            if (WIFEXITED(status) && WEXITSTATUS(status) > result->getFailureCount()) {
+            if (WIFEXITED(status) && WEXITSTATUS(status) != 0) {
                 result->addFailure(TestFailure(shell, "Failed in separate process"));
             } else if (WIFSIGNALED(status)) {
                 SimpleString signal(StringFrom(WTERMSIG(status)));
@@ -111,7 +116,7 @@ static void GccPlatformSpecificRunTestInASeperateProcess(UtestShell* shell, Test
                 result->addFailure(TestFailure(shell, "Stopped in separate process - continuing"));
                 kill(w, SIGCONT);
             }
-        } while (!WIFEXITED(status) && !WIFSIGNALED(status));
+        } while ((w == syscallError) || (!WIFEXITED(status) && !WIFSIGNALED(status)));
     }
 }
 

--- a/tests/CppUTest/CommandLineTestRunnerTest.cpp
+++ b/tests/CppUTest/CommandLineTestRunnerTest.cpp
@@ -159,14 +159,14 @@ TEST(CommandLineTestRunner, ReturnsZeroWhenNoErrors)
     LONGS_EQUAL(0, returned);
 }
 
-TEST(CommandLineTestRunner, ReturnsZeroWhenNoTestsMatchProvidedFilter)
+TEST(CommandLineTestRunner, ReturnsOneWhenNoTestsMatchProvidedFilter)
 {
     const char* argv[] = { "tests.exe", "-g", "NoSuchGroup"};
 
     CommandLineTestRunnerWithStringBufferOutput commandLineTestRunner(3, argv, &registry);
     int returned = commandLineTestRunner.runAllTestsMain();
 
-    LONGS_EQUAL(0, returned);
+    LONGS_EQUAL(1, returned);
 }
 
 TEST(CommandLineTestRunner, TeamcityOutputEnabled)

--- a/tests/CppUTest/TestOutputTest.cpp
+++ b/tests/CppUTest/TestOutputTest.cpp
@@ -76,6 +76,12 @@ TEST_GROUP(TestOutput)
         delete f3;
         delete result;
     }
+
+    void runOneTest()
+    {
+        result->countTest();
+        result->countRun();
+    }
 };
 
 TEST(TestOutput, PrintConstCharStar)
@@ -119,17 +125,21 @@ TEST(TestOutput, PrintTestALot)
 
 TEST(TestOutput, PrintTestALotAndSimulateRepeatRun)
 {
-    for (int i = 0; i < 60; ++i) {
+    const int repetitions = 60;
+
+    for (int i = 0; i < repetitions; ++i) {
+        runOneTest();
         printer->printCurrentTestEnded(*result);
     }
 
     printer->printTestsEnded(*result);
 
-    for (int i = 0; i < 60; ++i) {
+    for (int i = 0; i < repetitions; ++i) {
+        runOneTest();
         printer->printCurrentTestEnded(*result);
     }
     STRCMP_EQUAL("..................................................\n.........." \
-        "\nOK (0 tests, 0 ran, 0 checks, 0 ignored, 0 filtered out, 10 ms)\n\n" \
+        "\nOK (60 tests, 60 ran, 0 checks, 0 ignored, 0 filtered out, 10 ms)\n\n" \
         "..................................................\n..........", mock->getOutput().asCharString());
 }
 
@@ -164,17 +174,29 @@ TEST(TestOutput, PrintTestVerboseEnded)
 TEST(TestOutput, printColorWithSuccess)
 {
     mock->color();
+    runOneTest();
     printer->printTestsEnded(*result);
-    STRCMP_EQUAL("\n\033[32;1mOK (0 tests, 0 ran, 0 checks, 0 ignored, 0 filtered out, 10 ms)\033[m\n\n", mock->getOutput().asCharString());
+    STRCMP_EQUAL("\n\033[32;1mOK (1 tests, 1 ran, 0 checks, 0 ignored, 0 filtered out, 10 ms)\033[m\n\n", mock->getOutput().asCharString());
 }
 
 TEST(TestOutput, printColorWithFailures)
 {
     mock->color();
+    runOneTest();
     result->addFailure(*f);
     printer->flush();
     printer->printTestsEnded(*result);
-    STRCMP_EQUAL("\n\033[31;1mErrors (1 failures, 0 tests, 0 ran, 0 checks, 0 ignored, 0 filtered out, 10 ms)\033[m\n\n", mock->getOutput().asCharString());
+    STRCMP_EQUAL("\n\033[31;1mErrors (1 failures, 1 tests, 1 ran, 0 checks, 0 ignored, 0 filtered out, 10 ms)\033[m\n\n",
+        mock->getOutput().asCharString());
+}
+
+TEST(TestOutput, printColorWithNoTestsRun)
+{
+    mock->color();
+    printer->flush();
+    printer->printTestsEnded(*result);
+    STRCMP_EQUAL("\n\033[31;1mErrors (ran nothing, 0 tests, 0 ran, 0 checks, 0 ignored, 0 filtered out, 10 ms)\033[m\n\n",
+        mock->getOutput().asCharString());
 }
 
 TEST(TestOutput, PrintTestRun)
@@ -248,6 +270,15 @@ TEST(TestOutput, printTestsEndedWithFailures)
     printer->flush();
     printer->printTestsEnded(*result);
     STRCMP_EQUAL("\nErrors (1 failures, 0 tests, 0 ran, 0 checks, 0 ignored, 0 filtered out, 10 ms)\n\n", mock->getOutput().asCharString());
+}
+
+TEST(TestOutput, printTestsEndedWithNoTestsRun)
+{
+    result->countTest();
+    printer->flush();
+    printer->printTestsEnded(*result);
+    STRCMP_EQUAL("\nErrors (ran nothing, 1 tests, 0 ran, 0 checks, 0 ignored, 0 filtered out, 10 ms)\n\n",
+        mock->getOutput().asCharString());
 }
 
 class CompositeTestOutputTestStringBufferTestOutput : public StringBufferTestOutput

--- a/tests/CppUTest/TestResultTest.cpp
+++ b/tests/CppUTest/TestResultTest.cpp
@@ -57,10 +57,65 @@ TEST_GROUP(TestResult)
         delete printer;
         delete res;
     }
+
+    void addTestFailure()
+    {
+        res->addFailure(TestFailure(UtestShell::getCurrent(), StringFrom("dummy message")));
+    }
 };
 
 TEST(TestResult, TestEndedWillPrintResultsAndExecutionTime)
 {
     res->testsEnded();
     CHECK(mock->getOutput().contains("10 ms"));
+}
+
+TEST(TestResult, ResultIsOkIfNoFailures)
+{
+    res->countTest();
+    res->countRun();
+    CHECK_TRUE(res->isSuccess());
+}
+
+TEST(TestResult, ResultIsNotOkIfFailures)
+{
+    res->countTest();
+    res->countRun();
+    addTestFailure();
+    CHECK_FALSE(res->isSuccess());
+}
+
+TEST(TestResult, ResultIsNotOkIfNoTestsAtAll)
+{
+    CHECK_FALSE(res->isSuccess());
+}
+
+TEST(TestResult, ResultIsNotOkIfNoTestsRun)
+{
+    res->countTest();
+    CHECK_FALSE(res->isSuccess());
+}
+
+TEST(TestResult, CanBeCleared)
+{
+    res->countTest();
+    res->countRun();
+    res->countCheck();
+    res->countFilteredOut();
+    res->countIgnored();
+    addTestFailure();
+    res->setTotalExecutionTime(100);
+
+    res->clear();
+
+    LONGS_EQUAL(0, res->getTestCount());
+    LONGS_EQUAL(0, res->getRunCount());
+    LONGS_EQUAL(0, res->getCheckCount());
+    LONGS_EQUAL(0, res->getFilteredOutCount());
+    LONGS_EQUAL(0, res->getIgnoredCount());
+    LONGS_EQUAL(0, res->getFailureCount());
+    LONGS_EQUAL(0, res->getTotalExecutionTime());
+    // checking for consistency, but not set above:
+    LONGS_EQUAL(0, res->getCurrentTestTotalExecutionTime());
+    LONGS_EQUAL(0, res->getCurrentGroupTotalExecutionTime());
 }

--- a/tests/CppUTest/UtestPlatformTest.cpp
+++ b/tests/CppUTest/UtestPlatformTest.cpp
@@ -96,12 +96,20 @@ static void _stoppedTestFunction()
     kill(getpid(), SIGSTOP);
 }
 
+TEST(UTestPlatformsTest_PlatformSpecificRunTestInASeperateProcess, TestInSeparateProcessWorks)
+{
+    fixture.registry_->setRunTestsInSeperateProcess();
+    fixture.runAllTests();
+    fixture.assertPrintContains("OK (1 tests, 1 ran, 0 checks, 0 ignored, 0 filtered out");
+}
+
 TEST(UTestPlatformsTest_PlatformSpecificRunTestInASeperateProcess, FailureInSeparateProcessWorks)
 {
     fixture.registry_->setRunTestsInSeperateProcess();
     fixture.setTestFunction(_failFunction);
     fixture.runAllTests();
     fixture.assertPrintContains("Failed in separate process");
+    fixture.assertPrintContains("Errors (1 failures, 1 tests, 1 ran, 0 checks, 0 ignored, 0 filtered out");
 }
 
 TEST(UTestPlatformsTest_PlatformSpecificRunTestInASeperateProcess, AccessViolationInSeparateProcessWorks)
@@ -110,6 +118,7 @@ TEST(UTestPlatformsTest_PlatformSpecificRunTestInASeperateProcess, AccessViolati
     fixture.setTestFunction((void(*)())_accessViolationTestFunction);
     fixture.runAllTests();
     fixture.assertPrintContains("Failed in separate process - killed by signal 11");
+    fixture.assertPrintContains("Errors (1 failures, 1 tests, 1 ran");
 }
 
 TEST(UTestPlatformsTest_PlatformSpecificRunTestInASeperateProcess, StoppedInSeparateProcessWorks)
@@ -118,6 +127,7 @@ TEST(UTestPlatformsTest_PlatformSpecificRunTestInASeperateProcess, StoppedInSepa
     fixture.setTestFunction(_stoppedTestFunction);
     fixture.runAllTests();
     fixture.assertPrintContains("Stopped in separate process - continuing");
+    fixture.assertPrintContains("Errors (1 failures, 1 tests, 1 ran");
 }
 
 TEST(UTestPlatformsTest_PlatformSpecificRunTestInASeperateProcess, CallToForkFailedInSeparateProcessWorks)
@@ -126,6 +136,7 @@ TEST(UTestPlatformsTest_PlatformSpecificRunTestInASeperateProcess, CallToForkFai
     fixture.registry_->setRunTestsInSeperateProcess();
     fixture.runAllTests();
     fixture.assertPrintContains("Call to fork() failed");
+    fixture.assertPrintContains("Errors (1 failures, 1 tests, 0 ran");
 }
 
 TEST(UTestPlatformsTest_PlatformSpecificRunTestInASeperateProcess, CallToWaitPidWhileDebuggingInSeparateProcessWorks)
@@ -134,7 +145,7 @@ TEST(UTestPlatformsTest_PlatformSpecificRunTestInASeperateProcess, CallToWaitPid
     UT_PTR_SET(PlatformSpecificWaitPid, waitpid_while_debugging_stub);
     fixture.registry_->setRunTestsInSeperateProcess();
     fixture.runAllTests();
-    fixture.assertPrintContains("OK (1 tests, 0 ran, 0 checks, 0 ignored, 0 filtered out");
+    fixture.assertPrintContains("OK (1 tests, 1 ran, 0 checks, 0 ignored, 0 filtered out");
 }
 
 TEST(UTestPlatformsTest_PlatformSpecificRunTestInASeperateProcess, CallToWaitPidFailedInSeparateProcessWorks)
@@ -143,6 +154,20 @@ TEST(UTestPlatformsTest_PlatformSpecificRunTestInASeperateProcess, CallToWaitPid
     fixture.registry_->setRunTestsInSeperateProcess();
     fixture.runAllTests();
     fixture.assertPrintContains("Call to waitpid() failed");
+    fixture.assertPrintContains("Errors (1 failures, 1 tests, 1 ran");
+}
+
+TEST(UTestPlatformsTest_PlatformSpecificRunTestInASeperateProcess, MultipleTestsInSeparateProcessAreCountedProperly)
+{
+    fixture.registry_->setRunTestsInSeperateProcess();
+    fixture.runTestWithMethod(NULLPTR);
+    fixture.runTestWithMethod(_failFunction);
+    fixture.runTestWithMethod(NULLPTR);
+    fixture.runTestWithMethod(_stoppedTestFunction);
+    fixture.runTestWithMethod(NULLPTR);
+    fixture.assertPrintContains("Failed in separate process");
+    fixture.assertPrintContains("Stopped in separate process");
+    fixture.assertPrintContains("Errors (2 failures, 5 tests, 5 ran, 0 checks, 0 ignored, 0 filtered out");
 }
 
 #endif


### PR DESCRIPTION
- Print error result and return 1 for zero run tests (fixes #1262).
- Count tests run in separate process as 'run' (fixes #1210).
- Treat any non-zero return from child process as failure (fixes #1211).
- Fix waiting for test in separate process under debugger in GCC platform by avoiding checking uninitialized `status` variable (happens when `continue` checks loop condition)