### PR TITLE
Update UtestPlatform.cpp for compiling with Borland v5.4 compiler

### DIFF
--- a/src/Platforms/Borland/UtestPlatform.cpp
+++ b/src/Platforms/Borland/UtestPlatform.cpp
@@ -217,7 +217,14 @@ static const char* TimeStringImplementation()
 long (*GetPlatformSpecificTimeInMillis)() = TimeInMillisImplementation;
 const char* (*GetPlatformSpecificTimeString)() = TimeStringImplementation;
 
-int (*PlatformSpecificVSNprintf)(char *str, size_t size, const char* format, va_list va_args_list) = vsnprintf;
+static int BorlandVSNprintf(char *str, size_t size, const char* format, va_list args)
+{
+    int result = vsnprintf( str, size, format, args);
+    str[size-1] = 0;
+    return result;
+}
+
+int (*PlatformSpecificVSNprintf)(char *str, size_t size, const char* format, va_list va_args_list) = BorlandVSNprintf;
 
 static PlatformSpecificFile PlatformSpecificFOpenImplementation(const char* filename, const char* flag)
 {


### PR DESCRIPTION
Adding a Borland specific VSNprintf function.

This closes https://github.com/cpputest/cpputest/issues/1556
and is part of https://github.com/cpputest/cpputest/issues/1493