### PR TITLE
Add missing clang check

### DIFF
--- a/src/Platforms/Gcc/UtestPlatform.cpp
+++ b/src/Platforms/Gcc/UtestPlatform.cpp
@@ -175,8 +175,10 @@ static int PlatformSpecificSetJmpImplementation(void (*function) (void* data), v
  * MacOSX clang 3.0 doesn't seem to recognize longjmp and thus complains about _no_return_.
  * The later clang compilers complain when it isn't there. So only way is to check the clang compiler here :(
  */
-#if !((__clang_major__ == 3) && (__clang_minor__ == 0))
-_no_return_
+#ifdef __clang__
+ #if !((__clang_major__ == 3) && (__clang_minor__ == 0))
+ _no_return_
+ #endif
 #endif
 static void PlatformSpecificLongJmpImplementation()
 {


### PR DESCRIPTION
There is a check for a clang version that is not guarded by a check if clang is defined. This MR adds this guard otherwise there is a compiler warning for compiling with g++ and -Wundef.

Fixes #1445