### PR TITLE
GitHub actions

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -38,6 +38,18 @@ jobs:
           ./configure
           make tdd
 
+  mac-cmake:
+    runs-on: macos-latest
+    name: "Mac CMake"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@main
+      - name: Build
+        run: |
+          cmake -B build -S . -DCMAKE_CXX_STANDARD=17
+          cmake --build build
+          ctest --test-dir build
+
   windows:
     runs-on: windows-latest
     name: "Windows msbuild"

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -38,44 +38,64 @@ jobs:
           ./configure
           make tdd
 
-  mac-cmake:
-    runs-on: macos-latest
-    name: "Mac CMake"
+  cmake:
+    strategy:
+      matrix:
+        include:
+          # Windows
+          - os: windows-latest
+            cpp_version: 17
+          # Linux
+          #   CMake different C++ versions with clang
+          - os: ubuntu-latest
+            cpp_version: 11
+            cxx: clang++
+            cc: clang
+          - os: ubuntu-latest
+            cpp_version: 14
+            cxx: clang++
+            cc: clang
+          - os: ubuntu-latest
+            cpp_version: 17
+            cxx: clang++
+            cc: clang
+          #   CMake different C++ versions with gcc
+          - os: ubuntu-latest
+            cpp_version: 11
+            cxx: g++
+            cc: gcc
+          - os: ubuntu-latest
+            cpp_version: 14
+            cxx: g++
+            cc: gcc
+          - os: ubuntu-latest
+            cpp_version: 17
+            cxx: g++
+            cc: gcc
+          # Mac OSX
+          - os: macos-latest
+            cpp_version: 17
+            cxx: clang++
+            cc: clang
+          - os: macos-latest
+            cpp_version: 14
+            cxx: g++
+            cc: gcc
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@main
+      - if: ${{ matrix.cxx }}
+        run: echo "CXX=${{ matrix.cxx }}" >> $GITHUB_ENV
+      - if: ${{ matrix.cc }}
+        run: echo "CC=${{ matrix.cc }}" >> $GITHUB_ENV
+      - name: Configure
+        run: cmake -B build -S . -DCMAKE_CXX_STANDARD=${{ matrix.cpp_version }}
+        if: ${{ matrix.cpp_version }}
       - name: Build
-        run: |
-          cmake -B build -S . -DCMAKE_CXX_STANDARD=17
-          cmake --build build
-          ctest --test-dir build
-
-  windows:
-    runs-on: windows-latest
-    name: "Windows msbuild"
-    steps:
-      - name: Checkout
-        uses: actions/checkout@main
-      - name: Build
-        run: |
-          cmake -B build -S . -DCMAKE_CXX_STANDARD=17
-          cmake --build build
-          ctest --test-dir build
-
-  linux-gcc-cmake:
-    runs-on: ubuntu-latest
-    env:
-      CC: gcc
-      CXX: g++
-    name: "Linux GCC CMake"
-    steps:
-      - name: Checkout
-        uses: actions/checkout@main
-      - name: Build
-        run: |
-          cmake -B build -S . -DCMAKE_CXX_STANDARD=17
-          cmake --build build
-          ctest --test-dir build
+        run: cmake --build build
+      - name: Test
+        run: ctest --test-dir build
 
   linux-gcc-autotools:
     runs-on: ubuntu-latest

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -1,0 +1,41 @@
+---
+name: Basic builds
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  mac-gcc-autotools:
+    runs-on: macos-latest
+    env:
+      BUILD: autotools
+      CC: gcc
+      CXX: g++
+    name: "basic build & test"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@main
+      - name: Build
+        run: |
+          brew install automake
+          autoreconf -i .
+          ./configure
+          make tdd
+
+  mac-clang-autotools:
+    runs-on: macos-latest
+    env:
+      BUILD: autotools
+      CC: clang
+      CXX: clang++
+    name: "basic build & test"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@main
+      - name: Build
+        run: |
+          brew install automake
+          autoreconf -i .
+          ./configure
+          make tdd

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -6,37 +6,40 @@ on:
   pull_request:
 
 jobs:
-  mac-gcc-autotools:
-    runs-on: macos-latest
-    env:
-      CC: gcc
-      CXX: g++
-    name: "Mac GCC Autotools"
+  automake:
+    strategy:
+      matrix:
+        include:
+          # Mac OSX
+          - os: macos-latest
+            cc: gcc
+            cxx: g++
+          - os: macos-latest
+            cc: clang
+            cxx: clang++
+          # Linux
+          - os: ubuntu-latest
+            cc: gcc
+            cxx: g++
+          - os: ubuntu-latest
+            cc: clang
+            cxx: clang++
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@main
-      - name: Build
+      - run: brew install automake
+        if: ${{ startswith(matrix.os, 'macos') }}
+      - if: ${{ matrix.cxx }}
+        run: echo "CXX=${{ matrix.cxx }}" >> $GITHUB_ENV
+      - if: ${{ matrix.cc }}
+        run: echo "CC=${{ matrix.cc }}" >> $GITHUB_ENV
+      - name: Configure
         run: |
-          brew install automake
           autoreconf -i .
           ./configure
-          make tdd
-
-  mac-clang-autotools:
-    runs-on: macos-latest
-    env:
-      CC: clang
-      CXX: clang++
-    name: "Mac Clang Autotools"
-    steps:
-      - name: Checkout
-        uses: actions/checkout@main
-      - name: Build
-        run: |
-          brew install automake
-          autoreconf -i .
-          ./configure
-          make tdd
+      - name: Build and test
+        run: make tdd
 
   cmake:
     strategy:
@@ -96,33 +99,3 @@ jobs:
         run: cmake --build build
       - name: Test
         run: ctest --test-dir build
-
-  linux-gcc-autotools:
-    runs-on: ubuntu-latest
-    env:
-      CC: gcc
-      CXX: g++
-    name: "Linux GCC autotools"
-    steps:
-      - name: Checkout
-        uses: actions/checkout@main
-      - name: Build
-        run: |
-          autoreconf -i .
-          ./configure
-          make tdd
-
-  linux-clang-autotools:
-    runs-on: ubuntu-latest
-    env:
-      CC: clang
-      CXX: clang++
-    name: "Linux Clang autotools"
-    steps:
-      - name: Checkout
-        uses: actions/checkout@main
-      - name: Build
-        run: |
-          autoreconf -i .
-          ./configure
-          make tdd

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -40,14 +40,57 @@ jobs:
 
   windows:
     runs-on: windows-latest
-    env:
-      CPP_STD: 17
     name: "Windows msbuild"
     steps:
       - name: Checkout
         uses: actions/checkout@main
       - name: Build
         run: |
-          cmake -B build -S .
+          cmake -B build -S . -DCMAKE_CXX_STANDARD=17
           cmake --build build
           ctest --test-dir build
+
+  linux-gcc-cmake:
+    runs-on: ubuntu-latest
+    env:
+      CC: gcc
+      CXX: g++
+    name: "Linux GCC CMake"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@main
+      - name: Build
+        run: |
+          cmake -B build -S . -DCMAKE_CXX_STANDARD=17
+          cmake --build build
+          ctest --test-dir build
+
+  linux-gcc-autotools:
+    runs-on: ubuntu-latest
+    env:
+      CC: gcc
+      CXX: g++
+    name: "Linux GCC autotools"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@main
+      - name: Build
+        run: |
+          autoreconf -i .
+          ./configure
+          make tdd
+
+  linux-clang-autotools:
+    runs-on: ubuntu-latest
+    env:
+      CC: clang
+      CXX: clang++
+    name: "Linux Clang autotools"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@main
+      - name: Build
+        run: |
+          autoreconf -i .
+          ./configure
+          make tdd

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -9,10 +9,9 @@ jobs:
   mac-gcc-autotools:
     runs-on: macos-latest
     env:
-      BUILD: autotools
       CC: gcc
       CXX: g++
-    name: "basic build & test"
+    name: "Mac GCC Autotools"
     steps:
       - name: Checkout
         uses: actions/checkout@main
@@ -26,10 +25,9 @@ jobs:
   mac-clang-autotools:
     runs-on: macos-latest
     env:
-      BUILD: autotools
       CC: clang
       CXX: clang++
-    name: "basic build & test"
+    name: "Mac Clang Autotools"
     steps:
       - name: Checkout
         uses: actions/checkout@main
@@ -39,3 +37,17 @@ jobs:
           autoreconf -i .
           ./configure
           make tdd
+
+  windows:
+    runs-on: windows-latest
+    env:
+      CPP_STD: 17
+    name: "Windows msbuild"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@main
+      - name: Build
+        run: |
+          cmake -B build -S .
+          cmake --build build
+          ctest --test-dir build

--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -1,0 +1,25 @@
+name: Extended builds
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test_report:
+    runs-on: ubuntu-latest
+    env:
+      CC: gcc
+      CXX: g++
+    steps:
+      - name: Install tools
+        run: sudo apt-get install -y ant-optional
+      - name: Checkout
+        uses: actions/checkout@main
+      - run: |
+          autoreconf -i .
+          ./configure
+          make check
+          ./CppUTestTests -ojunit
+          ./CppUTestExtTests -ojunit
+          cp ./scripts/generate_junit_report_ant.xml .
+          ant -f generate_junit_report_ant.xml

--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -7,9 +7,6 @@ on:
 jobs:
   test_report:
     runs-on: ubuntu-latest
-    env:
-      CC: gcc
-      CXX: g++
     steps:
       - name: Install tools
         run: sudo apt-get install -y ant-optional
@@ -23,3 +20,16 @@ jobs:
           ./CppUTestExtTests -ojunit
           cp ./scripts/generate_junit_report_ant.xml .
           ant -f generate_junit_report_ant.xml
+
+  cmake_coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install tools
+        run: pip install --user cpp-coveralls gcovr
+      - name: Checkout
+        uses: actions/checkout@main
+      - run: |
+          cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DC++11=ON -DCOVERAGE=ON -DLONGLONG=ON
+          cmake --build build
+          ctest --test-dir build
+          coveralls -b build -r . -i "src" -i "include" --gcov-options="-lbc" || true


### PR DESCRIPTION
This gets at least some of the old travis builds running again using GitHub actions. There's still a bunch of follow on work we'll need to take on after this:

- C++98 support is broken because newer features have been introduced in TestFailure.cpp, CompatiblityTests.cpp, SimpleStringTest.cpp for example.
- The old version of GTest/GMock that travis used seems to depend on python2 which is EOL.
- DOSBox has trouble running in GitHub Actions' terminal.
- There are a bunch of other configs from travis that need to migrate too.