### PR TITLE
Extract 'extern C', add missing include guards

### DIFF
--- a/tests/CppUTest/DummyMemoryLeakDetector.h
+++ b/tests/CppUTest/DummyMemoryLeakDetector.h
@@ -25,6 +25,9 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifndef DUMMYMEMORYLEAKDETECTOR_H
+#define DUMMYMEMORYLEAKDETECTOR_H
+
 class DummyMemoryLeakDetector : public MemoryLeakDetector
 {
 public:
@@ -49,3 +52,4 @@ private:
     static bool memoryLeakFailureWasDelete;
 };
 
+#endif /* DUMMYMEMORYLEAKDETECTOR_H */

--- a/tests/CppUTestExt/IEEE754PluginTest.cpp
+++ b/tests/CppUTestExt/IEEE754PluginTest.cpp
@@ -34,10 +34,7 @@
 #ifdef CPPUTEST_HAVE_FENV
 #if CPPUTEST_FENV_IS_WORKING_PROPERLY
 
-extern "C"
-{
-    #include "IEEE754PluginTest_c.h"
-}
+#include "IEEE754PluginTest_c.h"
 
 TEST_GROUP(FE_with_Plugin)
 {

--- a/tests/CppUTestExt/IEEE754PluginTest_c.h
+++ b/tests/CppUTestExt/IEEE754PluginTest_c.h
@@ -25,9 +25,17 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void set_divisionbyzero_c(void);
 void set_overflow_c(void);
 void set_underflow_c(void);
 void set_inexact_c(void);
 void set_nothing_c(void);
 void set_everything_c(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/tests/CppUTestExt/IEEE754PluginTest_c.h
+++ b/tests/CppUTestExt/IEEE754PluginTest_c.h
@@ -25,6 +25,9 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifndef IEEE754PLUGINTEST_C_H
+#define IEEE754PLUGINTEST_C_H
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -39,3 +42,5 @@ void set_everything_c(void);
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* IEEE754PLUGINTEST_C_H */


### PR DESCRIPTION
Extracts `extern "C"` to the header so consumers don't need to care and adds two missing include guards.