### PR TITLE
Update GH Action branch

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,7 +15,7 @@ jobs:
     name: "CodeQL"
     steps:
       - name: Checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@main
       - name: CodeQL Initialization
         uses: github/codeql-action/init@v1
         with:


### PR DESCRIPTION
The `checkout` step has switched to `main` as default branch. `master` still exists, but isn't updated anymore.