### PR TITLE
Add missing include

### DIFF
--- a/include/CppUTest/TestPlugin.h
+++ b/include/CppUTest/TestPlugin.h
@@ -28,6 +28,8 @@
 #ifndef D_TestPlugin_h
 #define D_TestPlugin_h
 
+#include "SimpleString.h"
+
 class UtestShell;
 class TestResult;
 


### PR DESCRIPTION
A complete type definition of `SimpleString` is needed for the
[`TestPlugin::name_`](https://github.com/cpputest/cpputest/pull/1595/files#diff-dcad8947c1a84d4452d86a21d72741888fced98bdd41055d74e7a665b757eac9L75) member.