### PR TITLE
Resolve malformed override specifiers with function pointers

### DIFF
--- a/cmake/Modules/CppUTestWarningFlags.cmake
+++ b/cmake/Modules/CppUTestWarningFlags.cmake
@@ -64,12 +64,13 @@ else (MSVC)
 
     if (DEFINED CMAKE_CXX_STANDARD AND NOT CMAKE_CXX_STANDARD EQUAL 98)
         set(WARNING_CXX_FLAGS
-           ${WARNING_CXX_FLAGS}
-           Wno-c++98-compat
-           Wno-c++98-compat-pedantic
-           Wno-c++14-compat
-           Wno-inconsistent-missing-destructor-override
-           )
+            ${WARNING_CXX_FLAGS}
+            Wno-c++98-compat
+            Wno-c++98-compat-pedantic
+            Wno-c++14-compat
+            Wno-inconsistent-missing-destructor-override
+            Wsuggest-override
+        )
     endif ()
 
     check_and_append_c_warning_flags(${WARNING_C_FLAGS})

--- a/examples/AllTests/AllTests.cpp
+++ b/examples/AllTests/AllTests.cpp
@@ -34,12 +34,12 @@
 class MyDummyComparator : public MockNamedValueComparator
 {
 public:
-    virtual bool isEqual(const void* object1, const void* object2)
+    virtual bool isEqual(const void* object1, const void* object2) _override
     {
         return object1 == object2;
     }
 
-    virtual SimpleString valueToString(const void* object)
+    virtual SimpleString valueToString(const void* object) _override
     {
         return StringFrom(object);
     }

--- a/examples/AllTests/CircularBufferTest.cpp
+++ b/examples/AllTests/CircularBufferTest.cpp
@@ -33,11 +33,11 @@ TEST_GROUP(CircularBuffer)
 {
     CircularBuffer* buffer;
 
-    void setup()
+    void setup() _override
     {
         buffer = new CircularBuffer();
     }
-    void teardown()
+    void teardown() _override
     {
         delete buffer;
     }

--- a/examples/AllTests/EventDispatcherTest.cpp
+++ b/examples/AllTests/EventDispatcherTest.cpp
@@ -32,7 +32,7 @@
 class ObserverMock : public EventObserver
 {
 public:
-    virtual void notify(const Event& event, int timeOutInSeconds)
+    virtual void notify(const Event& event, int timeOutInSeconds) _override
     {
         mock()
             .actualCall("notify")
@@ -40,7 +40,7 @@ public:
             .withParameterOfType("Event", "event", (void*)&event)
             .withParameter("timeOutInSeconds", timeOutInSeconds);
     }
-    virtual void notifyRegistration(EventObserver* newObserver)
+    virtual void notifyRegistration(EventObserver* newObserver) _override
     {
         mock().actualCall("notifyRegistration").onObject(this).withParameter("newObserver", newObserver);
     }
@@ -49,11 +49,11 @@ public:
 class EventComparator : public MockNamedValueComparator
 {
 public:
-    virtual bool isEqual(const void* object1, const void* object2)
+    virtual bool isEqual(const void* object1, const void* object2) _override
     {
         return ((const Event*)object1)->type == ((const Event*)object2)->type;
     }
-    virtual SimpleString valueToString(const void* object)
+    virtual SimpleString valueToString(const void* object) _override
     {
         return StringFrom(((const Event*)object)->type);
     }
@@ -67,12 +67,12 @@ TEST_GROUP(EventDispatcher)
     ObserverMock observer2;
     EventComparator eventComparator;
 
-    void setup()
+    void setup() _override
     {
         dispatcher = new EventDispatcher;
         mock().installComparator("Event", eventComparator);
     }
-    void teardown()
+    void teardown() _override
     {
         delete dispatcher;
         mock().removeAllComparatorsAndCopiers();

--- a/examples/AllTests/FEDemoTest.cpp
+++ b/examples/AllTests/FEDemoTest.cpp
@@ -48,7 +48,7 @@ static volatile float f;
 
 TEST_GROUP(FE_Demo)
 {
-    void setup()
+    void setup() _override
     {
         IEEE754ExceptionsPlugin::disableInexact();
     }

--- a/examples/AllTests/HelloTest.cpp
+++ b/examples/AllTests/HelloTest.cpp
@@ -43,12 +43,12 @@ TEST_GROUP(HelloWorld)
         va_end(arguments);
         return 1;
     }
-    void setup()
+    void setup() _override
     {
         buffer = new SimpleString();
         UT_PTR_SET(PrintFormated, &output_method);
     }
-    void teardown()
+    void teardown() _override
     {
         delete buffer;
     }

--- a/examples/AllTests/MockDocumentationTest.cpp
+++ b/examples/AllTests/MockDocumentationTest.cpp
@@ -69,7 +69,7 @@ public:
 class ClassFromProductionCodeMock : public ClassFromProductionCode
 {
 public:
-    virtual void importantFunction()
+    virtual void importantFunction() _override
     {
         mock().actualCall("importantFunction").onObject(this);
     }
@@ -102,11 +102,11 @@ TEST(MockDocumentation, parameters)
 class MyTypeComparator : public MockNamedValueComparator
 {
 public:
-    virtual bool isEqual(const void* object1, const void* object2)
+    virtual bool isEqual(const void* object1, const void* object2) _override
     {
         return object1 == object2;
     }
-    virtual SimpleString valueToString(const void* object)
+    virtual SimpleString valueToString(const void* object) _override
     {
         return StringFrom(object);
     }
@@ -199,12 +199,12 @@ TEST(MockDocumentation, CInterface)
 
 TEST_GROUP(FooTestGroup)
 {
-    void setup()
+    void setup() _override
     {
         // Init stuff
     }
 
-    void teardown()
+    void teardown() _override
     {
         // Uninit stuff
     }
@@ -222,7 +222,7 @@ TEST(FooTestGroup, MoreFoo)
 
 TEST_GROUP(BarTestGroup)
 {
-    void setup()
+    void setup() _override
     {
         // Init Bar
     }

--- a/examples/AllTests/MockPrinter.h
+++ b/examples/AllTests/MockPrinter.h
@@ -46,12 +46,12 @@ public:
     explicit MockPrinter() {}
     virtual ~MockPrinter() {}
 
-    virtual void Print(const char* s)
+    virtual void Print(const char* s) _override
     {
         savedOutput.append(s);
     }
 
-    virtual void Print(long int value)
+    virtual void Print(long int value) _override
     {
         SimpleString buffer;
         buffer = StringFromFormat("%ld", value);

--- a/examples/AllTests/PrinterTest.cpp
+++ b/examples/AllTests/PrinterTest.cpp
@@ -34,12 +34,12 @@ TEST_GROUP(Printer)
     Printer* printer;
     MockPrinter* mockPrinter;
 
-    void setup()
+    void setup() _override
     {
         mockPrinter = new MockPrinter();
         printer = mockPrinter;
     }
-    void teardown()
+    void teardown() _override
     {
         delete printer;
     }

--- a/include/CppUTestExt/MockCheckedActualCall.h
+++ b/include/CppUTestExt/MockCheckedActualCall.h
@@ -92,8 +92,9 @@ public:
     virtual void * returnPointerValue() _override;
     virtual void * returnPointerValueOrDefault(void *) _override;
 
-    virtual void (*returnFunctionPointerValue())() _override;
-    virtual void (*returnFunctionPointerValueOrDefault(void (*)()))() _override;
+    typedef void (*FunctionPointerReturnValue)();
+    virtual FunctionPointerReturnValue returnFunctionPointerValue() _override;
+    virtual FunctionPointerReturnValue returnFunctionPointerValueOrDefault(void (*)()) _override;
 
     virtual MockActualCall& onObject(const void* objectPtr) _override;
 
@@ -213,8 +214,8 @@ public:
     virtual const void * returnConstPointerValue() _override;
     virtual const void * returnConstPointerValueOrDefault(const void * default_value) _override;
 
-    virtual void (*returnFunctionPointerValue())() _override;
-    virtual void (*returnFunctionPointerValueOrDefault(void (*)()))() _override;
+    virtual MockCheckedActualCall::FunctionPointerReturnValue returnFunctionPointerValue() _override;
+    virtual MockCheckedActualCall::FunctionPointerReturnValue returnFunctionPointerValueOrDefault(void (*)()) _override;
 
     virtual MockActualCall& onObject(const void* objectPtr) _override;
 
@@ -289,8 +290,8 @@ public:
     virtual const void * returnConstPointerValue() _override { return NULLPTR; }
     virtual const void * returnConstPointerValueOrDefault(const void * value) _override { return value; }
 
-    virtual void (*returnFunctionPointerValue())() _override { return NULLPTR; }
-    virtual void (*returnFunctionPointerValueOrDefault(void (*value)()))() _override { return value; }
+    virtual MockCheckedActualCall::FunctionPointerReturnValue returnFunctionPointerValue() _override { return NULLPTR; }
+    virtual MockCheckedActualCall::FunctionPointerReturnValue returnFunctionPointerValueOrDefault(void (*value)()) _override { return value; }
 
     virtual MockActualCall& onObject(const void* ) _override { return *this; }
 


### PR DESCRIPTION
These raised warnings with [`-Wsuggest-override`](https://gcc.gnu.org/onlinedocs/gcc/C_002b_002b-Dialect-Options.html#index-Wsuggest-override). I personally find this easier to read as well.