### PR TITLE
add .withOutputParameter to expected call

### DIFF
--- a/include/CppUTestExt/MockCheckedExpectedCall.h
+++ b/include/CppUTestExt/MockCheckedExpectedCall.h
@@ -59,6 +59,7 @@ public:
     virtual MockExpectedCall& withParameterOfType(const SimpleString& typeName, const SimpleString& name, const void* value) _override;
     virtual MockExpectedCall& withOutputParameterReturning(const SimpleString& name, const void* value, size_t size) _override;
     virtual MockExpectedCall& withOutputParameterOfTypeReturning(const SimpleString& typeName, const SimpleString& name, const void* value) _override;
+    virtual MockExpectedCall& withUnmodifiedOutputParameter(const SimpleString& name) _override;
     virtual MockExpectedCall& ignoreOtherParameters() _override;
 
     virtual MockExpectedCall& andReturnValue(bool value) _override;
@@ -170,6 +171,7 @@ public:
     virtual MockExpectedCall& withParameterOfType(const SimpleString&, const SimpleString&, const void*) _override { return *this; }
     virtual MockExpectedCall& withOutputParameterReturning(const SimpleString&, const void*, size_t) _override { return *this; }
     virtual MockExpectedCall& withOutputParameterOfTypeReturning(const SimpleString&, const SimpleString&, const void*) _override { return *this; }
+    virtual MockExpectedCall& withUnmodifiedOutputParameter(const SimpleString&) _override { return *this; }
     virtual MockExpectedCall& ignoreOtherParameters() _override { return *this;}
 
     virtual MockExpectedCall& andReturnValue(bool) _override { return *this; }

--- a/include/CppUTestExt/MockExpectedCall.h
+++ b/include/CppUTestExt/MockExpectedCall.h
@@ -60,6 +60,7 @@ public:
     virtual MockExpectedCall& withParameterOfType(const SimpleString& typeName, const SimpleString& name, const void* value)=0;
     virtual MockExpectedCall& withOutputParameterReturning(const SimpleString& name, const void* value, size_t size)=0;
     virtual MockExpectedCall& withOutputParameterOfTypeReturning(const SimpleString& typeName, const SimpleString& name, const void* value)=0;
+    virtual MockExpectedCall& withUnmodifiedOutputParameter(const SimpleString& name)=0;
     virtual MockExpectedCall& ignoreOtherParameters()=0;
 
     virtual MockExpectedCall& withBoolParameter(const SimpleString& name, bool value)=0;

--- a/include/CppUTestExt/MockSupport_c.h
+++ b/include/CppUTestExt/MockSupport_c.h
@@ -145,6 +145,7 @@ struct SMockExpectedCall_c
     MockExpectedCall_c* (*withParameterOfType)(const char* type, const char* name, const void* value);
     MockExpectedCall_c* (*withOutputParameterReturning)(const char* name, const void* value, size_t size);
     MockExpectedCall_c* (*withOutputParameterOfTypeReturning)(const char* type, const char* name, const void* value);
+    MockExpectedCall_c* (*withUnmodifiedOutputParameter)(const char* name);
     MockExpectedCall_c* (*ignoreOtherParameters)(void);
 
     MockExpectedCall_c* (*andReturnBoolValue)(int value);

--- a/src/CppUTestExt/MockExpectedCall.cpp
+++ b/src/CppUTestExt/MockExpectedCall.cpp
@@ -240,6 +240,11 @@ MockExpectedCall& MockCheckedExpectedCall::withOutputParameterOfTypeReturning(co
     return *this;
 }
 
+MockExpectedCall& MockCheckedExpectedCall::withUnmodifiedOutputParameter(const SimpleString& name)
+{
+    return withOutputParameterReturning(name, NULLPTR, 0);
+}
+
 SimpleString MockCheckedExpectedCall::getInputParameterType(const SimpleString& name)
 {
     MockNamedValue * p = inputParameters_->getValueByName(name);

--- a/src/CppUTestExt/MockSupport_c.cpp
+++ b/src/CppUTestExt/MockSupport_c.cpp
@@ -160,6 +160,7 @@ MockExpectedCall_c* withMemoryBufferParameters_c(const char* name, const unsigne
 MockExpectedCall_c* withParameterOfType_c(const char* type, const char* name, const void* value);
 MockExpectedCall_c* withOutputParameterReturning_c(const char* name, const void* value, size_t size);
 MockExpectedCall_c* withOutputParameterOfTypeReturning_c(const char* type, const char* name, const void* value);
+MockExpectedCall_c* withUnmodifiedOutputParameter_c(const char* name);
 MockExpectedCall_c* ignoreOtherParameters_c();
 MockExpectedCall_c* andReturnBoolValue_c(int value);
 MockExpectedCall_c* andReturnIntValue_c(int value);
@@ -261,6 +262,7 @@ static MockExpectedCall_c gExpectedCall = {
         withParameterOfType_c,
         withOutputParameterReturning_c,
         withOutputParameterOfTypeReturning_c,
+        withUnmodifiedOutputParameter_c,
         ignoreOtherParameters_c,
         andReturnBoolValue_c,
         andReturnUnsignedIntValue_c,
@@ -493,6 +495,12 @@ MockExpectedCall_c* withOutputParameterReturning_c(const char* name, const void*
 MockExpectedCall_c* withOutputParameterOfTypeReturning_c(const char* type, const char* name, const void* value)
 {
     expectedCall = &expectedCall->withOutputParameterOfTypeReturning(type, name, value);
+    return &gExpectedCall;
+}
+
+MockExpectedCall_c* withUnmodifiedOutputParameter_c(const char* name)
+{
+    expectedCall = &expectedCall->withUnmodifiedOutputParameter(name);
     return &gExpectedCall;
 }
 

--- a/tests/CppUTestExt/MockExpectedCallTest.cpp
+++ b/tests/CppUTestExt/MockExpectedCallTest.cpp
@@ -610,6 +610,15 @@ TEST(MockExpectedCall, toStringForMultipleOutputParameters)
     STRCMP_EQUAL("name -> const void* buffer1: <output>, const void* buffer2: <output> (expected 1 call, called 1 time)", expectedCall.callToString().asCharString());
 }
 
+TEST(MockExpectedCall, toStringForUnmodifiedOutputParameter)
+{
+    MockCheckedExpectedCall expectedCall(1);
+    expectedCall.withName("name");
+    expectedCall.withUnmodifiedOutputParameter("buffer1");
+    expectedCall.callWasMade(1);
+    STRCMP_EQUAL("name -> const void* buffer1: <output> (expected 1 call, called 1 time)", expectedCall.callToString().asCharString());
+}
+
 TEST(MockExpectedCall, toStringForParameterAndIgnored)
 {
     MockCheckedExpectedCall expectedCall(1);
@@ -706,6 +715,15 @@ TEST(MockExpectedCall, hasOutputParameter)
     CHECK(call->hasOutputParameter(foo));
 }
 
+TEST(MockExpectedCall, hasUnmodifiedOutputParameter)
+{
+    call->withUnmodifiedOutputParameter("foo");
+    MockNamedValue foo("foo");
+    foo.setValue((const void *)NULLPTR);
+    foo.setSize(0);
+    CHECK(call->hasOutputParameter(foo));
+}
+
 TEST(MockExpectedCall, hasNoOutputParameter)
 {
     call->withIntParameter("foo", (int)1);
@@ -771,6 +789,7 @@ TEST(MockIgnoredExpectedCall, worksAsItShould)
     ignored.withParameterOfType( "mytype", "top", (const void*) NULLPTR);
     ignored.withOutputParameterReturning("bar", (void*) NULLPTR, 1);
     ignored.withOutputParameterOfTypeReturning("mytype", "bar", (const void*) NULLPTR);
+    ignored.withUnmodifiedOutputParameter("unmod");
     ignored.ignoreOtherParameters();
     ignored.andReturnValue(true);
     ignored.andReturnValue((double) 1.0f);

--- a/tests/CppUTestExt/MockFailureTest.cpp
+++ b/tests/CppUTestExt/MockFailureTest.cpp
@@ -181,6 +181,28 @@ TEST(MockFailureTest, MockUnexpectedOutputParameterFailure)
                  "\t\tvoid* bar", failure.getMessage().asCharString());
 }
 
+TEST(MockFailureTest, MockUnexpectedUnmodifiedOutputParameterFailure)
+{
+    int out1;
+    call1->withName("foo").withOutputParameterReturning("boo", &out1, sizeof(out1));
+    call2->withName("foo").withUnmodifiedOutputParameter("boo");
+    call3->withName("unrelated");
+    addAllToList();
+
+    MockNamedValue actualParameter("bar");
+    actualParameter.setValue((void *)0x123);
+
+    MockUnexpectedOutputParameterFailure failure(UtestShell::getCurrent(), "foo", actualParameter, *list);
+    STRCMP_EQUAL("Mock Failure: Unexpected output parameter name to function \"foo\": bar\n"
+                 "\tEXPECTED calls that WERE NOT fulfilled related to function: foo\n"
+                 "\t\tfoo -> const void* boo: <output> (expected 1 call, called 0 times)\n"
+                 "\t\tfoo -> const void* boo: <output> (expected 1 call, called 0 times)\n"
+                 "\tEXPECTED calls that WERE fulfilled related to function: foo\n"
+                 "\t\t<none>\n"
+                 "\tACTUAL unexpected output parameter passed to function: foo\n"
+                 "\t\tvoid* bar", failure.getMessage().asCharString());
+}
+
 TEST(MockFailureTest, MockUnexpectedParameterValueFailure)
 {
     call1->withName("foo").withParameter("boo", 2);

--- a/tests/CppUTestExt/MockParameterTest.cpp
+++ b/tests/CppUTestExt/MockParameterTest.cpp
@@ -634,6 +634,17 @@ TEST(MockParameterTest, outputParameterSucceeds)
     mock().checkExpectations();
 }
 
+TEST(MockParameterTest, unmodifiedOutputParameterSucceeds)
+{
+    int param = 1;
+
+    mock().expectOneCall("function").withUnmodifiedOutputParameter("parameterName");
+    mock().actualCall("function").withOutputParameter("parameterName", &param);
+
+    CHECK_EQUAL(param, 1);
+    mock().checkExpectations();
+}
+
 TEST(MockParameterTest, noActualCallForOutputParameter)
 {
     MockFailureReporterInstaller failureReporterInstaller;
@@ -643,6 +654,20 @@ TEST(MockParameterTest, noActualCallForOutputParameter)
     mock().expectOneCall("foo").withOutputParameterReturning("output", &output, sizeof(output));
 
     expectations.addFunction("foo")->withOutputParameterReturning("output", &output, sizeof(output));
+    MockExpectedCallsDidntHappenFailure expectedFailure(mockFailureTest(), expectations);
+
+    mock().checkExpectations();
+    CHECK_EXPECTED_MOCK_FAILURE(expectedFailure);
+}
+
+TEST(MockParameterTest, noActualCallForUnmodifiedOutputParameter)
+{
+    MockFailureReporterInstaller failureReporterInstaller;
+
+    MockExpectedCallsListForTest expectations;
+    mock().expectOneCall("foo").withUnmodifiedOutputParameter("output");
+
+    expectations.addFunction("foo")->withUnmodifiedOutputParameter("output");
     MockExpectedCallsDidntHappenFailure expectedFailure(mockFailureTest(), expectations);
 
     mock().checkExpectations();

--- a/tests/CppUTestExt/MockSupport_cTest.cpp
+++ b/tests/CppUTestExt/MockSupport_cTest.cpp
@@ -195,6 +195,15 @@ TEST(MockSupport_c, outputParameters)
     LONGS_EQUAL(2, retval);
 }
 
+TEST(MockSupport_c, unmodifiedOutputParameter)
+{
+    int param = 1;
+    mock_c()->expectOneCall("foo")->withUnmodifiedOutputParameter("out");
+    mock_c()->actualCall("foo")->withOutputParameter("out", &param);
+    mock_c()->checkExpectations();
+    LONGS_EQUAL(1, param);
+}
+
 TEST(MockSupport_c, outputParameters_differentType)
 {
     long param = 1;


### PR DESCRIPTION
When writing mock expectations, a mock implementation may have an output
parameter. In some tests it may be that the output parameter remains
unmodified.

To write an expectation which has an output parameter that is unmodified
you can use the following code:

    .withOutputParameterReturning("name", NULL, 0)

This is somewhat confusing, so add a shorthand

    .withOutputParameter("name")

This sets up the mock function to expect the "name" output parameter but
leave it unmodified.