### PR TITLE
C++17 ci builds with latest gcc and clang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,30 @@ jobs:
         apt:
           packages:
             - libc++-dev
+      env: BUILD=cmake CPP_STD=17
+      addons:
+        apt:
+          packages:
+            - libc++-dev
+
+    - compiler: gcc
+      env: BUILD=cmake CPP_STD=98
+    - compiler: gcc
+      env: BUILD=cmake CPP_STD=11
+    - compiler: gcc
+      env: BUILD=cmake CPP_STD=14
+    - compiler: gcc
+      env: BUILD=cmake CPP_STD=17
+
+    - compiler: gcc
+      env: BUILD=cmake CPP_STD=17
+        - CC=gcc-10
+        - CXX=g++-10
+      addons:
+        apt:
+          packages: ['g++-10']
+          sources:
+            - sourceline: 'ppa:ubuntu-toolchain-r/test'
     - compiler: clang
       env: BUILD=cmake CPP_STD=17
         - CC=clang-10
@@ -32,22 +56,6 @@ jobs:
             - sourceline: 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main'
               key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
           packages: ['clang-10', 'libc++-10-dev', 'libc++abi-10-dev']
-
-    - compiler: gcc
-      env: BUILD=cmake CPP_STD=98
-    - compiler: gcc
-      env: BUILD=cmake CPP_STD=11
-    - compiler: gcc
-      env: BUILD=cmake CPP_STD=14
-    - compiler: gcc
-      env: BUILD=cmake CPP_STD=17
-        - CC=gcc-10
-        - CXX=g++-10
-      addons:
-        apt:
-          packages: ['g++-10']
-          sources:
-            - sourceline: 'ppa:ubuntu-toolchain-r/test'
 
     - compiler: gcc
       env: BUILD=autotools

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,14 @@ jobs:
             - libc++-dev
     - compiler: clang
       env: BUILD=cmake CPP_STD=17
+        - CC=clang-10
+        - CXX=clang++-10
       addons:
         apt:
-          packages:
-            - libc++-dev
+          sources:
+            - sourceline: 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main'
+              key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
+          packages: ['clang-10', 'libc++-10-dev', 'libc++abi-10-dev']
 
     - compiler: gcc
       env: BUILD=cmake CPP_STD=98
@@ -37,6 +41,13 @@ jobs:
       env: BUILD=cmake CPP_STD=14
     - compiler: gcc
       env: BUILD=cmake CPP_STD=17
+        - CC=gcc-10
+        - CXX=g++-10
+      addons:
+        apt:
+          packages: ['g++-10']
+          sources:
+            - sourceline: 'ppa:ubuntu-toolchain-r/test'
 
     - compiler: gcc
       env: BUILD=autotools


### PR DESCRIPTION
Builds the two C++17 linux builds with latest gcc and clang versions, providing feedback for the most recent compiler / standard versions.