### PR TITLE
Normalize `find_package` and `add_subdirectory` usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,9 @@ It can be used then like so:
 
 ```cmake
 add_executable(run_tests UnitTest1.cpp UnitTest2.cpp)
-target_link_libraries(run_tests PRIVATE CppUTest CppUTestExt)
+target_link_libraries(run_tests PRIVATE
+    CppUTest::CppUTest
+    CppUTest::CppUTestExt)
 ```
 
 [conan-center]: https://conan.io/center/cpputest

--- a/examples/AllTests/CMakeLists.txt
+++ b/examples/AllTests/CMakeLists.txt
@@ -8,11 +8,11 @@ add_executable(ExampleTests
     PrinterTest.cpp
 )
 
-target_include_directories(ExampleTests
-    PRIVATE
-        ../ApplicationLib
-)
-
 cpputest_normalize_test_output_location(ExampleTests)
-target_link_libraries(ExampleTests ApplicationLib ${CppUTestLibName} ${CppUTestExtLibName})
+target_link_libraries(ExampleTests
+    PRIVATE
+        ApplicationLib
+        CppUTest::${CppUTestLibName}
+        CppUTest::${CppUTestExtLibName}
+)
 cpputest_buildtime_discover_tests(ExampleTests)

--- a/examples/ApplicationLib/CMakeLists.txt
+++ b/examples/ApplicationLib/CMakeLists.txt
@@ -4,8 +4,7 @@ add_library(ApplicationLib
     hello.c
     Printer.cpp
 )
-target_include_directories(ExampleTests
+target_include_directories(ApplicationLib
     PUBLIC
         .
 )
-

--- a/src/CppUTest/CMakeLists.txt
+++ b/src/CppUTest/CMakeLists.txt
@@ -79,6 +79,9 @@ set_target_properties(${CppUTestLibName} PROPERTIES
 if (WIN32)
     target_link_libraries(${CppUTestLibName} winmm)
 endif (WIN32)
+
+add_library(CppUTest::${CppUTestLibName} ALIAS ${CppUTestLibName})
+
 install(TARGETS ${CppUTestLibName}
     EXPORT CppUTestTargets
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/src/CppUTestExt/CMakeLists.txt
+++ b/src/CppUTestExt/CMakeLists.txt
@@ -58,6 +58,9 @@ target_include_directories(${CppUTestExtLibName}
 
 set_target_properties(${CppUTestExtLibName} PROPERTIES
     PUBLIC_HEADER "${CppUTestExt_headers}")
+
+add_library(CppUTest::${CppUTestExtLibName} ALIAS ${CppUTestExtLibName})
+
 install(TARGETS ${CppUTestExtLibName}
     EXPORT CppUTestTargets
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}


### PR DESCRIPTION
Add `ALIAS` targets so that usage with `add_subdirectory` or `FetchContent` is the same as with `find_package`.