### PR TITLE
Automatically disable C++ standard library usage when exceptions are disabled

### DIFF
--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -97,6 +97,23 @@ jobs:
       - name: Test
         run: ctest --test-dir build
 
+  cmake_no_exceptions:
+    runs-on: ubuntu-latest
+    name: Disable exceptions
+    env:
+      CC: gcc
+      CXX: g++
+      CXXFLAGS: -fno-exceptions
+    steps:
+      - name: Checkout
+        uses: actions/checkout@main
+      - name: Configure
+        run: cmake -B cpputest_build -S .
+      - name: Build
+        run: cmake --build cpputest_build --verbose
+      - name: Test
+        run: ctest --test-dir cpputest_build
+
   cmake_install:
     runs-on: ubuntu-latest
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,8 +60,8 @@ cmake_dependent_option(CPPUTEST_BUILD_TESTING "Compile and make tests for CppUTe
 option(CPPUTEST_TESTS_DETAILED "Run each test separately instead of grouped?" OFF)
 cmake_dependent_option(CPPUTEST_TEST_DISCOVERY "Build time test discover"
   ON "CPPUTEST_BUILD_TESTING;CMAKE_CROSSCOMPILING_EMULATOR OR NOT CMAKE_CROSSCOMPILING" OFF)
-
-option(CPPUTEST_EXAMPLES "Compile and make examples?" ${PROJECT_IS_TOP_LEVEL})
+cmake_dependent_option(CPPUTEST_EXAMPLES "Compile and make examples?"
+  ${PROJECT_IS_TOP_LEVEL} "NOT CPPUTEST_STD_CPP_LIB_DISABLED" OFF)
 option(CPPUTEST_VERBOSE_CONFIG "Print configuration to stdout during generation" ${PROJECT_IS_TOP_LEVEL})
 
 cmake_dependent_option(CPPUTEST_LIBNAME_POSTFIX_BITSIZE "Add architecture bitsize (32/64) to the library name?"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,8 +28,15 @@ include(CTest)
 
 include(CMakeDependentOption)
 option(CPPUTEST_STD_C_LIB_DISABLED "Disable the standard C library")
+
+include(CheckCXXSourceCompiles)
+check_cxx_source_compiles(
+  "int main(int argc, char ** argv) { throw 20; }"
+  CPPUTEST_HAVE_EXCEPTIONS
+)
+
 cmake_dependent_option(CPPUTEST_STD_CPP_LIB_DISABLED "Use the standard C++ library"
-  OFF "NOT CPPUTEST_STD_C_LIB_DISABLED" ON)
+  OFF "NOT CPPUTEST_STD_C_LIB_DISABLED;CPPUTEST_HAVE_EXCEPTIONS" ON)
 option(CPPUTEST_FLAGS "Use the CFLAGS/CXXFLAGS/LDFLAGS set by CppUTest" ON)
 cmake_dependent_option(CPPUTEST_MEM_LEAK_DETECTION_DISABLED "Enable memory leak detection"
   OFF "NOT BORLAND;NOT CPPUTEST_STD_C_LIB_DISABLED" ON)

--- a/tests/CppUTest/TestFailureNaNTest.cpp
+++ b/tests/CppUTest/TestFailureNaNTest.cpp
@@ -29,13 +29,13 @@
 #include "CppUTest/TestOutput.h"
 #include "CppUTest/PlatformSpecificFunctions.h"
 
+#if CPPUTEST_HAS_NAN == 1 && CPPUTEST_HAS_INF == 1
+
 namespace
 {
 const int failLineNumber = 2;
 const char* failFileName = "fail.cpp";
 }
-
-#if CPPUTEST_HAS_NAN == 1 && CPPUTEST_HAS_INF == 1
 
 static double zero = 0.0;
 static double one = 1.0;


### PR DESCRIPTION
Depends on #1620