### PR TITLE
Required to compile with Borland Compiler v5.4 part9

### DIFF
--- a/src/CppUTestExt/MockExpectedCall.cpp
+++ b/src/CppUTestExt/MockExpectedCall.cpp
@@ -368,7 +368,7 @@ void MockCheckedExpectedCall::outputParameterWasPassed(const SimpleString& name)
 SimpleString MockCheckedExpectedCall::getInputParameterValueString(const SimpleString& name)
 {
     MockNamedValue * p = inputParameters_->getValueByName(name);
-    return (p) ? StringFrom(*p) : "failed";
+    return (p) ? StringFrom(*p) : StringFrom("failed");
 }
 
 bool MockCheckedExpectedCall::hasInputParameter(const MockNamedValue& parameter)


### PR DESCRIPTION
In the expression a? true : false; True and False have to be the same type. The Borland Compiler v5.4 is unable to automatically promote the char array "failed" to a SimpleString in this expression.
Updating src/CppUTestExt/MockExpectedCall.cpp