### PR TITLE
Required to compile with Borland Compiler v5.4 part5

### DIFF
--- a/src/CppUTest/SimpleString.cpp
+++ b/src/CppUTest/SimpleString.cpp
@@ -984,7 +984,7 @@ SimpleString StringFromBinary(const unsigned char* value, size_t size)
 
 SimpleString StringFromBinaryOrNull(const unsigned char* value, size_t size)
 {
-    return (value) ? StringFromBinary(value, size) : "(null)";
+    return (value) ? StringFromBinary(value, size) : StringFrom("(null)");
 }
 
 SimpleString StringFromBinaryWithSize(const unsigned char* value, size_t size)


### PR DESCRIPTION
In the expression a? true : false; True and False have to be the same type. The Borland Compiler v5.4 is unable to automatically promote the char array "(null)" to a SimpleString in this expression.