### PR TITLE
Update SimpleString.cpp for Borland 5.4 compiler

### DIFF
--- a/src/CppUTest/SimpleString.cpp
+++ b/src/CppUTest/SimpleString.cpp
@@ -358,7 +358,7 @@ size_t SimpleString::count(const SimpleString& substr) const
 {
     size_t num = 0;
     const char* str = getBuffer();
-    const char* strpart;
+    const char* strpart = NULL;
     if (*str){
         strpart = StrStr(str, substr.getBuffer());
     }

--- a/src/CppUTest/SimpleString.cpp
+++ b/src/CppUTest/SimpleString.cpp
@@ -358,9 +358,15 @@ size_t SimpleString::count(const SimpleString& substr) const
 {
     size_t num = 0;
     const char* str = getBuffer();
-    while (*str && (str = StrStr(str, substr.getBuffer()))) {
+    const char* strpart;
+    if (*str){
+        strpart = StrStr(str, substr.getBuffer());
+    }
+    while (*str && strpart) {
+        str = strpart;
         str++;
         num++;
+        strpart = StrStr(str, substr.getBuffer());
     }
     return num;
 }


### PR DESCRIPTION
 Borland 5.4 does not like (str = StrStr(str, substr.getBuffer())) in a while condition. This rewrites the while() moving the assignment out of the while condition