### PR TITLE
Option for build discover of tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,7 @@ option(WERROR "Compile with warnings as errors" OFF)
 
 option(TESTS "Compile and make tests for the code?" ON)
 option(TESTS_DETAILED "Run each test separately instead of grouped?" OFF)
+option(TESTS_BUILD_DISCOVER "Build time test discover" ON)
 
 option(EXAMPLES "Compile and make exaples?" OFF)
 

--- a/tests/CppUTest/CMakeLists.txt
+++ b/tests/CppUTest/CMakeLists.txt
@@ -55,4 +55,6 @@ add_executable(CppUTestTests ${CppUTestTests_src})
 cpputest_normalize_test_output_location(CppUTestTests)
 target_link_libraries(CppUTestTests CppUTest ${THREAD_LIB})
 
-cpputest_buildtime_discover_tests(CppUTestTests)
+if (TESTS_BUILD_DISCOVER)
+    cpputest_buildtime_discover_tests(CppUTestTests)
+endif()

--- a/tests/CppUTestExt/CMakeLists.txt
+++ b/tests/CppUTestExt/CMakeLists.txt
@@ -37,4 +37,7 @@ endif (MINGW)
 add_executable(CppUTestExtTests ${CppUTestExtTests_src})
 cpputest_normalize_test_output_location(CppUTestExtTests)
 target_link_libraries(CppUTestExtTests CppUTest CppUTestExt ${THREAD_LIB} ${CPPUNIT_EXTERNAL_LIBRARIES})
-cpputest_buildtime_discover_tests(CppUTestExtTests)
+
+if (TESTS_BUILD_DISCOVER)
+    cpputest_buildtime_discover_tests(CppUTestExtTests)
+endif()


### PR DESCRIPTION
Adds an option `TESTS_BUILD_DISCOVER` (default: `ON`) to disable build time discover of tests, see #1144. 