### PR TITLE
Ignore apple clang warnings properly

### DIFF
--- a/build/MakefileWorker.mk
+++ b/build/MakefileWorker.mk
@@ -214,6 +214,7 @@ CLANG_VERSION := $(shell echo $(CC_VERSION_OUTPUT) | sed -n 's/.* \([0-9]*\.[0-9
 CLANG_VERSION_NUM := $(subst .,,$(CLANG_VERSION))
 CLANG_VERSION_NUM_GT_700 := $(shell [ "$(CLANG_VERSION_NUM)" -ge 700 ] && echo Y || echo N)
 CLANG_VERSION_NUM_GT_1200 := $(shell [ "$(CLANG_VERSION_NUM)" -ge 1200 ] && echo Y || echo N)
+CLANG_VERSION_NUM_GT_1205 := $(shell [ "$(CLANG_VERSION_NUM)" -ge 1205 ] && echo Y || echo N)
 
 ifeq ($(CLANG_VERSION_NUM_GT_700), Y)
 # -Wno-reserved-id-macro -> Many CppUTest macros start with __, which is a reserved namespace
@@ -221,10 +222,20 @@ ifeq ($(CLANG_VERSION_NUM_GT_700), Y)
 	CPPUTEST_CXX_WARNINGFLAGS += -Wno-reserved-id-macro -Wno-keyword-macro
 	CPPUTEST_C_WARNINGFLAGS += -Wno-reserved-id-macro -Wno-keyword-macro
 endif
+
+ifeq ($(UNAME_OS),$(MACOSX_STR))
+#apple clang has some special behavior
 ifeq ($(CLANG_VERSION_NUM_GT_1200), Y)
 # -Wno-poison-system-directories -> Apparently apple clang thinks everything is a cross compile, making this useless
 	CPPUTEST_CXX_WARNINGFLAGS += -Wno-poison-system-directories
 	CPPUTEST_C_WARNINGFLAGS += -Wno-poison-system-directories
+endif # clang 1200
+
+ifeq ($(CLANG_VERSION_NUM_GT_1205), Y)
+# Not sure why apple clang throws these warnings on cpputest code when clang doesn't
+	CPPUTEST_CXX_WARNINGFLAGS += -Wno-suggest-override -Wno-suggest-destructor-override
+	CPPUTEST_C_WARNINGFLAGS += -Wno-suggest-override -Wno-suggest-destructor-override
+endif
 endif
 endif
 


### PR DESCRIPTION
Apple clang is different than normal clang for reasons.
We need to ignore some stuff specifically for apple clang.

I did some testing with https://github.com/sickcodes/Docker-OSX to
figure out what versions of apple clang need what warnings surpressed.

None of these warnings happen with normal clang.
```
10.15: "Catalina"
 Apple clang version 11.0.3 (clang-1103.0.32.62)  Xcode_11.5
   No extra warning suppression required
 Apple clang version 12.0.0 (clang-1200.0.32.2)   Xcode_12
 Apple clang version 12.0.0 (clang-1200.0.32.27)  Xcode_12.2
 Apple clang version 12.0.0 (clang-1200.0.32.28)  Xcode_12.3
 Apple clang version 12.0.0 (clang-1200.0.32.29)  Xcode_12.4
   poison-system-directories
11: "Big Sur"
 Apple clang version 12.0.5 (clang-1205.0.22.9)   Xcode_12.5
 Apple clang version 12.0.5 (clang-1205.0.22.11)  Xcode 12.5.1
   suggest-override
   suggest-destructor-override
   poison-system-directories
12: "Monterey"
 Apple clang version 13.1.6 (clang-1316.0.21.2.5) Xcode ???
   suggest-override
   suggest-destructor-override
```

I tested this change on all three versions of macos with one or two versions of clang and it worked fine on all of them.