### PR TITLE
Fix weird behavior of Debian docker image's autotools

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,7 @@
 
 AC_PREREQ([2.68])
 AC_INIT([CppUTest], [3.8], [https://github.com/cpputest/cpputest])
+AC_CONFIG_AUX_DIR([.])
 AM_INIT_AUTOMAKE([subdir-objects])
 AC_CONFIG_SRCDIR([src/CppUTest/Utest.cpp])
 AC_CONFIG_HEADERS([config.h])


### PR DESCRIPTION
Weird behavior with some autotools in Debian caused the default directories to be different. Adding the additional configuration flag fixes that.