### PR TITLE
Remove extensions from CppUTest tests

### DIFF
--- a/tests/CppUTest/CommandLineTestRunnerTest.cpp
+++ b/tests/CppUTest/CommandLineTestRunnerTest.cpp
@@ -32,7 +32,6 @@
 #include "CppUTest/TestPlugin.h"
 #include "CppUTest/JUnitTestOutput.h"
 #include "CppUTest/PlatformSpecificFunctions.h"
-#include "CppUTestExt/MockSupport.h"
 
 
 class DummyPluginWhichCountsThePlugins : public TestPlugin


### PR DESCRIPTION
Since CppUTest can build without CppUTestExt, it we should be able to test without it as well.  This header was unreferenced.