### PR TITLE
Errors for string comparisons to show non-printable control characters as C escape codes

### DIFF
--- a/include/CppUTest/SimpleString.h
+++ b/include/CppUTest/SimpleString.h
@@ -127,6 +127,10 @@ private:
     static bool isDigit(char ch);
     static bool isSpace(char ch);
     static bool isUpper(char ch);
+    static bool isControl(char ch);
+    static bool isControlWithShortEscapeSequence(char ch);
+    
+    size_t getPrintableSize() const;
 };
 
 class SimpleStringCollection

--- a/include/CppUTest/SimpleString.h
+++ b/include/CppUTest/SimpleString.h
@@ -83,6 +83,8 @@ public:
     SimpleString subStringFromTill(char startChar, char lastExcludedChar) const;
     void copyToBuffer(char* buffer, size_t bufferSize) const;
 
+    SimpleString printable() const;
+
     const char *asCharString() const;
     size_t size() const;
     bool isEmpty() const;
@@ -219,6 +221,7 @@ SimpleString BracketsFormattedHexStringFrom(cpputest_longlong value);
 SimpleString BracketsFormattedHexStringFrom(cpputest_ulonglong value);
 SimpleString BracketsFormattedHexStringFrom(signed char value);
 SimpleString BracketsFormattedHexString(SimpleString hexString);
+SimpleString PrintableStringFromOrNull(const char * expected);
 
 /*
  * ARM compiler has only partial support for C++11.

--- a/include/CppUTest/TestFailure.h
+++ b/include/CppUTest/TestFailure.h
@@ -63,13 +63,8 @@ public:
 
 
 protected:
-    enum DifferenceFormat
-    {
-        DIFFERENCE_STRING, DIFFERENCE_BINARY
-    };
-
     SimpleString createButWasString(const SimpleString& expected, const SimpleString& actual);
-    SimpleString createDifferenceAtPosString(const SimpleString& actual, size_t position, DifferenceFormat format = DIFFERENCE_STRING);
+    SimpleString createDifferenceAtPosString(const SimpleString& actual, size_t offset, size_t reportedPosition);
     SimpleString createUserText(const SimpleString& text);
 
     SimpleString testName_;

--- a/src/CppUTest/SimpleString.cpp
+++ b/src/CppUTest/SimpleString.cpp
@@ -424,7 +424,7 @@ void SimpleString::replace(const char* to, const char* with)
 
 SimpleString SimpleString::printable() const
 {
-    const char* shortEscapeCodes[] =
+    static const char* shortEscapeCodes[] =
     {
         "\\a",
         "\\b",
@@ -435,35 +435,20 @@ SimpleString SimpleString::printable() const
         "\\r"
     };
 
-    size_t str_size = size();
-    size_t new_str_size = str_size;
-
-    for (size_t i = 0; i < str_size; i++)
-    {
-        unsigned char c = (unsigned char) buffer_[i];
-        if ((c >= 0x07) && (c <= 0x0D))
-        {
-            new_str_size += 1;
-        }
-        else if ((c < 0x20) || (c == 0x7F))
-        {
-            new_str_size += 3;
-        }
-    }
-
     SimpleString result;
-    result.setInternalBufferToNewBuffer(new_str_size + 1);
+    result.setInternalBufferToNewBuffer(getPrintableSize() + 1);
 
+    size_t str_size = size();
     size_t j = 0;
     for (size_t i = 0; i < str_size; i++)
     {
-        unsigned char c = (unsigned char) buffer_[i];
-        if ((c >= 0x07) && (c <= 0x0D))
+        char c = buffer_[i];
+        if (isControlWithShortEscapeSequence(c))
         {
-            StrNCpy(&result.buffer_[j], shortEscapeCodes[c - 0x07], 2);
+            StrNCpy(&result.buffer_[j], shortEscapeCodes[(unsigned char)(c - '\a')], 2);
             j += 2;
         }
-        else if ((c < 0x20) || (c == 0x7F))
+        else if (isControl(c))
         {
             SimpleString hexEscapeCode = StringFromFormat("\\x%02X ", c);
             StrNCpy(&result.buffer_[j], hexEscapeCode.asCharString(), 4);
@@ -471,13 +456,34 @@ SimpleString SimpleString::printable() const
         }
         else
         {
-            result.buffer_[j] = (char) c;
+            result.buffer_[j] = c;
             j++;
         }
     }
     result.buffer_[j] = 0;
 
     return result;
+}
+
+size_t SimpleString::getPrintableSize() const
+{
+    size_t str_size = size();
+    size_t printable_str_size = str_size;
+
+    for (size_t i = 0; i < str_size; i++)
+    {
+        char c = buffer_[i];
+        if (isControlWithShortEscapeSequence(c))
+        {
+            printable_str_size += 1;
+        }
+        else if (isControl(c))
+        {
+            printable_str_size += 3;
+        }
+    }
+
+    return printable_str_size;
 }
 
 SimpleString SimpleString::lowerCase() const
@@ -642,6 +648,16 @@ bool SimpleString::isSpace(char ch)
 bool SimpleString::isUpper(char ch)
 {
     return 'A' <= ch && 'Z' >= ch;
+}
+
+bool SimpleString::isControl(char ch)
+{
+    return ch < ' ' || ch == char(0x7F);
+}
+
+bool SimpleString::isControlWithShortEscapeSequence(char ch)
+{
+    return '\a' <= ch && '\r' >= ch;
 }
 
 SimpleString StringFrom(bool value)

--- a/tests/CppUTest/SimpleStringTest.cpp
+++ b/tests/CppUTest/SimpleStringTest.cpp
@@ -294,6 +294,14 @@ TEST(SimpleString, lowerCase)
     STRCMP_EQUAL("AbCdEfG1234", s1.asCharString());
 }
 
+TEST(SimpleString, printable)
+{
+    SimpleString s1("ABC\01\06\a\n\r\b\t\v\f\x0E\x1F\x7F""abc");
+    SimpleString s2(s1.printable());
+    STRCMP_EQUAL("ABC\\x01\\x06\\a\\n\\r\\b\\t\\v\\f\\x0E\\x1F\\x7Fabc", s2.asCharString());
+    STRCMP_EQUAL("ABC\01\06\a\n\r\b\t\v\f\x0E\x1F\x7F""abc", s1.asCharString());
+}
+
 TEST(SimpleString, Addition)
 {
     SimpleString s1("hello!");
@@ -576,6 +584,11 @@ TEST(SimpleString, ContainsNull)
 TEST(SimpleString, NULLReportsNullString)
 {
     STRCMP_EQUAL("(null)", StringFromOrNull((char*) NULLPTR).asCharString());
+}
+
+TEST(SimpleString, NULLReportsNullStringPrintable)
+{
+    STRCMP_EQUAL("(null)", PrintableStringFromOrNull((char*) NULLPTR).asCharString());
 }
 
 TEST(SimpleString, Booleans)

--- a/tests/CppUTest/TestFailureTest.cpp
+++ b/tests/CppUTest/TestFailureTest.cpp
@@ -212,10 +212,10 @@ TEST(TestFailure, StringsEqualFailureWithNewLinesAndTabs)
             "StringWith\t\nDifferentString",
             "StringWith\t\ndifferentString", "");
 
-    FAILURE_EQUAL("expected <StringWith\t\nDifferentString>\n"
-                "\tbut was  <StringWith\t\ndifferentString>\n"
-                "\tdifference starts at position 12 at: <ringWith\t\ndifferentS>\n"
-                "\t                                              \t\n^", f);
+    FAILURE_EQUAL("expected <StringWith\\t\\nDifferentString>\n"
+                "\tbut was  <StringWith\\t\\ndifferentString>\n"
+                "\tdifference starts at position 12 at: <ngWith\\t\\ndifferentS>\n"
+                "\t                                                ^", f);
 }
 
 TEST(TestFailure, StringsEqualFailureInTheMiddle)


### PR DESCRIPTION
When a string comparison (e.g. STRCMP_EQUAL) fails and the string contains non-printable characters (newlines, tabs, or even worse, ANSI color escape codes!) it's a mess to locate in the error log exactly where the comparison failed.

To avoid this, this PR makes cpputest replace non-printable characters with their corresponding C escape cores when printing the error log, making it easier to compare both strings.