### PR TITLE
redirect to github.io

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <html>
   <head>
-   <meta http-equiv="refresh" content="0;url=http://cpputest.github.com">
+   <meta http-equiv="refresh" content="0;url=http://cpputest.github.io">
     <meta charset='utf-8'>
     <meta http-equiv="X-UA-Compatible" content="chrome=1">
     <title>Cpputest</title>
   </head>
 
   <body>
-    Moved to cpputest.github.com
+    Moved to cpputest.github.io
   </body>
 </html>


### PR DESCRIPTION
github pages are now hosted under `.io` domain

( https://docs.github.com/en/pages/getting-started-with-github-pages/about-github-pages )