### PR TITLE
Update UtestPlatform.cpp for compiling with Borland 5.4 compiler

### DIFF
--- a/src/Platforms/Borland/UtestPlatform.cpp
+++ b/src/Platforms/Borland/UtestPlatform.cpp
@@ -59,6 +59,8 @@
 
 #include "CppUTest/PlatformSpecificFunctions.h"
 
+const std::nothrow_t std::nothrow;
+
 static jmp_buf test_exit_jmp_buf[10];
 static int jmp_buf_index = 0;
 


### PR DESCRIPTION
Create std::nothrow constant

This will close #1546
and is part of #1493 (see https://github.com/cpputest/cpputest/issues/1493#issuecomment-948318023)