### PR TITLE
Types pid_t and int are not always the same.

### DIFF
--- a/include/CppUTest/PlatformSpecificFunctions.h
+++ b/include/CppUTest/PlatformSpecificFunctions.h
@@ -33,8 +33,8 @@ TestOutput::WorkingEnvironment PlatformSpecificGetWorkingEnvironment();
 
 class TestPlugin;
 extern void (*PlatformSpecificRunTestInASeperateProcess)(UtestShell* shell, TestPlugin* plugin, TestResult* result);
-extern int (*PlatformSpecificFork)(void);
-extern int (*PlatformSpecificWaitPid)(int pid, int* status, int options);
+extern pid_t (*PlatformSpecificFork)(void);
+extern pid_t (*PlatformSpecificWaitPid)(int pid, int* status, int options);
 
 /* Platform specific interface we use in order to minimize dependencies with LibC.
  * This enables porting to different embedded platforms.

--- a/src/Platforms/Gcc/UtestPlatform.cpp
+++ b/src/Platforms/Gcc/UtestPlatform.cpp
@@ -68,12 +68,12 @@ static void GccPlatformSpecificRunTestInASeperateProcess(UtestShell* shell, Test
     result->addFailure(TestFailure(shell, "-p doesn't work on this platform, as it is lacking fork.\b"));
 }
 
-static int PlatformSpecificForkImplementation(void)
+static pid_t PlatformSpecificForkImplementation(void)
 {
     return 0;
 }
 
-static int PlatformSpecificWaitPidImplementation(int, int*, int)
+static pid_t PlatformSpecificWaitPidImplementation(int, int*, int)
 {
     return 0;
 }
@@ -155,8 +155,8 @@ TestOutput::WorkingEnvironment PlatformSpecificGetWorkingEnvironment()
 
 void (*PlatformSpecificRunTestInASeperateProcess)(UtestShell* shell, TestPlugin* plugin, TestResult* result) =
         GccPlatformSpecificRunTestInASeperateProcess;
-int (*PlatformSpecificFork)(void) = PlatformSpecificForkImplementation;
-int (*PlatformSpecificWaitPid)(int, int*, int) = PlatformSpecificWaitPidImplementation;
+pid_t (*PlatformSpecificFork)(void) = PlatformSpecificForkImplementation;
+pid_t (*PlatformSpecificWaitPid)(int, int*, int) = PlatformSpecificWaitPidImplementation;
 
 extern "C" {
 

--- a/tests/CppUTest/UtestPlatformTest.cpp
+++ b/tests/CppUTest/UtestPlatformTest.cpp
@@ -75,11 +75,11 @@ static int waitpid_while_debugging_stub_forced_failures = 0;
 
 extern "C" {
 
-    static int (*original_waitpid)(int, int*, int) = NULLPTR;
+    static pid_t (*original_waitpid)(int, int*, int) = NULLPTR;
 
-    static int fork_failed_stub(void) { return -1; }
+    static pid_t fork_failed_stub(void) { return -1; }
 
-    static int waitpid_while_debugging_stub(int pid, int* status, int options)
+    static pid_t waitpid_while_debugging_stub(int pid, int* status, int options)
     {
         static int saved_status;
 
@@ -94,7 +94,7 @@ extern "C" {
         }
     }
 
-    static int waitpid_failed_stub(int, int*, int) { return -1; }
+    static pid_t waitpid_failed_stub(int, int*, int) { return -1; }
 }
 
 #include <unistd.h>


### PR DESCRIPTION
We get build error when pid_t is not equal to int.
e.g on solaris when building 32bit version of cpputest pid_t is typedef to long.