### PR TITLE
add -ll argument for retrieving test locations (file names and line numbers)

### DIFF
--- a/include/CppUTest/CommandLineArguments.h
+++ b/include/CppUTest/CommandLineArguments.h
@@ -47,6 +47,7 @@ public:
     bool isColor() const;
     bool isListingTestGroupNames() const;
     bool isListingTestGroupAndCaseNames() const;
+    bool isListingTestLocations() const;
     bool isRunIgnored() const;
     size_t getRepeatCount() const;
     bool isShuffling() const;
@@ -80,6 +81,7 @@ private:
     bool runTestsAsSeperateProcess_;
     bool listTestGroupNames_;
     bool listTestGroupAndCaseNames_;
+    bool listTestLocations_;
     bool runIgnored_;
     bool reversing_;
     bool crashOnFail_;

--- a/include/CppUTest/TestRegistry.h
+++ b/include/CppUTest/TestRegistry.h
@@ -55,6 +55,7 @@ public:
     virtual void reverseTests();
     virtual void listTestGroupNames(TestResult& result);
     virtual void listTestGroupAndCaseNames(TestResult& result);
+    virtual void listTestLocations(TestResult& result);
     virtual void setNameFilters(const TestFilter* filters);
     virtual void setGroupFilters(const TestFilter* filters);
     virtual void installPlugin(TestPlugin* plugin);

--- a/src/CppUTest/CommandLineArguments.cpp
+++ b/src/CppUTest/CommandLineArguments.cpp
@@ -30,7 +30,7 @@
 #include "CppUTest/PlatformSpecificFunctions.h"
 
 CommandLineArguments::CommandLineArguments(int ac, const char *const *av) :
-    ac_(ac), av_(av), needHelp_(false), verbose_(false), veryVerbose_(false), color_(false), runTestsAsSeperateProcess_(false), listTestGroupNames_(false), listTestGroupAndCaseNames_(false), runIgnored_(false), reversing_(false), crashOnFail_(false), shuffling_(false), shufflingPreSeeded_(false), repeat_(1), shuffleSeed_(0), groupFilters_(NULLPTR), nameFilters_(NULLPTR), outputType_(OUTPUT_ECLIPSE)
+    ac_(ac), av_(av), needHelp_(false), verbose_(false), veryVerbose_(false), color_(false), runTestsAsSeperateProcess_(false), listTestGroupNames_(false), listTestGroupAndCaseNames_(false), listTestLocations_(false), runIgnored_(false), reversing_(false), crashOnFail_(false), shuffling_(false), shufflingPreSeeded_(false), repeat_(1), shuffleSeed_(0), groupFilters_(NULLPTR), nameFilters_(NULLPTR), outputType_(OUTPUT_ECLIPSE)
 {
 }
 
@@ -65,6 +65,7 @@ bool CommandLineArguments::parse(TestPlugin* plugin)
         else if (argument == "-b") reversing_ = true;
         else if (argument == "-lg") listTestGroupNames_ = true;
         else if (argument == "-ln") listTestGroupAndCaseNames_ = true;
+        else if (argument == "-ll") listTestLocations_ = true;
         else if (argument == "-ri") runIgnored_ = true;
         else if (argument == "-f") crashOnFail_ = true;
         else if (argument.startsWith("-r")) setRepeatCount(ac_, av_, i);
@@ -169,6 +170,11 @@ bool CommandLineArguments::isListingTestGroupNames() const
 bool CommandLineArguments::isListingTestGroupAndCaseNames() const
 {
     return listTestGroupAndCaseNames_;
+}
+
+bool CommandLineArguments::isListingTestLocations() const
+{
+    return listTestLocations_;
 }
 
 bool CommandLineArguments::isRunIgnored() const

--- a/src/CppUTest/CommandLineTestRunner.cpp
+++ b/src/CppUTest/CommandLineTestRunner.cpp
@@ -120,6 +120,13 @@ int CommandLineTestRunner::runAllTests()
         return 0;
     }
 
+    if (arguments_->isListingTestLocations())
+    {
+        TestResult tr(*output_);
+        registry_->listTestLocations(tr);
+        return 0;
+    }
+
     if (arguments_->isReversing())
         registry_->reverseTests();
 

--- a/src/CppUTest/TestRegistry.cpp
+++ b/src/CppUTest/TestRegistry.cpp
@@ -123,6 +123,26 @@ void TestRegistry::listTestGroupAndCaseNames(TestResult& result)
     result.print(groupAndNameList.asCharString());
 }
 
+void TestRegistry::listTestLocations(TestResult& result)
+{
+    SimpleString testLocations;
+
+    for (UtestShell *test = tests_; test != NULLPTR; test = test->getNext()) {
+            SimpleString testLocation;
+            testLocation += test->getGroup();
+            testLocation += ".";
+            testLocation += test->getName();
+            testLocation += ".";
+            testLocation += test->getFile();
+            testLocation += ".";
+            testLocation += StringFromFormat("%d\n",test->getLineNumber());
+
+            testLocations += testLocation;
+    }
+
+    result.print(testLocations.asCharString());
+}
+
 bool TestRegistry::endOfGroup(UtestShell* test)
 {
     return (!test || !test->getNext() || test->getGroup() != test->getNext()->getGroup());

--- a/tests/CppUTest/CommandLineTestRunnerTest.cpp
+++ b/tests/CppUTest/CommandLineTestRunnerTest.cpp
@@ -269,6 +269,16 @@ TEST(CommandLineTestRunner, listTestGroupAndCaseNamesShouldWorkProperly)
     STRCMP_CONTAINS("group1.test1", commandLineTestRunner.fakeConsoleOutputWhichIsReallyABuffer->getOutput().asCharString());
 }
 
+TEST(CommandLineTestRunner, listTestLocationsShouldWorkProperly)
+{
+    const char* argv[] = { "tests.exe", "-ll" };
+
+    CommandLineTestRunnerWithStringBufferOutput commandLineTestRunner(2, argv, &registry);
+    commandLineTestRunner.runAllTestsMain();
+
+    STRCMP_CONTAINS("group1.test1", commandLineTestRunner.fakeConsoleOutputWhichIsReallyABuffer->getOutput().asCharString());
+}
+
 TEST(CommandLineTestRunner, randomShuffleSeedIsPrintedAndRandFuncIsExercised)
 {
     // more than 1 item in test list ensures that shuffle algorithm calls rand_()

--- a/tests/CppUTest/TestRegistryTest.cpp
+++ b/tests/CppUTest/TestRegistryTest.cpp
@@ -361,6 +361,29 @@ TEST(TestRegistry, listTestGroupAndCaseNames_shouldListBackwardsGroupATestaAfter
     STRCMP_EQUAL("GROUP_A.test_aa GROUP_B.test_b GROUP_A.test_a", s.asCharString());
 }
 
+TEST(TestRegistry, listTestLocations_shouldListBackwardsGroupATestaAfterGroupAtestaa)
+{
+    test1->setGroupName("GROUP_A");
+    test1->setTestName("test_a");
+    test1->setFileName("cpptest_simple/my_tests/testa.cpp");
+    test1->setLineNumber(100);
+    myRegistry->addTest(test1);
+    test2->setGroupName("GROUP_B");
+    test2->setTestName("test_b");
+    test2->setFileName("cpptest_simple/my tests/testb.cpp");
+    test2->setLineNumber(200);
+    myRegistry->addTest(test2);
+    test3->setGroupName("GROUP_A");
+    test3->setTestName("test_aa");
+    test3->setFileName("cpptest_simple/my_tests/testaa.cpp");
+    test3->setLineNumber(300);
+    myRegistry->addTest(test3);
+
+    myRegistry->listTestLocations(*result);
+    SimpleString s = output->getOutput();
+    STRCMP_EQUAL("GROUP_A.test_aa.cpptest_simple/my_tests/testaa.cpp.300\nGROUP_B.test_b.cpptest_simple/my tests/testb.cpp.200\nGROUP_A.test_a.cpptest_simple/my_tests/testa.cpp.100\n", s.asCharString());
+}
+
 TEST(TestRegistry, shuffleEmptyListIsNoOp)
 {
     CHECK_TRUE(myRegistry->getFirstTest() == NULLPTR);


### PR DESCRIPTION
In the format of 
TestGroup.TestName.FileLocation.LineNumber\n

This is to close #1497 