### PR TITLE
cpputest_ulonglong for unsigned long long

### DIFF
--- a/include/CppUTest/UtestMacros.h
+++ b/include/CppUTest/UtestMacros.h
@@ -242,7 +242,7 @@
         do { UtestShell::getCurrent()->assertLongLongsEqual((cpputest_longlong)expected, (cpputest_longlong)actual, text, file, line); } while(0)
 
 #define UNSIGNED_LONGLONGS_EQUAL_LOCATION(expected, actual, text, file, line)\
-        do { UtestShell::getCurrent()->assertUnsignedLongLongsEqual((unsigned long long)expected, (unsigned long long)actual, text, file, line); } while(0)
+        do { UtestShell::getCurrent()->assertUnsignedLongLongsEqual((cpputest_ulonglong)expected, (cpputest_ulonglong)actual, text, file, line); } while(0)
 
 #define BYTES_EQUAL(expected, actual)\
     LONGS_EQUAL((expected) & 0xff,(actual) & 0xff)


### PR DESCRIPTION
unsigned long long is compiler specific and we already have a cpputest_ulonglong typedef that takes care of this for us.