### PR TITLE
Improve support for strongly-typed/scoped enums

### DIFF
--- a/include/CppUTest/SimpleString.h
+++ b/include/CppUTest/SimpleString.h
@@ -241,4 +241,14 @@ SimpleString StringFrom(const std::string& other);
 
 #endif
 
+#if defined(__cplusplus) && __cplusplus >= 201103L
+
+template<typename E, typename = typename std::enable_if<std::is_enum<E>::value>::type>
+SimpleString StringFrom(E enumValue)
+{
+  return StringFrom(static_cast<typename std::underlying_type<E>::type>(enumValue));
+}
+
+#endif
+
 #endif

--- a/include/CppUTestExt/MockActualCall.h
+++ b/include/CppUTestExt/MockActualCall.h
@@ -75,6 +75,14 @@ public:
     virtual MockActualCall& withConstPointerParameter(const SimpleString& name, const void* value)=0;
     virtual MockActualCall& withMemoryBufferParameter(const SimpleString& name, const unsigned char* value, size_t size)=0;
 
+#if defined(__cplusplus) && __cplusplus >= 201103L
+    template<typename E, typename = typename std::enable_if<std::is_enum<E>::value>::type>
+    MockActualCall& withParameter(const SimpleString& name, E enumValue)
+    {
+        return withParameter(name, static_cast<typename std::underlying_type<E>::type>(enumValue));
+    }
+#endif
+
     virtual bool hasReturnValue()=0;
     virtual MockNamedValue returnValue()=0;
 
@@ -113,6 +121,27 @@ public:
 
     virtual void (*returnFunctionPointerValue())()=0;
     virtual void (*returnFunctionPointerValueOrDefault(void (*default_value)()))()=0;
+
+    bool returnValueOrDefault(bool default_value) { return returnBoolValueOrDefault(default_value); }
+    int returnValueOrDefault(int default_value) { return returnIntValueOrDefault(default_value); }
+    unsigned long int returnValueOrDefault(unsigned long int default_value) { return returnUnsignedLongIntValueOrDefault(default_value); }
+    long int returnValueOrDefault(long int default_value) { return returnLongIntValueOrDefault(default_value); }
+    cpputest_ulonglong returnValueOrDefault(cpputest_ulonglong default_value) { return returnUnsignedLongLongIntValueOrDefault(default_value); }
+    cpputest_longlong returnValueOrDefault(cpputest_longlong default_value) { return returnLongLongIntValueOrDefault(default_value); }
+    unsigned int returnValueOrDefault(unsigned int default_value) { return returnUnsignedIntValueOrDefault(default_value); }
+    const char * returnValueOrDefault(const char * default_value) { return returnStringValueOrDefault(default_value); }
+    double returnValueOrDefault(double default_value) { return returnDoubleValueOrDefault(default_value); }
+    void * returnValueOrDefault(void * default_value) { return returnPointerValueOrDefault(default_value); }
+    const void * returnValueOrDefault(const void * default_value) { return returnConstPointerValueOrDefault(default_value); }
+    void (*returnValueOrDefault(void (*default_value)()))() { return returnFunctionPointerValueOrDefault(default_value); }
+
+#if defined(__cplusplus) && __cplusplus >= 201103L
+    template<typename E, typename = typename std::enable_if<std::is_enum<E>::value>::type>
+    E returnValueOrDefault(E enumValue)
+    {
+      return static_cast<E>(returnValueOrDefault(static_cast<typename std::underlying_type<E>::type>(enumValue)));
+    }
+#endif
 
     virtual MockActualCall& onObject(const void* objectPtr)=0;
 };

--- a/include/CppUTestExt/MockExpectedCall.h
+++ b/include/CppUTestExt/MockExpectedCall.h
@@ -77,6 +77,15 @@ public:
     virtual MockExpectedCall& withFunctionPointerParameter(const SimpleString& name, void (*value)())=0;
     virtual MockExpectedCall& withConstPointerParameter(const SimpleString& name, const void* value)=0;
     virtual MockExpectedCall& withMemoryBufferParameter(const SimpleString& name, const unsigned char* value, size_t size)=0;
+
+#if defined(__cplusplus) && __cplusplus >= 201103L
+    template<typename E, typename = typename std::enable_if<std::is_enum<E>::value>::type>
+    MockExpectedCall& withParameter(const SimpleString& name, E enumValue)
+    {
+        return withParameter(name, static_cast<typename std::underlying_type<E>::type>(enumValue));
+    }
+#endif
+
     virtual MockExpectedCall& andReturnValue(bool value)=0;
     virtual MockExpectedCall& andReturnValue(int value)=0;
     virtual MockExpectedCall& andReturnValue(unsigned int value)=0;
@@ -89,6 +98,14 @@ public:
     virtual MockExpectedCall& andReturnValue(void* value)=0;
     virtual MockExpectedCall& andReturnValue(const void* value)=0;
     virtual MockExpectedCall& andReturnValue(void (*value)())=0;
+
+#if defined(__cplusplus) && __cplusplus >= 201103L
+    template<typename E, typename = typename std::enable_if<std::is_enum<E>::value>::type>
+    MockExpectedCall& andReturnValue(E enumValue)
+    {
+        return andReturnValue(static_cast<typename std::underlying_type<E>::type>(enumValue));
+    }
+#endif
 
     virtual MockExpectedCall& onObject(void* objectPtr)=0;
 };

--- a/tests/CppUTestExt/MockParameterTest.cpp
+++ b/tests/CppUTestExt/MockParameterTest.cpp
@@ -86,6 +86,42 @@ TEST(MockParameterTest, expectOneLongLongIntegerParameterAndValue)
 
 #endif
 
+#if defined(__cplusplus) && __cplusplus >= 201103L
+
+enum class TestScopedEnum { A, B };
+enum class TestScopedEnumUnsignedChar : unsigned char { A = 3, B = 5 };
+
+TEST(MockParameterTest, expectOneScopedEnumParameterAndValue)
+{
+  TestScopedEnum value = TestScopedEnum::A;
+  mock().expectOneCall("foo").withParameter("parameter", value);
+  mock().actualCall("foo").withParameter("parameter", value);
+
+  mock().checkExpectations();
+}
+
+TEST(MockParameterTest, expectOneScopedEnumClassUnsignedCharParameterAndValue)
+{
+  TestScopedEnumUnsignedChar value = TestScopedEnumUnsignedChar::A;
+  mock().expectOneCall("foo").withParameter("parameter", value);
+  mock().actualCall("foo").withParameter("parameter", value);
+
+  mock().checkExpectations();
+}
+
+#endif
+
+enum TestUnscopedEnum { TestUnscopedEnum_A, TestUnscopedEnum_B };
+
+TEST(MockParameterTest, expectOneUnscopedEnumClassParameterAndValue)
+{
+  TestUnscopedEnum value = TestUnscopedEnum_A;
+  mock().expectOneCall("foo").withParameter("parameter", value);
+  mock().actualCall("foo").withParameter("parameter", value);
+
+  mock().checkExpectations();
+}
+
 TEST(MockParameterTest, mismatchedIntegerTypesIntAndLongAreAllowed)
 {
     mock().expectOneCall("foo").withParameter("parameter", (int)1);

--- a/tests/CppUTestExt/MockReturnValueTest.cpp
+++ b/tests/CppUTestExt/MockReturnValueTest.cpp
@@ -223,6 +223,9 @@ TEST(MockReturnValueTest, WhenADoubleReturnValueIsExpectedAndAlsoThereIsADefault
 
     DOUBLES_EQUAL(expected_return_value, mock().actualCall("foo").returnDoubleValueOrDefault(default_return_value), 0.05);
     DOUBLES_EQUAL(expected_return_value, mock().returnDoubleValueOrDefault(default_return_value), 0.05);
+
+    mock().expectOneCall("foo").andReturnValue(expected_return_value);
+    DOUBLES_EQUAL(expected_return_value, mock().actualCall("foo").returnValueOrDefault(default_return_value), 0.05);
 }
 
 TEST(MockReturnValueTest, WhenNoDoubleReturnValueIsExpectedButThereIsADefaultShouldlUseTheDefaultValue)
@@ -231,6 +234,9 @@ TEST(MockReturnValueTest, WhenNoDoubleReturnValueIsExpectedButThereIsADefaultSho
     mock().expectOneCall("foo");
     DOUBLES_EQUAL(default_return_value, mock().actualCall("foo").returnDoubleValueOrDefault(default_return_value), 0.05);
     DOUBLES_EQUAL(default_return_value, mock().returnDoubleValueOrDefault(default_return_value), 0.05);
+
+    mock().expectOneCall("foo");
+    DOUBLES_EQUAL(default_return_value, mock().actualCall("foo").returnValueOrDefault(default_return_value), 0.05);
 }
 
 TEST(MockReturnValueTest, WhenAUnsignedIntegerReturnValueIsExpectedAndAlsoThereIsADefaultShouldlIgnoreTheDefault)
@@ -240,6 +246,9 @@ TEST(MockReturnValueTest, WhenAUnsignedIntegerReturnValueIsExpectedAndAlsoThereI
     mock().expectOneCall("foo").andReturnValue(expected_return_value);
     LONGS_EQUAL(expected_return_value, mock().actualCall("foo").returnUnsignedIntValueOrDefault(default_return_value));
     LONGS_EQUAL(expected_return_value, mock().returnUnsignedIntValueOrDefault(default_return_value));
+
+    mock().expectOneCall("foo").andReturnValue(expected_return_value);
+    LONGS_EQUAL(expected_return_value, mock().actualCall("foo").returnValueOrDefault(default_return_value));
 }
 
 TEST(MockReturnValueTest, WhenNoUnsignedIntegerReturnValueIsExpectedButThereIsADefaultShouldlUseTheDefaultValue)
@@ -248,6 +257,9 @@ TEST(MockReturnValueTest, WhenNoUnsignedIntegerReturnValueIsExpectedButThereIsAD
     mock().expectOneCall("foo");
     LONGS_EQUAL(default_return_value, mock().actualCall("foo").returnUnsignedIntValueOrDefault(default_return_value));
     LONGS_EQUAL(default_return_value, mock().returnUnsignedIntValueOrDefault(default_return_value));
+
+    mock().expectOneCall("foo");
+    LONGS_EQUAL(default_return_value, mock().actualCall("foo").returnValueOrDefault(default_return_value));
 }
 
 TEST(MockReturnValueTest, WhenAUnsignedLongIntegerReturnValueIsExpectedAndAlsoThereIsADefaultShouldlIgnoreTheDefault)
@@ -257,6 +269,9 @@ TEST(MockReturnValueTest, WhenAUnsignedLongIntegerReturnValueIsExpectedAndAlsoTh
     mock().expectOneCall("foo").andReturnValue(expected_return_value);
     LONGS_EQUAL(expected_return_value, mock().actualCall("foo").returnUnsignedLongIntValueOrDefault(default_return_value));
     LONGS_EQUAL(expected_return_value, mock().returnUnsignedLongIntValueOrDefault(default_return_value));
+
+    mock().expectOneCall("foo").andReturnValue(expected_return_value);
+    LONGS_EQUAL(expected_return_value, mock().actualCall("foo").returnValueOrDefault(default_return_value));
 }
 
 TEST(MockReturnValueTest, WhenNoUnsignedLongIntegerReturnValueIsExpectedButThereIsADefaultShouldlUseTheDefaultValue)
@@ -265,6 +280,9 @@ TEST(MockReturnValueTest, WhenNoUnsignedLongIntegerReturnValueIsExpectedButThere
     mock().expectOneCall("foo");
     LONGS_EQUAL(default_return_value, mock().actualCall("foo").returnUnsignedLongIntValueOrDefault(default_return_value));
     LONGS_EQUAL(default_return_value, mock().returnUnsignedLongIntValueOrDefault(default_return_value));
+
+    mock().expectOneCall("foo");
+    LONGS_EQUAL(default_return_value, mock().actualCall("foo").returnValueOrDefault(default_return_value));
 }
 
 TEST(MockReturnValueTest, WhenALongIntegerReturnValueIsExpectedAndAlsoThereIsADefaultShouldlIgnoreTheDefault)
@@ -274,6 +292,9 @@ TEST(MockReturnValueTest, WhenALongIntegerReturnValueIsExpectedAndAlsoThereIsADe
     mock().expectOneCall("foo").andReturnValue(expected_return_value);
     LONGS_EQUAL(expected_return_value, mock().actualCall("foo").returnLongIntValueOrDefault(default_return_value));
     LONGS_EQUAL(expected_return_value, mock().returnLongIntValueOrDefault(default_return_value));
+
+    mock().expectOneCall("foo").andReturnValue(expected_return_value);
+    LONGS_EQUAL(expected_return_value, mock().actualCall("foo").returnValueOrDefault(default_return_value));
 }
 
 TEST(MockReturnValueTest, WhenNoLongIntegerReturnValueIsExpectedButThereIsADefaultShouldlUseTheDefaultValue)
@@ -282,6 +303,9 @@ TEST(MockReturnValueTest, WhenNoLongIntegerReturnValueIsExpectedButThereIsADefau
     mock().expectOneCall("foo");
     LONGS_EQUAL(default_return_value, mock().actualCall("foo").returnLongIntValueOrDefault(default_return_value));
     LONGS_EQUAL(default_return_value, mock().returnLongIntValueOrDefault(default_return_value));
+
+    mock().expectOneCall("foo");
+    LONGS_EQUAL(default_return_value, mock().actualCall("foo").returnValueOrDefault(default_return_value));
 }
 
 #ifdef CPPUTEST_USE_LONG_LONG
@@ -293,6 +317,9 @@ TEST(MockReturnValueTest, WhenAUnsignedLongLongIntegerReturnValueIsExpectedAndAl
     mock().expectOneCall("foo").andReturnValue(expected_return_value);
     LONGS_EQUAL(expected_return_value, mock().actualCall("foo").returnUnsignedLongLongIntValueOrDefault(default_return_value));
     LONGS_EQUAL(expected_return_value, mock().returnUnsignedLongLongIntValueOrDefault(default_return_value));
+
+    mock().expectOneCall("foo").andReturnValue(expected_return_value);
+    LONGS_EQUAL(expected_return_value, mock().actualCall("foo").returnValueOrDefault(default_return_value));
 }
 
 TEST(MockReturnValueTest, WhenNoUnsignedLongLongIntegerReturnValueIsExpectedButThereIsADefaultShouldlUseTheDefaultValue)
@@ -301,6 +328,9 @@ TEST(MockReturnValueTest, WhenNoUnsignedLongLongIntegerReturnValueIsExpectedButT
     mock().expectOneCall("foo");
     LONGS_EQUAL(default_return_value, mock().actualCall("foo").returnUnsignedLongLongIntValueOrDefault(default_return_value));
     LONGS_EQUAL(default_return_value, mock().returnUnsignedLongLongIntValueOrDefault(default_return_value));
+
+    mock().expectOneCall("foo");
+    LONGS_EQUAL(default_return_value, mock().actualCall("foo").returnValueOrDefault(default_return_value));
 }
 
 TEST(MockReturnValueTest, WhenALongLongIntegerReturnValueIsExpectedAndAlsoThereIsADefaultShouldlIgnoreTheDefault)
@@ -310,6 +340,9 @@ TEST(MockReturnValueTest, WhenALongLongIntegerReturnValueIsExpectedAndAlsoThereI
     mock().expectOneCall("foo").andReturnValue(expected_return_value);
     LONGS_EQUAL(expected_return_value, mock().actualCall("foo").returnLongLongIntValueOrDefault(default_return_value));
     LONGS_EQUAL(expected_return_value, mock().returnLongLongIntValueOrDefault(default_return_value));
+
+    mock().expectOneCall("foo").andReturnValue(expected_return_value);
+    LONGS_EQUAL(expected_return_value, mock().actualCall("foo").returnValueOrDefault(default_return_value));
 }
 
 TEST(MockReturnValueTest, WhenNoLongLongIntegerReturnValueIsExpectedButThereIsADefaultShouldlUseTheDefaultValue)
@@ -318,6 +351,9 @@ TEST(MockReturnValueTest, WhenNoLongLongIntegerReturnValueIsExpectedButThereIsAD
     mock().expectOneCall("foo");
     LONGS_EQUAL(default_return_value, mock().actualCall("foo").returnLongLongIntValueOrDefault(default_return_value));
     LONGS_EQUAL(default_return_value, mock().returnLongLongIntValueOrDefault(default_return_value));
+
+    mock().expectOneCall("foo");
+    LONGS_EQUAL(default_return_value, mock().actualCall("foo").returnValueOrDefault(default_return_value));
 }
 
 #endif
@@ -329,6 +365,9 @@ TEST(MockReturnValueTest, WhenABooleanReturnValueIsExpectedAndAlsoThereIsADefaul
     mock().expectOneCall("foo").andReturnValue(expected_return_value);
     CHECK_EQUAL(expected_return_value, mock().actualCall("foo").returnBoolValueOrDefault(default_return_value));
     CHECK_EQUAL(expected_return_value, mock().returnBoolValueOrDefault(default_return_value));
+
+    mock().expectOneCall("foo").andReturnValue(expected_return_value);
+    CHECK_EQUAL(expected_return_value, mock().actualCall("foo").returnValueOrDefault(default_return_value));
 }
 
 TEST(MockReturnValueTest, WhenNoBooleanReturnValueIsExpectedButThereIsADefaultShouldlUseTheDefaultValue)
@@ -337,6 +376,9 @@ TEST(MockReturnValueTest, WhenNoBooleanReturnValueIsExpectedButThereIsADefaultSh
     mock().expectOneCall("foo");
     CHECK_EQUAL(default_return_value, mock().actualCall("foo").returnBoolValueOrDefault(default_return_value));
     CHECK_EQUAL(default_return_value, mock().returnBoolValueOrDefault(default_return_value));
+
+    mock().expectOneCall("foo");
+    CHECK_EQUAL(default_return_value, mock().actualCall("foo").returnValueOrDefault(default_return_value));
 }
 
 TEST(MockReturnValueTest, WhenAIntegerReturnValueIsExpectedAndAlsoThereIsADefaultShouldlIgnoreTheDefault)
@@ -346,6 +388,9 @@ TEST(MockReturnValueTest, WhenAIntegerReturnValueIsExpectedAndAlsoThereIsADefaul
     mock().expectOneCall("foo").andReturnValue(expected_return_value);
     LONGS_EQUAL(expected_return_value, mock().actualCall("foo").returnIntValueOrDefault(default_return_value));
     LONGS_EQUAL(expected_return_value, mock().returnIntValueOrDefault(default_return_value));
+
+    mock().expectOneCall("foo").andReturnValue(expected_return_value);
+    LONGS_EQUAL(expected_return_value, mock().actualCall("foo").returnValueOrDefault(default_return_value));
 }
 
 TEST(MockReturnValueTest, WhenNoIntegerReturnValueIsExpectedButThereIsADefaultShouldlUseTheDefaultValue)
@@ -354,6 +399,9 @@ TEST(MockReturnValueTest, WhenNoIntegerReturnValueIsExpectedButThereIsADefaultSh
     mock().expectOneCall("foo");
     LONGS_EQUAL(default_return_value, mock().actualCall("foo").returnIntValueOrDefault(default_return_value));
     LONGS_EQUAL(default_return_value, mock().returnIntValueOrDefault(default_return_value));
+
+    mock().expectOneCall("foo");
+    LONGS_EQUAL(default_return_value, mock().actualCall("foo").returnValueOrDefault(default_return_value));
 }
 
 TEST(MockReturnValueTest, BooleanReturnValue)
@@ -702,6 +750,44 @@ TEST(MockReturnValueTest, WhenNoFunctionPointerReturnValueIsExpectedButThereIsAD
     mock().expectOneCall("foo");
     FUNCTIONPOINTERS_EQUAL(default_return_value, mock().actualCall("foo").returnFunctionPointerValueOrDefault(default_return_value));
     FUNCTIONPOINTERS_EQUAL(default_return_value, mock().returnFunctionPointerValueOrDefault(default_return_value));
+}
+
+#if defined(__cplusplus) && __cplusplus >= 201103L
+
+enum class TestScopedEnum { A, B };
+
+TEST(MockReturnValueTest, WhenAScopedEnumReturnValueIsExpectedAndAlsoThereIsADefaultShouldlIgnoreTheDefault)
+{
+  TestScopedEnum default_return_value = TestScopedEnum::A;
+  TestScopedEnum expected_return_value = TestScopedEnum::B;
+  mock().expectOneCall("foo").andReturnValue(expected_return_value);
+  CHECK_EQUAL(expected_return_value, mock().actualCall("foo").returnValueOrDefault(default_return_value));
+}
+
+TEST(MockReturnValueTest, WhenNoScopedEnumReturnValueIsExpectedButThereIsADefaultShouldlUseTheDefaultValue)
+{
+  TestScopedEnum default_return_value = TestScopedEnum::A;
+  mock().expectOneCall("foo");
+  CHECK_EQUAL(default_return_value, mock().actualCall("foo").returnValueOrDefault(default_return_value));
+}
+
+#endif
+
+enum TestUnscopedEnum { TestUnscopedEnum_A, TestUnscopedEnum_B };
+
+TEST(MockReturnValueTest, WhenAnUnscopedEnumReturnValueIsExpectedAndAlsoThereIsADefaultShouldlIgnoreTheDefault)
+{
+  TestUnscopedEnum default_return_value = TestUnscopedEnum_A;
+  TestUnscopedEnum expected_return_value = TestUnscopedEnum_B;
+  mock().expectOneCall("foo").andReturnValue(expected_return_value);
+  CHECK_EQUAL(expected_return_value, mock().actualCall("foo").returnValueOrDefault(default_return_value));
+}
+
+TEST(MockReturnValueTest, WhenNoUnscopedEnumReturnValueIsExpectedButThereIsADefaultShouldlUseTheDefaultValue)
+{
+  TestUnscopedEnum default_return_value = TestUnscopedEnum_A;
+  mock().expectOneCall("foo");
+  CHECK_EQUAL(default_return_value, mock().actualCall("foo").returnValueOrDefault(default_return_value));
 }
 
 TEST(MockReturnValueTest, PointerReturnValue)


### PR DESCRIPTION
This commit specifically:
- Introduces support for strongly-typed enums for mock parameters and return values
- Support strongly-typed enums in CHECK_EQUAL
- Introduces a generic `MockActualCall::returnValueOrDefault` with overloads for each support type (just like it's done for `MockExpectedCall::withParameter`