### PR TITLE
More reliable `gettimeofday` detection.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,23 +18,24 @@ endif()
 
 # Check for functions before setting a lot of stuff
 include(CheckFunctionExists)
+include(CheckSymbolExists)
 set (CMAKE_REQUIRED_INCLUDES "unistd.h")
-check_function_exists(fork HAVE_FORK)
+check_symbol_exists(fork "unistd.h" HAVE_FORK)
 if(HAVE_FORK)
   add_definitions(-DCPPUTEST_HAVE_FORK)
 endif(HAVE_FORK)
 
-check_function_exists(waitpid HAVE_WAITPID)
+check_symbol_exists(waitpid "sys/wait.h" HAVE_WAITPID)
 if(HAVE_WAITPID)
   add_definitions(-DCPPUTEST_HAVE_WAITPID)
 endif(HAVE_WAITPID)
 
-check_function_exists(gettimeofday HAVE_GETTIMEOFDAY)
+check_symbol_exists(gettimeofday "sys/time.h" HAVE_GETTIMEOFDAY)
 if(HAVE_GETTIMEOFDAY)
   add_definitions(-DCPPUTEST_HAVE_GETTIMEOFDAY=1)
 endif(HAVE_GETTIMEOFDAY)
 
-check_function_exists(pthread_mutex_lock HAVE_PTHREAD_MUTEX_LOCK)
+check_symbol_exists(pthread_mutex_lock "pthread.h" HAVE_PTHREAD_MUTEX_LOCK)
 if(HAVE_PTHREAD_MUTEX_LOCK)
   add_definitions(-DCPPUTEST_HAVE_PTHREAD_MUTEX_LOCK=1)
 endif(HAVE_PTHREAD_MUTEX_LOCK)


### PR DESCRIPTION
`src/Platforms/Gcc/UTestPlatform.cpp:38` relies on `CPPUTEST_HAVE_GETTIMEOFDAY` as an indicator that
`sys/time.h` will exist but that header is not present with TI-CGT-ARM despite the original test succeeding.