### PR TITLE
Required to  compile with Borland Compiler v5.4

### DIFF
--- a/src/CppUTest/SimpleString.cpp
+++ b/src/CppUTest/SimpleString.cpp
@@ -680,7 +680,7 @@ SimpleString StringFrom(const char *value)
 
 SimpleString StringFromOrNull(const char * expected)
 {
-    return (expected) ? StringFrom(expected) : "(null)";
+    return (expected) ? StringFrom(expected) : StringFrom("(null)");
 }
 
 SimpleString PrintableStringFromOrNull(const char * expected)


### PR DESCRIPTION
In the expression a? true : false;  True and False have to be the same type.  The Borland Compiler v5.4 is unable to automatically  promote the char array "(null)" to a SimpleString in this expression.