### PR TITLE
Using the SimpleStringCache

### DIFF
--- a/include/CppUTest/SimpleString.h
+++ b/include/CppUTest/SimpleString.h
@@ -199,6 +199,7 @@ public:
     void clearCache();
     void clearAllIncludingCurrentlyUsedMemory();
 private:
+    void printDeallocatingUnknownMemory(char* memory);
 
     enum { amountOfInternalCacheNodes = 5};
     bool isCached(size_t size);

--- a/include/CppUTest/SimpleString.h
+++ b/include/CppUTest/SimpleString.h
@@ -221,6 +221,20 @@ private:
     TestMemoryAllocator* allocator_;
     SimpleStringInternalCacheNode* cache_;
     SimpleStringMemoryBlock* nonCachedAllocations_;
+    bool hasWarnedAboutDeallocations;
+};
+
+class SimpleStringCacheAllocator;
+class GlobalSimpleStringCache
+{
+    SimpleStringCacheAllocator* allocator_;
+    SimpleStringInternalCache cache_;
+
+public:
+    GlobalSimpleStringCache();
+    ~GlobalSimpleStringCache();
+
+    TestMemoryAllocator* getAllocator();
 };
 
 SimpleString StringFrom(bool value);

--- a/include/CppUTest/TestMemoryAllocator.h
+++ b/include/CppUTest/TestMemoryAllocator.h
@@ -272,6 +272,7 @@ public:
     virtual const char* free_name() const _override;
 
     virtual TestMemoryAllocator* actualAllocator() _override;
+    TestMemoryAllocator* originalAllocator();
 private:
     SimpleStringInternalCache& cache_;
     TestMemoryAllocator* originalAllocator_;

--- a/include/CppUTest/TestMemoryAllocator.h
+++ b/include/CppUTest/TestMemoryAllocator.h
@@ -161,6 +161,7 @@ class MemoryAccountant
 {
 public:
     MemoryAccountant();
+    ~MemoryAccountant();
 
     void useCacheSizes(size_t sizes[], size_t length);
 

--- a/include/CppUTestExt/MockCheckedActualCall.h
+++ b/include/CppUTestExt/MockCheckedActualCall.h
@@ -221,9 +221,12 @@ public:
     const char* getTraceOutput();
     void clear();
     static MockActualCallTrace& instance();
+    static void clearInstance();
 
 private:
     SimpleString traceBuffer_;
+
+    static MockActualCallTrace* instance_;
 
     void addParameterName(const SimpleString& name);
 };

--- a/src/CppUTest/CommandLineTestRunner.cpp
+++ b/src/CppUTest/CommandLineTestRunner.cpp
@@ -35,7 +35,6 @@
 
 int CommandLineTestRunner::RunAllTests(int ac, char** av)
 {
-    GlobalSimpleStringCache cache;
     return RunAllTests(ac, (const char *const *) av);
 }
 

--- a/src/CppUTest/CommandLineTestRunner.cpp
+++ b/src/CppUTest/CommandLineTestRunner.cpp
@@ -35,6 +35,7 @@
 
 int CommandLineTestRunner::RunAllTests(int ac, char** av)
 {
+    GlobalSimpleStringCache cache;
     return RunAllTests(ac, (const char *const *) av);
 }
 

--- a/src/CppUTest/MemoryLeakDetector.cpp
+++ b/src/CppUTest/MemoryLeakDetector.cpp
@@ -681,8 +681,9 @@ void MemoryLeakDetector::deallocMemory(TestMemoryAllocator* allocator, void* mem
    allocatNodesSeperately = true;
 #endif
     if (!allocator->hasBeenDestroyed()) {
+        size_t size = node->size_;
         checkForCorruption(node, file, line, allocator, allocatNodesSeperately);
-        allocator->free_memory((char*) memory, node->size_, file, line);
+        allocator->free_memory((char*) memory, size, file, line);
     }
 }
 

--- a/src/CppUTest/SimpleString.cpp
+++ b/src/CppUTest/SimpleString.cpp
@@ -497,6 +497,7 @@ void SimpleString::setInternalBufferToNewBuffer(size_t size)
 
     bufferSize_ = size;
     buffer_ = allocStringBuffer(bufferSize_, __FILE__, __LINE__);
+    buffer_[0] = '\0';
 }
 
 void SimpleString::setInternalBufferTo(char* buffer, size_t size)

--- a/src/CppUTest/TestMemoryAllocator.cpp
+++ b/src/CppUTest/TestMemoryAllocator.cpp
@@ -825,3 +825,8 @@ TestMemoryAllocator* SimpleStringCacheAllocator::actualAllocator()
     return originalAllocator_->actualAllocator();
 }
 
+TestMemoryAllocator* SimpleStringCacheAllocator::originalAllocator()
+{
+    return originalAllocator_;
+}
+

--- a/src/CppUTest/TestMemoryAllocator.cpp
+++ b/src/CppUTest/TestMemoryAllocator.cpp
@@ -426,6 +426,11 @@ MemoryAccountant::MemoryAccountant()
 {
 }
 
+MemoryAccountant::~MemoryAccountant()
+{
+    clear();
+}
+
 void MemoryAccountant::createCacheSizeNodes(size_t sizes[], size_t length)
 {
     for (size_t i = 0; i < length; i++)
@@ -467,6 +472,7 @@ void MemoryAccountant::clear()
         node = node->next_;
         destroyAccountantAllocationNode(to_be_deleted);
     }
+    head_ = NULLPTR;
 }
 
 MemoryAccountantAllocationNode* MemoryAccountant::findNodeOfSize(size_t size) const

--- a/src/CppUTestExt/MockActualCall.cpp
+++ b/src/CppUTestExt/MockActualCall.cpp
@@ -1003,10 +1003,19 @@ const char* MockActualCallTrace::getTraceOutput()
     return traceBuffer_.asCharString();
 }
 
+MockActualCallTrace* MockActualCallTrace::instance_ = NULLPTR;
+
 MockActualCallTrace& MockActualCallTrace::instance()
 {
-    static MockActualCallTrace call;
-    return call;
+    if (instance_ == NULLPTR)
+        instance_ = new MockActualCallTrace;
+    return *instance_;
+}
+
+void MockActualCallTrace::clearInstance()
+{
+    delete instance_;
+    instance_ = NULLPTR;
 }
 
 MockIgnoredActualCall& MockIgnoredActualCall::instance()

--- a/src/CppUTestExt/MockSupport.cpp
+++ b/src/CppUTestExt/MockSupport.cpp
@@ -116,7 +116,7 @@ void MockSupport::clear()
     lastActualFunctionCall_ = NULLPTR;
 
     tracing_ = false;
-    MockActualCallTrace::instance().clear();
+    MockActualCallTrace::clearInstance();
 
     expectations_.deleteAllExpectationsAndClearList();
     ignoreOtherCalls_ = false;

--- a/tests/CppUTest/AllTests.cpp
+++ b/tests/CppUTest/AllTests.cpp
@@ -32,21 +32,26 @@
 
 int main(int ac, char **av)
 {
-    /* These checks are here to make sure assertions outside test runs don't crash */
-    CHECK(true);
-    LONGS_EQUAL(1, 1);
+    int returnValue = 0;
+    GlobalSimpleStringCache stringCache;
+
+    {
+        /* These checks are here to make sure assertions outside test runs don't crash */
+        CHECK(true);
+        LONGS_EQUAL(1, 1);
 
 #if SHOW_MEMORY_REPORT
-    GlobalMemoryAccountant accountant;
-    accountant.start();
+        GlobalMemoryAccountant accountant;
+        accountant.start();
 #endif
 
-    int returnValue = CommandLineTestRunner::RunAllTests(ac, av); /* cover alternate method */
+        CommandLineTestRunner::RunAllTests(ac, av); /* cover alternate method */
 
 #if SHOW_MEMORY_REPORT
-    accountant.stop();
-    printf("%s", accountant.report().asCharString());
+        accountant.stop();
+        printf("%s", accountant.report().asCharString());
 #endif
+    }
 
     return returnValue;
 }

--- a/tests/CppUTest/SimpleStringTest.cpp
+++ b/tests/CppUTest/SimpleStringTest.cpp
@@ -1299,6 +1299,7 @@ TEST_GROUP(SimpleStringInternalCache)
     void teardown()
     {
         cache.clearAllIncludingCurrentlyUsedMemory();
+        accountant.clear();
         delete allocator;
         delete defaultAllocator;
     }
@@ -1513,6 +1514,7 @@ TEST(SimpleStringInternalCache, deallocatingMemoryThatWasntAllocatedWhileCacheWa
 static void _deallocatingStringMemoryTwiceThatWasntAllocatedWithCache(SimpleStringInternalCache* cache, size_t allocationSize)
 {
     char* mem = defaultMallocAllocator()->alloc_memory(allocationSize, __FILE__, __LINE__);
+    mem[0] = '\0';
     cache->dealloc(mem, allocationSize);
     cache->dealloc(mem, allocationSize);
     defaultMallocAllocator()->free_memory(mem, allocationSize, __FILE__, __LINE__);

--- a/tests/CppUTest/TestMemoryAllocatorTest.cpp
+++ b/tests/CppUTest/TestMemoryAllocatorTest.cpp
@@ -779,6 +779,7 @@ TEST_GROUP(SimpleStringCacheAllocator)
 
     void teardown()
     {
+        cache.clearCache();
         delete allocator;
         delete accountingAllocator;
     }

--- a/tests/CppUTest/TestMemoryAllocatorTest.cpp
+++ b/tests/CppUTest/TestMemoryAllocatorTest.cpp
@@ -612,10 +612,6 @@ class GlobalMemoryAccountantExecFunction
     : public ExecFunction
 {
 public:
-    virtual ~GlobalMemoryAccountantExecFunction() _destructor_override
-    {
-    }
-
     void (*testFunction_)(GlobalMemoryAccountant*);
     GlobalMemoryAccountant* parameter_;
 

--- a/tests/CppUTest/UtestPlatformTest.cpp
+++ b/tests/CppUTest/UtestPlatformTest.cpp
@@ -30,6 +30,7 @@
 #include "CppUTest/TestTestingFixture.h"
 #include "CppUTest/PlatformSpecificFunctions.h"
 #include "CppUTest/StandardCLibrary.h"
+#include "CppUTest/TestMemoryAllocator.h"
 
 #if CPPUTEST_USE_STD_C_LIB
 
@@ -62,6 +63,8 @@ static void _failFunction()
 static void _exitNonZeroFunction() __no_return__;
 static void _exitNonZeroFunction()
 {
+    /* destructor of static objects will be called. If StringCache was there then the allocator will report invalid deallocations of static SimpleString */
+    SimpleString::setStringAllocator(SimpleString::getStringAllocator()->actualAllocator());
     exit(1);
 }
 

--- a/tests/CppUTestExt/AllTests.cpp
+++ b/tests/CppUTestExt/AllTests.cpp
@@ -36,26 +36,33 @@
 
 int main(int ac, const char *const *av)
 {
+    int result = 0;
+    GlobalSimpleStringCache simpleStringCache;
+
+    {
 #ifdef CPPUTEST_INCLUDE_GTEST_TESTS
-    GTestConvertor convertor;
-    convertor.addAllGTestToTestRegistry();
+        GTestConvertor convertor;
+        convertor.addAllGTestToTestRegistry();
 #endif
 
-    MemoryReporterPlugin plugin;
-    MockSupportPlugin mockPlugin;
-    TestRegistry::getCurrentRegistry()->installPlugin(&plugin);
-    TestRegistry::getCurrentRegistry()->installPlugin(&mockPlugin);
+        MemoryReporterPlugin plugin;
+        MockSupportPlugin mockPlugin;
+        TestRegistry::getCurrentRegistry()->installPlugin(&plugin);
+        TestRegistry::getCurrentRegistry()->installPlugin(&mockPlugin);
 
 #ifndef GMOCK_RENAME_MAIN
-    return CommandLineTestRunner::RunAllTests(ac, av);
+        result = CommandLineTestRunner::RunAllTests(ac, av);
 #else
-    /* Don't have any memory leak detector when running the Google Test tests */
+        /* Don't have any memory leak detector when running the Google Test tests */
 
-    testing::GMOCK_FLAG(verbose) = testing::internal::kWarningVerbosity;
+        testing::GMOCK_FLAG(verbose) = testing::internal::kWarningVerbosity;
 
-    ConsoleTestOutput output;
-    CommandLineTestRunner runner(ac, av, TestRegistry::getCurrentRegistry());
-    return runner.runAllTestsMain();
+        ConsoleTestOutput output;
+        CommandLineTestRunner runner(ac, av, TestRegistry::getCurrentRegistry());
+        result = runner.runAllTestsMain();
 #endif
+    }
+
+    return result;
 }
 

--- a/tests/CppUTestExt/ExpectedFunctionsListTest.cpp
+++ b/tests/CppUTestExt/ExpectedFunctionsListTest.cpp
@@ -57,6 +57,7 @@ TEST_GROUP(MockExpectedCallsList)
         delete call4;
         delete list;
         CHECK_NO_MOCK_FAILURE();
+        MockFailureReporterForTest::clearReporter();
     }
 };
 

--- a/tests/CppUTestExt/MockActualCallTest.cpp
+++ b/tests/CppUTestExt/MockActualCallTest.cpp
@@ -48,6 +48,9 @@ TEST_GROUP(MockCheckedActualCall)
     void teardown()
     {
         CHECK_NO_MOCK_FAILURE();
+
+        MockFailureReporterForTest::clearReporter();
+
         delete emptyList;
         delete list;
     }

--- a/tests/CppUTestExt/MockActualCallTest.cpp
+++ b/tests/CppUTestExt/MockActualCallTest.cpp
@@ -263,3 +263,10 @@ TEST(MockCheckedActualCall, remainderOfMockActualCallTraceWorksAsItShould)
     CHECK(NULLPTR == actual.returnFunctionPointerValueOrDefault((void (*)()) NULLPTR));
 }
 
+TEST(MockCheckedActualCall, MockActualCallTraceClear)
+{
+    MockActualCallTrace actual;
+    actual.withName("func");
+    actual.clear();
+    STRCMP_EQUAL("", actual.getTraceOutput());
+}

--- a/tests/CppUTestExt/MockExpectedCallTest.cpp
+++ b/tests/CppUTestExt/MockExpectedCallTest.cpp
@@ -76,6 +76,7 @@ TEST_GROUP(MockNamedValueHandlerRepository)
     void teardown()
     {
         CHECK_NO_MOCK_FAILURE();
+        MockFailureReporterForTest::clearReporter();
     }
 };
 
@@ -165,6 +166,7 @@ TEST_GROUP(MockExpectedCall)
         MockNamedValue::setDefaultComparatorsAndCopiersRepository(originalComparatorRepository);
         delete call;
         CHECK_NO_MOCK_FAILURE();
+        MockFailureReporterForTest::clearReporter();
     }
 };
 

--- a/tests/CppUTestExt/MockFailureReporterForTest.cpp
+++ b/tests/CppUTestExt/MockFailureReporterForTest.cpp
@@ -32,10 +32,20 @@ void MockFailureReporterForTest::failTest(const MockFailure& failure)
     mockFailureString = failure.getMessage();
 }
 
+MockFailureReporterForTest* MockFailureReporterForTest::instance_ = NULLPTR;
+
 MockFailureReporterForTest* MockFailureReporterForTest::getReporter()
 {
-    static MockFailureReporterForTest reporter;
-    return &reporter;
+    if (instance_ == NULLPTR)
+        instance_ = new MockFailureReporterForTest;
+
+    return instance_;
+}
+
+void MockFailureReporterForTest::clearReporter()
+{
+    delete instance_;
+    instance_ = NULLPTR;
 }
 
 MockFailureReporterInstaller::MockFailureReporterInstaller()
@@ -46,6 +56,7 @@ MockFailureReporterInstaller::MockFailureReporterInstaller()
 MockFailureReporterInstaller::~MockFailureReporterInstaller()
 {
   mock().setMockFailureStandardReporter(NULLPTR);
+  MockFailureReporterForTest::clearReporter();
 }
 
 UtestShell* mockFailureTest()

--- a/tests/CppUTestExt/MockFailureReporterForTest.h
+++ b/tests/CppUTestExt/MockFailureReporterForTest.h
@@ -40,6 +40,9 @@ public:
 
     virtual void failTest(const MockFailure& failure);
     static MockFailureReporterForTest* getReporter();
+    static void clearReporter();
+private:
+    static MockFailureReporterForTest* instance_;
 };
 
 class MockFailureReporterInstaller

--- a/tests/CppUTestExt/MockFailureTest.cpp
+++ b/tests/CppUTestExt/MockFailureTest.cpp
@@ -54,7 +54,9 @@ TEST_GROUP(MockFailureTest)
         delete call2;
         delete call3;
         CHECK_NO_MOCK_FAILURE();
+        MockFailureReporterForTest::clearReporter();
     }
+
     void addAllToList()
     {
         list->addExpectedCall(call1);

--- a/tests/CppUTestExt/MockSupportTest.cpp
+++ b/tests/CppUTestExt/MockSupportTest.cpp
@@ -41,6 +41,7 @@ TEST_GROUP(MockSupportTest)
   {
       mock().checkExpectations();
       CHECK_NO_MOCK_FAILURE();
+      MockFailureReporterForTest::clearReporter();
       mock().clear();
   }
 };
@@ -175,6 +176,7 @@ TEST_GROUP(MockSupportTestWithFixture)
     void teardown()
     {
         mock().clear();
+        MockFailureReporterForTest::clearReporter();
     }
 };
 


### PR DESCRIPTION

Finally.

Had to kill all the static SimpleString's to avoid weird deallocations. This also now resolves the memory leaks in CppUTest when using C. It uses longjump and couldn't deallocate the strings. Now it can.