### PR TITLE
fix typo "exaples" to "examples"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,7 @@ option(TESTS "Compile and make tests for the code?" ON)
 option(TESTS_DETAILED "Run each test separately instead of grouped?" OFF)
 option(TESTS_BUILD_DISCOVER "Build time test discover" ON)
 
-option(EXAMPLES "Compile and make exaples?" OFF)
+option(EXAMPLES "Compile and make examples?" OFF)
 
 option(VERBOSE_CONFIG "Print configuration to stdout during generation" ON)
 


### PR DESCRIPTION
fix typo "exaples" to "examples"