### PR TITLE
msys2 fix multiple definition issue

### DIFF
--- a/src/CppUTest/MemoryLeakWarningPlugin.cpp
+++ b/src/CppUTest/MemoryLeakWarningPlugin.cpp
@@ -312,12 +312,12 @@ static void (*saved_operator_delete_fptr)(void* mem) UT_NOTHROW = mem_leak_opera
 static void (*saved_operator_delete_array_fptr)(void* mem) UT_NOTHROW = mem_leak_operator_delete_array;
 static int save_counter = 0;
 
-#if !defined(__MINGW32__)
+#if defined(__CYGWIN__) || !defined(__MINGW32__)
 void* operator new(size_t size) UT_THROW(std::bad_alloc)
 {
     return operator_new_fptr(size);
 }
-#endif // !defined(__MINGW32__)
+#endif // defined(__CYGWIN__) || !defined(__MINGW32__)
 
 void* operator new(size_t size, const char* file, size_t line) UT_THROW(std::bad_alloc)
 {
@@ -334,33 +334,33 @@ void operator delete(void* mem, const char*, size_t) UT_NOTHROW
     operator_delete_fptr(mem);
 }
 
-#if !defined(__MINGW32__)
+#if defined(__CYGWIN__) || !defined(__MINGW32__)
 #if __cplusplus >= 201402L
 void operator delete (void* mem, size_t) UT_NOTHROW
 {
     operator_delete_fptr(mem);
 }
 #endif // __cplusplus >= 201402L
-#endif // !defined(__MINGW32__)
+#endif // defined(__CYGWIN__) || !defined(__MINGW32__)
 
-#if !defined(__MINGW32__)
+#if defined(__CYGWIN__) || !defined(__MINGW32__)
 void* operator new[](size_t size) UT_THROW(std::bad_alloc)
 {
     return operator_new_array_fptr(size);
 }
-#endif // !defined(__MINGW32__)
+#endif // defined(__CYGWIN__) || !defined(__MINGW32__)
 
 void* operator new [](size_t size, const char* file, size_t line) UT_THROW(std::bad_alloc)
 {
     return operator_new_array_debug_fptr(size, file, line);
 }
 
-#if !defined(__MINGW32__)
+#if defined(__CYGWIN__) || !defined(__MINGW32__)
 void operator delete[](void* mem) UT_NOTHROW
 {
     operator_delete_array_fptr(mem);
 }
-#endif // !defined(__MINGW32__)
+#endif // defined(__CYGWIN__) || !defined(__MINGW32__)
 
 void operator delete[](void* mem, const char*, size_t) UT_NOTHROW
 {

--- a/src/CppUTest/MemoryLeakWarningPlugin.cpp
+++ b/src/CppUTest/MemoryLeakWarningPlugin.cpp
@@ -312,10 +312,12 @@ static void (*saved_operator_delete_fptr)(void* mem) UT_NOTHROW = mem_leak_opera
 static void (*saved_operator_delete_array_fptr)(void* mem) UT_NOTHROW = mem_leak_operator_delete_array;
 static int save_counter = 0;
 
+#if !defined(__MINGW32__)
 void* operator new(size_t size) UT_THROW(std::bad_alloc)
 {
     return operator_new_fptr(size);
 }
+#endif // !defined(__MINGW32__)
 
 void* operator new(size_t size, const char* file, size_t line) UT_THROW(std::bad_alloc)
 {
@@ -332,27 +334,33 @@ void operator delete(void* mem, const char*, size_t) UT_NOTHROW
     operator_delete_fptr(mem);
 }
 
+#if !defined(__MINGW32__)
 #if __cplusplus >= 201402L
 void operator delete (void* mem, size_t) UT_NOTHROW
 {
     operator_delete_fptr(mem);
 }
-#endif
+#endif // __cplusplus >= 201402L
+#endif // !defined(__MINGW32__)
 
+#if !defined(__MINGW32__)
 void* operator new[](size_t size) UT_THROW(std::bad_alloc)
 {
     return operator_new_array_fptr(size);
 }
+#endif // !defined(__MINGW32__)
 
 void* operator new [](size_t size, const char* file, size_t line) UT_THROW(std::bad_alloc)
 {
     return operator_new_array_debug_fptr(size, file, line);
 }
 
+#if !defined(__MINGW32__)
 void operator delete[](void* mem) UT_NOTHROW
 {
-     operator_delete_array_fptr(mem);
+    operator_delete_array_fptr(mem);
 }
+#endif // !defined(__MINGW32__)
 
 void operator delete[](void* mem, const char*, size_t) UT_NOTHROW
 {


### PR DESCRIPTION
Cpputest has been recently added to msys2 but unfortunately when I build my project under msys2 I got the following issue, which is fixed with this patch:

    C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/10.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/10.2.0/../../../../lib/libCppUTest.a(MemoryLeakWarningPlugin.cpp.obj):(.text+0xf10): multiple definition of `operator new(unsigned long long)'; C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/10.2.0/libstdc++.dll.a(d006537.o):(.text+0x0): first defined here
    C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/10.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/10.2.0/../../../../lib/libCppUTest.a(MemoryLeakWarningPlugin.cpp.obj):(.text+0xf50): multiple definition of `operator delete(void*, unsigned long long)'; C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/10.2.0/libstdc++.dll.a(d006531.o):(.text+0x0): first defined here
    C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/10.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/10.2.0/../../../../lib/libCppUTest.a(MemoryLeakWarningPlugin.cpp.obj):(.text+0xf60): multiple definition of `operator new[](unsigned long long)'; C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/10.2.0/libstdc++.dll.a(d006533.o):(.text+0x0): first defined here
    C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/10.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/10.2.0/../../../../lib/libCppUTest.a(MemoryLeakWarningPlugin.cpp.obj):(.text+0xf80): multiple definition of `operator delete[](void*)'; C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/10.2.0/libstdc++.dll.a(d006521.o):(.text+0x0): first defined here
    collect2.exe: error: ld returned 1 exit status
    make[2]: *** [tests/CMakeFiles/run_tests.dir/build.make:213: tests/run_tests.exe] Error 1
    make[1]: *** [CMakeFiles/Makefile2:321: tests/CMakeFiles/run_tests.dir/all] Error 2
    make: *** [Makefile:183: all] Error 2