### PR TITLE
Required to compile with Borland Compiler v5.4 part6

### DIFF
--- a/src/CppUTest/SimpleString.cpp
+++ b/src/CppUTest/SimpleString.cpp
@@ -1001,7 +1001,7 @@ SimpleString StringFromBinaryWithSize(const unsigned char* value, size_t size)
 
 SimpleString StringFromBinaryWithSizeOrNull(const unsigned char* value, size_t size)
 {
-    return (value) ? StringFromBinaryWithSize(value, size) : "(null)";
+    return (value) ? StringFromBinaryWithSize(value, size) : StringFrom("(null)");
 }
 
 SimpleString StringFromMaskedBits(unsigned long value, unsigned long mask, size_t byteCount)


### PR DESCRIPTION
In the expression a? true : false; True and False have to be the same type. The Borland Compiler v5.4 is unable to automatically promote the char array "(null)" to a SimpleString in this expression.