### PR TITLE
Fix warning about wrong printf format when compiling with MinGW-w64

### DIFF
--- a/include/CppUTest/CppUTestConfig.h
+++ b/include/CppUTest/CppUTestConfig.h
@@ -109,6 +109,12 @@
   #define _no_return_
 #endif
 
+#if defined(__MINGW32__)
+#define CPPUTEST_CHECK_FORMAT_TYPE __MINGW_PRINTF_FORMAT
+#else
+#define CPPUTEST_CHECK_FORMAT_TYPE printf
+#endif
+
 #if __has_attribute(format)
   #define _check_format_(type, format_parameter, other_parameters) __attribute__ ((format (type, format_parameter, other_parameters)))
 #else

--- a/include/CppUTest/SimpleString.h
+++ b/include/CppUTest/SimpleString.h
@@ -209,7 +209,7 @@ SimpleString HexStringFrom(const void* value);
 SimpleString HexStringFrom(void (*value)());
 SimpleString StringFrom(double value, int precision = 6);
 SimpleString StringFrom(const SimpleString& other);
-SimpleString StringFromFormat(const char* format, ...) _check_format_(printf, 1, 2);
+SimpleString StringFromFormat(const char* format, ...) _check_format_(CPPUTEST_CHECK_FORMAT_TYPE, 1, 2);
 SimpleString VStringFromFormat(const char* format, va_list args);
 SimpleString StringFromBinary(const unsigned char* value, size_t size);
 SimpleString StringFromBinaryOrNull(const unsigned char* value, size_t size);


### PR DESCRIPTION
When compiling CppUTest with MinGW-w64 (tested with different versions from 8.x to 10.x) with long long support enabled, the following warning is thrown:

 ```
[build] C:\Work\cpputest\src\CppUTest\SimpleString.cpp: In function 'SimpleString StringFrom(cpputest_longlong)':
[build] C:\Work\cpputest\src\CppUTest\SimpleString.cpp:788:32: warning: unknown conversion type character 'l' in format [-Wformat=]
[build]   788 |     return StringFromFormat("%lld", value);
[build]       |                                ^
[build] C:\Work\cpputest\src\CppUTest\SimpleString.cpp:788:29: warning: too many arguments for format [-Wformat-extra-args]
[build]   788 |     return StringFromFormat("%lld", value);
[build]       |                             ^~~~~~
[build] C:\Work\cpputest\src\CppUTest\SimpleString.cpp: In function 'SimpleString StringFrom(cpputest_ulonglong)':
[build] C:\Work\cpputest\src\CppUTest\SimpleString.cpp:793:32: warning: unknown conversion type character 'l' in format [-Wformat=]
[build]   793 |     return StringFromFormat("%llu", value);
[build]       |                                ^
[build] C:\Work\cpputest\src\CppUTest\SimpleString.cpp:793:29: warning: too many arguments for format [-Wformat-extra-args]
[build]   793 |     return StringFromFormat("%llu", value);
[build]       |                             ^~~~~~
[build] C:\Work\cpputest\src\CppUTest\SimpleString.cpp: In function 'SimpleString HexStringFrom(cpputest_longlong)':
[build] C:\Work\cpputest\src\CppUTest\SimpleString.cpp:798:32: warning: unknown conversion type character 'l' in format [-Wformat=]
[build]   798 |     return StringFromFormat("%llx", value);
[build]       |                                ^
[build] C:\Work\cpputest\src\CppUTest\SimpleString.cpp:798:29: warning: too many arguments for format [-Wformat-extra-args]
[build]   798 |     return StringFromFormat("%llx", value);
[build]       |                             ^~~~~~
[build] C:\Work\cpputest\src\CppUTest\SimpleString.cpp: In function 'SimpleString HexStringFrom(cpputest_ulonglong)':
[build] C:\Work\cpputest\src\CppUTest\SimpleString.cpp:803:32: warning: unknown conversion type character 'l' in format [-Wformat=]
[build]   803 |     return StringFromFormat("%llx", value);
[build]       |                                ^
[build] C:\Work\cpputest\src\CppUTest\SimpleString.cpp:803:29: warning: too many arguments for format [-Wformat-extra-args]
[build]   803 |     return StringFromFormat("%llx", value);
[build]       |                             ^~~~~~
```

This is a known [issue](https://stackoverflow.com/questions/54265217/mingw64-w64-attributeformat-and-cinttypes-header), and this PR solves the problem.