### PR TITLE
Add support for generating a test failure when an unexpected exception is thrown

### DIFF
--- a/include/CppUTest/CommandLineArguments.h
+++ b/include/CppUTest/CommandLineArguments.h
@@ -53,6 +53,7 @@ public:
     bool isShuffling() const;
     bool isReversing() const;
     bool isCrashingOnFail() const;
+    bool isRethrowingExceptions() const;
     size_t getShuffleSeed() const;
     const TestFilter* getGroupFilters() const;
     const TestFilter* getNameFilters() const;
@@ -85,6 +86,7 @@ private:
     bool runIgnored_;
     bool reversing_;
     bool crashOnFail_;
+    bool rethrowExceptions_;
     bool shuffling_;
     bool shufflingPreSeeded_;
     size_t repeat_;

--- a/include/CppUTest/TestFailure.h
+++ b/include/CppUTest/TestFailure.h
@@ -38,6 +38,10 @@
 
 #include "SimpleString.h"
 
+#if CPPUTEST_USE_STD_CPP_LIB
+#include <stdexcept>
+#endif
+
 class UtestShell;
 class TestOutput;
 
@@ -181,5 +185,14 @@ class FeatureUnsupportedFailure : public TestFailure
 public:
     FeatureUnsupportedFailure(UtestShell* test, const char* fileName, size_t lineNumber, const SimpleString& featureName, const SimpleString& text);
 };
+
+#if CPPUTEST_USE_STD_CPP_LIB
+class UnexpectedExceptionFailure : public TestFailure
+{
+public:
+    UnexpectedExceptionFailure(UtestShell* test);
+    UnexpectedExceptionFailure(UtestShell* test, const std::exception &e);
+};
+#endif
 
 #endif

--- a/include/CppUTest/Utest.h
+++ b/include/CppUTest/Utest.h
@@ -165,6 +165,8 @@ public:
     virtual void failWith(const TestFailure& failure);
     virtual void failWith(const TestFailure& failure, const TestTerminator& terminator);
 
+    virtual void addFailure(const TestFailure& failure);
+
 protected:
     UtestShell();
     UtestShell(const char *groupName, const char *testName, const char *fileName, size_t lineNumber, UtestShell *nextTest);

--- a/include/CppUTest/Utest.h
+++ b/include/CppUTest/Utest.h
@@ -99,6 +99,9 @@ public:
     static void setCrashOnFail();
     static void restoreDefaultTestTerminator();
 
+    static void setRethrowExceptions(bool rethrowExceptions);
+    static bool isRethrowingExceptions();
+
 public:
     UtestShell(const char* groupName, const char* testName, const char* fileName, size_t lineNumber);
     virtual ~UtestShell();
@@ -190,6 +193,8 @@ private:
     static TestResult* testResult_;
 
     static const TestTerminator *currentTestTerminator_;
+    
+    static bool rethrowExceptions_;
 };
 
 

--- a/src/CppUTest/CommandLineArguments.cpp
+++ b/src/CppUTest/CommandLineArguments.cpp
@@ -32,7 +32,7 @@
 CommandLineArguments::CommandLineArguments(int ac, const char *const *av) :
     ac_(ac), av_(av), needHelp_(false), verbose_(false), veryVerbose_(false), color_(false), runTestsAsSeperateProcess_(false),
     listTestGroupNames_(false), listTestGroupAndCaseNames_(false), listTestLocations_(false), runIgnored_(false), reversing_(false),
-    crashOnFail_(false), rethrowExceptions_(false), shuffling_(false), shufflingPreSeeded_(false), repeat_(1), shuffleSeed_(0),
+    crashOnFail_(false), rethrowExceptions_(true), shuffling_(false), shufflingPreSeeded_(false), repeat_(1), shuffleSeed_(0),
     groupFilters_(NULLPTR), nameFilters_(NULLPTR), outputType_(OUTPUT_ECLIPSE)
 {
 }
@@ -71,7 +71,7 @@ bool CommandLineArguments::parse(TestPlugin* plugin)
         else if (argument == "-ll") listTestLocations_ = true;
         else if (argument == "-ri") runIgnored_ = true;
         else if (argument == "-f") crashOnFail_ = true;
-        else if (argument == "-e") rethrowExceptions_ = true;
+        else if (argument == "-e") rethrowExceptions_ = false;
         else if (argument.startsWith("-r")) setRepeatCount(ac_, av_, i);
         else if (argument.startsWith("-g")) addGroupFilter(ac_, av_, i);
         else if (argument.startsWith("-t")) correctParameters = addGroupDotNameFilter(ac_, av_, i);
@@ -144,7 +144,7 @@ const char* CommandLineArguments::help() const
       "  -s [seed]        - shuffle tests randomly. Seed is optional\n"
       "  -r#              - repeat the tests some number (#) of times, or twice if # is not specified.\n"
       "  -f               - Cause the tests to crash on failure (to allow the test to be debugged if necessary)\n"
-      "  -e               - rethrow unexpected exceptions on failure (to allow the test to be debugged if necessary)\n";
+      "  -e               - do not rethrow unexpected exceptions on failure\n";
 }
 
 bool CommandLineArguments::needHelp() const

--- a/src/CppUTest/CommandLineArguments.cpp
+++ b/src/CppUTest/CommandLineArguments.cpp
@@ -72,6 +72,7 @@ bool CommandLineArguments::parse(TestPlugin* plugin)
         else if (argument == "-ri") runIgnored_ = true;
         else if (argument == "-f") crashOnFail_ = true;
         else if (argument == "-e") rethrowExceptions_ = false;
+        else if (argument == "-ci") rethrowExceptions_ = false;
         else if (argument.startsWith("-r")) setRepeatCount(ac_, av_, i);
         else if (argument.startsWith("-g")) addGroupFilter(ac_, av_, i);
         else if (argument.startsWith("-t")) correctParameters = addGroupDotNameFilter(ac_, av_, i);
@@ -100,7 +101,7 @@ bool CommandLineArguments::parse(TestPlugin* plugin)
 const char* CommandLineArguments::usage() const
 {
     return "use -h for more extensive help\n"
-           "usage [-h] [-v] [-vv] [-c] [-p] [-lg] [-ln] [-ri] [-r#] [-f] [-e]\n"
+           "usage [-h] [-v] [-vv] [-c] [-p] [-lg] [-ln] [-ri] [-r#] [-f] [-e] [-ci]\n"
            "      [-g|sg|xg|xsg groupName]... [-n|sn|xn|xsn testName]... [-t groupName.testName]...\n"
            "      [-b] [-s [randomizerSeed>0]] [\"TEST(groupName, testName)\"]...\n"
            "      [-o{normal, junit, teamcity}] [-k packageName]\n";
@@ -144,7 +145,8 @@ const char* CommandLineArguments::help() const
       "  -s [seed]        - shuffle tests randomly. Seed is optional\n"
       "  -r#              - repeat the tests some number (#) of times, or twice if # is not specified.\n"
       "  -f               - Cause the tests to crash on failure (to allow the test to be debugged if necessary)\n"
-      "  -e               - do not rethrow unexpected exceptions on failure\n";
+      "  -e               - do not rethrow unexpected exceptions on failure\n"
+      "  -ci              - continuous integration mode (equivalent to -e)\n";
 }
 
 bool CommandLineArguments::needHelp() const

--- a/src/CppUTest/CommandLineArguments.cpp
+++ b/src/CppUTest/CommandLineArguments.cpp
@@ -30,7 +30,10 @@
 #include "CppUTest/PlatformSpecificFunctions.h"
 
 CommandLineArguments::CommandLineArguments(int ac, const char *const *av) :
-    ac_(ac), av_(av), needHelp_(false), verbose_(false), veryVerbose_(false), color_(false), runTestsAsSeperateProcess_(false), listTestGroupNames_(false), listTestGroupAndCaseNames_(false), listTestLocations_(false), runIgnored_(false), reversing_(false), crashOnFail_(false), shuffling_(false), shufflingPreSeeded_(false), repeat_(1), shuffleSeed_(0), groupFilters_(NULLPTR), nameFilters_(NULLPTR), outputType_(OUTPUT_ECLIPSE)
+    ac_(ac), av_(av), needHelp_(false), verbose_(false), veryVerbose_(false), color_(false), runTestsAsSeperateProcess_(false),
+    listTestGroupNames_(false), listTestGroupAndCaseNames_(false), listTestLocations_(false), runIgnored_(false), reversing_(false),
+    crashOnFail_(false), rethrowExceptions_(false), shuffling_(false), shufflingPreSeeded_(false), repeat_(1), shuffleSeed_(0),
+    groupFilters_(NULLPTR), nameFilters_(NULLPTR), outputType_(OUTPUT_ECLIPSE)
 {
 }
 
@@ -68,6 +71,7 @@ bool CommandLineArguments::parse(TestPlugin* plugin)
         else if (argument == "-ll") listTestLocations_ = true;
         else if (argument == "-ri") runIgnored_ = true;
         else if (argument == "-f") crashOnFail_ = true;
+        else if (argument == "-e") rethrowExceptions_ = true;
         else if (argument.startsWith("-r")) setRepeatCount(ac_, av_, i);
         else if (argument.startsWith("-g")) addGroupFilter(ac_, av_, i);
         else if (argument.startsWith("-t")) correctParameters = addGroupDotNameFilter(ac_, av_, i);
@@ -96,7 +100,7 @@ bool CommandLineArguments::parse(TestPlugin* plugin)
 const char* CommandLineArguments::usage() const
 {
     return "use -h for more extensive help\n"
-           "usage [-h] [-v] [-vv] [-c] [-p] [-lg] [-ln] [-ri] [-r#] [-f]\n"
+           "usage [-h] [-v] [-vv] [-c] [-p] [-lg] [-ln] [-ri] [-r#] [-f] [-e]\n"
            "      [-g|sg|xg|xsg groupName]... [-n|sn|xn|xsn testName]... [-t groupName.testName]...\n"
            "      [-b] [-s [randomizerSeed>0]] [\"TEST(groupName, testName)\"]...\n"
            "      [-o{normal, junit, teamcity}] [-k packageName]\n";
@@ -139,7 +143,8 @@ const char* CommandLineArguments::help() const
       "  -b               - run the tests backwards, reversing the normal way\n"
       "  -s [seed]        - shuffle tests randomly. Seed is optional\n"
       "  -r#              - repeat the tests some number (#) of times, or twice if # is not specified.\n"
-      "  -f               - Cause the tests to crash on failure (to allow the test to be debugged if necessary)\n";
+      "  -f               - Cause the tests to crash on failure (to allow the test to be debugged if necessary)\n"
+      "  -e               - rethrow unexpected exceptions on failure (to allow the test to be debugged if necessary)\n";
 }
 
 bool CommandLineArguments::needHelp() const
@@ -201,6 +206,11 @@ bool CommandLineArguments::isReversing() const
 bool CommandLineArguments::isCrashingOnFail() const
 {
     return crashOnFail_;
+}
+
+bool CommandLineArguments::isRethrowingExceptions() const
+{
+    return rethrowExceptions_;
 }
 
 bool CommandLineArguments::isShuffling() const

--- a/src/CppUTest/CommandLineTestRunner.cpp
+++ b/src/CppUTest/CommandLineTestRunner.cpp
@@ -96,6 +96,8 @@ void CommandLineTestRunner::initializeTestRun()
     if (arguments_->runTestsInSeperateProcess()) registry_->setRunTestsInSeperateProcess();
     if (arguments_->isRunIgnored()) registry_->setRunIgnored();
     if (arguments_->isCrashingOnFail()) UtestShell::setCrashOnFail();
+
+    UtestShell::setRethrowExceptions( arguments_->isRethrowingExceptions() );
 }
 
 int CommandLineTestRunner::runAllTests()

--- a/src/CppUTest/TestFailure.cpp
+++ b/src/CppUTest/TestFailure.cpp
@@ -392,9 +392,10 @@ UnexpectedExceptionFailure::UnexpectedExceptionFailure(UtestShell* test)
 {
 }
 
-#if defined(__GNUC__)
-static SimpleString demangle(const char* name)
+static SimpleString getExceptionTypeName(const std::exception &e)
 {
+    const char *name = typeid(e).name();
+#if defined(__GNUC__)
     int status = -1;
 
     std::unique_ptr<char, void(*)(void*)> demangledName {
@@ -402,15 +403,14 @@ static SimpleString demangle(const char* name)
         std::free
     };
 
-    return (status==0) ? demangledName.get() : name ;
-}
-#define DEMANGLE(name) demangle(name).asCharString()
+    return (status==0) ? demangledName.get() : name;
 #else
-#define DEMANGLE(name) (name)
+    return name;
 #endif
+}
 
 UnexpectedExceptionFailure::UnexpectedExceptionFailure(UtestShell* test, const std::exception &e)
-: TestFailure(test, StringFromFormat("Unexpected exception of type '%s' was thrown: %s", DEMANGLE(typeid(e).name()), e.what()))
+: TestFailure(test, StringFromFormat("Unexpected exception of type '%s' was thrown: %s", getExceptionTypeName(e).asCharString(), e.what()))
 {
 }
 #endif

--- a/src/CppUTest/TestFailure.cpp
+++ b/src/CppUTest/TestFailure.cpp
@@ -31,6 +31,13 @@
 #include "CppUTest/SimpleString.h"
 #include "CppUTest/PlatformSpecificFunctions.h"
 
+#if CPPUTEST_USE_STD_CPP_LIB
+#include <typeinfo>
+#if defined(__GNUC__)
+#include <cxxabi.h>
+#endif
+#endif
+
 TestFailure::TestFailure(UtestShell* test, const char* fileName, size_t lineNumber, const SimpleString& theMessage) :
     testName_(test->getFormattedName()), testNameOnly_(test->getName()), fileName_(fileName), lineNumber_(lineNumber), testFileName_(test->getFile()), testLineNumber_(test->getLineNumber()), message_(theMessage)
 {
@@ -378,3 +385,32 @@ FeatureUnsupportedFailure::FeatureUnsupportedFailure(UtestShell* test, const cha
 
     message_ += StringFromFormat("The feature \"%s\" is not supported in this environment or with the feature set selected when building the library.", featureName.asCharString());
 }
+
+#if CPPUTEST_USE_STD_CPP_LIB
+UnexpectedExceptionFailure::UnexpectedExceptionFailure(UtestShell* test)
+: TestFailure(test, "Unexpected exception of unknown type was thrown.")
+{
+}
+
+#if defined(__GNUC__)
+static SimpleString demangle(const char* name)
+{
+    int status = -1;
+
+    std::unique_ptr<char, void(*)(void*)> demangledName {
+        abi::__cxa_demangle(name, nullptr, nullptr, &status),
+        std::free
+    };
+
+    return (status==0) ? demangledName.get() : name ;
+}
+#define DEMANGLE(name) demangle(name).asCharString()
+#else
+#define DEMANGLE(name) (name)
+#endif
+
+UnexpectedExceptionFailure::UnexpectedExceptionFailure(UtestShell* test, const std::exception &e)
+: TestFailure(test, StringFromFormat("Unexpected exception of type '%s' was thrown: %s", DEMANGLE(typeid(e).name()), e.what()))
+{
+}
+#endif

--- a/src/CppUTest/Utest.cpp
+++ b/src/CppUTest/Utest.cpp
@@ -672,10 +672,10 @@ void Utest::run()
     {
         PlatformSpecificRestoreJumpBuffer();
     }
-    catch (const std::exception& e)
+    catch (const std::exception &e)
     {
-        PlatformSpecificRestoreJumpBuffer();
         current->addFailure(UnexpectedExceptionFailure(current, e));
+        PlatformSpecificRestoreJumpBuffer();
         if (current->isRethrowingExceptions())
         {
             throw;
@@ -683,8 +683,8 @@ void Utest::run()
     }
     catch (...)
     {
-        PlatformSpecificRestoreJumpBuffer();
         current->addFailure(UnexpectedExceptionFailure(current));
+        PlatformSpecificRestoreJumpBuffer();
         if (current->isRethrowingExceptions())
         {
             throw;
@@ -700,10 +700,10 @@ void Utest::run()
     {
         PlatformSpecificRestoreJumpBuffer();
     }
-    catch (const std::exception& e)
+    catch (const std::exception &e)
     {
-        PlatformSpecificRestoreJumpBuffer();
         current->addFailure(UnexpectedExceptionFailure(current, e));
+        PlatformSpecificRestoreJumpBuffer();
         if (current->isRethrowingExceptions())
         {
             throw;
@@ -711,8 +711,8 @@ void Utest::run()
     }
     catch (...)
     {
-        PlatformSpecificRestoreJumpBuffer();
         current->addFailure(UnexpectedExceptionFailure(current));
+        PlatformSpecificRestoreJumpBuffer();
         if (current->isRethrowingExceptions())
         {
             throw;

--- a/src/CppUTest/Utest.cpp
+++ b/src/CppUTest/Utest.cpp
@@ -232,8 +232,11 @@ void UtestShell::runOneTestInCurrentProcess(TestPlugin* plugin, TestResult& resu
     UtestShell::setCurrentTest(this);
 
     Utest* testToRun = NULLPTR;
+
+#if CPPUTEST_USE_STD_CPP_LIB
     try
     {
+#endif
         result.printVeryVerbose("\n---- before createTest: ");
         testToRun = createTest();
         result.printVeryVerbose("\n---- after createTest: ");
@@ -244,12 +247,14 @@ void UtestShell::runOneTestInCurrentProcess(TestPlugin* plugin, TestResult& resu
 
         UtestShell::setCurrentTest(savedTest);
         UtestShell::setTestResult(savedResult);
+#if CPPUTEST_USE_STD_CPP_LIB
     }
     catch(...)
     {
         destroyTest(testToRun);
         throw;
     }
+#endif
 
     result.printVeryVerbose("\n---- before destroyTest: ");
     destroyTest(testToRun);

--- a/src/CppUTest/Utest.cpp
+++ b/src/CppUTest/Utest.cpp
@@ -375,10 +375,15 @@ void UtestShell::failWith(const TestFailure& failure)
 
 void UtestShell::failWith(const TestFailure& failure, const TestTerminator& terminator)
 {
-    hasFailed_ = true;
-    getTestResult()->addFailure(failure);
+    addFailure(failure);
     terminator.exitCurrentTest();
 } // LCOV_EXCL_LINE
+
+void UtestShell::addFailure(const TestFailure& failure)
+{
+    hasFailed_ = true;
+    getTestResult()->addFailure(failure);
+}
 
 void UtestShell::exitTest(const TestTerminator& terminator)
 {
@@ -646,6 +651,18 @@ void Utest::run()
     {
         PlatformSpecificRestoreJumpBuffer();
     }
+#if CPPUTEST_USE_STD_CPP_LIB
+    catch (const std::exception& e)
+    {
+        PlatformSpecificRestoreJumpBuffer();
+        current->addFailure(UnexpectedExceptionFailure(current, e));
+    }
+    catch (...)
+    {
+        PlatformSpecificRestoreJumpBuffer();
+        current->addFailure(UnexpectedExceptionFailure(current));
+    }
+#endif
 
     try {
         current->printVeryVerbose("\n--------  before teardown: ");
@@ -656,7 +673,18 @@ void Utest::run()
     {
         PlatformSpecificRestoreJumpBuffer();
     }
-
+#if CPPUTEST_USE_STD_CPP_LIB
+    catch (const std::exception& e)
+    {
+        PlatformSpecificRestoreJumpBuffer();
+        current->addFailure(UnexpectedExceptionFailure(current, e));
+    }
+    catch (...)
+    {
+        PlatformSpecificRestoreJumpBuffer();
+        current->addFailure(UnexpectedExceptionFailure(current));
+    }
+#endif
 }
 #else
 

--- a/src/CppUTest/Utest.cpp
+++ b/src/CppUTest/Utest.cpp
@@ -672,7 +672,6 @@ void Utest::run()
     {
         PlatformSpecificRestoreJumpBuffer();
     }
-#if CPPUTEST_USE_STD_CPP_LIB
     catch (const std::exception& e)
     {
         PlatformSpecificRestoreJumpBuffer();
@@ -691,7 +690,6 @@ void Utest::run()
             throw;
         }
     }
-#endif
 
     try {
         current->printVeryVerbose("\n--------  before teardown: ");
@@ -702,7 +700,6 @@ void Utest::run()
     {
         PlatformSpecificRestoreJumpBuffer();
     }
-#if CPPUTEST_USE_STD_CPP_LIB
     catch (const std::exception& e)
     {
         PlatformSpecificRestoreJumpBuffer();
@@ -721,7 +718,6 @@ void Utest::run()
             throw;
         }
     }
-#endif
 }
 #else
 

--- a/src/CppUTest/Utest.cpp
+++ b/src/CppUTest/Utest.cpp
@@ -231,7 +231,7 @@ void UtestShell::runOneTestInCurrentProcess(TestPlugin* plugin, TestResult& resu
     UtestShell::setTestResult(&result);
     UtestShell::setCurrentTest(this);
 
-    Utest* testToRun = nullptr;
+    Utest* testToRun = NULLPTR;
     try
     {
         result.printVeryVerbose("\n---- before createTest: ");

--- a/tests/CppUTest/CommandLineArgumentsTest.cpp
+++ b/tests/CppUTest/CommandLineArgumentsTest.cpp
@@ -466,7 +466,7 @@ TEST(CommandLineArguments, printUsage)
 {
     STRCMP_EQUAL(
             "use -h for more extensive help\n"
-            "usage [-h] [-v] [-vv] [-c] [-p] [-lg] [-ln] [-ri] [-r#] [-f]\n"
+            "usage [-h] [-v] [-vv] [-c] [-p] [-lg] [-ln] [-ri] [-r#] [-f] [-e]\n"
             "      [-g|sg|xg|xsg groupName]... [-n|sn|xn|xsn testName]... [-t groupName.testName]...\n"
             "      [-b] [-s [randomizerSeed>0]] [\"TEST(groupName, testName)\"]...\n"
             "      [-o{normal, junit, teamcity}] [-k packageName]\n",
@@ -549,4 +549,12 @@ TEST(CommandLineArguments, setOptCrashOnFail)
     const char* argv[] = { "tests.exe", "-f"};
     CHECK(newArgumentParser(argc, argv));
     CHECK(args->isCrashingOnFail());
+}
+
+TEST(CommandLineArguments, setOptRethrowExceptions)
+{
+    int argc = 2;
+    const char* argv[] = { "tests.exe", "-e"};
+    CHECK(newArgumentParser(argc, argv));
+    CHECK(args->isRethrowingExceptions());
 }

--- a/tests/CppUTest/CommandLineArgumentsTest.cpp
+++ b/tests/CppUTest/CommandLineArgumentsTest.cpp
@@ -504,6 +504,7 @@ TEST(CommandLineArguments, checkDefaultArguments)
     CHECK(args->isEclipseOutput());
     CHECK(SimpleString("") == args->getPackageName());
     CHECK(!args->isCrashingOnFail());
+    CHECK(args->isRethrowingExceptions());
 }
 
 TEST(CommandLineArguments, setPackageName)
@@ -556,5 +557,5 @@ TEST(CommandLineArguments, setOptRethrowExceptions)
     int argc = 2;
     const char* argv[] = { "tests.exe", "-e"};
     CHECK(newArgumentParser(argc, argv));
-    CHECK(args->isRethrowingExceptions());
+    CHECK_FALSE(args->isRethrowingExceptions());
 }

--- a/tests/CppUTest/CommandLineArgumentsTest.cpp
+++ b/tests/CppUTest/CommandLineArgumentsTest.cpp
@@ -466,7 +466,7 @@ TEST(CommandLineArguments, printUsage)
 {
     STRCMP_EQUAL(
             "use -h for more extensive help\n"
-            "usage [-h] [-v] [-vv] [-c] [-p] [-lg] [-ln] [-ri] [-r#] [-f] [-e]\n"
+            "usage [-h] [-v] [-vv] [-c] [-p] [-lg] [-ln] [-ri] [-r#] [-f] [-e] [-ci]\n"
             "      [-g|sg|xg|xsg groupName]... [-n|sn|xn|xsn testName]... [-t groupName.testName]...\n"
             "      [-b] [-s [randomizerSeed>0]] [\"TEST(groupName, testName)\"]...\n"
             "      [-o{normal, junit, teamcity}] [-k packageName]\n",
@@ -505,6 +505,21 @@ TEST(CommandLineArguments, checkDefaultArguments)
     CHECK(SimpleString("") == args->getPackageName());
     CHECK(!args->isCrashingOnFail());
     CHECK(args->isRethrowingExceptions());
+}
+
+TEST(CommandLineArguments, checkContinuousIntegrationMode)
+{
+    int argc = 2;
+    const char* argv[] = { "tests.exe", "-ci" };
+    CHECK(newArgumentParser(argc, argv));
+    CHECK(!args->isVerbose());
+    LONGS_EQUAL(1, args->getRepeatCount());
+    CHECK(NULLPTR == args->getGroupFilters());
+    CHECK(NULLPTR == args->getNameFilters());
+    CHECK(args->isEclipseOutput());
+    CHECK(SimpleString("") == args->getPackageName());
+    CHECK(!args->isCrashingOnFail());
+    CHECK_FALSE(args->isRethrowingExceptions());
 }
 
 TEST(CommandLineArguments, setPackageName)

--- a/tests/CppUTest/TestFailureTest.cpp
+++ b/tests/CppUTest/TestFailureTest.cpp
@@ -426,3 +426,20 @@ TEST(TestFailure, FeatureUnsupported)
     FeatureUnsupportedFailure f(test, failFileName, failLineNumber, "SOME_FEATURE", "");
     FAILURE_EQUAL("The feature \"SOME_FEATURE\" is not supported in this environment or with the feature set selected when building the library.", f);
 }
+
+#if CPPUTEST_USE_STD_CPP_LIB
+TEST(TestFailure, UnexpectedExceptionFailure_UnknownException)
+{
+    UnexpectedExceptionFailure f(test);
+    FAILURE_EQUAL("Unexpected exception of unknown type was thrown.", f);
+}
+
+TEST(TestFailure, UnexpectedExceptionFailure_StandardException)
+{
+    std::runtime_error e("Some error");
+    UnexpectedExceptionFailure f(test, e);
+    STRCMP_CONTAINS("Unexpected exception of type '", f.getMessage().asCharString());
+    STRCMP_CONTAINS("runtime_error", f.getMessage().asCharString());
+    STRCMP_CONTAINS("' was thrown: Some error", f.getMessage().asCharString());
+}
+#endif

--- a/tests/CppUTest/UtestTest.cpp
+++ b/tests/CppUTest/UtestTest.cpp
@@ -239,6 +239,52 @@ TEST(UtestShell, TestStopsAfterStandardExceptionIsThrown)
     fixture.assertPrintContains("' was thrown: exception text");
     LONGS_EQUAL(0, stopAfterFailure);
 }
+
+TEST(UtestShell, UnknownExceptionIsRethrownIfEnabled)
+{
+    bool exceptionRethrown = false;
+    stopAfterFailure = 0;
+    UtestShell::setRethrowExceptions(true);
+    fixture.setTestFunction(thrownUnknownExceptionMethod_);
+    try
+    {
+        fixture.runAllTests();
+        stopAfterFailure++;
+    }
+    catch(...)
+    {
+        exceptionRethrown = true;
+    }
+    CHECK_TRUE(exceptionRethrown);
+    LONGS_EQUAL(1, fixture.getFailureCount());
+    fixture.assertPrintContains("Unexpected exception of unknown type was thrown");
+    LONGS_EQUAL(0, stopAfterFailure);
+    UtestShell::setRethrowExceptions(false);
+}
+
+TEST(UtestShell, StandardExceptionIsRethrownIfEnabled)
+{
+    bool exceptionRethrown = false;
+    stopAfterFailure = 0;
+    UtestShell::setRethrowExceptions(true);
+    fixture.setTestFunction(thrownStandardExceptionMethod_);
+    try
+    {
+        fixture.runAllTests();
+        stopAfterFailure++;
+    }
+    catch(const std::exception &)
+    {
+        exceptionRethrown = true;
+    }
+    CHECK_TRUE(exceptionRethrown);
+    LONGS_EQUAL(1, fixture.getFailureCount());
+    fixture.assertPrintContains("Unexpected exception of type '");
+    fixture.assertPrintContains("runtime_error");
+    fixture.assertPrintContains("' was thrown: exception text");
+    LONGS_EQUAL(0, stopAfterFailure);
+    UtestShell::setRethrowExceptions(false);
+}
 #endif
 
 TEST(UtestShell, veryVebose)

--- a/tests/CppUTest/UtestTest.cpp
+++ b/tests/CppUTest/UtestTest.cpp
@@ -214,12 +214,15 @@ static void thrownUnknownExceptionMethod_()
 
 TEST(UtestShell, TestStopsAfterUnknownExceptionIsThrown)
 {
+    bool initialRethrowExceptions = UtestShell::isRethrowingExceptions();
+    UtestShell::setRethrowExceptions(false);
     stopAfterFailure = 0;
     fixture.setTestFunction(thrownUnknownExceptionMethod_);
     fixture.runAllTests();
     LONGS_EQUAL(1, fixture.getFailureCount());
     fixture.assertPrintContains("Unexpected exception of unknown type was thrown");
     LONGS_EQUAL(0, stopAfterFailure);
+    UtestShell::setRethrowExceptions(initialRethrowExceptions);
 }
 
 static void thrownStandardExceptionMethod_()
@@ -230,6 +233,8 @@ static void thrownStandardExceptionMethod_()
 
 TEST(UtestShell, TestStopsAfterStandardExceptionIsThrown)
 {
+    bool initialRethrowExceptions = UtestShell::isRethrowingExceptions();
+    UtestShell::setRethrowExceptions(false);
     stopAfterFailure = 0;
     fixture.setTestFunction(thrownStandardExceptionMethod_);
     fixture.runAllTests();
@@ -238,10 +243,12 @@ TEST(UtestShell, TestStopsAfterStandardExceptionIsThrown)
     fixture.assertPrintContains("runtime_error");
     fixture.assertPrintContains("' was thrown: exception text");
     LONGS_EQUAL(0, stopAfterFailure);
+    UtestShell::setRethrowExceptions(initialRethrowExceptions);
 }
 
 TEST(UtestShell, UnknownExceptionIsRethrownIfEnabled)
 {
+    bool initialRethrowExceptions = UtestShell::isRethrowingExceptions();
     bool exceptionRethrown = false;
     stopAfterFailure = 0;
     UtestShell::setRethrowExceptions(true);
@@ -259,11 +266,12 @@ TEST(UtestShell, UnknownExceptionIsRethrownIfEnabled)
     LONGS_EQUAL(1, fixture.getFailureCount());
     fixture.assertPrintContains("Unexpected exception of unknown type was thrown");
     LONGS_EQUAL(0, stopAfterFailure);
-    UtestShell::setRethrowExceptions(false);
+    UtestShell::setRethrowExceptions(initialRethrowExceptions);
 }
 
 TEST(UtestShell, StandardExceptionIsRethrownIfEnabled)
 {
+    bool initialRethrowExceptions = UtestShell::isRethrowingExceptions();
     bool exceptionRethrown = false;
     stopAfterFailure = 0;
     UtestShell::setRethrowExceptions(true);
@@ -283,7 +291,7 @@ TEST(UtestShell, StandardExceptionIsRethrownIfEnabled)
     fixture.assertPrintContains("runtime_error");
     fixture.assertPrintContains("' was thrown: exception text");
     LONGS_EQUAL(0, stopAfterFailure);
-    UtestShell::setRethrowExceptions(false);
+    UtestShell::setRethrowExceptions(initialRethrowExceptions);
 }
 #endif
 

--- a/tests/CppUTest/UtestTest.cpp
+++ b/tests/CppUTest/UtestTest.cpp
@@ -205,6 +205,42 @@ TEST(UtestShell, TestStopsAfterSetupFailure)
     LONGS_EQUAL(0, stopAfterFailure);
 }
 
+#if CPPUTEST_USE_STD_CPP_LIB
+static void thrownUnknownExceptionMethod_()
+{
+    throw 33;
+    stopAfterFailure++;
+}
+
+TEST(UtestShell, TestStopsAfterUnknownExceptionIsThrown)
+{
+    stopAfterFailure = 0;
+    fixture.setTestFunction(thrownUnknownExceptionMethod_);
+    fixture.runAllTests();
+    LONGS_EQUAL(1, fixture.getFailureCount());
+    fixture.assertPrintContains("Unexpected exception of unknown type was thrown");
+    LONGS_EQUAL(0, stopAfterFailure);
+}
+
+static void thrownStandardExceptionMethod_()
+{
+    throw std::runtime_error("exception text");
+    stopAfterFailure++;
+}
+
+TEST(UtestShell, TestStopsAfterStandardExceptionIsThrown)
+{
+    stopAfterFailure = 0;
+    fixture.setTestFunction(thrownStandardExceptionMethod_);
+    fixture.runAllTests();
+    LONGS_EQUAL(1, fixture.getFailureCount());
+    fixture.assertPrintContains("Unexpected exception of type '");
+    fixture.assertPrintContains("runtime_error");
+    fixture.assertPrintContains("' was thrown: exception text");
+    LONGS_EQUAL(0, stopAfterFailure);
+}
+#endif
+
 TEST(UtestShell, veryVebose)
 {
     UtestShell shell("Group", "name", __FILE__, __LINE__);


### PR DESCRIPTION
This way when an unexpected exception is thrown it is handled as a test failure, so failure info is displayed, the remaining tests execution is not aborted, and in some platforms the OS does not display an error message or tries to launch a debugger.