### PR TITLE
Fixed build using bcc2 compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,11 @@ if(HAVE_FORK)
   add_definitions(-DCPPUTEST_HAVE_FORK)
 endif(HAVE_FORK)
 
+check_function_exists(waitpid HAVE_WAITPID)
+if(HAVE_WAITPID)
+  add_definitions(-DCPPUTEST_HAVE_WAITPID)
+endif(HAVE_WAITPID)
+
 check_function_exists(gettimeofday HAVE_GETTIMEOFDAY)
 if(HAVE_GETTIMEOFDAY)
   add_definitions(-DCPPUTEST_HAVE_GETTIMEOFDAY=1)

--- a/configure.ac
+++ b/configure.ac
@@ -62,7 +62,7 @@ AC_TYPE_LONG_LONG_INT
 
 # Checks for library functions.
 AC_FUNC_FORK
-AC_CHECK_FUNCS([gettimeofday memset strstr strdup pthread_mutex_lock])
+AC_CHECK_FUNCS([waitpid gettimeofday memset strstr strdup pthread_mutex_lock])
 
 AC_CHECK_PROG([CPPUTEST_HAS_GCC], [gcc], [yes], [no])
 AC_CHECK_PROG([CPPUTEST_HAS_CLANG], [clang], [yes], [no])

--- a/src/Platforms/Gcc/UtestPlatform.cpp
+++ b/src/Platforms/Gcc/UtestPlatform.cpp
@@ -37,7 +37,7 @@
 #ifdef CPPUTEST_HAVE_GETTIMEOFDAY
 #include <sys/time.h>
 #endif
-#ifdef CPPUTEST_HAVE_FORK
+#if defined(CPPUTEST_HAVE_FORK) && defined(CPPUTEST_HAVE_WAITPID)
 #include <unistd.h>
 #include <sys/wait.h>
 #include <errno.h>
@@ -61,7 +61,8 @@
 static jmp_buf test_exit_jmp_buf[10];
 static int jmp_buf_index = 0;
 
-#ifndef CPPUTEST_HAVE_FORK
+// There is a possibility that a compiler provides fork but not waitpid.
+#if !defined(CPPUTEST_HAVE_FORK) || !defined(CPPUTEST_HAVE_WAITPID)
 
 static void GccPlatformSpecificRunTestInASeperateProcess(UtestShell* shell, TestPlugin*, TestResult* result)
 {

--- a/tests/CppUTest/UtestPlatformTest.cpp
+++ b/tests/CppUTest/UtestPlatformTest.cpp
@@ -44,7 +44,8 @@ TEST_GROUP(UTestPlatformsTest_PlatformSpecificRunTestInASeperateProcess)
     TestTestingFixture fixture;
 };
 
-#ifndef CPPUTEST_HAVE_FORK
+// There is a possibility that a compiler provides fork but not waitpid.
+#if !defined(CPPUTEST_HAVE_FORK) || !defined(CPPUTEST_HAVE_WAITPID)
 
 TEST(UTestPlatformsTest_PlatformSpecificRunTestInASeperateProcess, DummyFailsWithMessage)
 {

--- a/tests/CppUTest/UtestTest.cpp
+++ b/tests/CppUTest/UtestTest.cpp
@@ -243,7 +243,8 @@ TEST(UtestShell, RunInSeparateProcessTest)
     fixture.assertPrintContains("Failed in separate process");
 }
 
-#ifndef CPPUTEST_HAVE_FORK
+// There is a possibility that a compiler provides fork but not waitpid.
+#if !defined(CPPUTEST_HAVE_FORK) || !defined(CPPUTEST_HAVE_WAITPID)
 
 IGNORE_TEST(UtestShell, TestDefaultCrashMethodInSeparateProcessTest) {}
 


### PR DESCRIPTION
I am doing some R&D regarding the bcc2 compiler from Gaisler and I wanted to use cpputest as a test library in the future.

While trying to build the library using that compiler, with STD_C `on`, I encountered a linker error - undefined reference to `waitpid`. After some debugging I found, that the library checks if the compiler provides `fork` function and if it does it uses platform specific fork and waitpid implementations (UtestPlatform.cpp:64). Apparently Gaisler uses a stub fork (among some others), but waitpid is missing:
![image](https://user-images.githubusercontent.com/5027115/126275939-b61afcd4-14e7-4a91-8b9a-4eb9c9be2688.png)

To be able to compile the library in such situation I added an additional check - for waitpid availability. With this I am able to use cpputest with my project, and run tests using LEON3 simulator.