### PR TITLE
GCC 11 compatibility

### DIFF
--- a/src/CppUTest/Utest.cpp
+++ b/src/CppUTest/Utest.cpp
@@ -30,6 +30,10 @@
 #include "CppUTest/PlatformSpecificFunctions.h"
 #include "CppUTest/TestOutput.h"
 
+#if defined(__GNUC__) && __GNUC__ >= 11
+# define NEEDS_DISABLE_NULL_WARNING
+#endif /* GCC >= 11 */
+
 bool doubles_equal(double d1, double d2, double threshold)
 {
     if (PlatformSpecificIsNan(d1) || PlatformSpecificIsNan(d2) || PlatformSpecificIsNan(threshold))
@@ -158,10 +162,20 @@ UtestShell::~UtestShell()
 }
 
 // LCOV_EXCL_START - actually covered but not in .gcno due to race condition
+#ifdef NEEDS_DISABLE_NULL_WARNING
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wnonnull"
+#endif /* NEEDS_DISABLE_NULL_WARNING */
+
 static void defaultCrashMethod()
 {
-    UtestShell* ptr = (UtestShell*) NULLPTR; ptr->countTests();
+    UtestShell* ptr = (UtestShell*) NULLPTR;
+    ptr->countTests();
 }
+
+#ifdef NEEDS_DISABLE_NULL_WARNING
+# pragma GCC diagnostic pop
+#endif /* NEEDS_DISABLE_NULL_WARNING */
 // LCOV_EXCL_STOP
 
 static void (*pleaseCrashMeRightNow) () = defaultCrashMethod;

--- a/tests/CppUTest/MemoryOperatorOverloadTest.cpp
+++ b/tests/CppUTest/MemoryOperatorOverloadTest.cpp
@@ -10,6 +10,11 @@
 #include "CppUTest/TestHarness_c.h"
 #include "AllocationInCFile.h"
 
+#if defined(__GNUC__) && __GNUC__ >= 11
+# define NEEDS_DISABLE_FREE_NON_HEEP_WARNING
+#endif /* GCC >= 11 */
+
+
 TEST_GROUP(BasicBehavior)
 {
 };
@@ -60,11 +65,21 @@ TEST(BasicBehavior, DeleteWithSizeParameterWorks)
 }
 #endif
 
+#ifdef NEEDS_DISABLE_FREE_NON_HEEP_WARNING
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wfree-nonheap-object"
+#endif /* NEEDS_DISABLE_FREE_NON_HEEP_WARNING */
+
 static void deleteUnallocatedMemory()
 {
     delete (char*) 0x1234678;
     FAIL("Should never come here"); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
+
+#ifdef NEEDS_DISABLE_FREE_NON_HEEP_WARNING
+# pragma GCC diagnostic pop
+#endif /* NEEDS_DISABLE_FREE_NON_HEEP_WARNING */
+
 
 TEST(BasicBehavior, deleteWillNotThrowAnExceptionWhenDeletingUnallocatedMemoryButCanStillCauseTestFailures)
 {


### PR DESCRIPTION
GCC 11 has introduced a set of new warnings. Since the behaviour they should prevent is used in tests explicitly, they need to be disabled – with minimal scope.