### PR TITLE
Fix compile gcc from cygwin

### DIFF
--- a/src/CppUTest/CMakeLists.txt
+++ b/src/CppUTest/CMakeLists.txt
@@ -69,7 +69,7 @@ set_target_properties(CppUTest PROPERTIES
     PUBLIC_HEADER "${CppUTest_headers}")
 
 if (WIN32)
-    target_link_libraries(CppUTest winmm.lib)
+    target_link_libraries(CppUTest winmm)
 endif (WIN32)
 install(TARGETS CppUTest
     EXPORT CppUTestTargets


### PR DESCRIPTION
By letting CMake handle the windows library suffix (.lib or .a)


_First contribution Hope requirements are met_