### PR TITLE
Extracted the DummyMemoryLeakDetector

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -145,6 +145,7 @@ CppUTestTests_SOURCES = \
 	tests/CppUTest/CheatSheetTest.cpp \
 	tests/CppUTest/CommandLineArgumentsTest.cpp \
 	tests/CppUTest/CommandLineTestRunnerTest.cpp \
+	tests/CppUTest/DummyMemoryLeakDetector.cpp \
 	tests/CppUTest/JUnitOutputTest.cpp \
 	tests/CppUTest/MemoryLeakDetectorTest.cpp \
 	tests/CppUTest/MemoryOperatorOverloadTest.cpp \

--- a/platforms/Dos/sources.mk
+++ b/platforms/Dos/sources.mk
@@ -44,6 +44,7 @@ CPPU1_OBJECTS := \
   $(CPPUTEST_HOME)/tests/CppUTest/CommandLineArgumentsTest.o \
   $(CPPUTEST_HOME)/tests/CppUTest/CommandLineTestRunnerTest.o \
   $(CPPUTEST_HOME)/tests/CppUTest/JUnitOutputTest.o \
+  $(CPPUTEST_HOME)/tests/CppUTest/DummyMemoryLeakDetector.o \
   $(CPPUTEST_HOME)/tests/CppUTest/MemoryLeakWarningTest.o \
   $(CPPUTEST_HOME)/tests/CppUTest/PluginTest.o \
   $(CPPUTEST_HOME)/tests/CppUTest/PreprocessorTest.o \

--- a/tests/AllTests.vcproj
+++ b/tests/AllTests.vcproj
@@ -547,6 +547,29 @@
 				</FileConfiguration>
 			</File>
 			<File
+				RelativePath="CppUTest\DummyMemoryLeakDetector.cpp"
+				>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+						ForcedIncludeFiles=""
+					/>
+				</FileConfiguration>
+			</File>
+			<File
 				RelativePath="CppUTest\MemoryLeakWarningTest.cpp"
 				>
 				<FileConfiguration

--- a/tests/AllTests.vcxproj
+++ b/tests/AllTests.vcxproj
@@ -281,6 +281,7 @@
     <ClCompile Include="CppUTest\JUnitOutputTest.cpp" />
     <ClCompile Include="CppUTest\MemoryLeakDetectorTest.cpp" />
     <ClCompile Include="CppUTest\MemoryOperatorOverloadTest.cpp" />
+    <ClCompile Include="CppUTest\DummyMemoryLeakDetector.cpp" />
     <ClCompile Include="CppUTest\MemoryLeakWarningTest.cpp" />
     <ClCompile Include="CppUTest\PluginTest.cpp" />
     <ClCompile Include="CppUTest\PreprocessorTest.cpp" />

--- a/tests/CppUTest/CMakeLists.txt
+++ b/tests/CppUTest/CMakeLists.txt
@@ -13,6 +13,7 @@ set(CppUTestTests_src
     TestHarness_cTest.cpp
     JUnitOutputTest.cpp
     TestHarness_cTestCFile.c
+    DummyMemoryLeakDetector.cpp
     MemoryLeakDetectorTest.cpp
     TestInstallerTest.cpp
     AllocLetTestFree.c

--- a/tests/CppUTest/DummyMemoryLeakDetector.cpp
+++ b/tests/CppUTest/DummyMemoryLeakDetector.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2007, Michael Feathers, James Grenning and Bas Vodde
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the <organization> nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE EARLIER MENTIONED AUTHORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL <copyright holder> BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "CppUTest/TestHarness.h"
+#include "CppUTest/MemoryLeakDetector.h"
+#include "DummyMemoryLeakDetector.h"
+
+DummyMemoryLeakDetector::DummyMemoryLeakDetector(MemoryLeakFailure* reporter) : MemoryLeakDetector(reporter)
+{
+    memoryLeakDetectorWasDeleted = false;
+}
+
+DummyMemoryLeakDetector::~DummyMemoryLeakDetector() _destructor_override
+{
+    memoryLeakDetectorWasDeleted = true;
+}
+
+bool DummyMemoryLeakDetector::wasDeleted()
+{
+    return memoryLeakDetectorWasDeleted;
+}
+
+bool DummyMemoryLeakDetector::memoryLeakDetectorWasDeleted = false;
+
+DummyMemoryLeakFailure::DummyMemoryLeakFailure()
+    : MemoryLeakFailure()
+{
+    memoryLeakFailureWasDelete = false;
+}
+
+DummyMemoryLeakFailure::~DummyMemoryLeakFailure() _destructor_override
+{
+    memoryLeakFailureWasDelete = true;
+}
+
+bool DummyMemoryLeakFailure::wasDeleted()
+{
+    return memoryLeakFailureWasDelete;
+}
+
+void DummyMemoryLeakFailure::fail(char*) _override
+{
+}
+
+bool DummyMemoryLeakFailure::memoryLeakFailureWasDelete = false;
+
+
+

--- a/tests/CppUTest/DummyMemoryLeakDetector.cpp
+++ b/tests/CppUTest/DummyMemoryLeakDetector.cpp
@@ -34,7 +34,7 @@ DummyMemoryLeakDetector::DummyMemoryLeakDetector(MemoryLeakFailure* reporter) : 
     memoryLeakDetectorWasDeleted = false;
 }
 
-DummyMemoryLeakDetector::~DummyMemoryLeakDetector() _destructor_override
+DummyMemoryLeakDetector::~DummyMemoryLeakDetector()
 {
     memoryLeakDetectorWasDeleted = true;
 }
@@ -52,7 +52,7 @@ DummyMemoryLeakFailure::DummyMemoryLeakFailure()
     memoryLeakFailureWasDelete = false;
 }
 
-DummyMemoryLeakFailure::~DummyMemoryLeakFailure() _destructor_override
+DummyMemoryLeakFailure::~DummyMemoryLeakFailure()
 {
     memoryLeakFailureWasDelete = true;
 }
@@ -62,7 +62,7 @@ bool DummyMemoryLeakFailure::wasDeleted()
     return memoryLeakFailureWasDelete;
 }
 
-void DummyMemoryLeakFailure::fail(char*) _override
+void DummyMemoryLeakFailure::fail(char*)
 {
 }
 

--- a/tests/CppUTest/DummyMemoryLeakDetector.h
+++ b/tests/CppUTest/DummyMemoryLeakDetector.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2007, Michael Feathers, James Grenning and Bas Vodde
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the <organization> nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE EARLIER MENTIONED AUTHORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL <copyright holder> BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+class DummyMemoryLeakDetector : public MemoryLeakDetector
+{
+public:
+    DummyMemoryLeakDetector(MemoryLeakFailure* reporter);
+    virtual ~DummyMemoryLeakDetector() _destructor_override;
+    static bool wasDeleted();
+
+private:
+    static bool memoryLeakDetectorWasDeleted;
+};
+
+class DummyMemoryLeakFailure : public MemoryLeakFailure
+{
+public:
+    DummyMemoryLeakFailure();
+
+    virtual ~DummyMemoryLeakFailure() _destructor_override;
+    static bool wasDeleted();
+    virtual void fail(char*) _override;
+
+private:
+    static bool memoryLeakFailureWasDelete;
+};
+


### PR DESCRIPTION
Extracted the DummyMemoryLeakDetector to be in a separate file. This cleans up the test a bit and it also ought to help with the Watcom build that is continuously failing.