### PR TITLE
Required to compile with Borland Compiler v5.4 part7

### DIFF
--- a/src/CppUTest/TestMemoryAllocator.cpp
+++ b/src/CppUTest/TestMemoryAllocator.cpp
@@ -598,7 +598,7 @@ SimpleString MemoryAccountant::reportFooter() const
 
 SimpleString MemoryAccountant::stringSize(size_t size) const
 {
-    return (size == 0) ? "other" : StringFromFormat("%5d", (int) size);
+    return (size == 0) ? StringFrom("other") : StringFromFormat("%5d", (int) size);
 }
 
 SimpleString MemoryAccountant::report() const


### PR DESCRIPTION
In the expression a? true : false; True and False have to be the same type. The Borland Compiler v5.4 is unable to automatically promote the char array "other" to a SimpleString in this expression.
Updating src/CppUTest/TestMemoryAllocator.cpp