### PR TITLE
Should not do Standard library includes outside the StandardCLibrary/h

### DIFF
--- a/include/CppUTest/SimpleString.h
+++ b/include/CppUTest/SimpleString.h
@@ -230,8 +230,6 @@ SimpleString StringFrom(const std::nullptr_t value);
 
 #if CPPUTEST_USE_STD_CPP_LIB
 
-#include <string>
-
 SimpleString StringFrom(const std::string& other);
 
 #endif

--- a/include/CppUTest/StandardCLibrary.h
+++ b/include/CppUTest/StandardCLibrary.h
@@ -14,6 +14,7 @@
 #ifdef __cplusplus
  #if CPPUTEST_USE_STD_CPP_LIB
   #include <cstdlib>
+  #include <string>
  #endif
 #endif
 


### PR DESCRIPTION
Doing so might cause conflict with the memory macros.

Moves the <string> include to the right place.