### PR TITLE
Fix GCC platform-specific error cases for -p flag

### DIFF
--- a/src/CppUTest/Utest.cpp
+++ b/src/CppUTest/Utest.cpp
@@ -177,6 +177,7 @@ void UtestShell::crash()
 void UtestShell::runOneTest(TestPlugin* plugin, TestResult& result)
 {
     hasFailed_ = false;
+    result.countRun();
     HelperTestRunInfo runInfo(this, plugin, &result);
     if (isRunInSeperateProcess())
         PlatformSpecificSetJmp(helperDoRunOneTestSeperateProcess, &runInfo);
@@ -202,7 +203,6 @@ void UtestShell::runOneTestInCurrentProcess(TestPlugin* plugin, TestResult& resu
     UtestShell* savedTest = UtestShell::getCurrent();
     TestResult* savedResult = UtestShell::getTestResult();
 
-    result.countRun();
     UtestShell::setTestResult(&result);
     UtestShell::setCurrentTest(this);
 

--- a/src/Platforms/Gcc/UtestPlatform.cpp
+++ b/src/Platforms/Gcc/UtestPlatform.cpp
@@ -115,8 +115,8 @@ static void GccPlatformSpecificRunTestInASeperateProcess(UtestShell* shell, Test
                     return;
                 }
             } else {
-                if (WIFSTOPPED(status)) kill(w, SIGCONT);
                 SetTestFailureByStatusCode(shell, result, status);
+                if (WIFSTOPPED(status)) kill(w, SIGCONT);
             }
         } while ((w == syscallError) || (!WIFEXITED(status) && !WIFSIGNALED(status)));
     }

--- a/src/Platforms/Gcc/UtestPlatform.cpp
+++ b/src/Platforms/Gcc/UtestPlatform.cpp
@@ -74,6 +74,19 @@ static int PlatformSpecificWaitPidImplementation(int, int*, int)
 
 #else
 
+static void SetTestFailureByStatusCode(UtestShell* shell, TestResult* result, int status)
+{
+    if (WIFEXITED(status) && WEXITSTATUS(status) != 0) {
+        result->addFailure(TestFailure(shell, "Failed in separate process"));
+    } else if (WIFSIGNALED(status)) {
+        SimpleString message("Failed in separate process - killed by signal ");
+        message += StringFrom(WTERMSIG(status));
+        result->addFailure(TestFailure(shell, message));
+    } else if (WIFSTOPPED(status)) {
+        result->addFailure(TestFailure(shell, "Stopped in separate process - continuing"));
+    }
+}
+
 static void GccPlatformSpecificRunTestInASeperateProcess(UtestShell* shell, TestPlugin* plugin, TestResult* result)
 {
     const pid_t syscallError = -1;
@@ -93,27 +106,17 @@ static void GccPlatformSpecificRunTestInASeperateProcess(UtestShell* shell, Test
         shell->runOneTestInCurrentProcess(plugin, *result);        // LCOV_EXCL_LINE
         _exit(initialFailureCount < result->getFailureCount());    // LCOV_EXCL_LINE
     } else {                    /* Code executed by parent */
-        result->countRun();
         do {
             w = PlatformSpecificWaitPid(cpid, &status, WUNTRACED);
             if (w == syscallError) {
-                if(EINTR == errno) continue; /* OS X debugger */
-                result->addFailure(TestFailure(shell, "Call to waitpid() failed"));
-                return;
-            }
-
-            if (WIFEXITED(status) && WEXITSTATUS(status) != 0) {
-                result->addFailure(TestFailure(shell, "Failed in separate process"));
-            } else if (WIFSIGNALED(status)) {
-                SimpleString signal(StringFrom(WTERMSIG(status)));
-                {
-                    SimpleString message("Failed in separate process - killed by signal ");
-                    message += signal;
-                    result->addFailure(TestFailure(shell, message));
+                // OS X debugger causes EINTR
+                if (EINTR != errno) {
+                    result->addFailure(TestFailure(shell, "Call to waitpid() failed"));
+                    return;
                 }
-            } else if (WIFSTOPPED(status)) {
-                result->addFailure(TestFailure(shell, "Stopped in separate process - continuing"));
-                kill(w, SIGCONT);
+            } else {
+                if (WIFSTOPPED(status)) kill(w, SIGCONT);
+                SetTestFailureByStatusCode(shell, result, status);
             }
         } while ((w == syscallError) || (!WIFEXITED(status) && !WIFSIGNALED(status)));
     }

--- a/tests/CppUTest/UtestPlatformTest.cpp
+++ b/tests/CppUTest/UtestPlatformTest.cpp
@@ -146,7 +146,7 @@ TEST(UTestPlatformsTest_PlatformSpecificRunTestInASeperateProcess, CallToForkFai
     fixture.registry_->setRunTestsInSeperateProcess();
     fixture.runAllTests();
     fixture.assertPrintContains("Call to fork() failed");
-    fixture.assertPrintContains("Errors (1 failures, 1 tests, 0 ran");
+    fixture.assertPrintContains("Errors (1 failures, 1 tests, 1 ran");
 }
 
 TEST(UTestPlatformsTest_PlatformSpecificRunTestInASeperateProcess, CallToWaitPidWhileDebuggingInSeparateProcessWorks)

--- a/tests/CppUTest/UtestPlatformTest.cpp
+++ b/tests/CppUTest/UtestPlatformTest.cpp
@@ -58,6 +58,7 @@ static void _failFunction()
     FAIL("This test fails");
 }
 
+static void _exitNonZeroFunction() __no_return__;
 static void _exitNonZeroFunction()
 {
     exit(1);

--- a/tests/CppUTest/UtestPlatformTest.cpp
+++ b/tests/CppUTest/UtestPlatformTest.cpp
@@ -25,6 +25,8 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <stdlib.h>
+
 #include "CppUTest/CommandLineTestRunner.h"
 #include "CppUTest/TestHarness.h"
 #include "CppUTest/TestTestingFixture.h"
@@ -56,7 +58,15 @@ static void _failFunction()
     FAIL("This test fails");
 }
 
+static void _exitNonZeroFunction()
+{
+    exit(1);
+}
+
 #include <errno.h>
+
+static int waitpid_while_debugging_stub_number_called = 0;
+const int waitpid_while_debugging_stub_forced_failures = 10;
 
 extern "C" {
 
@@ -66,10 +76,9 @@ extern "C" {
 
     static int waitpid_while_debugging_stub(int pid, int* status, int options)
     {
-        static int number_called = 0;
         static int saved_status;
 
-        if (number_called++ < 10) {
+        if (waitpid_while_debugging_stub_number_called++ < waitpid_while_debugging_stub_forced_failures) {
             saved_status = *status;
             errno=EINTR;
             return -1;
@@ -96,12 +105,20 @@ static void _stoppedTestFunction()
     kill(getpid(), SIGSTOP);
 }
 
+TEST(UTestPlatformsTest_PlatformSpecificRunTestInASeperateProcess, TestInSeparateProcessWorks)
+{
+    fixture.registry_->setRunTestsInSeperateProcess();
+    fixture.runAllTests();
+    fixture.assertPrintContains("OK (1 tests, 1 ran, 0 checks, 0 ignored, 0 filtered out");
+}
+
 TEST(UTestPlatformsTest_PlatformSpecificRunTestInASeperateProcess, FailureInSeparateProcessWorks)
 {
     fixture.registry_->setRunTestsInSeperateProcess();
     fixture.setTestFunction(_failFunction);
     fixture.runAllTests();
     fixture.assertPrintContains("Failed in separate process");
+    fixture.assertPrintContains("Errors (1 failures, 1 tests, 1 ran, 0 checks, 0 ignored, 0 filtered out");
 }
 
 TEST(UTestPlatformsTest_PlatformSpecificRunTestInASeperateProcess, AccessViolationInSeparateProcessWorks)
@@ -110,6 +127,7 @@ TEST(UTestPlatformsTest_PlatformSpecificRunTestInASeperateProcess, AccessViolati
     fixture.setTestFunction((void(*)())_accessViolationTestFunction);
     fixture.runAllTests();
     fixture.assertPrintContains("Failed in separate process - killed by signal 11");
+    fixture.assertPrintContains("Errors (1 failures, 1 tests, 1 ran");
 }
 
 TEST(UTestPlatformsTest_PlatformSpecificRunTestInASeperateProcess, StoppedInSeparateProcessWorks)
@@ -118,6 +136,7 @@ TEST(UTestPlatformsTest_PlatformSpecificRunTestInASeperateProcess, StoppedInSepa
     fixture.setTestFunction(_stoppedTestFunction);
     fixture.runAllTests();
     fixture.assertPrintContains("Stopped in separate process - continuing");
+    fixture.assertPrintContains("Errors (1 failures, 1 tests, 1 ran");
 }
 
 TEST(UTestPlatformsTest_PlatformSpecificRunTestInASeperateProcess, CallToForkFailedInSeparateProcessWorks)
@@ -126,15 +145,19 @@ TEST(UTestPlatformsTest_PlatformSpecificRunTestInASeperateProcess, CallToForkFai
     fixture.registry_->setRunTestsInSeperateProcess();
     fixture.runAllTests();
     fixture.assertPrintContains("Call to fork() failed");
+    fixture.assertPrintContains("Errors (1 failures, 1 tests, 0 ran");
 }
 
 TEST(UTestPlatformsTest_PlatformSpecificRunTestInASeperateProcess, CallToWaitPidWhileDebuggingInSeparateProcessWorks)
 {
     UT_PTR_SET(original_waitpid, PlatformSpecificWaitPid);
     UT_PTR_SET(PlatformSpecificWaitPid, waitpid_while_debugging_stub);
+    waitpid_while_debugging_stub_number_called = 0;
     fixture.registry_->setRunTestsInSeperateProcess();
     fixture.runAllTests();
-    fixture.assertPrintContains("OK (1 tests, 0 ran, 0 checks, 0 ignored, 0 filtered out");
+    fixture.assertPrintContains("OK (1 tests, 1 ran, 0 checks, 0 ignored, 0 filtered out");
+    // extra check to confirm that waitpid() was polled until it passed (and passed call adds one)
+    LONGS_EQUAL(waitpid_while_debugging_stub_forced_failures + 1, waitpid_while_debugging_stub_number_called);
 }
 
 TEST(UTestPlatformsTest_PlatformSpecificRunTestInASeperateProcess, CallToWaitPidFailedInSeparateProcessWorks)
@@ -143,6 +166,20 @@ TEST(UTestPlatformsTest_PlatformSpecificRunTestInASeperateProcess, CallToWaitPid
     fixture.registry_->setRunTestsInSeperateProcess();
     fixture.runAllTests();
     fixture.assertPrintContains("Call to waitpid() failed");
+    fixture.assertPrintContains("Errors (1 failures, 1 tests, 1 ran");
+}
+
+TEST(UTestPlatformsTest_PlatformSpecificRunTestInASeperateProcess, MultipleTestsInSeparateProcessAreCountedProperly)
+{
+    fixture.registry_->setRunTestsInSeperateProcess();
+    fixture.runTestWithMethod(NULLPTR);
+    fixture.runTestWithMethod(_stoppedTestFunction);
+    fixture.runTestWithMethod(NULLPTR);
+    fixture.runTestWithMethod(_exitNonZeroFunction);
+    fixture.runTestWithMethod(NULLPTR);
+    fixture.assertPrintContains("Failed in separate process");
+    fixture.assertPrintContains("Stopped in separate process");
+    fixture.assertPrintContains("Errors (2 failures, 5 tests, 5 ran, 0 checks, 0 ignored, 0 filtered out");
 }
 
 #endif

--- a/tests/CppUTest/UtestPlatformTest.cpp
+++ b/tests/CppUTest/UtestPlatformTest.cpp
@@ -25,12 +25,11 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <stdlib.h>
-
 #include "CppUTest/CommandLineTestRunner.h"
 #include "CppUTest/TestHarness.h"
 #include "CppUTest/TestTestingFixture.h"
 #include "CppUTest/PlatformSpecificFunctions.h"
+#include "CppUTest/StandardCLibrary.h"
 
 // This will cause a crash in VS2010 due to PlatformSpecificFree being uninitialized
 static const SimpleString str1("abc");


### PR DESCRIPTION
- Treat any non-zero return from child process as failure (fixes #1211).
- Fix waiting for test in separate process under debugger by not checking uninitialized status variable (happens when continue checks loop condition).
- Count tests run in separate process as 'run' if fork() succeeds (fixes #1210).