### PR TITLE
CodeQL Github Action

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,30 @@
+name: codeql
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 5 * * 3'
+
+jobs:
+  codeql:
+    runs-on: ubuntu-20.04
+    env:
+      CC: gcc-10
+      CXX: g++-10
+    name: "CodeQL"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+      - name: CodeQL Initialization
+        uses: github/codeql-action/init@v1
+        with:
+          languages: cpp
+          queries: +security-and-quality
+      - name: Build
+        run: |
+          mkdir _build && cd _build
+          cmake -DWERROR=ON -DCMAKE_CXX_STANDARD=17 ..
+          make -j2
+      - name: CodeQL Analysis
+        uses: github/codeql-action/analyze@v1


### PR DESCRIPTION
Adds a CodeQL build, based on Github Action. A weekly cron ensures checking with latest queries on a regular basis, even if there's no commit in the repo.

@basvodde With the current situation on Travis, what's your opinion on moving to GH Actions in general?