### PR TITLE
Update UtestPlatform.cpp

### DIFF
--- a/src/Platforms/Borland/UtestPlatform.cpp
+++ b/src/Platforms/Borland/UtestPlatform.cpp
@@ -205,13 +205,7 @@ static const char* TimeStringImplementation()
 {
     time_t theTime = time(NULLPTR);
     static char dateTime[80];
-#if defined(_WIN32) && defined(MINGW_HAS_SECURE_API)
-    static struct tm lastlocaltime;
-    localtime_s(&lastlocaltime, &theTime);
-    struct tm *tmp = &lastlocaltime;
-#else
     struct tm *tmp = localtime(&theTime);
-#endif
     strftime(dateTime, 80, "%Y-%m-%dT%H:%M:%S", tmp);
     return dateTime;
 }


### PR DESCRIPTION
 removed reference to a MinGW specific function that Borland 5.4 does not have