### PR TITLE
Call cmake_minimum_required() before project() in CMakeLists.txt.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,11 @@
+# 2.6.3 is needed for ctest support
+# 3.1 is needed for target_sources
+cmake_minimum_required(VERSION 3.1)
+
 project(CppUTest)
 
 set(CppUTest_version_major 4)
 set(CppUTest_version_minor 0)
-
-# 2.6.3 is needed for ctest support
-# 3.1 is needed for target_sources
-cmake_minimum_required(VERSION 3.1)
 
 ###############
 # Conan support


### PR DESCRIPTION
From https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html:
Note: Call the cmake_minimum_required() command at the beginning of the top-level CMakeLists.txt file even before calling the project() command. It is important to establish version and policy settings before invoking other commands whose behavior they may affect. See also policy CMP0000.

For instance, if cmake_minimum_required is called from within the project, I am unable to build the project with `cmake .. -DCMAKE_POLICY_DEFAULT_CMP0091=NEW` because the global policy scope is overwritten with the more specific project policy scope.