### PR TITLE
Encode newlines for -ojunit as their XML equivalent instead of {newline}

### DIFF
--- a/src/CppUTest/JUnitTestOutput.cpp
+++ b/src/CppUTest/JUnitTestOutput.cpp
@@ -209,7 +209,8 @@ SimpleString JUnitTestOutput::encodeXmlText(const SimpleString& textbody)
     buf.replace("\"", "&quot;");
     buf.replace("<", "&lt;");
     buf.replace(">", "&gt;");
-    buf.replace("\n", "{newline}");
+    buf.replace("\r", "&#13;");
+    buf.replace("\n", "&#10;");
     return buf;
 }
 

--- a/tests/CppUTest/JUnitOutputTest.cpp
+++ b/tests/CppUTest/JUnitOutputTest.cpp
@@ -544,7 +544,7 @@ TEST(JUnitOutputTest, testFailureWithNewlineInIt)
 
     outputFile = fileSystem.file("cpputest_testGroupWithFailingTest.xml");
 
-    STRCMP_EQUAL("<failure message=\"thisfile:10: Test {newline}failed\" type=\"AssertionFailedError\">\n", outputFile->line(6));
+    STRCMP_EQUAL("<failure message=\"thisfile:10: Test &#10;    failed\" type=\"AssertionFailedError\">\n", outputFile->line(6));
 }
 
 TEST(JUnitOutputTest, testFailureWithDifferentFileAndLine)
@@ -755,5 +755,5 @@ TEST(JUnitOutputTest, UTPRINTOutputInJUnitOutputWithSpecials)
             .end();
 
     outputFile = fileSystem.file("cpputest_groupname.xml");
-    STRCMP_EQUAL("<system-out>The &lt;rain&gt; in &quot;Spain&quot;{newline}Goes \\mainly\\ down the Dr&amp;in{newline}</system-out>\n", outputFile->lineFromTheBack(3));
+    STRCMP_EQUAL("<system-out>The &lt;rain&gt; in &quot;Spain&quot;&#10;    Goes \\mainly\\ down the Dr&amp;in&#10; </system-out>\n", outputFile->lineFromTheBack(3));
 }


### PR DESCRIPTION
When calling the tests with `-ojunit` (Junit output), `\n` are replaced by `{newline}` which causes the Github Checks output to be inlined. 
This PR is replacing `\n` and `\r` by their encoded equivalent respectively `&#10;` and `&#13;`.
Now, when Jenkins reports the tests to Github Checks, the tests failures are readable.

What is the reason we are not replacing `\n` by `{newline}`? Should this instead be a Jenkins Junit plugin update to support `{newline}` or a post process from the user in the Jenkins pipeline?

Closes https://github.com/cpputest/cpputest/issues/1594