### PR TITLE
enable_testing() moved to project source root directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,8 @@ include("${CppUTestRootDirectory}/cmake/Modules/CppUTestBuildTimeDiscoverTests.c
 include("${CppUTestRootDirectory}/cmake/Modules/CppUTestNormalizeTestOutputLocation.cmake")
 include(GNUInstallDirs)
 
+enable_testing()
+
 configure_file (
     "${PROJECT_SOURCE_DIR}/config.h.cmake"
     "${PROJECT_BINARY_DIR}/generated/CppUTestGeneratedConfig.h"

--- a/examples/AllTests/CMakeLists.txt
+++ b/examples/AllTests/CMakeLists.txt
@@ -1,5 +1,3 @@
-enable_testing()
-
 include_directories(../ApplicationLib)
 
 add_executable(ExampleTests

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,4 +1,2 @@
-enable_testing()
-
 add_subdirectory(AllTests)
 add_subdirectory(ApplicationLib)

--- a/tests/CppUTest/CMakeLists.txt
+++ b/tests/CppUTest/CMakeLists.txt
@@ -1,5 +1,3 @@
-enable_testing()
-
 set(CppUTestTests_src
     AllTests.cpp
     SetPluginTest.cpp


### PR DESCRIPTION
Moves `enable_testing()` to the project source root directory as mentioned in the [docs](https://cmake.org/cmake/help/latest/command/enable_testing.html).

Starting from v3.15 the documentation explicitly mentions that it's _"automatically invoked, when CTest module is included"_. Earlier version may do that too, but since the minimum version is v3.1 I kept the `enable_testing()` call, just be be safe.