### PR TITLE
stop creating temp files that aren't cleaned up

### DIFF
--- a/build/MakefileWorker.mk
+++ b/build/MakefileWorker.mk
@@ -520,13 +520,14 @@ else
 endif
 	$(SILENCE)$(RANLIB) $@
 
-TEST_RUN_RETURN_CODE_FILE:=$(shell mktemp /tmp/cpputestResult.XXX)
 test: $(TEST_TARGET)
-	($(RUN_TEST_TARGET); echo $$? > $(TEST_RUN_RETURN_CODE_FILE)) | tee $(TEST_OUTPUT)
+	@$(eval TEST_RUN_RETURN_CODE_FILE=$(shell mktemp /tmp/cpputestResult.XXX))
+	@($(RUN_TEST_TARGET); echo $$? > $(TEST_RUN_RETURN_CODE_FILE)) | tee $(TEST_OUTPUT)
 	@ret=$$(cat $(TEST_RUN_RETURN_CODE_FILE)); rm $(TEST_RUN_RETURN_CODE_FILE); if [ "$$ret" -ne 0 ]; then echo "$$(tput setaf 1)$(TEST_TARGET) returned $${ret}$$(tput sgr0)"; fi; exit $$ret
 
 vtest: $(TEST_TARGET)
-	($(RUN_TEST_TARGET) -v; echo $$? > $(TEST_RUN_RETURN_CODE_FILE)) | tee $(TEST_OUTPUT)
+	@$(eval TEST_RUN_RETURN_CODE_FILE=$(shell mktemp /tmp/cpputestResult.XXX))
+	@($(RUN_TEST_TARGET) -v; echo $$? > $(TEST_RUN_RETURN_CODE_FILE)) | tee $(TEST_OUTPUT)
 	@ret=$$(cat $(TEST_RUN_RETURN_CODE_FILE)); rm $(TEST_RUN_RETURN_CODE_FILE); if [ "$$ret" -ne 0 ]; then echo "$$(tput setaf 1)$(TEST_TARGET) returned $${ret}$$(tput sgr0)"; fi; exit $$ret
 
 $(CPPUTEST_OBJS_DIR)/%.o: %.cc


### PR DESCRIPTION
When I made 7fc2a5e18e5567df67a135d6a7fe6311f92a9660 I stored the
return code from the test binary in a temp file and then deleted the
temp file.
But that temp file was created every time MakefileWorker.mk was sourced,
not just when the targets were run.

This commit changes it so the temp file is only created if the relevant
targets are being run so it will always get deleted.