### PR TITLE
Run statements cleanup

### DIFF
--- a/docker/Dockerfile.dos
+++ b/docker/Dockerfile.dos
@@ -1,12 +1,7 @@
 FROM ubuntu
 
-RUN apt-get update
-RUN apt-get install -y wget
-RUN apt-get install -y unzip
-RUN apt-get install -y dosbox
-RUN apt-get install -y make
+RUN apt-get update && apt-get install -y --no-install-recommends wget unzip dosbox make
 
 WORKDIR /cpputest_build
 
 CMD BUILD=make_dos /cpputest/scripts/travis_ci_build.sh
-

--- a/docker/Dockerfile.gcc10
+++ b/docker/Dockerfile.gcc10
@@ -1,13 +1,8 @@
 FROM okannen/gcc-10
 
-RUN apt-get update
-RUN apt-get install -y -q file
-RUN apt-get install -y -q git
-RUN apt-get install -y -q make
-RUN apt-get install -y -q automake
-RUN apt-get install -y -q autoconf
-RUN apt-get install -y -q libtool
-RUN update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 100
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends file git make automake autoconf libtool && \
+    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 100
 
 WORKDIR /cpputest_build
 

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -1,16 +1,8 @@
 FROM ubuntu
 
-RUN apt-get update
-RUN apt-get install -y -q file
-RUN apt-get install -y -q git
-RUN apt-get install -y -q gcc
-RUN apt-get install -y -q g++
-RUN apt-get install -y -q make
-RUN apt-get install -y -q automake
-RUN apt-get install -y -q autoconf
-RUN apt-get install -y -q libtool
+RUN apt-get update && \
+    apt-get install -y -q --no-install-recommends file git gcc g++ make automake autoconf libtool
 
 WORKDIR /cpputest_build
 
 CMD autoreconf -i ../cpputest && ../cpputest/configure && make tdd
-


### PR DESCRIPTION
Dockerfile RUN statements improved to avoid unnecessary layers and prevent apt issues (see https://docs.docker.com/develop/develop-images/dockerfile_best-practices/).