### PR TITLE
Library names indicating architecture size and debug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,9 @@ option(EXAMPLES "Compile and make examples?" OFF)
 
 option(VERBOSE_CONFIG "Print configuration to stdout during generation" ON)
 
+option(LIBNAME_POSTFIX_BITSIZE "Add architecture bitsize (32/64) to the library name?" OFF)
+option(LIBNAME_POSTFIX_DEBUG "Add indication of debug compilation to the library name?" OFF)
+
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "What kind of build this is" FORCE)
 endif(NOT CMAKE_BUILD_TYPE)
@@ -93,6 +96,19 @@ include(FindPkgConfig)
 set(CppUTest_PKGCONFIG_FILE cpputest.pc)
 
 set(CppUTestRootDirectory ${PROJECT_SOURCE_DIR})
+
+set( CppUTestLibName "CppUTest" )
+set( CppUTestExtLibName "CppUTestExt" )
+
+if(LIBNAME_POSTFIX_BITSIZE)
+  if( "${CMAKE_SIZEOF_VOID_P}" STREQUAL "8" )
+      set( CppUTestLibName "${CppUTestLibName}64" )
+      set( CppUTestExtLibName "${CppUTestExtLibName}64" )
+  elseif( "${CMAKE_SIZEOF_VOID_P}" STREQUAL "4" )
+      set( CppUTestLibName "${CppUTestLibName}32" )
+      set( CppUTestExtLibName "${CppUTestExtLibName}32" )
+  endif()
+endif(LIBNAME_POSTFIX_BITSIZE)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CppUTestRootDirectory}/cmake/Modules)
 
@@ -179,10 +195,10 @@ if(PkgHelpers_AVAILABLE)
     INSTALL_DESTINATION ${CMAKE_CURRENT_BINARY_DIR}
     PATH_VARS INCLUDE_DIR CMAKE_CURRENT_BINARY_DIR)
   if (EXTENSIONS)
-    export(TARGETS CppUTest CppUTestExt
+    export(TARGETS ${CppUTestLibName} ${CppUTestExtLibName}
       FILE "${CMAKE_CURRENT_BINARY_DIR}/CppUTestTargets.cmake")
   else()
-    export(TARGETS CppUTest
+    export(TARGETS ${CppUTestLibName}
       FILE "${CMAKE_CURRENT_BINARY_DIR}/CppUTestTargets.cmake")
   endif()
   write_basic_package_version_file(
@@ -223,6 +239,10 @@ Features configured in CppUTest:
 
     Compile and run self-tests          ${TESTS}
     Run self-tests separately           ${TESTS_DETAILED}
+
+Library name options:
+    Add architecture bitsize (32/64)    ${LIBNAME_POSTFIX_BITSIZE}
+    Add debug compilation indicator     ${LIBNAME_POSTFIX_DEBUG}
 
 -------------------------------------------------------
 ")

--- a/examples/AllTests/CMakeLists.txt
+++ b/examples/AllTests/CMakeLists.txt
@@ -11,5 +11,5 @@ add_executable(ExampleTests
 )
 
 cpputest_normalize_test_output_location(ExampleTests)
-target_link_libraries(ExampleTests ApplicationLib CppUTest CppUTestExt)
+target_link_libraries(ExampleTests ApplicationLib ${CppUTestLibName} ${CppUTestExtLibName})
 cpputest_buildtime_discover_tests(ExampleTests)

--- a/src/CppUTest/CMakeLists.txt
+++ b/src/CppUTest/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(CppUTest
+add_library(${CppUTestLibName}
         CommandLineArguments.cpp
         MemoryLeakWarningPlugin.cpp
         TestHarness_c.cpp
@@ -20,16 +20,20 @@ add_library(CppUTest
         Utest.cpp
 )
 
+if(LIBNAME_POSTFIX_DEBUG)
+    set_target_properties(${CppUTestLibName} PROPERTIES DEBUG_POSTFIX "d")
+endif()
+
 #[[Set CPP_PLATFORM in a parent CMakeLists.txt if reusing one of the provided platforms, else supply the missing definitions]]
 if (CPP_PLATFORM)
-    target_sources(CppUTest
+    target_sources(${CppUTestLibName}
         PRIVATE
             ${CMAKE_CURRENT_LIST_DIR}/../Platforms/${CPP_PLATFORM}/UtestPlatform.cpp
     )
 endif(CPP_PLATFORM)
 
 #[[Arrange for the include directory to be added to the include paths of any CMake target depending on CppUTest.]]
-target_include_directories(CppUTest
+target_include_directories(${CppUTestLibName}
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../include>
         $<INSTALL_INTERFACE:include>
@@ -65,13 +69,13 @@ set(CppUTest_headers
         ${CppUTestRootDirectory}/include/CppUTest/SimpleMutex.h
 )
 
-set_target_properties(CppUTest PROPERTIES
+set_target_properties(${CppUTestLibName} PROPERTIES
     PUBLIC_HEADER "${CppUTest_headers}")
 
 if (WIN32)
-    target_link_libraries(CppUTest winmm)
+    target_link_libraries(${CppUTestLibName} winmm)
 endif (WIN32)
-install(TARGETS CppUTest
+install(TARGETS ${CppUTestLibName}
     EXPORT CppUTestTargets
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/src/CppUTestExt/CMakeLists.txt
+++ b/src/CppUTestExt/CMakeLists.txt
@@ -40,19 +40,23 @@ set(CppUTestExt_headers
         ${CppUTestRootDirectory}/include/CppUTestExt/MockSupport.h
 )
 
-add_library(CppUTestExt STATIC ${CppUTestExt_src} ${CppUTestExt_headers})
-target_link_libraries(CppUTestExt ${CPPUNIT_EXTERNAL_LIBRARIES})
+add_library(${CppUTestExtLibName} STATIC ${CppUTestExt_src} ${CppUTestExt_headers})
+target_link_libraries(${CppUTestExtLibName} ${CPPUNIT_EXTERNAL_LIBRARIES})
+
+if(LIBNAME_POSTFIX_DEBUG)
+    set_target_properties(${CppUTestExtLibName} PROPERTIES DEBUG_POSTFIX "d")
+endif()
 
 #[[Arrange for the include directory to be added to the include paths of any CMake target depending on CppUTestExt.]]
-target_include_directories(CppUTestExt
+target_include_directories(${CppUTestExtLibName}
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../include>
         $<INSTALL_INTERFACE:include>
 )
 
-set_target_properties(CppUTestExt PROPERTIES
+set_target_properties(${CppUTestExtLibName} PROPERTIES
     PUBLIC_HEADER "${CppUTestExt_headers}")
-install(TARGETS CppUTestExt
+install(TARGETS ${CppUTestExtLibName}
     EXPORT CppUTestTargets
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/tests/CppUTest/CMakeLists.txt
+++ b/tests/CppUTest/CMakeLists.txt
@@ -54,7 +54,7 @@ endif ()
 
 add_executable(CppUTestTests ${CppUTestTests_src})
 cpputest_normalize_test_output_location(CppUTestTests)
-target_link_libraries(CppUTestTests CppUTest ${THREAD_LIB})
+target_link_libraries(CppUTestTests ${CppUTestLibName} ${THREAD_LIB})
 
 if (TESTS_BUILD_DISCOVER)
     cpputest_buildtime_discover_tests(CppUTestTests)

--- a/tests/CppUTestExt/CMakeLists.txt
+++ b/tests/CppUTestExt/CMakeLists.txt
@@ -36,7 +36,7 @@ endif (MINGW)
 
 add_executable(CppUTestExtTests ${CppUTestExtTests_src})
 cpputest_normalize_test_output_location(CppUTestExtTests)
-target_link_libraries(CppUTestExtTests CppUTest CppUTestExt ${THREAD_LIB} ${CPPUNIT_EXTERNAL_LIBRARIES})
+target_link_libraries(CppUTestExtTests ${CppUTestLibName} ${CppUTestExtLibName} ${THREAD_LIB} ${CPPUNIT_EXTERNAL_LIBRARIES})
 
 if (TESTS_BUILD_DISCOVER)
     cpputest_buildtime_discover_tests(CppUTestExtTests)


### PR DESCRIPTION
Added options to CMake scripts for appending architecture size and debug indication to generated library names.

This way it is easier to deploy together both debug and release versions of the library, and 32/64 bits versions, avoiding headaches when trying to find out with which CppUTest library your are linking.