### PR TITLE
zero as null pointer warning fixed

### DIFF
--- a/tests/CppUTest/UtestTest.cpp
+++ b/tests/CppUTest/UtestTest.cpp
@@ -438,7 +438,7 @@ TEST(UtestShellPointerArrayTest, empty)
 {
     UtestShellPointerArray tests(NULLPTR);
     tests.shuffle(0);
-    CHECK(NULL == tests.getFirstTest());
+    CHECK(NULLPTR == tests.getFirstTest());
 }
 
 TEST(UtestShellPointerArrayTest, testsAreInOrder)
@@ -499,5 +499,3 @@ TEST(UtestShellPointerArrayTest, reverse)
     CHECK(tests.get(1) == test1);
     CHECK(tests.get(2) == test0);
 }
-
-


### PR DESCRIPTION
Fixes the _"zero as null pointer constant"_ warning, when compiling with Clang 5:

```
/mnt/tests/CppUTest/UtestTest.cpp:441:11: error: zero as null pointer constant
      [-Werror,-Wzero-as-null-pointer-constant]
    CHECK(NULL == tests.getFirstTest());
          ^~~~
          nullptr
/usr/include/clang/5.0.2/include/stddef.h:100:18: note: expanded from macro
      'NULL'
#    define NULL __null
                 ^
```