### PR TITLE
Compiler extensions disabled

### DIFF
--- a/cmake/Modules/CppUTestConfigurationOptions.cmake
+++ b/cmake/Modules/CppUTestConfigurationOptions.cmake
@@ -54,9 +54,13 @@ if (COVERAGE AND NOT MSVC)
     set(CMAKE_BUILD_TYPE "Debug")
 endif (COVERAGE AND NOT MSVC)
 
-if (NOT CMAKE_CXX_STANDARD AND C++11)
+if (CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_EXTENSIONS OFF)
+elseif (C++11)
     find_package(CXX11 REQUIRED)
     set(CPPUTEST_CXX_FLAGS "${CPPUTEST_CXX_FLAGS} ${CXX11_FLAGS}")
+else()
+    # No standard specified
 endif ()
 
 set(GMOCK_HOME $ENV{GMOCK_HOME})


### PR DESCRIPTION
Compiler extensions disabled on the CMake build (see [docs](https://cmake.org/cmake/help/latest/prop_tgt/CXX_EXTENSIONS.html)). This ensures the build pure standard and prevents eg. the usage of gnu extensions.

@basvodde what's your opinion on unconditionally set this option? Or alternatively, set it to `OFF` unless it's already set to `ON` (eg. option explicitly passed).