### PR TITLE
rand / srand for DOS platform

### DIFF
--- a/src/Platforms/Dos/UtestPlatform.cpp
+++ b/src/Platforms/Dos/UtestPlatform.cpp
@@ -186,6 +186,16 @@ void (*PlatformSpecificFree)(void* memory) = DosFree;
 void* (*PlatformSpecificMemCpy)(void* s1, const void* s2, size_t size) = DosMemCpy;
 void* (*PlatformSpecificMemset)(void* mem, int c, size_t size) = DosMemset;
 
+static void DosSrand(unsigned int seed)
+{
+    srand(seed);
+}
+
+static int DosRand()
+{
+    return rand();
+}
+
 static double DosFabs(double d)
 {
     return fabs(d);
@@ -201,6 +211,8 @@ static int DosIsInf(double d)
     return isinf(d);
 }
 
+void (*PlatformSpecificSrand)(unsigned int) = DosSrand;
+int (*PlatformSpecificRand)(void) = DosRand;
 double (*PlatformSpecificFabs)(double) = DosFabs;
 int (*PlatformSpecificIsNan)(double d) = DosIsNan;
 int (*PlatformSpecificIsInf)(double d) = DosIsInf;


### PR DESCRIPTION
Adds the platform specific rand and srand functions for DOS.

Mainly for fixing the broken DOS CI build – which still fails, but now with mem leak test failures.