### PR TITLE
Fix nullptr for modern compiler

### DIFF
--- a/src/CppUTest/SimpleString.cpp
+++ b/src/CppUTest/SimpleString.cpp
@@ -358,7 +358,7 @@ size_t SimpleString::count(const SimpleString& substr) const
 {
     size_t num = 0;
     const char* str = getBuffer();
-    const char* strpart = NULL;
+    const char* strpart = NULLPTR;
     if (*str){
         strpart = StrStr(str, substr.getBuffer());
     }


### PR DESCRIPTION
The usage of `NULL` causes warnings on some modern compiler.