### PR TITLE
Address sanitizer on clang linux 

### DIFF
--- a/include/CppUTest/CppUTestConfig.h
+++ b/include/CppUTest/CppUTestConfig.h
@@ -188,6 +188,13 @@
 #if CPPUTEST_SANITIZE_ADDRESS
 #define CPPUTEST_SANITIZE_ADDRESS 1
 #define CPPUTEST_DO_NOT_SANITIZE_ADDRESS __attribute__((no_sanitize_address))
+  #if defined(__linux__) && defined(__clang__)
+    #if CPPUTEST_USE_MEM_LEAK_DETECTION 
+    #warning Compiling with Address Sanitizer with clang on linux will cause duplicate symbols for operator new. Turning off memory leak detection. Compile with -DCPPUTEST_MEM_LEAK_DETECTION_DISABLED to get rid of this warning.
+    #undef CPPUTEST_USE_MEM_LEAK_DETECTION
+    #define CPPUTEST_USE_MEM_LEAK_DETECTION 0
+    #endif
+  #endif
 #else
 #define CPPUTEST_SANITIZER_ADDRESS 0
 #define CPPUTEST_DO_NOT_SANITIZE_ADDRESS
@@ -239,7 +246,7 @@
 /*
  * Support for "long long" type.
  *
- * Not supported when CPUTEST_LONG_LONG_DISABLED is set.
+ * Not supported when CPPUTEST_LONG_LONG_DISABLED is set.
  * Can be overridden by using CPPUTEST_USE_LONG_LONG
  *
  * CPPUTEST_HAVE_LONG_LONG_INT is set by configure

--- a/tests/CppUTest/MemoryLeakWarningTest.cpp
+++ b/tests/CppUTest/MemoryLeakWarningTest.cpp
@@ -266,7 +266,7 @@ TEST(MemoryLeakWarningGlobalDetectorTest, MemoryWarningPluginCanBeSetToDestroyTh
     CHECK(DummyMemoryLeakDetector::wasDeleted());
 }
 
-#ifndef CPPUTEST_MEM_LEAK_DETECTION_DISABLED
+#if CPPUTEST_USE_MEM_LEAK_DETECTION
 
 TEST(MemoryLeakWarningGlobalDetectorTest, crashOnLeakWithOperatorNew)
 {
@@ -390,7 +390,7 @@ TEST(MemoryLeakWarningGlobalDetectorTest, turnOffNewOverloadsNoThrowCausesNoAddi
 #endif
 }
 
-#ifndef CPPUTEST_MEM_LEAK_DETECTION_DISABLED
+#if CPPUTEST_USE_MEM_LEAK_DETECTION
 
 static int mutexLockCount = 0;
 static int mutexUnlockCount = 0;

--- a/tests/CppUTest/MemoryOperatorOverloadTest.cpp
+++ b/tests/CppUTest/MemoryOperatorOverloadTest.cpp
@@ -20,7 +20,7 @@ TEST(BasicBehavior, CanDeleteNullPointers)
     delete [] (char*) NULLPTR;
 }
 
-#ifndef CPPUTEST_MEM_LEAK_DETECTION_DISABLED
+#if CPPUTEST_USE_MEM_LEAK_DETECTION
 
 CPPUTEST_DO_NOT_SANITIZE_ADDRESS
 static void deleteArrayInvalidatesMemory()


### PR DESCRIPTION
will turn off memory leak checker automatically