### PR TITLE
Fix clang version check and remove clang 12 warning

### DIFF
--- a/build/MakefileWorker.mk
+++ b/build/MakefileWorker.mk
@@ -201,16 +201,22 @@ ifeq ($(COMPILER_NAME),$(CLANG_STR))
 	CPPUTEST_CXX_WARNINGFLAGS += -Weverything -Wno-disabled-macro-expansion -Wno-padded -Wno-global-constructors -Wno-exit-time-destructors -Wno-weak-vtables -Wno-old-style-cast -Wno-c++11-long-long -Wno-c++98-compat-pedantic -Wno-reserved-id-macro -Wno-keyword-macro
 	CPPUTEST_C_WARNINGFLAGS += -Weverything -Wno-padded
 
-# Clang "7" or newer (Xcode 7 or newer command-line tools) introduced new warnings by default that don't exist on previous versions of clang and cause errors when present.
-CLANG_VERSION := $(shell echo $(CC_VERSION_OUTPUT) | grep -o 'clang-[0-9][0-9][0-9]*.')
-CLANG_VERSION_NUM := $(subst .,,$(subst clang-,,$(CLANG_VERSION)))
-CLANG_VERSION_NUM_GT_700 := $(shell [[ $(CLANG_VERSION_NUM) -ge 700 ]] && echo Y)
+# Clang 7 and 12 introduced new warnings by default that don't exist on previous versions of clang and cause errors when present.
+CLANG_VERSION := $(shell echo $(CC_VERSION_OUTPUT) | sed -n 's/.* \([0-9]*\.[0-9]*\.[0-9]*\).*/\1/p')
+CLANG_VERSION_NUM := $(subst .,,$(CLANG_VERSION))
+CLANG_VERSION_NUM_GT_700 := $(shell [ "$(CLANG_VERSION_NUM)" -ge 700 ] && echo Y || echo N)
+CLANG_VERSION_NUM_GT_1200 := $(shell [ "$(CLANG_VERSION_NUM)" -ge 1200 ] && echo Y || echo N)
 
 ifeq ($(CLANG_VERSION_NUM_GT_700), Y)
 # -Wno-reserved-id-macro -> Many CppUTest macros start with __, which is a reserved namespace
 # -Wno-keyword-macro -> CppUTest redefines the 'new' keyword for memory leak tracking
 	CPPUTEST_CXX_WARNINGFLAGS += -Wno-reserved-id-macro -Wno-keyword-macro
 	CPPUTEST_C_WARNINGFLAGS += -Wno-reserved-id-macro -Wno-keyword-macro
+endif
+ifeq ($(CLANG_VERSION_NUM_GT_1200), Y)
+# -Wno-poison-system-directories -> Apparently apple clang thinks everything is a cross compile, making this useless
+	CPPUTEST_CXX_WARNINGFLAGS += -Wno-poison-system-directories
+	CPPUTEST_C_WARNINGFLAGS += -Wno-poison-system-directories
 endif
 endif
 


### PR DESCRIPTION
The clang version check in build/MakefileWorker.mk only worked for apple
clang, so this changes the version checking to work with apple, debian,
and ubuntu clang version strings.

Additionally, clang 12 added -Wpoison-system-directories, which warns if
you if you include stuff from /usr/local/include when doing a cross
compile.
Apple clang thinks it's always doing a cross compile for some reason, so
that always complains.

Closes #1456
