### PR TITLE
Update SimpleString.cpp for Borland compiler

### DIFF
--- a/src/CppUTest/SimpleString.cpp
+++ b/src/CppUTest/SimpleString.cpp
@@ -196,8 +196,10 @@ char* SimpleString::StrNCpy(char* s1, const char* s2, size_t n)
 
     if((NULLPTR == s1) || (0 == n)) return result;
 
-    while ((*s1++ = *s2++) && --n != 0)
-        ;
+    *s1 = *s2;
+    while ((--n != 0) && *s1){
+        *++s1 = *++s2;
+    }
     return result;
 }
 


### PR DESCRIPTION
the Borland compiler does not like the expression (*s1++ = *s2++) as part of a while condition,  This commit rewrites the while loop, moving the assignment out of the while test expression.