### PR TITLE
Backport CMake option fix when available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,11 @@ if (EXISTS "${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
     conan_basic_setup()
 endif()
 
+# Backport option handling fix from CMake 3.13 if available.
+if(POLICY CMP0077)
+  cmake_policy(SET CMP0077 NEW)
+endif()
+
 option(STD_C "Use the standard C library" ON)
 option(STD_CPP "Use the standard C++ library" ON)
 option(CPPUTEST_FLAGS "Use the CFLAGS/CXXFLAGS/LDFLAGS set by CppUTest" ON)


### PR DESCRIPTION
Since [CMake v3.13](https://cmake.org/cmake/help/v3.13/release/3.13.html#other-changes), CMake has been able to correctly honor existing variables when interpretting `option()`.  The current minimum version (3.1 from 2014) suppresses this behavior regardless of the version of CMake used.

This change adopts this CMake feature when using a new enough version of CMake without breaking compatibility with older versions. This enables the expected behavior in a use case like this which didn't work before.

```cmake
cmake_minimum_required(VERSION 3.13)

project(someconsumingproject)

set(CPPUTEST_FLAGS OFF) # This will now be honored.
add_subdirectory(clone/of/cpputest)
```