### PR TITLE
Update TestFailureNaNTest.cpp for compiling with Borland 5.4 compiler

### DIFF
--- a/tests/CppUTest/TestFailureNaNTest.cpp
+++ b/tests/CppUTest/TestFailureNaNTest.cpp
@@ -35,6 +35,8 @@ const int failLineNumber = 2;
 const char* failFileName = "fail.cpp";
 }
 
+#if CPPUTEST_HAS_NAN == 1 && CPPUTEST_HAS_INF == 1
+
 static double zero = 0.0;
 static double one = 1.0;
 static double not_a_number = zero / zero;
@@ -115,3 +117,5 @@ TEST(TestFailureNanAndInf, DoublesEqualThresholdIsInf)
                 "\tbut was  <Nan - Not a number> threshold used was <Inf - Infinity>\n"
                 "\tCannot make comparisons with Nan", f);
 }
+
+#endif


### PR DESCRIPTION
The Borland v5.4 compiler does not do NaN or Inf so we need to guard all the tests in this file with CPPUTEST_HAS_NAN == 1 && CPPUTEST_HAS_INF == 1

This will close #1544
and is part of #1493 (see https://github.com/cpputest/cpputest/issues/1493#issuecomment-948575510)