### PR TITLE
Fix reserved identifier usage

### DIFF
--- a/tests/CppUTest/MemoryLeakWarningTest.cpp
+++ b/tests/CppUTest/MemoryLeakWarningTest.cpp
@@ -99,7 +99,7 @@ TEST_GROUP(MemoryLeakWarningTest)
     }
 };
 
-static void _testTwoLeaks()
+static void testTwoLeaks_()
 {
     leak1 = detector->allocMemory(allocator, 10);
     leak2 = (long*) (void*) detector->allocMemory(allocator, 4);
@@ -109,7 +109,7 @@ static void _testTwoLeaks()
 
 TEST(MemoryLeakWarningTest, TwoLeaks)
 {
-    fixture->setTestFunction(_testTwoLeaks);
+    fixture->setTestFunction(testTwoLeaks_);
     fixture->runAllTests();
 
     LONGS_EQUAL(1, fixture->getFailureCount());
@@ -119,7 +119,7 @@ TEST(MemoryLeakWarningTest, TwoLeaks)
 
 TEST(MemoryLeakWarningTest, TwoLeaks)
 {
-    fixture->setTestFunction(_testTwoLeaks);
+    fixture->setTestFunction(testTwoLeaks_);
     fixture->runAllTests();
 
     LONGS_EQUAL(0, fixture->getFailureCount());
@@ -128,7 +128,7 @@ TEST(MemoryLeakWarningTest, TwoLeaks)
 #endif
 
 
-static void _testLeakWarningWithPluginDisabled()
+static void testLeakWarningWithPluginDisabled_()
 {
     memPlugin->expectLeaksInTest(1);
     leak1 = (char*) cpputest_malloc_location_with_leak_detection(10, __FILE__, __LINE__);
@@ -136,7 +136,7 @@ static void _testLeakWarningWithPluginDisabled()
 
 TEST(MemoryLeakWarningTest, LeakWarningWithPluginDisabled)
 {
-    fixture->setTestFunction(_testLeakWarningWithPluginDisabled);
+    fixture->setTestFunction(testLeakWarningWithPluginDisabled_);
 
     MemoryLeakWarningPlugin::saveAndDisableNewDeleteOverloads();
 
@@ -151,7 +151,7 @@ TEST(MemoryLeakWarningTest, LeakWarningWithPluginDisabled)
     MemoryLeakWarningPlugin::restoreNewDeleteOverloads();
 }
 
-static void _testIgnore2()
+static void testIgnore2_()
 {
     memPlugin->expectLeaksInTest(2);
     leak1 = detector->allocMemory(allocator, 10);
@@ -160,12 +160,12 @@ static void _testIgnore2()
 
 TEST(MemoryLeakWarningTest, Ignore2)
 {
-    fixture->setTestFunction(_testIgnore2);
+    fixture->setTestFunction(testIgnore2_);
     fixture->runAllTests();
     LONGS_EQUAL(0, fixture->getFailureCount());
 }
 
-static void _failAndLeakMemory()
+static void failAndLeakMemory_()
 {
     leak1 = detector->allocMemory(allocator, 10);
     FAIL("");
@@ -173,7 +173,7 @@ static void _failAndLeakMemory()
 
 TEST(MemoryLeakWarningTest, FailingTestDoesNotReportMemoryLeaks)
 {
-    fixture->setTestFunction(_failAndLeakMemory);
+    fixture->setTestFunction(failAndLeakMemory_);
     fixture->runAllTests();
     LONGS_EQUAL(1, fixture->getFailureCount());
 }

--- a/tests/CppUTest/SimpleStringCacheTest.cpp
+++ b/tests/CppUTest/SimpleStringCacheTest.cpp
@@ -251,7 +251,7 @@ TEST(SimpleStringInternalCache, clearAllIncludingCurrentlyUsedMemoryAlsoReleases
     LONGS_EQUAL(3, accountant.totalDeallocationsOfSize(1234));
 }
 
-static void _deallocatingStringMemoryThatWasntAllocatedWithCache(SimpleStringInternalCache* cache, size_t allocationSize)
+static void deallocatingStringMemoryThatWasntAllocatedWithCache_(SimpleStringInternalCache* cache, size_t allocationSize)
 {
     char* mem = defaultMallocAllocator()->alloc_memory(allocationSize, __FILE__, __LINE__);
     mem[0] = 'B';
@@ -264,7 +264,7 @@ static void _deallocatingStringMemoryThatWasntAllocatedWithCache(SimpleStringInt
 
 TEST(SimpleStringInternalCache, deallocatingMemoryThatWasntAllocatedWhileCacheWasInPlaceProducesWarning)
 {
-    testFunction.testFunction = _deallocatingStringMemoryThatWasntAllocatedWithCache;
+    testFunction.testFunction = deallocatingStringMemoryThatWasntAllocatedWithCache_;
     testFunction.allocationSize = 123;
 
     cache.setAllocator(allocator);
@@ -277,7 +277,7 @@ TEST(SimpleStringInternalCache, deallocatingMemoryThatWasntAllocatedWhileCacheWa
 
 }
 
-static void _deallocatingStringMemoryTwiceThatWasntAllocatedWithCache(SimpleStringInternalCache* cache, size_t allocationSize)
+static void deallocatingStringMemoryTwiceThatWasntAllocatedWithCache_(SimpleStringInternalCache* cache, size_t allocationSize)
 {
     char* mem = defaultMallocAllocator()->alloc_memory(allocationSize, __FILE__, __LINE__);
     mem[0] = '\0';
@@ -288,7 +288,7 @@ static void _deallocatingStringMemoryTwiceThatWasntAllocatedWithCache(SimpleStri
 
 TEST(SimpleStringInternalCache, deallocatingMemoryThatWasntAllocatedWhileCacheWasInPlaceProducesWarningButOnlyOnce)
 {
-    testFunction.testFunction = _deallocatingStringMemoryTwiceThatWasntAllocatedWithCache;
+    testFunction.testFunction = deallocatingStringMemoryTwiceThatWasntAllocatedWithCache_;
     testFunction.allocationSize = 123;
 
     cache.setAllocator(allocator);
@@ -299,7 +299,7 @@ TEST(SimpleStringInternalCache, deallocatingMemoryThatWasntAllocatedWhileCacheWa
 
 TEST(SimpleStringInternalCache, deallocatingLargeMemoryThatWasntAllocatedWhileCacheWasInPlaceProducesWarning)
 {
-    testFunction.testFunction = _deallocatingStringMemoryThatWasntAllocatedWithCache;
+    testFunction.testFunction = deallocatingStringMemoryThatWasntAllocatedWithCache_;
     testFunction.allocationSize = 12345;
 
     cache.setAllocator(allocator);
@@ -314,7 +314,7 @@ TEST(SimpleStringInternalCache, deallocatingLargeMemoryThatWasntAllocatedWhileCa
 
 TEST(SimpleStringInternalCache, deallocatingLargeMemoryThatWasntAllocatedWhileCacheWasInPlaceProducesWarningButOnlyOnce)
 {
-    testFunction.testFunction = _deallocatingStringMemoryTwiceThatWasntAllocatedWithCache;
+    testFunction.testFunction = deallocatingStringMemoryTwiceThatWasntAllocatedWithCache_;
     testFunction.allocationSize = 12345;
 
     cache.setAllocator(allocator);

--- a/tests/CppUTest/SimpleStringTest.cpp
+++ b/tests/CppUTest/SimpleStringTest.cpp
@@ -105,19 +105,19 @@ TEST(GlobalSimpleStringMemoryAccountant, stop)
     POINTERS_EQUAL(originalAllocator, SimpleString::getStringAllocator());
 }
 
-static void _stopAccountant(GlobalSimpleStringMemoryAccountant* accountant)
+static void stopAccountant_(GlobalSimpleStringMemoryAccountant* accountant)
 {
     accountant->stop();
 }
 
 TEST(GlobalSimpleStringMemoryAccountant, stopWithoutStartWillFail)
 {
-    testFunction.testFunction_ = _stopAccountant;
+    testFunction.testFunction_ = stopAccountant_;
     fixture.runAllTests();
     fixture.assertPrintContains("Global SimpleString allocator stopped without starting");
 }
 
-static void _changeAllocatorBetweenStartAndStop(GlobalSimpleStringMemoryAccountant* accountant)
+static void changeAllocatorBetweenStartAndStop_(GlobalSimpleStringMemoryAccountant* accountant)
 {
     TestMemoryAllocator* originalAllocator = SimpleString::getStringAllocator();
     accountant->start();
@@ -127,7 +127,7 @@ static void _changeAllocatorBetweenStartAndStop(GlobalSimpleStringMemoryAccounta
 
 TEST(GlobalSimpleStringMemoryAccountant, stopFailsWhenAllocatorWasChangedInBetween)
 {
-    testFunction.testFunction_ = _changeAllocatorBetweenStartAndStop;
+    testFunction.testFunction_ = changeAllocatorBetweenStartAndStop_;
     fixture.runAllTests();
     fixture.assertPrintContains("GlobalStrimpleStringMemoryAccountant: allocator has changed between start and stop!");
 }
@@ -847,7 +847,7 @@ TEST(SimpleString, CollectionWritingToEmptyString)
 
 #ifdef CPPUTEST_64BIT
 
-TEST(SimpleString, _64BitAddressPrintsCorrectly)
+TEST(SimpleString, 64BitAddressPrintsCorrectly)
 {
     char* p = (char*) 0x0012345678901234;
     SimpleString expected("0x12345678901234");
@@ -878,7 +878,7 @@ TEST(SimpleString, BracketsFormattedHexStringFromForLongOnDifferentPlatform)
 /*
  * This test case cannot pass on 32 bit systems.
  */
-IGNORE_TEST(SimpleString, _64BitAddressPrintsCorrectly)
+IGNORE_TEST(SimpleString, 64BitAddressPrintsCorrectly)
 {
 }
 

--- a/tests/CppUTest/TestHarness_cTest.cpp
+++ b/tests/CppUTest/TestHarness_cTest.cpp
@@ -84,7 +84,7 @@ TEST_GROUP(TestHarness_c)
     }
 };
 
-static void _failBoolMethod()
+static void failBoolMethod_()
 {
     HasTheDestructorBeenCalledChecker checker;
     CHECK_EQUAL_C_BOOL(1, 0);
@@ -94,14 +94,14 @@ TEST(TestHarness_c, checkBool)
 {
     CHECK_EQUAL_C_BOOL(1, 1);
     CHECK_EQUAL_C_BOOL(1, 2);
-    fixture->setTestFunction(_failBoolMethod);
+    fixture->setTestFunction(failBoolMethod_);
     fixture->runAllTests();
     fixture->assertPrintContains("expected <true>\n	but was  <false>");
     fixture->assertPrintContains("arness_c");
     CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
-static void _failBoolTextMethod()
+static void failBoolTextMethod_()
 {
     HasTheDestructorBeenCalledChecker checker;
     CHECK_EQUAL_C_BOOL_TEXT(1, 0, "BoolTestText");
@@ -111,7 +111,7 @@ TEST(TestHarness_c, checkBoolText)
 {
     CHECK_EQUAL_C_BOOL_TEXT(1, 1, "Text");
     CHECK_EQUAL_C_BOOL_TEXT(1, 2, "Text");
-    fixture->setTestFunction(_failBoolTextMethod);
+    fixture->setTestFunction(failBoolTextMethod_);
     fixture->runAllTests();
     fixture->assertPrintContains("expected <true>\n	but was  <false>");
     fixture->assertPrintContains("arness_c");
@@ -119,7 +119,7 @@ TEST(TestHarness_c, checkBoolText)
     CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
-static void _failIntMethod()
+static void failIntMethod_()
 {
     HasTheDestructorBeenCalledChecker checker;
     CHECK_EQUAL_C_INT(1, 2);
@@ -128,14 +128,14 @@ static void _failIntMethod()
 TEST(TestHarness_c, checkInt)
 {
     CHECK_EQUAL_C_INT(2, 2);
-    fixture->setTestFunction(_failIntMethod);
+    fixture->setTestFunction(failIntMethod_);
     fixture->runAllTests();
     fixture->assertPrintContains("expected <1 (0x1)>\n	but was  <2 (0x2)>");
     fixture->assertPrintContains("arness_c");
     CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
-static void _failIntTextMethod()
+static void failIntTextMethod_()
 {
     HasTheDestructorBeenCalledChecker checker;
     CHECK_EQUAL_C_INT_TEXT(1, 2, "IntTestText");
@@ -144,7 +144,7 @@ static void _failIntTextMethod()
 TEST(TestHarness_c, checkIntText)
 {
     CHECK_EQUAL_C_INT_TEXT(2, 2, "Text");
-    fixture->setTestFunction(_failIntTextMethod);
+    fixture->setTestFunction(failIntTextMethod_);
     fixture->runAllTests();
     fixture->assertPrintContains("expected <1 (0x1)>\n	but was  <2 (0x2)>");
     fixture->assertPrintContains("arness_c");
@@ -152,7 +152,7 @@ TEST(TestHarness_c, checkIntText)
     CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
-static void _failUnsignedIntMethod()
+static void failUnsignedIntMethod_()
 {
     HasTheDestructorBeenCalledChecker checker;
     CHECK_EQUAL_C_UINT(1, 2);
@@ -161,14 +161,14 @@ static void _failUnsignedIntMethod()
 TEST(TestHarness_c, checkUnsignedInt)
 {
     CHECK_EQUAL_C_UINT(2, 2);
-    fixture->setTestFunction(_failUnsignedIntMethod);
+    fixture->setTestFunction(failUnsignedIntMethod_);
     fixture->runAllTests();
     fixture->assertPrintContains("expected <1 (0x1)>\n	but was  <2 (0x2)>");
     fixture->assertPrintContains("arness_c");
     CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
-static void _failUnsignedIntTextMethod()
+static void failUnsignedIntTextMethod_()
 {
     HasTheDestructorBeenCalledChecker checker;
     CHECK_EQUAL_C_UINT_TEXT(1, 2, "UnsignedIntTestText");
@@ -177,7 +177,7 @@ static void _failUnsignedIntTextMethod()
 TEST(TestHarness_c, checkUnsignedIntText)
 {
     CHECK_EQUAL_C_UINT_TEXT(2, 2, "Text");
-    fixture->setTestFunction(_failUnsignedIntTextMethod);
+    fixture->setTestFunction(failUnsignedIntTextMethod_);
     fixture->runAllTests();
     fixture->assertPrintContains("expected <1 (0x1)>\n	but was  <2 (0x2)>");
     fixture->assertPrintContains("arness_c");
@@ -185,7 +185,7 @@ TEST(TestHarness_c, checkUnsignedIntText)
     CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
-static void _failLongIntMethod()
+static void failLongIntMethod_()
 {
     HasTheDestructorBeenCalledChecker checker;
     CHECK_EQUAL_C_LONG(1, 2);
@@ -194,14 +194,14 @@ static void _failLongIntMethod()
 TEST(TestHarness_c, checkLongInt)
 {
     CHECK_EQUAL_C_LONG(2, 2);
-    fixture->setTestFunction(_failLongIntMethod);
+    fixture->setTestFunction(failLongIntMethod_);
     fixture->runAllTests();
     fixture->assertPrintContains("expected <1 (0x1)>\n	but was  <2 (0x2)>");
     fixture->assertPrintContains("arness_c");
     CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
-static void _failLongIntTextMethod()
+static void failLongIntTextMethod_()
 {
     HasTheDestructorBeenCalledChecker checker;
     CHECK_EQUAL_C_LONG_TEXT(1, 2, "LongIntTestText");
@@ -210,7 +210,7 @@ static void _failLongIntTextMethod()
 TEST(TestHarness_c, checkLongIntText)
 {
     CHECK_EQUAL_C_LONG_TEXT(2, 2, "Text");
-    fixture->setTestFunction(_failLongIntTextMethod);
+    fixture->setTestFunction(failLongIntTextMethod_);
     fixture->runAllTests();
     fixture->assertPrintContains("expected <1 (0x1)>\n	but was  <2 (0x2)>");
     fixture->assertPrintContains("arness_c");
@@ -218,7 +218,7 @@ TEST(TestHarness_c, checkLongIntText)
     CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
-static void _failUnsignedLongIntMethod()
+static void failUnsignedLongIntMethod_()
 {
     HasTheDestructorBeenCalledChecker checker;
     CHECK_EQUAL_C_ULONG(1, 2);
@@ -227,14 +227,14 @@ static void _failUnsignedLongIntMethod()
 TEST(TestHarness_c, checkUnsignedLongInt)
 {
     CHECK_EQUAL_C_ULONG(2, 2);
-    fixture->setTestFunction(_failUnsignedLongIntMethod);
+    fixture->setTestFunction(failUnsignedLongIntMethod_);
     fixture->runAllTests();
     fixture->assertPrintContains("expected <1 (0x1)>\n	but was  <2 (0x2)>");
     fixture->assertPrintContains("arness_c");
     CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
-static void _failUnsignedLongIntTextMethod()
+static void failUnsignedLongIntTextMethod_()
 {
     HasTheDestructorBeenCalledChecker checker;
     CHECK_EQUAL_C_ULONG_TEXT(1, 2, "UnsignedLongIntTestText");
@@ -243,7 +243,7 @@ static void _failUnsignedLongIntTextMethod()
 TEST(TestHarness_c, checkUnsignedLongIntText)
 {
     CHECK_EQUAL_C_ULONG_TEXT(2, 2, "Text");
-    fixture->setTestFunction(_failUnsignedLongIntTextMethod);
+    fixture->setTestFunction(failUnsignedLongIntTextMethod_);
     fixture->runAllTests();
     fixture->assertPrintContains("expected <1 (0x1)>\n	but was  <2 (0x2)>");
     fixture->assertPrintContains("arness_c");
@@ -253,7 +253,7 @@ TEST(TestHarness_c, checkUnsignedLongIntText)
 
 #ifdef CPPUTEST_USE_LONG_LONG
 
-static void _failLongLongIntMethod()
+static void failLongLongIntMethod_()
 {
     HasTheDestructorBeenCalledChecker checker;
     CHECK_EQUAL_C_LONGLONG(1, 2);
@@ -262,14 +262,14 @@ static void _failLongLongIntMethod()
 TEST(TestHarness_c, checkLongLongInt)
 {
     CHECK_EQUAL_C_LONGLONG(2, 2);
-    fixture->setTestFunction(_failLongLongIntMethod);
+    fixture->setTestFunction(failLongLongIntMethod_);
     fixture->runAllTests();
     fixture->assertPrintContains("expected <1 (0x1)>\n	but was  <2 (0x2)>");
     fixture->assertPrintContains("arness_c");
     CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
-static void _failLongLongIntTextMethod()
+static void failLongLongIntTextMethod_()
 {
     HasTheDestructorBeenCalledChecker checker;
     CHECK_EQUAL_C_LONGLONG_TEXT(1, 2, "LongLongTestText");
@@ -278,7 +278,7 @@ static void _failLongLongIntTextMethod()
 TEST(TestHarness_c, checkLongLongIntText)
 {
     CHECK_EQUAL_C_LONGLONG_TEXT(2, 2, "Text");
-    fixture->setTestFunction(_failLongLongIntTextMethod);
+    fixture->setTestFunction(failLongLongIntTextMethod_);
     fixture->runAllTests();
     fixture->assertPrintContains("expected <1 (0x1)>\n	but was  <2 (0x2)>");
     fixture->assertPrintContains("arness_c");
@@ -286,7 +286,7 @@ TEST(TestHarness_c, checkLongLongIntText)
     CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
-static void _failUnsignedLongLongIntMethod()
+static void failUnsignedLongLongIntMethod_()
 {
     HasTheDestructorBeenCalledChecker checker;
     CHECK_EQUAL_C_ULONGLONG(1, 2);
@@ -295,14 +295,14 @@ static void _failUnsignedLongLongIntMethod()
 TEST(TestHarness_c, checkUnsignedLongLongInt)
 {
     CHECK_EQUAL_C_ULONGLONG(2, 2);
-    fixture->setTestFunction(_failUnsignedLongLongIntMethod);
+    fixture->setTestFunction(failUnsignedLongLongIntMethod_);
     fixture->runAllTests();
     fixture->assertPrintContains("expected <1 (0x1)>\n	but was  <2 (0x2)>");
     fixture->assertPrintContains("arness_c");
     CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
-static void _failUnsignedLongLongIntTextMethod()
+static void failUnsignedLongLongIntTextMethod_()
 {
     HasTheDestructorBeenCalledChecker checker;
     CHECK_EQUAL_C_ULONGLONG_TEXT(1, 2, "UnsignedLongLongTestText");
@@ -311,7 +311,7 @@ static void _failUnsignedLongLongIntTextMethod()
 TEST(TestHarness_c, checkUnsignedLongLongIntText)
 {
     CHECK_EQUAL_C_ULONGLONG_TEXT(2, 2, "Text");
-    fixture->setTestFunction(_failUnsignedLongLongIntTextMethod);
+    fixture->setTestFunction(failUnsignedLongLongIntTextMethod_);
     fixture->runAllTests();
     fixture->assertPrintContains("expected <1 (0x1)>\n	but was  <2 (0x2)>");
     fixture->assertPrintContains("arness_c");
@@ -321,7 +321,7 @@ TEST(TestHarness_c, checkUnsignedLongLongIntText)
 
 #else
 
-static void _failLongLongIntMethod()
+static void failLongLongIntMethod_()
 {
     cpputest_longlong dummy_longlong;
     CHECK_EQUAL_C_LONGLONG(dummy_longlong, dummy_longlong);
@@ -329,13 +329,13 @@ static void _failLongLongIntMethod()
 
 TEST(TestHarness_c, checkLongLongInt)
 {
-    fixture->setTestFunction(_failLongLongIntMethod);
+    fixture->setTestFunction(failLongLongIntMethod_);
     fixture->runAllTests();
     fixture->assertPrintContains("is not supported");
     fixture->assertPrintContains("arness_c");
 }
 
-static void _failLongLongIntTextMethod()
+static void failLongLongIntTextMethod_()
 {
     cpputest_longlong dummy_longlong;
     CHECK_EQUAL_C_LONGLONG_TEXT(dummy_longlong, dummy_longlong, "Text");
@@ -343,13 +343,13 @@ static void _failLongLongIntTextMethod()
 
 TEST(TestHarness_c, checkLongLongIntText)
 {
-    fixture->setTestFunction(_failLongLongIntTextMethod);
+    fixture->setTestFunction(failLongLongIntTextMethod_);
     fixture->runAllTests();
     fixture->assertPrintContains("is not supported");
     fixture->assertPrintContains("arness_c");
 }
 
-static void _failUnsignedLongLongIntMethod()
+static void failUnsignedLongLongIntMethod_()
 {
     cpputest_ulonglong dummy_ulonglong;
     CHECK_EQUAL_C_ULONGLONG(dummy_ulonglong, dummy_ulonglong);
@@ -357,13 +357,13 @@ static void _failUnsignedLongLongIntMethod()
 
 TEST(TestHarness_c, checkUnsignedLongLongInt)
 {
-    fixture->setTestFunction(_failUnsignedLongLongIntMethod);
+    fixture->setTestFunction(failUnsignedLongLongIntMethod_);
     fixture->runAllTests();
     fixture->assertPrintContains("is not supported");
     fixture->assertPrintContains("arness_c");
 }
 
-static void _failUnsignedLongLongIntTextMethod()
+static void failUnsignedLongLongIntTextMethod_()
 {
     cpputest_ulonglong dummy_ulonglong;
     CHECK_EQUAL_C_ULONGLONG_TEXT(dummy_ulonglong, dummy_ulonglong, "Text");
@@ -371,7 +371,7 @@ static void _failUnsignedLongLongIntTextMethod()
 
 TEST(TestHarness_c, checkUnsignedLongLongIntText)
 {
-    fixture->setTestFunction(_failUnsignedLongLongIntTextMethod);
+    fixture->setTestFunction(failUnsignedLongLongIntTextMethod_);
     fixture->runAllTests();
     fixture->assertPrintContains("is not supported");
     fixture->assertPrintContains("arness_c");
@@ -379,7 +379,7 @@ TEST(TestHarness_c, checkUnsignedLongLongIntText)
 
 #endif
 
-static void _failRealMethod()
+static void failRealMethod_()
 {
     HasTheDestructorBeenCalledChecker checker;
     CHECK_EQUAL_C_REAL(1.0, 2.0, 0.5);
@@ -388,14 +388,14 @@ static void _failRealMethod()
 TEST(TestHarness_c, checkReal)
 {
     CHECK_EQUAL_C_REAL(1.0, 1.1, 0.5);
-    fixture->setTestFunction(_failRealMethod);
+    fixture->setTestFunction(failRealMethod_);
     fixture->runAllTests();
     fixture->assertPrintContains("expected <1>\n	but was  <2>");
     fixture->assertPrintContains("arness_c");
     CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
-static void _failRealTextMethod()
+static void failRealTextMethod_()
 {
     HasTheDestructorBeenCalledChecker checker;
     CHECK_EQUAL_C_REAL_TEXT(1.0, 2.0, 0.5, "RealTestText");
@@ -404,7 +404,7 @@ static void _failRealTextMethod()
 TEST(TestHarness_c, checkRealText)
 {
     CHECK_EQUAL_C_REAL_TEXT(1.0, 1.1, 0.5, "Text");
-    fixture->setTestFunction(_failRealTextMethod);
+    fixture->setTestFunction(failRealTextMethod_);
     fixture->runAllTests();
     fixture->assertPrintContains("expected <1>\n	but was  <2>");
     fixture->assertPrintContains("arness_c");
@@ -412,7 +412,7 @@ TEST(TestHarness_c, checkRealText)
     CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
-static void _failCharMethod()
+static void failCharMethod_()
 {
     HasTheDestructorBeenCalledChecker checker;
     CHECK_EQUAL_C_CHAR('a', 'c');
@@ -421,14 +421,14 @@ static void _failCharMethod()
 TEST(TestHarness_c, checkChar)
 {
     CHECK_EQUAL_C_CHAR('a', 'a');
-    fixture->setTestFunction(_failCharMethod);
+    fixture->setTestFunction(failCharMethod_);
     fixture->runAllTests();
     fixture->assertPrintContains("expected <a>\n	but was  <c>");
     fixture->assertPrintContains("arness_c");
     CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
-static void _failCharTextMethod()
+static void failCharTextMethod_()
 {
     HasTheDestructorBeenCalledChecker checker;
     CHECK_EQUAL_C_CHAR_TEXT('a', 'c', "CharTestText");
@@ -437,7 +437,7 @@ static void _failCharTextMethod()
 TEST(TestHarness_c, checkCharText)
 {
     CHECK_EQUAL_C_CHAR_TEXT('a', 'a', "Text");
-    fixture->setTestFunction(_failCharTextMethod);
+    fixture->setTestFunction(failCharTextMethod_);
     fixture->runAllTests();
     fixture->assertPrintContains("expected <a>\n	but was  <c>");
     fixture->assertPrintContains("arness_c");
@@ -445,7 +445,7 @@ TEST(TestHarness_c, checkCharText)
     CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
-static void _failUnsignedByteMethod()
+static void failUnsignedByteMethod_()
 {
     HasTheDestructorBeenCalledChecker checker;
     CHECK_EQUAL_C_UBYTE(254, 253);
@@ -454,14 +454,14 @@ static void _failUnsignedByteMethod()
 TEST(TestHarness_c, checkUnsignedByte)
 {
     CHECK_EQUAL_C_UBYTE(254, 254);
-    fixture->setTestFunction(_failUnsignedByteMethod);
+    fixture->setTestFunction(failUnsignedByteMethod_);
     fixture->runAllTests();
     fixture->assertPrintContains("expected <254>\n	but was  <253>");
     fixture->assertPrintContains("arness_c");
     CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
-static void _failUnsignedByteTextMethod()
+static void failUnsignedByteTextMethod_()
 {
     HasTheDestructorBeenCalledChecker checker;
     CHECK_EQUAL_C_UBYTE_TEXT(254, 253, "UnsignedByteTestText");
@@ -470,7 +470,7 @@ static void _failUnsignedByteTextMethod()
 TEST(TestHarness_c, checkUnsignedByteText)
 {
     CHECK_EQUAL_C_UBYTE_TEXT(254, 254, "Text");
-    fixture->setTestFunction(_failUnsignedByteTextMethod);
+    fixture->setTestFunction(failUnsignedByteTextMethod_);
     fixture->runAllTests();
     fixture->assertPrintContains("expected <254>\n	but was  <253>");
     fixture->assertPrintContains("arness_c");
@@ -478,7 +478,7 @@ TEST(TestHarness_c, checkUnsignedByteText)
     CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
-static void _failSignedByteMethod()
+static void failSignedByteMethod_()
 {
     HasTheDestructorBeenCalledChecker checker;
     CHECK_EQUAL_C_SBYTE(-3, -5);
@@ -487,14 +487,14 @@ static void _failSignedByteMethod()
 TEST(TestHarness_c, checkSignedByte)
 {
     CHECK_EQUAL_C_SBYTE(-3, -3);
-    fixture->setTestFunction(_failSignedByteMethod);
+    fixture->setTestFunction(failSignedByteMethod_);
     fixture->runAllTests();
     fixture->assertPrintContains("expected <-3>\n	but was  <-5>");
     fixture->assertPrintContains("arness_c");
     CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
-static void _failSignedByteTextMethod()
+static void failSignedByteTextMethod_()
 {
     HasTheDestructorBeenCalledChecker checker;
     CHECK_EQUAL_C_SBYTE_TEXT(-3, -5, "SignedByteTestText");
@@ -503,7 +503,7 @@ static void _failSignedByteTextMethod()
 TEST(TestHarness_c, checkSignedByteText)
 {
     CHECK_EQUAL_C_SBYTE_TEXT(-3, -3, "Text");
-    fixture->setTestFunction(_failSignedByteTextMethod);
+    fixture->setTestFunction(failSignedByteTextMethod_);
     fixture->runAllTests();
     fixture->assertPrintContains("expected <-3>\n	but was  <-5>");
     fixture->assertPrintContains("arness_c");
@@ -511,7 +511,7 @@ TEST(TestHarness_c, checkSignedByteText)
     CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
-static void _failStringMethod()
+static void failStringMethod_()
 {
     HasTheDestructorBeenCalledChecker checker;
     CHECK_EQUAL_C_STRING("Hello", "Hello World");
@@ -520,7 +520,7 @@ static void _failStringMethod()
 TEST(TestHarness_c, checkString)
 {
     CHECK_EQUAL_C_STRING("Hello", "Hello");
-    fixture->setTestFunction(_failStringMethod);
+    fixture->setTestFunction(failStringMethod_);
     fixture->runAllTests();
 
     StringEqualFailure failure(UtestShell::getCurrent(), "file", 1, "Hello", "Hello World", "");
@@ -529,7 +529,7 @@ TEST(TestHarness_c, checkString)
     CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
-static void _failStringTextMethod()
+static void failStringTextMethod_()
 {
     HasTheDestructorBeenCalledChecker checker;
     CHECK_EQUAL_C_STRING_TEXT("Hello", "Hello World", "StringTestText");
@@ -538,7 +538,7 @@ static void _failStringTextMethod()
 TEST(TestHarness_c, checkStringText)
 {
     CHECK_EQUAL_C_STRING_TEXT("Hello", "Hello", "Text");
-    fixture->setTestFunction(_failStringTextMethod);
+    fixture->setTestFunction(failStringTextMethod_);
     fixture->runAllTests();
 
     StringEqualFailure failure(UtestShell::getCurrent(), "file", 1, "Hello", "Hello World", "");
@@ -548,7 +548,7 @@ TEST(TestHarness_c, checkStringText)
     CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
-static void _failPointerMethod()
+static void failPointerMethod_()
 {
     HasTheDestructorBeenCalledChecker checker;
     CHECK_EQUAL_C_POINTER(NULLPTR, (void *)0x1);
@@ -557,14 +557,14 @@ static void _failPointerMethod()
 TEST(TestHarness_c, checkPointer)
 {
     CHECK_EQUAL_C_POINTER(NULLPTR, NULLPTR);
-    fixture->setTestFunction(_failPointerMethod);
+    fixture->setTestFunction(failPointerMethod_);
     fixture->runAllTests();
     fixture->assertPrintContains("expected <0x0>\n	but was  <0x1>");
     fixture->assertPrintContains("arness_c");
     CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
-static void _failPointerTextMethod()
+static void failPointerTextMethod_()
 {
     HasTheDestructorBeenCalledChecker checker;
     CHECK_EQUAL_C_POINTER_TEXT(NULLPTR, (void *)0x1, "PointerTestText");
@@ -573,7 +573,7 @@ static void _failPointerTextMethod()
 TEST(TestHarness_c, checkPointerText)
 {
     CHECK_EQUAL_C_POINTER_TEXT(NULLPTR, NULLPTR, "Text");
-    fixture->setTestFunction(_failPointerTextMethod);
+    fixture->setTestFunction(failPointerTextMethod_);
     fixture->runAllTests();
     fixture->assertPrintContains("expected <0x0>\n	but was  <0x1>");
     fixture->assertPrintContains("arness_c");
@@ -581,7 +581,7 @@ TEST(TestHarness_c, checkPointerText)
     CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
-static void _failBitsMethod()
+static void failBitsMethod_()
 {
     HasTheDestructorBeenCalledChecker checker;
     CHECK_EQUAL_C_BITS(0x0001, (unsigned short)0x0003, 0xFFFF);
@@ -590,14 +590,14 @@ static void _failBitsMethod()
 TEST(TestHarness_c, checkBits)
 {
     CHECK_EQUAL_C_BITS(0xABCD, (unsigned short)0xABCD, 0xFFFF);
-    fixture->setTestFunction(_failBitsMethod);
+    fixture->setTestFunction(failBitsMethod_);
     fixture->runAllTests();
     fixture->assertPrintContains("expected <00000000 00000001>\n\tbut was  <00000000 00000011>");
     fixture->assertPrintContains("arness_c");
     CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
-static void _failBitsTextMethod()
+static void failBitsTextMethod_()
 {
     HasTheDestructorBeenCalledChecker checker;
     CHECK_EQUAL_C_BITS_TEXT(0x0001, (unsigned short)0x0003, 0xFFFF, "BitsTestText");
@@ -606,7 +606,7 @@ static void _failBitsTextMethod()
 TEST(TestHarness_c, checkBitsText)
 {
     CHECK_EQUAL_C_BITS_TEXT(0xABCD, (unsigned short)0xABCD, 0xFFFF, "Text");
-    fixture->setTestFunction(_failBitsTextMethod);
+    fixture->setTestFunction(failBitsTextMethod_);
     fixture->runAllTests();
     fixture->assertPrintContains("expected <00000000 00000001>\n\tbut was  <00000000 00000011>");
     fixture->assertPrintContains("arness_c");
@@ -614,7 +614,7 @@ TEST(TestHarness_c, checkBitsText)
     CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
-static void _failTextMethod()
+static void failTextMethod_()
 {
     HasTheDestructorBeenCalledChecker checker;
     FAIL_TEXT_C("Booo");
@@ -622,14 +622,14 @@ static void _failTextMethod()
 
 TEST(TestHarness_c, checkFailText)
 {
-    fixture->setTestFunction(_failTextMethod);
+    fixture->setTestFunction(failTextMethod_);
     fixture->runAllTests();
     fixture->assertPrintContains("Booo");
     fixture->assertPrintContains("arness_c");
     CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
-static void _failMethod()
+static void failMethod_()
 {
     HasTheDestructorBeenCalledChecker checker;
     FAIL_C();
@@ -637,14 +637,14 @@ static void _failMethod()
 
 TEST(TestHarness_c, checkFail)
 {
-    fixture->setTestFunction(_failMethod);
+    fixture->setTestFunction(failMethod_);
     fixture->runAllTests();
     LONGS_EQUAL(1, fixture->getFailureCount());
     fixture->assertPrintContains("arness_c");
     CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
-static void _CheckMethod()
+static void CheckMethod_()
 {
     HasTheDestructorBeenCalledChecker checker;
     CHECK_C(false);
@@ -653,13 +653,13 @@ static void _CheckMethod()
 TEST(TestHarness_c, checkCheck)
 {
     CHECK_C(true);
-    fixture->setTestFunction(_CheckMethod);
+    fixture->setTestFunction(CheckMethod_);
     fixture->runAllTests();
     LONGS_EQUAL(1, fixture->getFailureCount());
     CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
-static void _CheckTextMethod()
+static void CheckTextMethod_()
 {
     HasTheDestructorBeenCalledChecker checker;
     CHECK_C_TEXT(false, "CheckTestText");
@@ -668,7 +668,7 @@ static void _CheckTextMethod()
 TEST(TestHarness_c, checkCheckText)
 {
     CHECK_C_TEXT(true, "Text");
-    fixture->setTestFunction(_CheckTextMethod);
+    fixture->setTestFunction(CheckTextMethod_);
     fixture->runAllTests();
     LONGS_EQUAL(1, fixture->getFailureCount());
     fixture->assertPrintContains("Message: CheckTestText");

--- a/tests/CppUTest/TestMemoryAllocatorTest.cpp
+++ b/tests/CppUTest/TestMemoryAllocatorTest.cpp
@@ -261,7 +261,7 @@ TEST(FailableMemoryAllocator, FailSecondAndFourthMalloc)
     free(memory3);
 }
 
-static void _failingAllocIsNeverDone(FailableMemoryAllocator* failableMallocAllocator)
+static void failingAllocIsNeverDone_(FailableMemoryAllocator* failableMallocAllocator)
 {
     failableMallocAllocator->failAllocNumber(1);
     failableMallocAllocator->failAllocNumber(2);
@@ -273,7 +273,7 @@ static void _failingAllocIsNeverDone(FailableMemoryAllocator* failableMallocAllo
 
 TEST(FailableMemoryAllocator, CheckAllFailingAllocsWereDone)
 {
-    testFunction.testFunction_ = _failingAllocIsNeverDone;
+    testFunction.testFunction_ = failingAllocIsNeverDone_;
 
     fixture.runAllTests();
 
@@ -306,7 +306,7 @@ TEST(FailableMemoryAllocator, FailThirdAllocationAtGivenLine)
     LONGS_EQUAL(3, allocation);
 }
 
-static void _failingLocationAllocIsNeverDone(FailableMemoryAllocator* failableMallocAllocator)
+static void failingLocationAllocIsNeverDone_(FailableMemoryAllocator* failableMallocAllocator)
 {
     failableMallocAllocator->failNthAllocAt(1, "TestMemoryAllocatorTest.cpp", __LINE__);
     failableMallocAllocator->checkAllFailedAllocsWereDone();
@@ -314,7 +314,7 @@ static void _failingLocationAllocIsNeverDone(FailableMemoryAllocator* failableMa
 
 TEST(FailableMemoryAllocator, CheckAllFailingLocationAllocsWereDone)
 {
-    testFunction.testFunction_ = _failingLocationAllocIsNeverDone;
+    testFunction.testFunction_ = failingLocationAllocIsNeverDone_;
 
     fixture.runAllTests();
 
@@ -465,7 +465,7 @@ TEST(TestMemoryAccountant, reportAllocationsWithSizeZero)
 }
 
 
-static void _failUseCacheSizesAfterAllocation(MemoryAccountant* accountant)
+static void failUseCacheSizesAfterAllocation_(MemoryAccountant* accountant)
 {
     size_t cacheSizes[] = {0};
 
@@ -475,7 +475,7 @@ static void _failUseCacheSizesAfterAllocation(MemoryAccountant* accountant)
 
 TEST(TestMemoryAccountant, withCacheSizesFailsWhenAlreadyAllocatedMemory)
 {
-    testFunction.testFunction_ = _failUseCacheSizesAfterAllocation;
+    testFunction.testFunction_ = failUseCacheSizesAfterAllocation_;
 
     fixture.runAllTests();
 
@@ -695,19 +695,19 @@ TEST(GlobalMemoryAccountant, reportWithCacheSizes)
 
 #endif
 
-static void _failStopWithoutStartingWillFail(GlobalMemoryAccountant* accountant)
+static void failStopWithoutStartingWillFail_(GlobalMemoryAccountant* accountant)
 {
     accountant->stop();
 }
 
 TEST(GlobalMemoryAccountant, StopCantBeCalledWithoutStarting)
 {
-    testFunction.testFunction_ = _failStopWithoutStartingWillFail;
+    testFunction.testFunction_ = failStopWithoutStartingWillFail_;
     fixture.runAllTests();
     fixture.assertPrintContains("GlobalMemoryAccount: Stop called without starting");
 }
 
-static void _failStartingTwiceWillFail(GlobalMemoryAccountant* accountant)
+static void failStartingTwiceWillFail_(GlobalMemoryAccountant* accountant)
 {
     accountant->start();
     accountant->start();
@@ -715,14 +715,14 @@ static void _failStartingTwiceWillFail(GlobalMemoryAccountant* accountant)
 
 TEST(GlobalMemoryAccountant, startTwiceWillFail)
 {
-    testFunction.testFunction_ = _failStartingTwiceWillFail;
+    testFunction.testFunction_ = failStartingTwiceWillFail_;
     fixture.runAllTests();
     accountant.stop();
 
     fixture.assertPrintContains("Global allocator start called twice!");
 }
 
-static void _failChangeMallocMemoryAllocator(GlobalMemoryAccountant* accountant)
+static void failChangeMallocMemoryAllocator_(GlobalMemoryAccountant* accountant)
 {
     accountant->start();
     setCurrentMallocAllocator(defaultMallocAllocator());
@@ -731,12 +731,12 @@ static void _failChangeMallocMemoryAllocator(GlobalMemoryAccountant* accountant)
 
 TEST(GlobalMemoryAccountant, checkWhetherMallocAllocatorIsNotChanged)
 {
-    testFunction.testFunction_ = _failChangeMallocMemoryAllocator;
+    testFunction.testFunction_ = failChangeMallocMemoryAllocator_;
     fixture.runAllTests();
     fixture.assertPrintContains("GlobalMemoryAccountant: Malloc memory allocator has been changed while accounting for memory");
 }
 
-static void _failChangeNewMemoryAllocator(GlobalMemoryAccountant* accountant)
+static void failChangeNewMemoryAllocator_(GlobalMemoryAccountant* accountant)
 {
     accountant->start();
     setCurrentNewAllocator(defaultNewAllocator());
@@ -745,12 +745,12 @@ static void _failChangeNewMemoryAllocator(GlobalMemoryAccountant* accountant)
 
 TEST(GlobalMemoryAccountant, checkWhetherNewAllocatorIsNotChanged)
 {
-    testFunction.testFunction_ = _failChangeNewMemoryAllocator;
+    testFunction.testFunction_ = failChangeNewMemoryAllocator_;
     fixture.runAllTests();
     fixture.assertPrintContains("GlobalMemoryAccountant: New memory allocator has been changed while accounting for memory");
 }
 
-static void _failChangeNewArrayMemoryAllocator(GlobalMemoryAccountant* accountant)
+static void failChangeNewArrayMemoryAllocator_(GlobalMemoryAccountant* accountant)
 {
     accountant->start();
     setCurrentNewArrayAllocator(defaultNewArrayAllocator());
@@ -759,7 +759,7 @@ static void _failChangeNewArrayMemoryAllocator(GlobalMemoryAccountant* accountan
 
 TEST(GlobalMemoryAccountant, checkWhetherNewArrayAllocatorIsNotChanged)
 {
-    testFunction.testFunction_ = _failChangeNewArrayMemoryAllocator;
+    testFunction.testFunction_ = failChangeNewArrayMemoryAllocator_;
     fixture.runAllTests();
     fixture.assertPrintContains("GlobalMemoryAccountant: New Array memory allocator has been changed while accounting for memory");
 }

--- a/tests/CppUTest/TestUTestMacro.cpp
+++ b/tests/CppUTest/TestUTestMacro.cpp
@@ -48,7 +48,7 @@ TEST_GROUP(UnitTestMacros)
     TestTestingFixture fixture;
 };
 
-static void _failingTestMethodWithFAIL()
+static void failingTestMethodWithFAIL_()
 {
     FAIL("This test fails");
     TestTestingFixture::lineExecutedAfterCheck(); // LCOV_EXCL_LINE
@@ -56,13 +56,13 @@ static void _failingTestMethodWithFAIL()
 
 TEST(UnitTestMacros, FAILMakesTheTestFailPrintsTheRightResultAndStopsExecuting)
 {
-    fixture.runTestWithMethod(_failingTestMethodWithFAIL);
+    fixture.runTestWithMethod(failingTestMethodWithFAIL_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("This test fails");
 }
 
 TEST(UnitTestMacros, FAILWillPrintTheFileThatItFailed)
 {
-    fixture.runTestWithMethod(_failingTestMethodWithFAIL);
+    fixture.runTestWithMethod(failingTestMethodWithFAIL_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT(__FILE__);
 }
 
@@ -80,7 +80,7 @@ IGNORE_TEST(UnitTestMacros, FAILworksInAnIgnoredTest)
     FAIL("die!"); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
-static void _UNSIGNED_LONGS_EQUALTestMethod()
+static void UNSIGNED_LONGS_EQUALTestMethod_()
 {
     UNSIGNED_LONGS_EQUAL(1, 1);
     UNSIGNED_LONGS_EQUAL(1, 0);
@@ -88,7 +88,7 @@ static void _UNSIGNED_LONGS_EQUALTestMethod()
 
 TEST(UnitTestMacros, TestUNSIGNED_LONGS_EQUAL)
 {
-    fixture.runTestWithMethod(_UNSIGNED_LONGS_EQUALTestMethod);
+    fixture.runTestWithMethod(UNSIGNED_LONGS_EQUALTestMethod_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <1 (0x1)>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <0 (0x0)>");
 }
@@ -104,14 +104,14 @@ IGNORE_TEST(UnitTestMacros, UNSIGNED_LONGS_EQUALWorksInAnIgnoredTest)
     UNSIGNED_LONGS_EQUAL(1, 0); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
-static void _UNSIGNED_LONGS_EQUAL_TEXTTestMethod()
+static void UNSIGNED_LONGS_EQUAL_TEXTTestMethod_()
 {
     UNSIGNED_LONGS_EQUAL_TEXT(1, 0, "Failed because it failed");
 } // LCOV_EXCL_LINE
 
 TEST(UnitTestMacros, TestUNSIGNED_LONGS_EQUAL_TEXT)
 {
-    fixture.runTestWithMethod(_UNSIGNED_LONGS_EQUAL_TEXTTestMethod);
+    fixture.runTestWithMethod(UNSIGNED_LONGS_EQUAL_TEXTTestMethod_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <1 (0x1)>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <0 (0x0)>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("Failed because it failed");
@@ -130,7 +130,7 @@ IGNORE_TEST(UnitTestMacros, UNSIGNED_LONGS_EQUAL_TEXTWorksInAnIgnoredTest)
 
 #ifdef CPPUTEST_USE_LONG_LONG
 
-static void _LONGLONGS_EQUALTestMethod()
+static void LONGLONGS_EQUALTestMethod_()
 {
     LONGLONGS_EQUAL(1, 1);
     LONGLONGS_EQUAL(1, 0);
@@ -138,7 +138,7 @@ static void _LONGLONGS_EQUALTestMethod()
 
 TEST(UnitTestMacros, TestLONGLONGS_EQUAL)
 {
-    fixture.runTestWithMethod(_LONGLONGS_EQUALTestMethod);
+    fixture.runTestWithMethod(LONGLONGS_EQUALTestMethod_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <1 (0x1)>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <0 (0x0)>");
 }
@@ -154,14 +154,14 @@ IGNORE_TEST(UnitTestMacros, LONGLONGS_EQUALWorksInAnIgnoredTest)
     LONGLONGS_EQUAL(1, 0); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
-static void _LONGLONGS_EQUAL_TEXTTestMethod()
+static void LONGLONGS_EQUAL_TEXTTestMethod_()
 {
     LONGLONGS_EQUAL_TEXT(1, 0, "Failed because it failed");
 } // LCOV_EXCL_LINE
 
 TEST(UnitTestMacros, TestLONGLONGS_EQUAL_TEXT)
 {
-    fixture.runTestWithMethod(_LONGLONGS_EQUAL_TEXTTestMethod);
+    fixture.runTestWithMethod(LONGLONGS_EQUAL_TEXTTestMethod_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <1 (0x1)>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <0 (0x0)>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("Failed because it failed");
@@ -178,7 +178,7 @@ IGNORE_TEST(UnitTestMacros, LONGLONGS_EQUAL_TEXTWorksInAnIgnoredTest)
     LONGLONGS_EQUAL_TEXT(1, 0, "Failed because it failed"); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
-static void _UNSIGNED_LONGLONGS_EQUALTestMethod()
+static void UNSIGNED_LONGLONGS_EQUALTestMethod_()
 {
     UNSIGNED_LONGLONGS_EQUAL(1, 1);
     UNSIGNED_LONGLONGS_EQUAL(1, 0);
@@ -186,7 +186,7 @@ static void _UNSIGNED_LONGLONGS_EQUALTestMethod()
 
 TEST(UnitTestMacros, TestUNSIGNED_LONGLONGS_EQUAL)
 {
-    fixture.runTestWithMethod(_UNSIGNED_LONGLONGS_EQUALTestMethod);
+    fixture.runTestWithMethod(UNSIGNED_LONGLONGS_EQUALTestMethod_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <1 (0x1)>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <0 (0x0)>");
 }
@@ -202,14 +202,14 @@ IGNORE_TEST(UnitTestMacros, UNSIGNED_LONGLONGS_EQUALWorksInAnIgnoredTest)
     UNSIGNED_LONGLONGS_EQUAL(1, 0); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
-static void _UNSIGNED_LONGLONGS_EQUAL_TEXTTestMethod()
+static void UNSIGNED_LONGLONGS_EQUAL_TEXTTestMethod_()
 {
     UNSIGNED_LONGLONGS_EQUAL_TEXT(1, 0, "Failed because it failed");
 } // LCOV_EXCL_LINE
 
 TEST(UnitTestMacros, TestUNSIGNED_LONGLONGS_EQUAL_TEXT)
 {
-    fixture.runTestWithMethod(_UNSIGNED_LONGLONGS_EQUAL_TEXTTestMethod);
+    fixture.runTestWithMethod(UNSIGNED_LONGLONGS_EQUAL_TEXTTestMethod_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <1 (0x1)>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <0 (0x0)>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("Failed because it failed");
@@ -228,31 +228,31 @@ IGNORE_TEST(UnitTestMacros, UNSIGNED_LONGLONGS_EQUAL_TEXTWorksInAnIgnoredTest)
 
 #else
 
-static void _LONGLONGS_EQUALFailsWithUnsupportedFeatureTestMethod()
+static void LONGLONGS_EQUALFailsWithUnsupportedFeatureTestMethod_()
 {
     LONGLONGS_EQUAL(1, 1);
 } // LCOV_EXCL_LINE
 
-static void _UNSIGNED_LONGLONGS_EQUALFailsWithUnsupportedFeatureTestMethod()
+static void UNSIGNED_LONGLONGS_EQUALFailsWithUnsupportedFeatureTestMethod()
 {
     UNSIGNED_LONGLONGS_EQUAL(1, 1);
 } // LCOV_EXCL_LINE
 
 TEST(UnitTestMacros, LONGLONGS_EQUALFailsWithUnsupportedFeature)
 {
-    fixture.runTestWithMethod(_LONGLONGS_EQUALFailsWithUnsupportedFeatureTestMethod);
+    fixture.runTestWithMethod(LONGLONGS_EQUALFailsWithUnsupportedFeatureTestMethod_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("\"CPPUTEST_USE_LONG_LONG\" is not supported");
 }
 
 TEST(UnitTestMacros, UNSIGNED_LONGLONGS_EQUALFailsWithUnsupportedFeature)
 {
-    fixture.runTestWithMethod(_UNSIGNED_LONGLONGS_EQUALFailsWithUnsupportedFeatureTestMethod);
+    fixture.runTestWithMethod(UNSIGNED_LONGLONGS_EQUALFailsWithUnsupportedFeatureTestMethod_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("\"CPPUTEST_USE_LONG_LONG\" is not supported");
 }
 
 #endif /* CPPUTEST_USE_LONG_LONG */
 
-static void _failingTestMethodWithCHECK()
+static void failingTestMethodWithCHECK_()
 {
     CHECK(false);
     TestTestingFixture::lineExecutedAfterCheck(); // LCOV_EXCL_LINE
@@ -260,7 +260,7 @@ static void _failingTestMethodWithCHECK()
 
 TEST(UnitTestMacros, FailureWithCHECK)
 {
-    fixture.runTestWithMethod(_failingTestMethodWithCHECK);
+    fixture.runTestWithMethod(failingTestMethodWithCHECK_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("CHECK(false) failed");
 }
 
@@ -275,7 +275,7 @@ IGNORE_TEST(UnitTestMacros, CHECKWorksInAnIgnoredTest)
     CHECK(false); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
-static void _failingTestMethodWithCHECK_TEXT()
+static void failingTestMethodWithCHECK_TEXT_()
 {
     CHECK_TEXT(false, "Failed because it failed");
     TestTestingFixture::lineExecutedAfterCheck(); // LCOV_EXCL_LINE
@@ -283,7 +283,7 @@ static void _failingTestMethodWithCHECK_TEXT()
 
 TEST(UnitTestMacros, FailureWithCHECK_TEXT)
 {
-    fixture.runTestWithMethod(_failingTestMethodWithCHECK_TEXT);
+    fixture.runTestWithMethod(failingTestMethodWithCHECK_TEXT_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("CHECK(false) failed");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("Failed because it failed");
 }
@@ -299,7 +299,7 @@ IGNORE_TEST(UnitTestMacros, CHECK_TEXTWorksInAnIgnoredTest)
     CHECK_TEXT(false, "false"); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
-static void _failingTestMethodWithCHECK_TRUE()
+static void failingTestMethodWithCHECK_TRUE_()
 {
     CHECK_TRUE(false);
     TestTestingFixture::lineExecutedAfterCheck(); // LCOV_EXCL_LINE
@@ -307,7 +307,7 @@ static void _failingTestMethodWithCHECK_TRUE()
 
 TEST(UnitTestMacros, FailureWithCHECK_TRUE)
 {
-    fixture.runTestWithMethod(_failingTestMethodWithCHECK_TRUE);
+    fixture.runTestWithMethod(failingTestMethodWithCHECK_TRUE_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("CHECK_TRUE(false) failed");
 }
 
@@ -322,7 +322,7 @@ IGNORE_TEST(UnitTestMacros, CHECK_TRUEWorksInAnIgnoredTest)
     CHECK_TRUE(false); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
-static void _failingTestMethodWithCHECK_TRUE_TEXT()
+static void failingTestMethodWithCHECK_TRUE_TEXT_()
 {
     CHECK_TRUE_TEXT(false, "Failed because it failed");
     TestTestingFixture::lineExecutedAfterCheck(); // LCOV_EXCL_LINE
@@ -330,7 +330,7 @@ static void _failingTestMethodWithCHECK_TRUE_TEXT()
 
 TEST(UnitTestMacros, FailureWithCHECK_TRUE_TEXT)
 {
-    fixture.runTestWithMethod(_failingTestMethodWithCHECK_TRUE_TEXT);
+    fixture.runTestWithMethod(failingTestMethodWithCHECK_TRUE_TEXT_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("CHECK_TRUE(false) failed");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("Failed because it failed");
 }
@@ -346,7 +346,7 @@ IGNORE_TEST(UnitTestMacros, CHECK_TRUE_TEXTWorksInAnIgnoredTest)
     CHECK_TRUE_TEXT(false, "Failed because it failed"); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
-static void _failingTestMethodWithCHECK_FALSE()
+static void failingTestMethodWithCHECK_FALSE_()
 {
     CHECK_FALSE(true);
     TestTestingFixture::lineExecutedAfterCheck(); // LCOV_EXCL_LINE
@@ -354,7 +354,7 @@ static void _failingTestMethodWithCHECK_FALSE()
 
 TEST(UnitTestMacros, FailureWithCHECK_FALSE)
 {
-    fixture.runTestWithMethod(_failingTestMethodWithCHECK_FALSE);
+    fixture.runTestWithMethod(failingTestMethodWithCHECK_FALSE_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("CHECK_FALSE(true) failed");
 }
 
@@ -369,7 +369,7 @@ IGNORE_TEST(UnitTestMacros, CHECK_FALSEWorksInAnIgnoredTest)
     CHECK_FALSE(true); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
-static void _failingTestMethodWithCHECK_FALSE_TEXT()
+static void failingTestMethodWithCHECK_FALSE_TEXT_()
 {
     CHECK_FALSE_TEXT(true, "Failed because it failed");
     TestTestingFixture::lineExecutedAfterCheck(); // LCOV_EXCL_LINE
@@ -377,7 +377,7 @@ static void _failingTestMethodWithCHECK_FALSE_TEXT()
 
 TEST(UnitTestMacros, FailureWithCHECK_FALSE_TEXT)
 {
-    fixture.runTestWithMethod(_failingTestMethodWithCHECK_FALSE_TEXT);
+    fixture.runTestWithMethod(failingTestMethodWithCHECK_FALSE_TEXT_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("CHECK_FALSE(true)");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("Failed because it failed");
 }
@@ -393,7 +393,7 @@ IGNORE_TEST(UnitTestMacros, CHECK_FALSE_TEXTWorksInAnIgnoredTest)
     CHECK_FALSE_TEXT(true, "Failed because it failed"); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
-static void _failingTestMethodWithCHECK_EQUAL()
+static void failingTestMethodWithCHECK_EQUAL_()
 {
     CHECK_EQUAL(1, 2);
     TestTestingFixture::lineExecutedAfterCheck(); // LCOV_EXCL_LINE
@@ -401,12 +401,12 @@ static void _failingTestMethodWithCHECK_EQUAL()
 
 TEST(UnitTestMacros, FailureWithCHECK_EQUAL)
 {
-    fixture.runTestWithMethod(_failingTestMethodWithCHECK_EQUAL);
+    fixture.runTestWithMethod(failingTestMethodWithCHECK_EQUAL_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <1>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <2>");
 }
 
-static void _failingTestMethodWithCHECK_COMPARE()
+static void failingTestMethodWithCHECK_COMPARE_()
 {
     double small = 0.5, big = 0.8;
     CHECK_COMPARE(small, >=, big);
@@ -415,7 +415,7 @@ static void _failingTestMethodWithCHECK_COMPARE()
 
 TEST(UnitTestMacros, FailureWithCHECK_COMPARE)
 {
-    fixture.runTestWithMethod(_failingTestMethodWithCHECK_COMPARE);
+    fixture.runTestWithMethod(failingTestMethodWithCHECK_COMPARE_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("CHECK_COMPARE(0.5 >= 0.8)");
 }
 
@@ -430,7 +430,7 @@ IGNORE_TEST(UnitTestMacros, CHECK_COMPAREWorksInAnIgnoredTest)
   CHECK_COMPARE(1, >, 2); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
-static void _failingTestMethodWithCHECK_COMPARE_TEXT()
+static void failingTestMethodWithCHECK_COMPARE_TEXT_()
 {
     double small = 0.5, big = 0.8;
     CHECK_COMPARE_TEXT(small, >=, big, "small bigger than big");
@@ -439,7 +439,7 @@ static void _failingTestMethodWithCHECK_COMPARE_TEXT()
 
 TEST(UnitTestMacros, FailureWithCHECK_COMPARE_TEXT)
 {
-    fixture.runTestWithMethod(_failingTestMethodWithCHECK_COMPARE_TEXT);
+    fixture.runTestWithMethod(failingTestMethodWithCHECK_COMPARE_TEXT_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("CHECK_COMPARE(0.5 >= 0.8)");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("small bigger than big");
 }
@@ -456,7 +456,7 @@ IGNORE_TEST(UnitTestMacros, CHECK_COMPARE_TEXTWorksInAnIgnoredTest)
 } // LCOV_EXCL_LINE
 
 static int countInCountingMethod;
-static int _countingMethod()
+static int countingMethod_()
 {
     return countInCountingMethod++;
 }
@@ -480,36 +480,36 @@ TEST(UnitTestMacros, UNSIGNED_LONGS_EQUAL_macroExpressionSafety)
 TEST(UnitTestMacros, passingCheckEqualWillNotBeEvaluatedMultipleTimesWithCHECK_EQUAL)
 {
     countInCountingMethod = 0;
-    CHECK_EQUAL(0, _countingMethod());
+    CHECK_EQUAL(0, countingMethod_());
 
     LONGS_EQUAL(1, countInCountingMethod);
 }
 
-static void _failing_CHECK_EQUAL_WithActualBeingEvaluatesMultipleTimesWillGiveAWarning()
+static void failing_CHECK_EQUAL_WithActualBeingEvaluatesMultipleTimesWillGiveAWarning_()
 {
-    CHECK_EQUAL(12345, _countingMethod());
+    CHECK_EQUAL(12345, countingMethod_());
 } // LCOV_EXCL_LINE
 
 TEST(UnitTestMacros, failing_CHECK_EQUAL_WithActualBeingEvaluatesMultipleTimesWillGiveAWarning)
 {
-    fixture.runTestWithMethod(_failing_CHECK_EQUAL_WithActualBeingEvaluatesMultipleTimesWillGiveAWarning);
+    fixture.runTestWithMethod(failing_CHECK_EQUAL_WithActualBeingEvaluatesMultipleTimesWillGiveAWarning_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("WARNING:\n\tThe \"Actual Parameter\" parameter is evaluated multiple times resulting in different values.\n\tThus the value in the error message is probably incorrect.");
 }
 
-static void _failing_CHECK_EQUAL_WithExpectedBeingEvaluatesMultipleTimesWillGiveAWarning()
+static void failing_CHECK_EQUAL_WithExpectedBeingEvaluatesMultipleTimesWillGiveAWarning_()
 {
-    CHECK_EQUAL(_countingMethod(), 12345);
+    CHECK_EQUAL(countingMethod_(), 12345);
 } // LCOV_EXCL_LINE
 
 TEST(UnitTestMacros, failing_CHECK_EQUAL_WithExpectedBeingEvaluatesMultipleTimesWillGiveAWarning)
 {
-    fixture.runTestWithMethod(_failing_CHECK_EQUAL_WithExpectedBeingEvaluatesMultipleTimesWillGiveAWarning);
+    fixture.runTestWithMethod(failing_CHECK_EQUAL_WithExpectedBeingEvaluatesMultipleTimesWillGiveAWarning_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("WARNING:\n\tThe \"Expected Parameter\" parameter is evaluated multiple times resulting in different values.\n\tThus the value in the error message is probably incorrect.");
 }
 
 TEST(UnitTestMacros, failing_CHECK_EQUAL_withParamatersThatDontChangeWillNotGiveAnyWarning)
 {
-    fixture.runTestWithMethod(_failingTestMethodWithCHECK_EQUAL);
+    fixture.runTestWithMethod(failingTestMethodWithCHECK_EQUAL_);
     fixture.assertPrintContainsNot("WARNING");
 }
 
@@ -524,7 +524,7 @@ IGNORE_TEST(UnitTestMacros, CHECK_EQUALWorksInAnIgnoredTest)
     CHECK_EQUAL(1, 2); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
-static void _failingTestMethodWithCHECK_EQUAL_TEXT()
+static void failingTestMethodWithCHECK_EQUAL_TEXT_()
 {
     CHECK_EQUAL_TEXT(1, 2, "Failed because it failed");
     TestTestingFixture::lineExecutedAfterCheck(); // LCOV_EXCL_LINE
@@ -532,7 +532,7 @@ static void _failingTestMethodWithCHECK_EQUAL_TEXT()
 
 TEST(UnitTestMacros, FailureWithCHECK_EQUAL_TEXT)
 {
-    fixture.runTestWithMethod(_failingTestMethodWithCHECK_EQUAL_TEXT);
+    fixture.runTestWithMethod(failingTestMethodWithCHECK_EQUAL_TEXT_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <1>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <2>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("Failed because it failed");
@@ -549,7 +549,7 @@ IGNORE_TEST(UnitTestMacros, CHECK_EQUAL_TEXTWorksInAnIgnoredTest)
     CHECK_EQUAL_TEXT(1, 2, "Failed because it failed"); // LCOV_EXCL_LINE;
 } // LCOV_EXCL_LINE
 
-static void _failingTestMethodWithCHECK_EQUAL_ZERO()
+static void failingTestMethodWithCHECK_EQUAL_ZERO_()
 {
     CHECK_EQUAL_ZERO(1);
     TestTestingFixture::lineExecutedAfterCheck(); // LCOV_EXCL_LINE
@@ -557,7 +557,7 @@ static void _failingTestMethodWithCHECK_EQUAL_ZERO()
 
 TEST(UnitTestMacros, FailureWithCHECK_EQUAL_ZERO)
 {
-    fixture.runTestWithMethod(_failingTestMethodWithCHECK_EQUAL_ZERO);
+    fixture.runTestWithMethod(failingTestMethodWithCHECK_EQUAL_ZERO_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <0>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <1>");
 }
@@ -565,26 +565,26 @@ TEST(UnitTestMacros, FailureWithCHECK_EQUAL_ZERO)
 TEST(UnitTestMacros, passingCheckEqualWillNotBeEvaluatedMultipleTimesWithCHECK_EQUAL_ZERO)
 {
     countInCountingMethod = 0;
-    CHECK_EQUAL_ZERO(_countingMethod());
+    CHECK_EQUAL_ZERO(countingMethod_());
 
     LONGS_EQUAL(1, countInCountingMethod);
 }
 
-static void _failing_CHECK_EQUAL_ZERO_WithActualBeingEvaluatesMultipleTimesWillGiveAWarning()
+static void failing_CHECK_EQUAL_ZERO_WithActualBeingEvaluatesMultipleTimesWillGiveAWarning_()
 {
     countInCountingMethod = 1;
-    CHECK_EQUAL_ZERO(_countingMethod());
+    CHECK_EQUAL_ZERO(countingMethod_());
 } // LCOV_EXCL_LINE
 
 TEST(UnitTestMacros, failing_CHECK_EQUAL_ZERO_WithActualBeingEvaluatesMultipleTimesWillGiveAWarning)
 {
-    fixture.runTestWithMethod(_failing_CHECK_EQUAL_ZERO_WithActualBeingEvaluatesMultipleTimesWillGiveAWarning);
+    fixture.runTestWithMethod(failing_CHECK_EQUAL_ZERO_WithActualBeingEvaluatesMultipleTimesWillGiveAWarning_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("WARNING:\n\tThe \"Actual Parameter\" parameter is evaluated multiple times resulting in different values.\n\tThus the value in the error message is probably incorrect.");
 }
 
 TEST(UnitTestMacros, failing_CHECK_EQUAL_ZERO_withParamatersThatDontChangeWillNotGiveAnyWarning)
 {
-    fixture.runTestWithMethod(_failingTestMethodWithCHECK_EQUAL_ZERO);
+    fixture.runTestWithMethod(failingTestMethodWithCHECK_EQUAL_ZERO_);
     fixture.assertPrintContainsNot("WARNING");
 }
 
@@ -599,7 +599,7 @@ TEST(UnitTestMacros, CHECK_EQUAL_ZERO_BehavesAsProperMacro)
     else CHECK_EQUAL_ZERO(0);
 }
 
-static void _failingTestMethodWithCHECK_EQUAL_ZERO_TEXT()
+static void failingTestMethodWithCHECK_EQUAL_ZERO_TEXT_()
 {
     CHECK_EQUAL_ZERO_TEXT(1, "Failed because it failed");
     TestTestingFixture::lineExecutedAfterCheck(); // LCOV_EXCL_LINE
@@ -607,7 +607,7 @@ static void _failingTestMethodWithCHECK_EQUAL_ZERO_TEXT()
 
 TEST(UnitTestMacros, FailureWithCHECK_EQUAL_ZERO_TEXT)
 {
-    fixture.runTestWithMethod(_failingTestMethodWithCHECK_EQUAL_ZERO_TEXT);
+    fixture.runTestWithMethod(failingTestMethodWithCHECK_EQUAL_ZERO_TEXT_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <0>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <1>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("Failed because it failed");
@@ -624,7 +624,7 @@ IGNORE_TEST(UnitTestMacros, CHECK_EQUAL_ZERO_TEXTWorksInAnIgnoredTest)
     CHECK_EQUAL_ZERO_TEXT(1, "Failed because it failed"); // LCOV_EXCL_LINE;
 } // LCOV_EXCL_LINE
 
-static void _failingTestMethodWithLONGS_EQUAL()
+static void failingTestMethodWithLONGS_EQUAL_()
 {
     LONGS_EQUAL(1, 0xff);
     TestTestingFixture::lineExecutedAfterCheck(); // LCOV_EXCL_LINE
@@ -632,12 +632,12 @@ static void _failingTestMethodWithLONGS_EQUAL()
 
 TEST(UnitTestMacros, FailureWithLONGS_EQUALS)
 {
-    fixture.runTestWithMethod(_failingTestMethodWithLONGS_EQUAL);
+    fixture.runTestWithMethod(failingTestMethodWithLONGS_EQUAL_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <  1 (0x1)>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <255 (0xff)>");
 }
 
-static void _failingTestMethodWithLONGS_EQUALWithSymbolicParameters()
+static void failingTestMethodWithLONGS_EQUALWithSymbolicParameters_()
 {
 #define _MONDAY 1
     int day_of_the_week = _MONDAY+1;
@@ -647,7 +647,7 @@ static void _failingTestMethodWithLONGS_EQUALWithSymbolicParameters()
 
 TEST(UnitTestMacros, FailureWithLONGS_EQUALShowsSymbolicParameters)
 {
-    fixture.runTestWithMethod(_failingTestMethodWithLONGS_EQUALWithSymbolicParameters);
+    fixture.runTestWithMethod(failingTestMethodWithLONGS_EQUALWithSymbolicParameters_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("LONGS_EQUAL(_MONDAY, day_of_the_week) failed");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <1 (0x1)>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <2 (0x2)>");
@@ -665,7 +665,7 @@ IGNORE_TEST(UnitTestMacros, LONGS_EQUALWorksInAnIgnoredTest)
     LONGS_EQUAL(11, 22); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
-static void _failingTestMethodWithLONGS_EQUAL_TEXT()
+static void failingTestMethodWithLONGS_EQUAL_TEXT_()
 {
     LONGS_EQUAL_TEXT(1, 0xff, "Failed because it failed");
     TestTestingFixture::lineExecutedAfterCheck(); // LCOV_EXCL_LINE
@@ -673,7 +673,7 @@ static void _failingTestMethodWithLONGS_EQUAL_TEXT()
 
 TEST(UnitTestMacros, FailureWithLONGS_EQUALS_TEXT)
 {
-    fixture.runTestWithMethod(_failingTestMethodWithLONGS_EQUAL_TEXT);
+    fixture.runTestWithMethod(failingTestMethodWithLONGS_EQUAL_TEXT_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <  1 (0x1)>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <255 (0xff)>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("Failed because it failed");
@@ -690,7 +690,7 @@ IGNORE_TEST(UnitTestMacros, LONGS_EQUAL_TEXTWorksInAnIgnoredTest)
     LONGS_EQUAL_TEXT(11, 22, "Failed because it failed"); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
-static void _failingTestMethodWithBYTES_EQUAL()
+static void failingTestMethodWithBYTES_EQUAL_()
 {
     BYTES_EQUAL('a', 'b');
     TestTestingFixture::lineExecutedAfterCheck(); // LCOV_EXCL_LINE
@@ -698,7 +698,7 @@ static void _failingTestMethodWithBYTES_EQUAL()
 
 TEST(UnitTestMacros, FailureWithBYTES_EQUAL)
 {
-    fixture.runTestWithMethod(_failingTestMethodWithBYTES_EQUAL);
+    fixture.runTestWithMethod(failingTestMethodWithBYTES_EQUAL_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <97 (0x61)>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <98 (0x62)>");
 }
@@ -714,7 +714,7 @@ IGNORE_TEST(UnitTestMacros, BYTES_EQUALWorksInAnIgnoredTest)
     BYTES_EQUAL('q', 'w'); // LCOV_EXCL_LINE;
 } // LCOV_EXCL_LINE
 
-static void _failingTestMethodWithBYTES_EQUAL_TEXT()
+static void failingTestMethodWithBYTES_EQUAL_TEXT_()
 {
     BYTES_EQUAL_TEXT('a', 'b', "Failed because it failed");
     TestTestingFixture::lineExecutedAfterCheck(); // LCOV_EXCL_LINE
@@ -722,7 +722,7 @@ static void _failingTestMethodWithBYTES_EQUAL_TEXT()
 
 TEST(UnitTestMacros, FailureWithBYTES_EQUAL_TEXT)
 {
-    fixture.runTestWithMethod(_failingTestMethodWithBYTES_EQUAL_TEXT);
+    fixture.runTestWithMethod(failingTestMethodWithBYTES_EQUAL_TEXT_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <97 (0x61)>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <98 (0x62)>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("Failed because it failed");
@@ -739,7 +739,7 @@ IGNORE_TEST(UnitTestMacros, BYTES_EQUAL_TEXTWorksInAnIgnoredTest)
     BYTES_EQUAL_TEXT('q', 'w', "Failed because it failed"); // LCOV_EXCL_LINE;
 } // LCOV_EXCL_LINE
 
-static void _failingTestMethodWithSIGNED_BYTES_EQUAL()
+static void failingTestMethodWithSIGNED_BYTES_EQUAL_()
 {
     SIGNED_BYTES_EQUAL(-1, -2);
     TestTestingFixture::lineExecutedAfterCheck(); // LCOV_EXCL_LINE
@@ -747,7 +747,7 @@ static void _failingTestMethodWithSIGNED_BYTES_EQUAL()
 
 TEST(UnitTestMacros, FailureWithSIGNED_BYTES_EQUAL)
 {
-    fixture.runTestWithMethod(_failingTestMethodWithSIGNED_BYTES_EQUAL);
+    fixture.runTestWithMethod(failingTestMethodWithSIGNED_BYTES_EQUAL_);
 #if CPPUTEST_CHAR_BIT == 16
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <-1 (0xffff)>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <-2 (0xfffe)>");
@@ -768,7 +768,7 @@ IGNORE_TEST(UnitTestMacros, CHARS_EQUALWorksInAnIgnoredTest)
     SIGNED_BYTES_EQUAL(-7, 19); // LCOV_EXCL_LINE;
 } // LCOV_EXCL_LINE
 
-static void _failingTestMethodWithSIGNED_BYTES_EQUAL_TEXT()
+static void failingTestMethodWithSIGNED_BYTES_EQUAL_TEXT_()
 {
     SIGNED_BYTES_EQUAL_TEXT(-127, -126, "Failed because it failed");
     TestTestingFixture::lineExecutedAfterCheck(); // LCOV_EXCL_LINE
@@ -776,7 +776,7 @@ static void _failingTestMethodWithSIGNED_BYTES_EQUAL_TEXT()
 
 TEST(UnitTestMacros, FailureWithSIGNED_BYTES_EQUAL_TEXT)
 {
-    fixture.runTestWithMethod(_failingTestMethodWithSIGNED_BYTES_EQUAL_TEXT);
+    fixture.runTestWithMethod(failingTestMethodWithSIGNED_BYTES_EQUAL_TEXT_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <-127 (0x81)>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <-126 (0x82)>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("Failed because it failed");
@@ -793,7 +793,7 @@ IGNORE_TEST(UnitTestMacros, SIGNED_BYTES_EQUAL_TEXTWorksInAnIgnoredTest)
     SIGNED_BYTES_EQUAL_TEXT(-7, 19, "Failed because it failed"); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
-static void _failingTestMethodWithPOINTERS_EQUAL()
+static void failingTestMethodWithPOINTERS_EQUAL_()
 {
     POINTERS_EQUAL((void*)0xa5a5, (void*)0xf0f0);
     TestTestingFixture::lineExecutedAfterCheck(); // LCOV_EXCL_LINE
@@ -801,7 +801,7 @@ static void _failingTestMethodWithPOINTERS_EQUAL()
 
 TEST(UnitTestMacros, FailureWithPOINTERS_EQUAL)
 {
-    fixture.runTestWithMethod(_failingTestMethodWithPOINTERS_EQUAL);
+    fixture.runTestWithMethod(failingTestMethodWithPOINTERS_EQUAL_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <0xa5a5>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <0xf0f0>");
 }
@@ -817,7 +817,7 @@ IGNORE_TEST(UnitTestMacros, POINTERS_EQUALWorksInAnIgnoredTest)
     POINTERS_EQUAL((void*) 0xbeef, (void*) 0xdead); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
-static void _failingTestMethodWithPOINTERS_EQUAL_TEXT()
+static void failingTestMethodWithPOINTERS_EQUAL_TEXT_()
 {
     POINTERS_EQUAL_TEXT((void*)0xa5a5, (void*)0xf0f0, "Failed because it failed");
     TestTestingFixture::lineExecutedAfterCheck(); // LCOV_EXCL_LINE
@@ -825,7 +825,7 @@ static void _failingTestMethodWithPOINTERS_EQUAL_TEXT()
 
 TEST(UnitTestMacros, FailureWithPOINTERS_EQUAL_TEXT)
 {
-    fixture.runTestWithMethod(_failingTestMethodWithPOINTERS_EQUAL_TEXT);
+    fixture.runTestWithMethod(failingTestMethodWithPOINTERS_EQUAL_TEXT_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <0xa5a5>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <0xf0f0>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("Failed because it failed");
@@ -843,7 +843,7 @@ IGNORE_TEST(UnitTestMacros, POINTERS_EQUAL_TEXTWorksInAnIgnoredTest)
 } // LCOV_EXCL_LINE
 
 
-static void _failingTestMethodWithFUNCTIONPOINTERS_EQUAL()
+static void failingTestMethodWithFUNCTIONPOINTERS_EQUAL_()
 {
     FUNCTIONPOINTERS_EQUAL((void (*)())0xa5a5, (void (*)())0xf0f0);
     TestTestingFixture::lineExecutedAfterCheck(); // LCOV_EXCL_LINE
@@ -851,7 +851,7 @@ static void _failingTestMethodWithFUNCTIONPOINTERS_EQUAL()
 
 TEST(UnitTestMacros, FailureWithFUNCTIONPOINTERS_EQUAL)
 {
-    fixture.runTestWithMethod(_failingTestMethodWithFUNCTIONPOINTERS_EQUAL);
+    fixture.runTestWithMethod(failingTestMethodWithFUNCTIONPOINTERS_EQUAL_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <0xa5a5>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <0xf0f0>");
 }
@@ -867,7 +867,7 @@ IGNORE_TEST(UnitTestMacros, FUNCTIONPOINTERS_EQUALWorksInAnIgnoredTest)
     FUNCTIONPOINTERS_EQUAL((void (*)())0xbeef, (void (*)())0xdead); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
-static void _failingTestMethodWithFUNCTIONPOINTERS_EQUAL_TEXT()
+static void failingTestMethodWithFUNCTIONPOINTERS_EQUAL_TEXT_()
 {
     FUNCTIONPOINTERS_EQUAL_TEXT((void (*)())0xa5a5, (void (*)())0xf0f0, "Failed because it failed");
     TestTestingFixture::lineExecutedAfterCheck(); // LCOV_EXCL_LINE
@@ -875,7 +875,7 @@ static void _failingTestMethodWithFUNCTIONPOINTERS_EQUAL_TEXT()
 
 TEST(UnitTestMacros, FailureWithFUNCTIONPOINTERS_EQUAL_TEXT)
 {
-    fixture.runTestWithMethod(_failingTestMethodWithFUNCTIONPOINTERS_EQUAL_TEXT);
+    fixture.runTestWithMethod(failingTestMethodWithFUNCTIONPOINTERS_EQUAL_TEXT_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <0xa5a5>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <0xf0f0>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("Failed because it failed");
@@ -895,7 +895,7 @@ IGNORE_TEST(UnitTestMacros, FUNCTIONPOINTERS_EQUAL_TEXTWorksInAnIgnoredTest)
 
 
 
-static void _failingTestMethodWithDOUBLES_EQUAL()
+static void failingTestMethodWithDOUBLES_EQUAL_()
 {
     DOUBLES_EQUAL(0.12, 44.1, 0.3);
     TestTestingFixture::lineExecutedAfterCheck(); // LCOV_EXCL_LINE
@@ -903,7 +903,7 @@ static void _failingTestMethodWithDOUBLES_EQUAL()
 
 TEST(UnitTestMacros, FailureWithDOUBLES_EQUAL)
 {
-    fixture.runTestWithMethod(_failingTestMethodWithDOUBLES_EQUAL);
+    fixture.runTestWithMethod(failingTestMethodWithDOUBLES_EQUAL_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <0.12>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <44.1>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("threshold used was <0.3>");
@@ -920,7 +920,7 @@ IGNORE_TEST(UnitTestMacros, DOUBLES_EQUALWorksInAnIgnoredTest)
     DOUBLES_EQUAL(100.0, 0.0, 0.2); // LCOV_EXCL_LINE;
 } // LCOV_EXCL_LINE
 
-static void _failingTestMethodWithDOUBLES_EQUAL_TEXT()
+static void failingTestMethodWithDOUBLES_EQUAL_TEXT_()
 {
     DOUBLES_EQUAL_TEXT(0.12, 44.1, 0.3, "Failed because it failed");
     TestTestingFixture::lineExecutedAfterCheck(); // LCOV_EXCL_LINE
@@ -928,7 +928,7 @@ static void _failingTestMethodWithDOUBLES_EQUAL_TEXT()
 
 TEST(UnitTestMacros, FailureWithDOUBLES_EQUAL_TEXT)
 {
-    fixture.runTestWithMethod(_failingTestMethodWithDOUBLES_EQUAL_TEXT);
+    fixture.runTestWithMethod(failingTestMethodWithDOUBLES_EQUAL_TEXT_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <0.12>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <44.1>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("threshold used was <0.3>");
@@ -948,7 +948,7 @@ IGNORE_TEST(UnitTestMacros, DOUBLES_EQUAL_TEXTWorksInAnIgnoredTest)
 
 static bool lineOfCodeExecutedAfterCheck = false;
 
-static void _passingTestMethod()
+static void passingTestMethod_()
 {
     CHECK(true);
     lineOfCodeExecutedAfterCheck = true;
@@ -956,35 +956,35 @@ static void _passingTestMethod()
 
 TEST(UnitTestMacros, SuccessPrintsNothing)
 {
-    fixture.runTestWithMethod(_passingTestMethod);
+    fixture.runTestWithMethod(passingTestMethod_);
 
     LONGS_EQUAL(0, fixture.getFailureCount());
     fixture.assertPrintContains(".\nOK (1 tests");
     CHECK(lineOfCodeExecutedAfterCheck);
 }
 
-static void _methodThatOnlyPrints()
+static void methodThatOnlyPrints_()
 {
     UT_PRINT("Hello World!");
 }
 
 TEST(UnitTestMacros, PrintPrintsWhateverPrintPrints)
 {
-    fixture.runTestWithMethod(_methodThatOnlyPrints);
+    fixture.runTestWithMethod(methodThatOnlyPrints_);
 
     LONGS_EQUAL(0, fixture.getFailureCount());
     fixture.assertPrintContains("Hello World!");
     fixture.assertPrintContains(__FILE__);
 }
 
-static void _methodThatOnlyPrintsUsingSimpleStringFromFormat()
+static void methodThatOnlyPrintsUsingSimpleStringFromFormat_()
 {
     UT_PRINT(StringFromFormat("Hello %s %d", "World!", 2009));
 }
 
 TEST(UnitTestMacros, PrintPrintsSimpleStringsForExampleThoseReturnedByFromString)
 {
-    fixture.runTestWithMethod(_methodThatOnlyPrintsUsingSimpleStringFromFormat);
+    fixture.runTestWithMethod(methodThatOnlyPrintsUsingSimpleStringFromFormat_);
     fixture.assertPrintContains("Hello World! 2009");
 }
 
@@ -1035,7 +1035,7 @@ IGNORE_TEST(UnitTestMacros, MEMCMP_EQUALWorksInAnIgnoredTest)
     MEMCMP_EQUAL("TEST", "test", 5); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
-static void _MEMCMP_EQUALFailingTestMethodWithUnequalInput()
+static void MEMCMP_EQUALFailingTestMethodWithUnequalInput_()
 {
     unsigned char expectedData[] = { 0x00, 0x01, 0x02, 0x03 };
     unsigned char actualData[] = { 0x00, 0x01, 0x03, 0x03 };
@@ -1046,13 +1046,13 @@ static void _MEMCMP_EQUALFailingTestMethodWithUnequalInput()
 
 TEST(UnitTestMacros, MEMCMP_EQUALFailureWithUnequalInput)
 {
-    fixture.runTestWithMethod(_MEMCMP_EQUALFailingTestMethodWithUnequalInput);
+    fixture.runTestWithMethod(MEMCMP_EQUALFailingTestMethodWithUnequalInput_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <00 01 02 03>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <00 01 03 03>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("difference starts at position 2");
 }
 
-static void _MEMCMP_EQUALFailingTestMethodWithNullExpected()
+static void MEMCMP_EQUALFailingTestMethodWithNullExpected_()
 {
     unsigned char actualData[] = { 0x00, 0x01, 0x02, 0x03 };
 
@@ -1062,12 +1062,12 @@ static void _MEMCMP_EQUALFailingTestMethodWithNullExpected()
 
 TEST(UnitTestMacros, MEMCMP_EQUALFailureWithNullExpected)
 {
-    fixture.runTestWithMethod(_MEMCMP_EQUALFailingTestMethodWithNullExpected);
+    fixture.runTestWithMethod(MEMCMP_EQUALFailingTestMethodWithNullExpected_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <(null)>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <00 01 02 03>");
 }
 
-static void _MEMCMP_EQUALFailingTestMethodWithNullActual()
+static void MEMCMP_EQUALFailingTestMethodWithNullActual_()
 {
     unsigned char expectedData[] = { 0x00, 0x01, 0x02, 0x03 };
 
@@ -1077,7 +1077,7 @@ static void _MEMCMP_EQUALFailingTestMethodWithNullActual()
 
 TEST(UnitTestMacros, MEMCMP_EQUALFailureWithNullActual)
 {
-    fixture.runTestWithMethod(_MEMCMP_EQUALFailingTestMethodWithNullActual);
+    fixture.runTestWithMethod(MEMCMP_EQUALFailingTestMethodWithNullActual_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <00 01 02 03>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <(null)>");
 }
@@ -1100,7 +1100,7 @@ TEST(UnitTestMacros, MEMCMP_EQUALNullPointerIgnoredInActualWhenSize0)
 	MEMCMP_EQUAL(expectedData, NULLPTR, 0);
 }
 
-static void _failingTestMethodWithMEMCMP_EQUAL_TEXT()
+static void failingTestMethodWithMEMCMP_EQUAL_TEXT_()
 {
     unsigned char expectedData[] = { 0x00, 0x01, 0x02, 0x03 };
     unsigned char actualData[] = { 0x00, 0x01, 0x03, 0x03 };
@@ -1111,7 +1111,7 @@ static void _failingTestMethodWithMEMCMP_EQUAL_TEXT()
 
 TEST(UnitTestMacros, FailureWithMEMCMP_EQUAL_TEXT)
 {
-    fixture.runTestWithMethod(_failingTestMethodWithMEMCMP_EQUAL_TEXT);
+    fixture.runTestWithMethod(failingTestMethodWithMEMCMP_EQUAL_TEXT_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <00 01 02 03>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <00 01 03 03>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("difference starts at position 2");
@@ -1140,7 +1140,7 @@ IGNORE_TEST(UnitTestMacros, BITS_EQUALWorksInAnIgnoredTest)
     BITS_EQUAL(0x00, 0xFF, 0xFF); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
-static void _BITS_EQUALFailingTestMethodWithUnequalInput()
+static void BITS_EQUALFailingTestMethodWithUnequalInput_()
 {
     BITS_EQUAL(0x00, 0xFF, 0xFF);
     TestTestingFixture::lineExecutedAfterCheck(); // LCOV_EXCL_LINE
@@ -1148,7 +1148,7 @@ static void _BITS_EQUALFailingTestMethodWithUnequalInput()
 
 TEST(UnitTestMacros, BITS_EQUALFailureWithUnequalInput)
 {
-    fixture.runTestWithMethod(_BITS_EQUALFailingTestMethodWithUnequalInput);
+    fixture.runTestWithMethod(BITS_EQUALFailingTestMethodWithUnequalInput_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("00000000>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("11111111>");
 }
@@ -1158,7 +1158,7 @@ TEST(UnitTestMacros, BITS_EQUALZeroMaskEqual)
     BITS_EQUAL(0x00, 0xFF, 0x00);
 }
 
-static void _failingTestMethodWithBITS_EQUAL_TEXT()
+static void failingTestMethodWithBITS_EQUAL_TEXT_()
 {
     BITS_EQUAL_TEXT(0x00, 0xFFFFFFFF, 0xFF, "Failed because it failed");
     TestTestingFixture::lineExecutedAfterCheck(); // LCOV_EXCL_LINE
@@ -1166,7 +1166,7 @@ static void _failingTestMethodWithBITS_EQUAL_TEXT()
 
 TEST(UnitTestMacros, FailureWithBITS_EQUAL_TEXT)
 {
-    fixture.runTestWithMethod(_failingTestMethodWithBITS_EQUAL_TEXT);
+    fixture.runTestWithMethod(failingTestMethodWithBITS_EQUAL_TEXT_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <xxxxxxxx xxxxxxxx xxxxxxxx 00000000>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <xxxxxxxx xxxxxxxx xxxxxxxx 11111111>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("Failed because it failed");
@@ -1188,7 +1188,7 @@ enum class ScopedIntEnum {
     A, B
 };
 
-static void _ENUMS_EQUAL_INTWithScopedIntEnumTestMethod()
+static void ENUMS_EQUAL_INTWithScopedIntEnumTestMethod_()
 {
     ENUMS_EQUAL_INT(ScopedIntEnum::B, ScopedIntEnum::B);
     ENUMS_EQUAL_INT(ScopedIntEnum::B, ScopedIntEnum::A);
@@ -1196,7 +1196,7 @@ static void _ENUMS_EQUAL_INTWithScopedIntEnumTestMethod()
 
 TEST(UnitTestMacros, TestENUMS_EQUAL_INTWithScopedIntEnum)
 {
-    fixture.runTestWithMethod(_ENUMS_EQUAL_INTWithScopedIntEnumTestMethod);
+    fixture.runTestWithMethod(ENUMS_EQUAL_INTWithScopedIntEnumTestMethod_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <1>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <0>");
 }
@@ -1212,14 +1212,14 @@ IGNORE_TEST(UnitTestMacros, ENUMS_EQUAL_INTWithScopedIntEnumWorksInAnIgnoredTest
     ENUMS_EQUAL_INT(ScopedIntEnum::B, ScopedIntEnum::A); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
-static void _ENUMS_EQUAL_INT_TEXTWithScopedIntEnumTestMethod()
+static void ENUMS_EQUAL_INT_TEXTWithScopedIntEnumTestMethod_()
 {
     ENUMS_EQUAL_INT_TEXT(ScopedIntEnum::B, ScopedIntEnum::A, "Failed because it failed");
 } // LCOV_EXCL_LINE
 
 TEST(UnitTestMacros, TestENUMS_EQUAL_INT_TEXTWithScopedIntEnum)
 {
-    fixture.runTestWithMethod(_ENUMS_EQUAL_INT_TEXTWithScopedIntEnumTestMethod);
+    fixture.runTestWithMethod(ENUMS_EQUAL_INT_TEXTWithScopedIntEnumTestMethod_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <1>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <0>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("Failed because it failed");
@@ -1240,7 +1240,7 @@ enum class ScopedLongEnum : long {
     A, B
 };
 
-static void _ENUMS_EQUAL_TYPEWithScopedLongEnumTestMethod()
+static void ENUMS_EQUAL_TYPEWithScopedLongEnumTestMethod_()
 {
     ENUMS_EQUAL_TYPE(long, ScopedLongEnum::B, ScopedLongEnum::B);
     ENUMS_EQUAL_TYPE(long, ScopedLongEnum::B, ScopedLongEnum::A);
@@ -1248,7 +1248,7 @@ static void _ENUMS_EQUAL_TYPEWithScopedLongEnumTestMethod()
 
 TEST(UnitTestMacros, TestENUMS_EQUAL_TYPEWithScopedLongEnum)
 {
-    fixture.runTestWithMethod(_ENUMS_EQUAL_TYPEWithScopedLongEnumTestMethod);
+    fixture.runTestWithMethod(ENUMS_EQUAL_TYPEWithScopedLongEnumTestMethod_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <1>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <0>");
 }
@@ -1264,14 +1264,14 @@ IGNORE_TEST(UnitTestMacros, ENUMS_EQUAL_TYPEWithScopedLongEnumWorksInAnIgnoredTe
     ENUMS_EQUAL_TYPE(long, ScopedLongEnum::B, ScopedLongEnum::A); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
-static void _ENUMS_EQUAL_TYPE_TEXTWithScopedLongEnumTestMethod()
+static void ENUMS_EQUAL_TYPE_TEXTWithScopedLongEnumTestMethod_()
 {
     ENUMS_EQUAL_TYPE_TEXT(long, ScopedLongEnum::B, ScopedLongEnum::A, "Failed because it failed");
 } // LCOV_EXCL_LINE
 
 TEST(UnitTestMacros, TestENUMS_EQUAL_TYPE_TEXTWithScopedLongEnum)
 {
-    fixture.runTestWithMethod(_ENUMS_EQUAL_TYPE_TEXTWithScopedLongEnumTestMethod);
+    fixture.runTestWithMethod(ENUMS_EQUAL_TYPE_TEXTWithScopedLongEnumTestMethod_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <1>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <0>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("Failed because it failed");
@@ -1294,7 +1294,7 @@ enum UnscopedEnum {
     UNSCOPED_ENUM_A, UNSCOPED_ENUM_B
 };
 
-static void _ENUMS_EQUAL_INTWithUnscopedEnumTestMethod()
+static void ENUMS_EQUAL_INTWithUnscopedEnumTestMethod_()
 {
     ENUMS_EQUAL_INT(UNSCOPED_ENUM_B, UNSCOPED_ENUM_B);
     ENUMS_EQUAL_INT(UNSCOPED_ENUM_B, UNSCOPED_ENUM_A);
@@ -1302,7 +1302,7 @@ static void _ENUMS_EQUAL_INTWithUnscopedEnumTestMethod()
 
 TEST(UnitTestMacros, TestENUMS_EQUAL_INTWithUnscopedEnum)
 {
-    fixture.runTestWithMethod(_ENUMS_EQUAL_INTWithUnscopedEnumTestMethod);
+    fixture.runTestWithMethod(ENUMS_EQUAL_INTWithUnscopedEnumTestMethod_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <1>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <0>");
 }
@@ -1318,14 +1318,14 @@ IGNORE_TEST(UnitTestMacros, ENUMS_EQUAL_INTWithUnscopedEnumWorksInAnIgnoredTest)
     ENUMS_EQUAL_INT(UNSCOPED_ENUM_B, UNSCOPED_ENUM_A); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
-static void _ENUMS_EQUAL_INT_TEXTWithUnscopedEnumTestMethod()
+static void ENUMS_EQUAL_INT_TEXTWithUnscopedEnumTestMethod_()
 {
     ENUMS_EQUAL_INT_TEXT(UNSCOPED_ENUM_B, UNSCOPED_ENUM_A, "Failed because it failed");
 } // LCOV_EXCL_LINE
 
 TEST(UnitTestMacros, TestENUMS_EQUAL_INT_TEXTWithUnscopedEnum)
 {
-    fixture.runTestWithMethod(_ENUMS_EQUAL_INT_TEXTWithUnscopedEnumTestMethod);
+    fixture.runTestWithMethod(ENUMS_EQUAL_INT_TEXTWithUnscopedEnumTestMethod_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <1>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <0>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("Failed because it failed");
@@ -1343,7 +1343,7 @@ IGNORE_TEST(UnitTestMacros, ENUMS_EQUAL_EQUAL_INT_TEXTWithUnscopedEnumWorksInAnI
 } // LCOV_EXCL_LINE
 
 #if CPPUTEST_USE_STD_CPP_LIB
-static void _failingTestMethod_NoThrowWithCHECK_THROWS()
+static void failingTestMethod_NoThrowWithCHECK_THROWS_()
 {
     CHECK_THROWS(int, (void) (1+2));
     TestTestingFixture::lineExecutedAfterCheck(); // LCOV_EXCL_LINE
@@ -1351,13 +1351,13 @@ static void _failingTestMethod_NoThrowWithCHECK_THROWS()
 
 TEST(UnitTestMacros, FailureWithCHECK_THROWS_whenDoesntThrow)
 {
-    fixture.runTestWithMethod(_failingTestMethod_NoThrowWithCHECK_THROWS);
+    fixture.runTestWithMethod(failingTestMethod_NoThrowWithCHECK_THROWS_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected to throw int");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but threw nothing");
     LONGS_EQUAL(1, fixture.getCheckCount());
 }
 
-static void _succeedingTestMethod_CorrectThrowWithCHECK_THROWS()
+static void succeedingTestMethod_CorrectThrowWithCHECK_THROWS_()
 {
     CHECK_THROWS(int, throw 4);
     TestTestingFixture::lineExecutedAfterCheck(); // LCOV_EXCL_LINE
@@ -1365,11 +1365,11 @@ static void _succeedingTestMethod_CorrectThrowWithCHECK_THROWS()
 
 TEST(UnitTestMacros, SuccessWithCHECK_THROWS)
 {
-    fixture.runTestWithMethod(_succeedingTestMethod_CorrectThrowWithCHECK_THROWS);
+    fixture.runTestWithMethod(succeedingTestMethod_CorrectThrowWithCHECK_THROWS_);
     LONGS_EQUAL(1, fixture.getCheckCount());
 }
 
-static void _failingTestMethod_WrongThrowWithCHECK_THROWS()
+static void failingTestMethod_WrongThrowWithCHECK_THROWS_()
 {
     CHECK_THROWS(int, throw 4.3);
     TestTestingFixture::lineExecutedAfterCheck(); // LCOV_EXCL_LINE
@@ -1377,7 +1377,7 @@ static void _failingTestMethod_WrongThrowWithCHECK_THROWS()
 
 TEST(UnitTestMacros, FailureWithCHECK_THROWS_whenWrongThrow)
 {
-    fixture.runTestWithMethod(_failingTestMethod_WrongThrowWithCHECK_THROWS);
+    fixture.runTestWithMethod(failingTestMethod_WrongThrowWithCHECK_THROWS_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected to throw int");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but threw a different type");
     LONGS_EQUAL(1, fixture.getCheckCount());

--- a/tests/CppUTest/TestUTestStringMacro.cpp
+++ b/tests/CppUTest/TestUTestStringMacro.cpp
@@ -36,128 +36,128 @@ TEST_GROUP(UnitTestStringMacros)
     TestTestingFixture fixture;
 };
 
-static void _STRCMP_EQUALWithActualIsNULLTestMethod()
+static void STRCMP_EQUALWithActualIsNULLTestMethod_()
 {
     STRCMP_EQUAL("ok", NULLPTR);
 } // LCOV_EXCL_LINE
 
 TEST(UnitTestStringMacros, FailureWithSTRCMP_EQUALAndActualIsNULL)
 {
-    fixture.runTestWithMethod(_STRCMP_EQUALWithActualIsNULLTestMethod);
+    fixture.runTestWithMethod(STRCMP_EQUALWithActualIsNULLTestMethod_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <(null)>");
 }
 
-static void _STRCMP_EQUALWithExpectedIsNULLTestMethod()
+static void STRCMP_EQUALWithExpectedIsNULLTestMethod_()
 {
     STRCMP_EQUAL(NULLPTR, "ok");
 } // LCOV_EXCL_LINE
 
 TEST(UnitTestStringMacros, FailureWithSTRCMP_EQUALAndExpectedIsNULL)
 {
-    fixture.runTestWithMethod(_STRCMP_EQUALWithExpectedIsNULLTestMethod);
+    fixture.runTestWithMethod(STRCMP_EQUALWithExpectedIsNULLTestMethod_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <(null)>");
 }
 
-static void _STRCMP_CONTAINSWithActualIsNULLTestMethod()
+static void STRCMP_CONTAINSWithActualIsNULLTestMethod_()
 {
     STRCMP_CONTAINS("ok", NULLPTR);
 } // LCOV_EXCL_LINE
 
 TEST(UnitTestStringMacros, FailureWithSTRCMP_CONTAINSAndActualIsNULL)
 {
-    fixture.runTestWithMethod(_STRCMP_CONTAINSWithActualIsNULLTestMethod);
+    fixture.runTestWithMethod(STRCMP_CONTAINSWithActualIsNULLTestMethod_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("did not contain  <ok>");
 }
 
-static void _STRCMP_CONTAINSWithExpectedIsNULLTestMethod()
+static void STRCMP_CONTAINSWithExpectedIsNULLTestMethod_()
 {
     STRCMP_CONTAINS(NULLPTR, "ok");
 } // LCOV_EXCL_LINE
 
 TEST(UnitTestStringMacros, FailureWithSTRCMP_CONTAINSAndExpectedIsNULL)
 {
-    fixture.runTestWithMethod(_STRCMP_CONTAINSWithExpectedIsNULLTestMethod);
+    fixture.runTestWithMethod(STRCMP_CONTAINSWithExpectedIsNULLTestMethod_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("did not contain  <>");
 }
 
-static void _STRNCMP_EQUALWithActualIsNULLTestMethod()
+static void STRNCMP_EQUALWithActualIsNULLTestMethod_()
 {
     STRNCMP_EQUAL("ok", NULLPTR, 2);
 } // LCOV_EXCL_LINE
 
 TEST(UnitTestStringMacros, FailureWithSTRNCMP_EQUALAndActualIsNULL)
 {
-    fixture.runTestWithMethod(_STRNCMP_EQUALWithActualIsNULLTestMethod);
+    fixture.runTestWithMethod(STRNCMP_EQUALWithActualIsNULLTestMethod_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <(null)>");
 }
 
-static void _STRNCMP_EQUALWithExpectedIsNULLTestMethod()
+static void STRNCMP_EQUALWithExpectedIsNULLTestMethod_()
 {
     STRNCMP_EQUAL(NULLPTR, "ok", 2);
 } // LCOV_EXCL_LINE
 
 TEST(UnitTestStringMacros, FailureWithSTRNCMP_EQUALAndExpectedIsNULL)
 {
-    fixture.runTestWithMethod(_STRNCMP_EQUALWithExpectedIsNULLTestMethod);
+    fixture.runTestWithMethod(STRNCMP_EQUALWithExpectedIsNULLTestMethod_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <(null)>");
 }
 
-static void _STRCMP_NOCASE_EQUALWithActualIsNULLTestMethod()
+static void STRCMP_NOCASE_EQUALWithActualIsNULLTestMethod_()
 {
     STRCMP_NOCASE_EQUAL("ok", NULLPTR);
 } // LCOV_EXCL_LINE
 
 TEST(UnitTestStringMacros, FailureWithSTRCMP_NOCASE_EQUALAndActualIsNULL)
 {
-    fixture.runTestWithMethod(_STRCMP_NOCASE_EQUALWithActualIsNULLTestMethod);
+    fixture.runTestWithMethod(STRCMP_NOCASE_EQUALWithActualIsNULLTestMethod_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <(null)>");
 }
 
-static void _STRCMP_NOCASE_EQUALWithExpectedIsNULLTestMethod()
+static void STRCMP_NOCASE_EQUALWithExpectedIsNULLTestMethod_()
 {
     STRCMP_NOCASE_EQUAL(NULLPTR, "ok");
 } // LCOV_EXCL_LINE
 
 TEST(UnitTestStringMacros, FailureWithSTRCMP_NOCASE_EQUALAndExpectedIsNULL)
 {
-    fixture.runTestWithMethod(_STRCMP_NOCASE_EQUALWithExpectedIsNULLTestMethod);
+    fixture.runTestWithMethod(STRCMP_NOCASE_EQUALWithExpectedIsNULLTestMethod_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <(null)>");
 }
 
-static void _STRCMP_NOCASE_EQUALWithUnequalInputTestMethod()
+static void STRCMP_NOCASE_EQUALWithUnequalInputTestMethod_()
 {
     STRCMP_NOCASE_EQUAL("no", "ok");
 } // LCOV_EXCL_LINE
 
 TEST(UnitTestStringMacros, FailureWithSTRCMP_NOCASE_EQUALAndUnequalInput)
 {
-    fixture.runTestWithMethod(_STRCMP_NOCASE_EQUALWithUnequalInputTestMethod);
+    fixture.runTestWithMethod(STRCMP_NOCASE_EQUALWithUnequalInputTestMethod_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <ok>");
 }
 
-static void _STRCMP_NOCASE_CONTAINSWithActualIsNULLTestMethod()
+static void STRCMP_NOCASE_CONTAINSWithActualIsNULLTestMethod_()
 {
     STRCMP_NOCASE_CONTAINS("ok", NULLPTR);
 } // LCOV_EXCL_LINE
 
 TEST(UnitTestStringMacros, FailureWithSTRCMP_NOCASE_CONTAINSAndActualIsNULL)
 {
-    fixture.runTestWithMethod(_STRCMP_NOCASE_CONTAINSWithActualIsNULLTestMethod);
+    fixture.runTestWithMethod(STRCMP_NOCASE_CONTAINSWithActualIsNULLTestMethod_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("did not contain  <ok>");
 }
 
-static void _STRCMP_NOCASE_CONTAINSWithExpectedIsNULLTestMethod()
+static void STRCMP_NOCASE_CONTAINSWithExpectedIsNULLTestMethod_()
 {
     STRCMP_NOCASE_CONTAINS(NULLPTR, "ok");
 } // LCOV_EXCL_LINE
 
 TEST(UnitTestStringMacros, FailureWithSTRCMP_NOCASE_CONTAINSAndExpectedIsNULL)
 {
-    fixture.runTestWithMethod(_STRCMP_NOCASE_CONTAINSWithExpectedIsNULLTestMethod);
+    fixture.runTestWithMethod(STRCMP_NOCASE_CONTAINSWithExpectedIsNULLTestMethod_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("did not contain  <>");
 }
 
-static void _failingTestMethodWithSTRCMP_EQUAL()
+static void failingTestMethodWithSTRCMP_EQUAL_()
 {
     STRCMP_EQUAL("hello", "hell");
     TestTestingFixture::lineExecutedAfterCheck(); // LCOV_EXCL_LINE
@@ -165,7 +165,7 @@ static void _failingTestMethodWithSTRCMP_EQUAL()
 
 TEST(UnitTestStringMacros, FailureWithSTRCMP_EQUAL)
 {
-    fixture.runTestWithMethod(_failingTestMethodWithSTRCMP_EQUAL);
+    fixture.runTestWithMethod(failingTestMethodWithSTRCMP_EQUAL_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <hello>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <hell>");
 }
@@ -181,7 +181,7 @@ IGNORE_TEST(UnitTestStringMacros, STRCMP_EQUALWorksInAnIgnoredTest)
     STRCMP_EQUAL("Hello", "World"); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
-static void _failingTestMethodWithSTRCMP_EQUAL_TEXT()
+static void failingTestMethodWithSTRCMP_EQUAL_TEXT_()
 {
     STRCMP_EQUAL_TEXT("hello", "hell", "Failed because it failed");
     TestTestingFixture::lineExecutedAfterCheck(); // LCOV_EXCL_LINE
@@ -189,7 +189,7 @@ static void _failingTestMethodWithSTRCMP_EQUAL_TEXT()
 
 TEST(UnitTestStringMacros, FailureWithSTRCMP_EQUAL_TEXT)
 {
-    fixture.runTestWithMethod(_failingTestMethodWithSTRCMP_EQUAL_TEXT);
+    fixture.runTestWithMethod(failingTestMethodWithSTRCMP_EQUAL_TEXT_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <hello>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <hell>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("Failed because it failed");
@@ -206,7 +206,7 @@ IGNORE_TEST(UnitTestStringMacros, STRCMP_EQUAL_TEXTWorksInAnIgnoredTest)
     STRCMP_EQUAL_TEXT("Hello", "World", "Failed because it failed"); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
-static void _failingTestMethodWithSTRNCMP_EQUAL()
+static void failingTestMethodWithSTRNCMP_EQUAL_()
 {
     STRNCMP_EQUAL("hello", "hallo", 5);
     TestTestingFixture::lineExecutedAfterCheck(); // LCOV_EXCL_LINE
@@ -214,7 +214,7 @@ static void _failingTestMethodWithSTRNCMP_EQUAL()
 
 TEST(UnitTestStringMacros, FailureWithSTRNCMP_EQUAL)
 {
-    fixture.runTestWithMethod(_failingTestMethodWithSTRNCMP_EQUAL);
+    fixture.runTestWithMethod(failingTestMethodWithSTRNCMP_EQUAL_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <hello>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <hallo>");
 }
@@ -230,7 +230,7 @@ IGNORE_TEST(UnitTestStringMacros, STRNCMP_EQUALWorksInAnIgnoredTest)
     STRNCMP_EQUAL("Hello", "World", 3); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
-static void _failingTestMethodWithSTRNCMP_EQUAL_TEXT()
+static void failingTestMethodWithSTRNCMP_EQUAL_TEXT_()
 {
     STRNCMP_EQUAL_TEXT("hello", "hallo", 5, "Failed because it failed");
     TestTestingFixture::lineExecutedAfterCheck(); // LCOV_EXCL_LINE
@@ -238,7 +238,7 @@ static void _failingTestMethodWithSTRNCMP_EQUAL_TEXT()
 
 TEST(UnitTestStringMacros, FailureWithSTRNCMP_EQUAL_TEXT)
 {
-    fixture.runTestWithMethod(_failingTestMethodWithSTRNCMP_EQUAL_TEXT);
+    fixture.runTestWithMethod(failingTestMethodWithSTRNCMP_EQUAL_TEXT_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <hello>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <hallo>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("Failed because it failed");
@@ -255,7 +255,7 @@ IGNORE_TEST(UnitTestStringMacros, STRNCMP_EQUAL_TEXTWorksInAnIgnoredTest)
     STRNCMP_EQUAL_TEXT("Hello", "World", 3, "Failed because it failed"); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
-static void _failingTestMethodWithSTRCMP_NOCASE_EQUAL()
+static void failingTestMethodWithSTRCMP_NOCASE_EQUAL_()
 {
     STRCMP_NOCASE_EQUAL("hello", "Hell");
     TestTestingFixture::lineExecutedAfterCheck(); // LCOV_EXCL_LINE
@@ -263,7 +263,7 @@ static void _failingTestMethodWithSTRCMP_NOCASE_EQUAL()
 
 TEST(UnitTestStringMacros, FailureWithSTRCMP_NOCASE_EQUAL)
 {
-    fixture.runTestWithMethod(_failingTestMethodWithSTRCMP_NOCASE_EQUAL);
+    fixture.runTestWithMethod(failingTestMethodWithSTRCMP_NOCASE_EQUAL_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <hello>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <Hell>");
 }
@@ -279,7 +279,7 @@ IGNORE_TEST(UnitTestStringMacros, STRCMP_NOCASE_EQUALWorksInAnIgnoredTest)
     STRCMP_NOCASE_EQUAL("Hello", "World"); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
-static void _failingTestMethodWithSTRCMP_NOCASE_EQUAL_TEXT()
+static void failingTestMethodWithSTRCMP_NOCASE_EQUAL_TEXT_()
 {
     STRCMP_NOCASE_EQUAL_TEXT("hello", "hell", "Failed because it failed");
     TestTestingFixture::lineExecutedAfterCheck(); // LCOV_EXCL_LINE
@@ -287,7 +287,7 @@ static void _failingTestMethodWithSTRCMP_NOCASE_EQUAL_TEXT()
 
 TEST(UnitTestStringMacros, FailureWithSTRCMP_NOCASE_EQUAL_TEXT)
 {
-    fixture.runTestWithMethod(_failingTestMethodWithSTRCMP_NOCASE_EQUAL_TEXT);
+    fixture.runTestWithMethod(failingTestMethodWithSTRCMP_NOCASE_EQUAL_TEXT_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <hello>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <hell>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("Failed because it failed");
@@ -304,7 +304,7 @@ IGNORE_TEST(UnitTestStringMacros, STRCMP_NOCASE_EQUAL_TEXTWorksInAnIgnoredTest)
     STRCMP_NOCASE_EQUAL_TEXT("Hello", "World", "Failed because it failed"); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
-static void _failingTestMethodWithSTRCMP_CONTAINS()
+static void failingTestMethodWithSTRCMP_CONTAINS_()
 {
     STRCMP_CONTAINS("hello", "world");
     TestTestingFixture::lineExecutedAfterCheck(); // LCOV_EXCL_LINE
@@ -312,7 +312,7 @@ static void _failingTestMethodWithSTRCMP_CONTAINS()
 
 TEST(UnitTestStringMacros, FailureWithSTRCMP_CONTAINS)
 {
-    fixture.runTestWithMethod(_failingTestMethodWithSTRCMP_CONTAINS);
+    fixture.runTestWithMethod(failingTestMethodWithSTRCMP_CONTAINS_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("actual <world>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("did not contain  <hello>");
 }
@@ -328,7 +328,7 @@ IGNORE_TEST(UnitTestStringMacros, STRCMP_CONTAINSWorksInAnIgnoredTest)
     STRCMP_CONTAINS("Hello", "World"); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
-static void _failingTestMethodWithSTRCMP_CONTAINS_TEXT()
+static void failingTestMethodWithSTRCMP_CONTAINS_TEXT_()
 {
     STRCMP_CONTAINS_TEXT("hello", "world", "Failed because it failed");
     TestTestingFixture::lineExecutedAfterCheck(); // LCOV_EXCL_LINE
@@ -336,7 +336,7 @@ static void _failingTestMethodWithSTRCMP_CONTAINS_TEXT()
 
 TEST(UnitTestStringMacros, FailureWithSTRCMP_CONTAINS_TEXT)
 {
-    fixture.runTestWithMethod(_failingTestMethodWithSTRCMP_CONTAINS_TEXT);
+    fixture.runTestWithMethod(failingTestMethodWithSTRCMP_CONTAINS_TEXT_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("actual <world>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("did not contain  <hello>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("Failed because it failed");
@@ -353,7 +353,7 @@ IGNORE_TEST(UnitTestStringMacros, STRCMP_CONTAINS_TEXTWorksInAnIgnoredTest)
     STRCMP_CONTAINS_TEXT("Hello", "World", "Failed because it failed"); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
-static void _failingTestMethodWithSTRCMP_NOCASE_CONTAINS()
+static void failingTestMethodWithSTRCMP_NOCASE_CONTAINS_()
 {
     STRCMP_NOCASE_CONTAINS("hello", "WORLD");
     TestTestingFixture::lineExecutedAfterCheck(); // LCOV_EXCL_LINE
@@ -361,7 +361,7 @@ static void _failingTestMethodWithSTRCMP_NOCASE_CONTAINS()
 
 TEST(UnitTestStringMacros, FailureWithSTRCMP_NOCASE_CONTAINS)
 {
-    fixture.runTestWithMethod(_failingTestMethodWithSTRCMP_NOCASE_CONTAINS);
+    fixture.runTestWithMethod(failingTestMethodWithSTRCMP_NOCASE_CONTAINS_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("actual <WORLD>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("did not contain  <hello>");
 }
@@ -377,7 +377,7 @@ IGNORE_TEST(UnitTestStringMacros, STRCMP_NO_CASE_CONTAINSWorksInAnIgnoredTest)
     STRCMP_NOCASE_CONTAINS("Hello", "World"); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
-static void _failingTestMethodWithSTRCMP_NOCASE_CONTAINS_TEXT()
+static void failingTestMethodWithSTRCMP_NOCASE_CONTAINS_TEXT_()
 {
     STRCMP_NOCASE_CONTAINS_TEXT("hello", "WORLD", "Failed because it failed");
     TestTestingFixture::lineExecutedAfterCheck(); // LCOV_EXCL_LINE
@@ -385,7 +385,7 @@ static void _failingTestMethodWithSTRCMP_NOCASE_CONTAINS_TEXT()
 
 TEST(UnitTestStringMacros, FailureWithSTRCMP_NOCASE_CONTAINS_TEXT)
 {
-    fixture.runTestWithMethod(_failingTestMethodWithSTRCMP_NOCASE_CONTAINS_TEXT);
+    fixture.runTestWithMethod(failingTestMethodWithSTRCMP_NOCASE_CONTAINS_TEXT_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("actual <WORLD>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("did not contain  <hello>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("Failed because it failed");
@@ -410,7 +410,7 @@ TEST(UnitTestStringMacros, NFirstCharsComparison)
     STRNCMP_EQUAL("Hello World!", "Hello", 5);
 }
 
-static void _compareNFirstCharsWithUpperAndLowercase()
+static void compareNFirstCharsWithUpperAndLowercase_()
 {
     STRNCMP_EQUAL("hello world!", "HELLO WORLD!", 12);
     TestTestingFixture::lineExecutedAfterCheck(); // LCOV_EXCL_LINE
@@ -418,13 +418,13 @@ static void _compareNFirstCharsWithUpperAndLowercase()
 
 TEST(UnitTestStringMacros, CompareNFirstCharsWithUpperAndLowercase)
 {
-    fixture.runTestWithMethod(_compareNFirstCharsWithUpperAndLowercase);
+    fixture.runTestWithMethod(compareNFirstCharsWithUpperAndLowercase_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <hello world!>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <HELLO WORLD!>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("difference starts at position 0");
 }
 
-static void _compareNFirstCharsWithDifferenceInTheMiddle()
+static void compareNFirstCharsWithDifferenceInTheMiddle_()
 {
     STRNCMP_EQUAL("Hello World!", "Hello Peter!", 12);
     TestTestingFixture::lineExecutedAfterCheck(); // LCOV_EXCL_LINE
@@ -432,13 +432,13 @@ static void _compareNFirstCharsWithDifferenceInTheMiddle()
 
 TEST(UnitTestStringMacros, CompareNFirstCharsWithDifferenceInTheMiddle)
 {
-    fixture.runTestWithMethod(_compareNFirstCharsWithDifferenceInTheMiddle);
+    fixture.runTestWithMethod(compareNFirstCharsWithDifferenceInTheMiddle_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <Hello World!>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <Hello Peter!>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("difference starts at position 6");
 }
 
-static void _compareNFirstCharsWithEmptyString()
+static void compareNFirstCharsWithEmptyString_()
 {
     STRNCMP_EQUAL("", "Not empty string", 5);
     TestTestingFixture::lineExecutedAfterCheck(); // LCOV_EXCL_LINE
@@ -446,13 +446,13 @@ static void _compareNFirstCharsWithEmptyString()
 
 TEST(UnitTestStringMacros, CompareNFirstCharsWithEmptyString)
 {
-    fixture.runTestWithMethod(_compareNFirstCharsWithEmptyString);
+    fixture.runTestWithMethod(compareNFirstCharsWithEmptyString_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <Not empty string>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("difference starts at position 0");
 }
 
-static void _compareNFirstCharsWithLastCharDifferent()
+static void compareNFirstCharsWithLastCharDifferent_()
 {
     STRNCMP_EQUAL("Not empty string?", "Not empty string!", 17);
     TestTestingFixture::lineExecutedAfterCheck(); // LCOV_EXCL_LINE
@@ -460,9 +460,8 @@ static void _compareNFirstCharsWithLastCharDifferent()
 
 TEST(UnitTestStringMacros, CompareNFirstCharsWithLastCharDifferent)
 {
-    fixture.runTestWithMethod(_compareNFirstCharsWithLastCharDifferent);
+    fixture.runTestWithMethod(compareNFirstCharsWithLastCharDifferent_);
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <Not empty string?>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <Not empty string!>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("difference starts at position 16");
 }
-

--- a/tests/CppUTest/UtestPlatformTest.cpp
+++ b/tests/CppUTest/UtestPlatformTest.cpp
@@ -56,13 +56,13 @@ TEST(UTestPlatformsTest_PlatformSpecificRunTestInASeperateProcess, DummyFailsWit
 
 #else
 
-static void _failFunction()
+static void failFunction_()
 {
     FAIL("This test fails");
 }
 
-static void _exitNonZeroFunction() _no_return_;
-static void _exitNonZeroFunction()
+static void exitNonZeroFunction_() _no_return_;
+static void exitNonZeroFunction_()
 {
     /* destructor of static objects will be called. If StringCache was there then the allocator will report invalid deallocations of static SimpleString */
     SimpleString::setStringAllocator(SimpleString::getStringAllocator()->actualAllocator());
@@ -101,7 +101,7 @@ extern "C" {
 #include <unistd.h>
 #include <signal.h>
 
-static void _stoppedTestFunction()
+static void stoppedTestFunction_()
 {
     kill(getpid(), SIGSTOP);
 }
@@ -116,7 +116,7 @@ TEST(UTestPlatformsTest_PlatformSpecificRunTestInASeperateProcess, TestInSeparat
 TEST(UTestPlatformsTest_PlatformSpecificRunTestInASeperateProcess, FailureInSeparateProcessWorks)
 {
     fixture.setRunTestsInSeperateProcess();
-    fixture.setTestFunction(_failFunction);
+    fixture.setTestFunction(failFunction_);
     fixture.runAllTests();
     fixture.assertPrintContains("Failed in separate process");
     fixture.assertPrintContains("Errors (1 failures, 1 tests, 1 ran, 0 checks, 0 ignored, 0 filtered out");
@@ -124,7 +124,7 @@ TEST(UTestPlatformsTest_PlatformSpecificRunTestInASeperateProcess, FailureInSepa
 
 #if (! CPPUTEST_SANITIZE_ADDRESS)
 
-static int _accessViolationTestFunction()
+static int accessViolationTestFunction_()
 {
     return *(volatile int*) NULLPTR;
 }
@@ -132,7 +132,7 @@ static int _accessViolationTestFunction()
 TEST(UTestPlatformsTest_PlatformSpecificRunTestInASeperateProcess, AccessViolationInSeparateProcessWorks)
 {
     fixture.setRunTestsInSeperateProcess();
-    fixture.setTestFunction((void(*)())_accessViolationTestFunction);
+    fixture.setTestFunction((void(*)())accessViolationTestFunction_);
     fixture.runAllTests();
     fixture.assertPrintContains("Failed in separate process - killed by signal 11");
     fixture.assertPrintContains("Errors (1 failures, 1 tests, 1 ran");
@@ -143,7 +143,7 @@ TEST(UTestPlatformsTest_PlatformSpecificRunTestInASeperateProcess, AccessViolati
 TEST(UTestPlatformsTest_PlatformSpecificRunTestInASeperateProcess, StoppedInSeparateProcessWorks)
 {
     fixture.setRunTestsInSeperateProcess();
-    fixture.setTestFunction(_stoppedTestFunction);
+    fixture.setTestFunction(stoppedTestFunction_);
     fixture.runAllTests();
     fixture.assertPrintContains("Stopped in separate process - continuing");
     fixture.assertPrintContains("Errors (1 failures, 1 tests, 1 ran");
@@ -198,9 +198,9 @@ TEST(UTestPlatformsTest_PlatformSpecificRunTestInASeperateProcess, MultipleTests
 {
     fixture.setRunTestsInSeperateProcess();
     fixture.runTestWithMethod(NULLPTR);
-    fixture.runTestWithMethod(_stoppedTestFunction);
+    fixture.runTestWithMethod(stoppedTestFunction_);
     fixture.runTestWithMethod(NULLPTR);
-    fixture.runTestWithMethod(_exitNonZeroFunction);
+    fixture.runTestWithMethod(exitNonZeroFunction_);
     fixture.runTestWithMethod(NULLPTR);
     fixture.assertPrintContains("Failed in separate process");
     fixture.assertPrintContains("Stopped in separate process");
@@ -209,4 +209,3 @@ TEST(UTestPlatformsTest_PlatformSpecificRunTestInASeperateProcess, MultipleTests
 
 #endif
 #endif
-

--- a/tests/CppUTest/UtestTest.cpp
+++ b/tests/CppUTest/UtestTest.cpp
@@ -35,22 +35,22 @@ TEST_GROUP(UtestShell)
     TestTestingFixture fixture;
 };
 
-static void _failMethod()
+static void failMethod_()
 {
     FAIL("This test fails");
 }
 
-static void _passingTestMethod()
+static void passingTestMethod_()
 {
     CHECK(true);
 }
 
-static void _passingCheckEqualTestMethod()
+static void passingCheckEqualTestMethod_()
 {
     CHECK_EQUAL(1, 1);
 }
 
-static void _exitTestMethod()
+static void exitTestMethod_()
 {
     TEST_EXIT;
     FAIL("Should not get here");
@@ -78,14 +78,14 @@ TEST(UtestShell, compareDoubles)
 
 TEST(UtestShell, FailWillIncreaseTheAmountOfChecks)
 {
-    fixture.setTestFunction(_failMethod);
+    fixture.setTestFunction(failMethod_);
     fixture.runAllTests();
     LONGS_EQUAL(1, fixture.getCheckCount());
 }
 
 TEST(UtestShell, PassedCheckEqualWillIncreaseTheAmountOfChecks)
 {
-    fixture.setTestFunction(_passingCheckEqualTestMethod);
+    fixture.setTestFunction(passingCheckEqualTestMethod_);
     fixture.runAllTests();
     LONGS_EQUAL(1, fixture.getCheckCount());
 }
@@ -98,8 +98,8 @@ IGNORE_TEST(UtestShell, IgnoreTestAccessingFixture)
 TEST(UtestShell, MacrosUsedInSetup)
 {
     IGNORE_ALL_LEAKS_IN_TEST();
-    fixture.setSetup(_failMethod);
-    fixture.setTestFunction(_passingTestMethod);
+    fixture.setSetup(failMethod_);
+    fixture.setTestFunction(passingTestMethod_);
     fixture.runAllTests();
     LONGS_EQUAL(1, fixture.getFailureCount());
 }
@@ -107,15 +107,15 @@ TEST(UtestShell, MacrosUsedInSetup)
 TEST(UtestShell, MacrosUsedInTearDown)
 {
     IGNORE_ALL_LEAKS_IN_TEST();
-    fixture.setTeardown(_failMethod);
-    fixture.setTestFunction(_passingTestMethod);
+    fixture.setTeardown(failMethod_);
+    fixture.setTestFunction(passingTestMethod_);
     fixture.runAllTests();
     LONGS_EQUAL(1, fixture.getFailureCount());
 }
 
 TEST(UtestShell, ExitLeavesQuietly)
 {
-    fixture.setTestFunction(_exitTestMethod);
+    fixture.setTestFunction(exitTestMethod_);
     fixture.runAllTests();
     LONGS_EQUAL(0, fixture.getFailureCount());
 }
@@ -132,7 +132,7 @@ TEST(UtestShell, FailWillNotCrashIfNotEnabled)
     cpputestHasCrashed = false;
     UtestShell::setCrashMethod(crashMethod);
 
-    fixture.setTestFunction(_failMethod);
+    fixture.setTestFunction(failMethod_);
     fixture.runAllTests();
 
     CHECK_FALSE(cpputestHasCrashed);
@@ -147,7 +147,7 @@ TEST(UtestShell, FailWillCrashIfEnabled)
     UtestShell::setCrashOnFail();
     UtestShell::setCrashMethod(crashMethod);
 
-    fixture.setTestFunction(_failMethod);
+    fixture.setTestFunction(failMethod_);
     fixture.runAllTests();
 
     CHECK(cpputestHasCrashed);
@@ -160,7 +160,7 @@ TEST(UtestShell, FailWillCrashIfEnabled)
 
 static int teardownCalled = 0;
 
-static void _teardownMethod()
+static void teardownMethod_()
 {
     teardownCalled++;
 }
@@ -169,15 +169,15 @@ TEST(UtestShell, TeardownCalledAfterTestFailure)
 {
     teardownCalled = 0;
     IGNORE_ALL_LEAKS_IN_TEST();
-    fixture.setTeardown(_teardownMethod);
-    fixture.setTestFunction(_failMethod);
+    fixture.setTeardown(teardownMethod_);
+    fixture.setTestFunction(failMethod_);
     fixture.runAllTests();
     LONGS_EQUAL(1, fixture.getFailureCount());
     LONGS_EQUAL(1, teardownCalled);
 }
 
 static int stopAfterFailure = 0;
-static void _stopAfterFailureMethod()
+static void stopAfterFailureMethod_()
 {
     FAIL("fail");
     stopAfterFailure++;
@@ -187,7 +187,7 @@ TEST(UtestShell, TestStopsAfterTestFailure)
 {
     IGNORE_ALL_LEAKS_IN_TEST();
     stopAfterFailure = 0;
-    fixture.setTestFunction(_stopAfterFailureMethod);
+    fixture.setTestFunction(stopAfterFailureMethod_);
     fixture.runAllTests();
     CHECK(fixture.hasTestFailed());
     LONGS_EQUAL(1, fixture.getFailureCount());
@@ -197,9 +197,9 @@ TEST(UtestShell, TestStopsAfterTestFailure)
 TEST(UtestShell, TestStopsAfterSetupFailure)
 {
     stopAfterFailure = 0;
-    fixture.setSetup(_stopAfterFailureMethod);
-    fixture.setTeardown(_stopAfterFailureMethod);
-    fixture.setTestFunction(_failMethod);
+    fixture.setSetup(stopAfterFailureMethod_);
+    fixture.setTeardown(stopAfterFailureMethod_);
+    fixture.setTestFunction(failMethod_);
     fixture.runAllTests();
     LONGS_EQUAL(2, fixture.getFailureCount());
     LONGS_EQUAL(0, stopAfterFailure);
@@ -271,7 +271,7 @@ TEST(UtestShell, TestDefaultCrashMethodInSeparateProcessTest)
 
 static bool destructorWasCalledOnFailedTest = false;
 
-static void _destructorCalledForLocalObjects()
+static void destructorCalledForLocalObjects_()
 {
     SetBooleanOnDestructorCall pleaseCallTheDestructor(destructorWasCalledOnFailedTest);
     destructorWasCalledOnFailedTest = false;
@@ -280,7 +280,7 @@ static void _destructorCalledForLocalObjects()
 
 TEST(UtestShell, DestructorIsCalledForLocalObjectsWhenTheTestFails)
 {
-    fixture.setTestFunction(_destructorCalledForLocalObjects);
+    fixture.setTestFunction(destructorCalledForLocalObjects_);
     fixture.runAllTests();
     CHECK(destructorWasCalledOnFailedTest);
 }

--- a/tests/CppUTestExt/GTest1Test.cpp
+++ b/tests/CppUTestExt/GTest1Test.cpp
@@ -117,37 +117,37 @@ TEST(gtest, SimpleGoogleTestGetCalled)
 
 static bool afterCheck;
 
-static void _failMethodEXPECT_EQ()
+static void failMethodEXPECT_EQ_()
 {
     EXPECT_EQ(1, 2);
     afterCheck = true;
 }
 
-static void _failMethodASSERT_EQ()
+static void failMethodASSERT_EQ_()
 {
     ASSERT_EQ(1, 2);
     afterCheck = true;
 }
 
-static void _failMethodEXPECT_TRUE()
+static void failMethodEXPECT_TRUE_()
 {
     EXPECT_TRUE(false);
     afterCheck = true;
 }
 
-static void _failMethodASSERT_TRUE()
+static void failMethodASSERT_TRUE_()
 {
     ASSERT_TRUE(false);
     afterCheck = true;
 }
 
-static void _failMethodEXPECT_FALSE()
+static void failMethodEXPECT_FALSE_()
 {
     EXPECT_FALSE(true);
     afterCheck = true;
 }
 
-static void _failMethodEXPECT_STREQ()
+static void failMethodEXPECT_STREQ_()
 {
     EXPECT_STREQ("hello", "world");
     afterCheck = true;
@@ -178,32 +178,32 @@ TEST_GROUP(gtestMacros)
 
 TEST(gtestMacros, EXPECT_EQFails)
 {
-    testFailureWith(_failMethodEXPECT_EQ);
+    testFailureWith(failMethodEXPECT_EQ_);
 }
 
 TEST(gtestMacros, EXPECT_TRUEFails)
 {
-    testFailureWith(_failMethodEXPECT_TRUE);
+    testFailureWith(failMethodEXPECT_TRUE_);
 }
 
 TEST(gtestMacros, EXPECT_FALSEFails)
 {
-    testFailureWith(_failMethodEXPECT_FALSE);
+    testFailureWith(failMethodEXPECT_FALSE_);
 }
 
 TEST(gtestMacros, EXPECT_STREQFails)
 {
-    testFailureWith(_failMethodEXPECT_STREQ);
+    testFailureWith(failMethodEXPECT_STREQ_);
 }
 
 TEST(gtestMacros, ASSERT_EQFails)
 {
-    testFailureWith(_failMethodASSERT_EQ);
+    testFailureWith(failMethodASSERT_EQ_);
 }
 
 TEST(gtestMacros, ASSERT_TRUEFails)
 {
-    testFailureWith(_failMethodASSERT_TRUE);
+    testFailureWith(failMethodASSERT_TRUE_);
 }
 
 #endif

--- a/tests/CppUTestExt/IEEE754PluginTest.cpp
+++ b/tests/CppUTestExt/IEEE754PluginTest.cpp
@@ -39,7 +39,7 @@ extern "C"
     #include "IEEE754PluginTest_c.h"
 }
 
-TEST_GROUP(FE__with_Plugin)
+TEST_GROUP(FE_with_Plugin)
 {
     TestTestingFixture fixture;
     IEEE754ExceptionsPlugin ieee754Plugin;
@@ -49,28 +49,28 @@ TEST_GROUP(FE__with_Plugin)
     }
 };
 
-TEST(FE__with_Plugin, should_fail____when__FE_DIVBYZERO__is_set)
+TEST(FE_with_Plugin, should_fail_when_FE_DIVBYZERO_is_set)
 {
     fixture.setTestFunction(set_divisionbyzero_c);
     fixture.runAllTests();
     fixture.assertPrintContains("IEEE754_CHECK_CLEAR(FE_DIVBYZERO) failed");
 }
 
-TEST(FE__with_Plugin, should_fail____when__FE_OVERFLOW___is_set)
+TEST(FE_with_Plugin, should_fail_when_FE_OVERFLOW_is_set)
 {
     fixture.setTestFunction(set_overflow_c);
     fixture.runAllTests();
     fixture.assertPrintContains("IEEE754_CHECK_CLEAR(FE_OVERFLOW) failed");
 }
 
-TEST(FE__with_Plugin, should_fail____when__FE_UNDERFLOW__is_set)
+TEST(FE_with_Plugin, should_fail_when_FE_UNDERFLOW_is_set)
 {
     fixture.setTestFunction(set_underflow_c);
     fixture.runAllTests();
     fixture.assertPrintContains("IEEE754_CHECK_CLEAR(FE_UNDERFLOW) failed");
 }
 
-TEST(FE__with_Plugin, should_fail____when__FE_INEXACT____is_set_and_enabled)
+TEST(FE_with_Plugin, should_fail_when_FE_INEXACT_is_set_and_enabled)
 {
     IEEE754ExceptionsPlugin::enableInexact();
     fixture.setTestFunction(set_inexact_c);
@@ -78,7 +78,7 @@ TEST(FE__with_Plugin, should_fail____when__FE_INEXACT____is_set_and_enabled)
     fixture.assertPrintContains("IEEE754_CHECK_CLEAR(FE_INEXACT) failed");
 }
 
-TEST(FE__with_Plugin, should_succeed_when__FE_INEXACT____is_set_and_disabled)
+TEST(FE_with_Plugin, should_succeed_when_FE_INEXACT_is_set_and_disabled)
 {
     IEEE754ExceptionsPlugin::enableInexact();
     IEEE754ExceptionsPlugin::disableInexact();
@@ -87,7 +87,7 @@ TEST(FE__with_Plugin, should_succeed_when__FE_INEXACT____is_set_and_disabled)
     fixture.assertPrintContains("OK");
 }
 
-TEST(FE__with_Plugin, should_succeed_with_5_checks_when_no_flags_are_set)
+TEST(FE_with_Plugin, should_succeed_with_5_checks_when_no_flags_are_set)
 {
     IEEE754ExceptionsPlugin::enableInexact();
     fixture.setTestFunction(set_nothing_c);
@@ -96,14 +96,14 @@ TEST(FE__with_Plugin, should_succeed_with_5_checks_when_no_flags_are_set)
     IEEE754ExceptionsPlugin::disableInexact();
 }
 
-TEST(FE__with_Plugin, should_check_five_times_when_all_flags_are_set)
+TEST(FE_with_Plugin, should_check_five_times_when_all_flags_are_set)
 {
     fixture.setTestFunction(set_everything_c);
     fixture.runAllTests();
     LONGS_EQUAL(5, fixture.getCheckCount());
 }
 
-TEST(FE__with_Plugin, should_fail_only_once_when_all_flags_are_set)
+TEST(FE_with_Plugin, should_fail_only_once_when_all_flags_are_set)
 {
     fixture.setTestFunction(set_everything_c);
     fixture.runAllTests();
@@ -116,7 +116,7 @@ static void set_everything_but_already_failed(void)
     CHECK(1 == 2);
 }
 
-TEST(FE__with_Plugin, should_not_fail_again_when_test_has_already_failed)
+TEST(FE_with_Plugin, should_not_fail_again_when_test_has_already_failed)
 {
     fixture.setTestFunction(set_everything_but_already_failed);
     fixture.runAllTests();

--- a/tests/CppUTestExt/MockFakeLongLong.cpp
+++ b/tests/CppUTestExt/MockFakeLongLong.cpp
@@ -44,7 +44,7 @@ TEST_GROUP(FakeLongLongs)
 
 #define CHECK_TEST_FAILS_PROPER_WITH_TEXT(text) fixture.checkTestFailsWithProperTestLocation(text, __FILE__, __LINE__)
 
-static void _actualCallWithFakeLongLongParameter()
+static void actualCallWithFakeLongLongParameter_()
 {
     cpputest_longlong value = {0};
 
@@ -55,12 +55,12 @@ static void _actualCallWithFakeLongLongParameter()
 
 TEST(FakeLongLongs, ActualCallWithFakeLongLongParameterFAILS)
 {
-    fixture.runTestWithMethod(_actualCallWithFakeLongLongParameter);
+    fixture.runTestWithMethod(actualCallWithFakeLongLongParameter);
     mock().clear();
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("Long Long type is not supported");
 }
 
-static void _actualCallWithFakeUnsignedLongLongParameter()
+static void actualCallWithFakeUnsignedLongLongParameter_()
 {
     cpputest_ulonglong value = {0};
 
@@ -71,12 +71,12 @@ static void _actualCallWithFakeUnsignedLongLongParameter()
 
 TEST(FakeLongLongs, ActualCallWithFakeUnsignedLongLongParameterFAILS)
 {
-    fixture.runTestWithMethod(_actualCallWithFakeUnsignedLongLongParameter);
+    fixture.runTestWithMethod(actualCallWithFakeUnsignedLongLongParameter_);
     mock().clear();
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("Unsigned Long Long type is not supported");
 }
 
-static void _actualCallWithFakeLongLongReturn()
+static void actualCallWithFakeLongLongReturn_()
 {
     mock().expectOneCall("foo").andReturnValue(0);
     mock().actualCall("foo").returnLongLongIntValue();
@@ -85,12 +85,12 @@ static void _actualCallWithFakeLongLongReturn()
 
 TEST(FakeLongLongs, ActualCallWithFakeLongLongReturnFAILS)
 {
-    fixture.runTestWithMethod(_actualCallWithFakeLongLongReturn);
+    fixture.runTestWithMethod(actualCallWithFakeLongLongReturn_);
     mock().clear();
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("Long Long type is not supported");
 }
 
-static void _actualCallWithFakeUnsignedLongLongReturn()
+static void actualCallWithFakeUnsignedLongLongReturn_()
 {
     mock().expectOneCall("foo").andReturnValue(0);
     mock().actualCall("foo").returnUnsignedLongLongIntValue();
@@ -99,12 +99,12 @@ static void _actualCallWithFakeUnsignedLongLongReturn()
 
 TEST(FakeLongLongs, ActualCallWithFakeUnsignedLongLongReturnFAILS)
 {
-    fixture.runTestWithMethod(_actualCallWithFakeUnsignedLongLongReturn);
+    fixture.runTestWithMethod(actualCallWithFakeUnsignedLongLongReturn_);
     mock().clear();
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("Unsigned Long Long type is not supported");
 }
 
-static void _expectOneCallWithFakeLongLongParameter()
+static void expectOneCallWithFakeLongLongParameter_()
 {
     cpputest_longlong value = {0};
 
@@ -115,12 +115,12 @@ static void _expectOneCallWithFakeLongLongParameter()
 
 TEST(FakeLongLongs, ExpectedCallWithFakeLongLongParameterFAILS)
 {
-    fixture.runTestWithMethod(_expectOneCallWithFakeLongLongParameter);
+    fixture.runTestWithMethod(expectOneCallWithFakeLongLongParameter_);
     mock().clear();
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("Long Long type is not supported");
 }
 
-static void _expectOneCallWithFakeUnsignedLongLongParameter()
+static void expectOneCallWithFakeUnsignedLongLongParameter_()
 {
     cpputest_ulonglong value = {0};
 
@@ -131,12 +131,12 @@ static void _expectOneCallWithFakeUnsignedLongLongParameter()
 
 TEST(FakeLongLongs, ExpectedCallWithFakeUnsignedLongLongParameterFAILS)
 {
-    fixture.runTestWithMethod(_expectOneCallWithFakeUnsignedLongLongParameter);
+    fixture.runTestWithMethod(expectOneCallWithFakeUnsignedLongLongParameter_);
     mock().clear();
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("Unsigned Long Long type is not supported");
 }
 
-static void _expectOneCallWithFakeLongLongReturn()
+static void expectOneCallWithFakeLongLongReturn_()
 {
     cpputest_longlong value = {0};
 
@@ -147,12 +147,12 @@ static void _expectOneCallWithFakeLongLongReturn()
 
 TEST(FakeLongLongs, ExpectedCallWithFakeLongLongReturnFAILS)
 {
-    fixture.runTestWithMethod(_expectOneCallWithFakeLongLongReturn);
+    fixture.runTestWithMethod(expectOneCallWithFakeLongLongReturn_);
     mock().clear();
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("Long Long type is not supported");
 }
 
-static void _expectOneCallWithFakeUnsignedLongLongReturn()
+static void expectOneCallWithFakeUnsignedLongLongReturn_()
 {
     cpputest_ulonglong value = {0};
 
@@ -163,7 +163,7 @@ static void _expectOneCallWithFakeUnsignedLongLongReturn()
 
 TEST(FakeLongLongs, ExpectedCallWithFakeUnsignedLongLongReturnFAILS)
 {
-    fixture.runTestWithMethod(_expectOneCallWithFakeUnsignedLongLongReturn);
+    fixture.runTestWithMethod(expectOneCallWithFakeUnsignedLongLongReturn_);
     mock().clear();
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("Unsigned Long Long type is not supported");
 }

--- a/tests/CppUTestExt/MockPluginTest.cpp
+++ b/tests/CppUTestExt/MockPluginTest.cpp
@@ -160,7 +160,7 @@ TEST(MockPlugin, preTestActionWillEnableMultipleComparatorsToTheGlobalMockSuppor
     plugin.clear();
 }
 
-static void _failTwiceFunction()
+static void failTwiceFunction_()
 {
     mock().expectOneCall("foobar");
     FAIL("This failed");
@@ -170,7 +170,7 @@ TEST(MockPlugin, shouldNotFailAgainWhenTestAlreadyFailed)
 {
     TestTestingFixture fixture;
     fixture.installPlugin(&plugin);
-    fixture.setTestFunction(_failTwiceFunction);
+    fixture.setTestFunction(failTwiceFunction_);
     fixture.runAllTests();
     fixture.assertPrintContains("1 failures, 1 tests, 1 ran, 2 checks,");
 }


### PR DESCRIPTION
Clang 13 has become more strict on usage of reserved identifier.