### PR TITLE
The first of a number of changes to make this file a Borland specific file.

### DIFF
--- a/src/Platforms/Borland/UtestPlatform.cpp
+++ b/src/Platforms/Borland/UtestPlatform.cpp
@@ -172,15 +172,6 @@ static int PlatformSpecificSetJmpImplementation(void (*function) (void* data), v
     return 0;
 }
 
-/*
- * MacOSX clang 3.0 doesn't seem to recognize longjmp and thus complains about _no_return_.
- * The later clang compilers complain when it isn't there. So only way is to check the clang compiler here :(
- */
-#ifdef __clang__
- #if !((__clang_major__ == 3) && (__clang_minor__ == 0))
- _no_return_
- #endif
-#endif
 static void PlatformSpecificLongJmpImplementation()
 {
     jmp_buf_index--;


### PR DESCRIPTION
removed the first #ifdef __clang__  as this will never be called as this file will only be included when __clang__ is not defined.