### PR TITLE
Required to compile with Borland Compiler v5.4 part8

### DIFF
--- a/src/CppUTestExt/MockExpectedCall.cpp
+++ b/src/CppUTestExt/MockExpectedCall.cpp
@@ -248,7 +248,7 @@ MockExpectedCall& MockCheckedExpectedCall::withUnmodifiedOutputParameter(const S
 SimpleString MockCheckedExpectedCall::getInputParameterType(const SimpleString& name)
 {
     MockNamedValue * p = inputParameters_->getValueByName(name);
-    return (p) ? p->getType() : "";
+    return (p) ? p->getType() : StringFrom("");
 }
 
 bool MockCheckedExpectedCall::hasInputParameterWithName(const SimpleString& name)


### PR DESCRIPTION
In the expression a? true : false; True and False have to be the same type. The Borland Compiler v5.4 is unable to automatically promote the char array "" to a SimpleString in this expression.
Updating src/CppUTestExt/MockExpectedCall.cpp