### PR TITLE
Update CppUTestConfig.h

### DIFF
--- a/include/CppUTest/CppUTestConfig.h
+++ b/include/CppUTest/CppUTestConfig.h
@@ -208,7 +208,7 @@
 #if CPPUTEST_USE_STD_C_LIB && \
   (!defined(_MSC_VER) || (_MSC_VER >= 1800)) && \
   (!defined(__APPLE__)) && \
-  (!defined(__ghs__) || !defined(__ColdFire__))
+  (!defined(__ghs__) || !defined(__ColdFire__)) && (!defined(__BCPLUSPLUS__))
 #define CPPUTEST_HAVE_FENV
 #if defined(__WATCOMC__) || defined(__ARMEL__) || defined(__m68k__)
 #define CPPUTEST_FENV_IS_WORKING_PROPERLY 0


### PR DESCRIPTION
this removed the fenv.h requirement.   This was simple, the other option is to workout how the control87 functions map and do something fancy but I just wanted the quickest and least trouble route to  a working cpputest.