### PR TITLE
filterGcov.sh fails if your filename or path contains "File"

### DIFF
--- a/scripts/filterGcov.sh
+++ b/scripts/filterGcov.sh
@@ -22,7 +22,7 @@ getRidOfCruft() {
 sed '-e s/^Lines.*://g' \
     '-e s/^[0-9]\./  &/g' \
     '-e s/^[0-9][0-9]\./ &/g' \
-    '-e s/of.*File/ /g' \
+    '-e s/of.\w[^'File']*File/ /g' \
     "-e s/'//g" \
     '-e s/^.*\/usr\/.*$//g' \
     '-e s/^.*\.$//g' 


### PR DESCRIPTION
If you filename contains "File" like ....configFile.c
The filter removes the whole file name minus ".c".
This inhibits the html output to access the coverage file.