### PR TITLE
Fix compilation with disabled memory leak detection

### DIFF
--- a/src/CppUTest/TestFailure.cpp
+++ b/src/CppUTest/TestFailure.cpp
@@ -35,6 +35,7 @@
 #include <typeinfo>
 #if defined(__GNUC__)
 #include <cxxabi.h>
+#include <memory>
 #endif
 #endif
 


### PR DESCRIPTION
When memory leak detection is disabled compilation fails due to
unique_ptr not being found. Adding the memory header fixes the
problem.

Configure command: `./configure --disable-memory-leak-detection ...`

Compilation error:
```
src/CppUTest/TestFailure.cpp: In function ‘SimpleString getExceptionTypeName(const std::exception&)’:
src/CppUTest/TestFailure.cpp:401:10: error: ‘unique_ptr’ is not a member of ‘std’
  401 |     std::unique_ptr<char, void(*)(void*)> demangledName(
      |          ^~~~~~~~~~
src/CppUTest/TestFailure.cpp:38:1: note: ‘std::unique_ptr’ is defined in header ‘<memory>’; did you forget to ‘#include <memory>’?
   37 | #include <cxxabi.h>
  +++ |+#include <memory>
   38 | #endif
src/CppUTest/TestFailure.cpp:401:21: error: expected primary-expression before ‘char’
  401 |     std::unique_ptr<char, void(*)(void*)> demangledName(
      |                     ^~~~
src/CppUTest/TestFailure.cpp:405:26: error: ‘demangledName’ was not declared in this scope
  405 |     return (status==0) ? demangledName.get() : name;
      |                          ^~~~~~~~~~~~~
```