### PR TITLE
Remove `-Weverything` flag

### DIFF
--- a/build/MakefileWorker.mk
+++ b/build/MakefileWorker.mk
@@ -206,8 +206,8 @@ ifeq ($(COMPILER_NAME),$(CLANG_STR))
 # -Wno-c++98-compat-pedantic -> Incompatibilities with C++98, these are happening through #define.
 # -Wno-reserved-id-macro -> Macro uses __ in MINGW... can't change that.
 # -Wno-keyword-macro -> new overload
-	CPPUTEST_CXX_WARNINGFLAGS += -Weverything -Wno-disabled-macro-expansion -Wno-padded -Wno-global-constructors -Wno-exit-time-destructors -Wno-weak-vtables -Wno-old-style-cast -Wno-c++11-long-long -Wno-c++98-compat-pedantic -Wno-reserved-id-macro -Wno-keyword-macro
-	CPPUTEST_C_WARNINGFLAGS += -Weverything -Wno-padded
+	CPPUTEST_CXX_WARNINGFLAGS += -Wno-disabled-macro-expansion -Wno-padded -Wno-global-constructors -Wno-exit-time-destructors -Wno-weak-vtables -Wno-old-style-cast -Wno-c++11-long-long -Wno-c++98-compat-pedantic -Wno-reserved-id-macro -Wno-keyword-macro
+	CPPUTEST_C_WARNINGFLAGS += -Wno-padded
 
 # Clang 7 and 12 introduced new warnings by default that don't exist on previous versions of clang and cause errors when present.
 CLANG_VERSION := $(shell echo $(CC_VERSION_OUTPUT) | sed -n 's/.* \([0-9]*\.[0-9]*\.[0-9]*\).*/\1/p')

--- a/cmake/Modules/CppUTestWarningFlags.cmake
+++ b/cmake/Modules/CppUTestWarningFlags.cmake
@@ -29,7 +29,6 @@ else (MSVC)
     endif (NOT GMOCK AND NOT REAL_GTEST)
 
     set(WARNING_C_FLAGS
-        Weverything
         Wall
         Wextra
         pedantic

--- a/configure.ac
+++ b/configure.ac
@@ -178,13 +178,6 @@ CFLAGS="$saved_cflags"
 
 
 #####################################################################################
-##### More of these warnings
-# FLag -Weverything.
-CFLAGS="-Werror -Weverything -Wno-unused-macros"
-AC_MSG_CHECKING([whether CC and CXX supports -Weverything])
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([])], [AC_MSG_RESULT([yes]); CPPUTEST_CWARNINGFLAGS="${CPPUTEST_CWARNINGFLAGS} -Weverything"; CPPUTEST_CXXWARNINGFLAGS="${CPPUTEST_CXXWARNINGFLAGS} -Weverything" ], [AC_MSG_RESULT([no])])
-CFLAGS="$saved_cflags"
-
 # FLag -Wall.
 CFLAGS="-Werror -Wall"
 AC_MSG_CHECKING([whether CC and CXX supports -Wall])


### PR DESCRIPTION
> Since `-Weverything` enables every diagnostic, we generally don’t
> recommend using it. `-Wall -Wextra` are a better choice for most projects.
> Using `-Weverything` means that updating your compiler is more difficult
> because you’re exposed to experimental diagnostics which might be of
> lower quality than the default ones.

https://clang.llvm.org/docs/UsersManual.html?highlight=weverything#diagnostics-enable-everything