### PR TITLE
Git ref of the cmake example updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ include(FetchContent)
 FetchContent_Declare(
     CppUTest
     GIT_REPOSITORY https://github.com/cpputest/cpputest.git
-    GIT_TAG        master # or use release tag, eg. v3.8
+    GIT_TAG        latest-passing-build # or use release tag, eg. v3.8
 )
 # Set this to ON if you want to have the CppUTests in your project as well.
 set(TESTS OFF CACHE BOOL "Switch off CppUTest Test build")


### PR DESCRIPTION
Example updated to use `latest-passing-build` instead of `master`.