### PR TITLE
Required to compile with Borland Compiler v5.4 part4

### DIFF
--- a/src/CppUTest/SimpleString.cpp
+++ b/src/CppUTest/SimpleString.cpp
@@ -685,7 +685,7 @@ SimpleString StringFromOrNull(const char * expected)
 
 SimpleString PrintableStringFromOrNull(const char * expected)
 {
-    return (expected) ? StringFrom(expected).printable() : "(null)";
+    return (expected) ? StringFrom(expected).printable() : StringFrom("(null)");
 }
 
 SimpleString StringFrom(int value)


### PR DESCRIPTION
In the expression a? true : false; True and False have to be the same type. The Borland Compiler v5.4 is unable to automatically promote the char array "(null)" to a SimpleString in this expression.