### PR TITLE
CMake coverage report generation

### DIFF
--- a/cmake/Modules/CppUTestConfigurationOptions.cmake
+++ b/cmake/Modules/CppUTestConfigurationOptions.cmake
@@ -52,7 +52,20 @@ if (COVERAGE AND NOT MSVC)
     set(CPPUTEST_C_FLAGS "${CPPUTEST_C_FLAGS} --coverage")
     set(CPPUTEST_CXX_FLAGS "${CPPUTEST_CXX_FLAGS} --coverage")
     set(CMAKE_BUILD_TYPE "Debug")
-endif (COVERAGE AND NOT MSVC)
+    find_program(GCOVR gcovr DOC "gcovr executable")
+
+    if (NOT GCOVR)
+        message(SEND_ERROR "gcovr not found")
+    endif()
+
+    add_custom_target(coverage ${GCOVR}
+        --root ${PROJECT_SOURCE_DIR}
+        --output "${CMAKE_BINARY_DIR}/coverage/coverage.html"
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+        COMMENT "Generate coverage data"
+        VERBATIM
+        )
+endif()
 
 if (CMAKE_CXX_STANDARD)
     set(CMAKE_CXX_EXTENSIONS OFF)

--- a/gcovr.cfg
+++ b/gcovr.cfg
@@ -1,0 +1,6 @@
+filter = src/
+filter = include/
+html = yes
+html-details = yes
+output = coverage.html
+print-summary = yes

--- a/scripts/travis_ci_build.sh
+++ b/scripts/travis_ci_build.sh
@@ -60,7 +60,7 @@ if [ "x$BUILD" = "xtest_report" ]; then
 fi
 
 if [ "x$BUILD" = "xcmake_coverage" ]; then
-    pip install --user cpp-coveralls
+    pip install --user cpp-coveralls gcovr
 
     cmake .. -DCMAKE_BUILD_TYPE=Debug -DC++11=ON -DCOVERAGE=ON -DLONGLONG=ON
     make
@@ -168,4 +168,3 @@ if [ "x$BUILD" = "xcmake_windows" ]; then
     make
     ctest -V
 fi
-


### PR DESCRIPTION
As mentioned in #1139.

@basvodde I used [gcovr](https://github.com/gcovr/gcovr) instead of lcov as it's much easier to install and use. It can create coverage results, reports in various formats etc. in a single pass and provides support for configuration file. If the the lcov is still set, can migrate it back.

Should I change the make target to `check_coverage` as used in `Makefile.am`? Would keep it consistent.