### PR TITLE
Disable test discovery when cross-compiling without an emulator

### DIFF
--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -113,3 +113,20 @@ jobs:
           cmake -B build -S examples
           cmake --build build -j
           ctest --test-dir build
+
+  arm-embedded:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@main
+      - uses: carlosperate/arm-none-eabi-gcc-action@v1
+      - name: Configure
+        run: >
+          cmake
+          -B cpputest_build
+          -D CMAKE_TOOLCHAIN_FILE=cmake/arm-none-eabi-gcc.toolchain.cmake
+      - name: Build
+        run: cmake --build cpputest_build
+      - name: Test
+        # This won't do anything, because there is no way to run the tests.
+        run: ctest --test-dir cpputest_build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ cmake_dependent_option(CPPUTEST_BUILD_TESTING "Compile and make tests for CppUTe
   ${PROJECT_IS_TOP_LEVEL} "BUILD_TESTING" OFF)
 option(CPPUTEST_TESTS_DETAILED "Run each test separately instead of grouped?" OFF)
 cmake_dependent_option(CPPUTEST_TEST_DISCOVERY "Build time test discover"
-  ON "CPPUTEST_BUILD_TESTING;NOT IAR" OFF)
+  ON "CPPUTEST_BUILD_TESTING;CMAKE_CROSSCOMPILING_EMULATOR OR NOT CMAKE_CROSSCOMPILING" OFF)
 
 option(CPPUTEST_EXAMPLES "Compile and make examples?" ${PROJECT_IS_TOP_LEVEL})
 option(CPPUTEST_VERBOSE_CONFIG "Print configuration to stdout during generation" ${PROJECT_IS_TOP_LEVEL})

--- a/cmake/arm-none-eabi-gcc.toolchain.cmake
+++ b/cmake/arm-none-eabi-gcc.toolchain.cmake
@@ -1,0 +1,8 @@
+set(CMAKE_SYSTEM_NAME Generic)
+set(CMAKE_SYSTEM_PROCESSOR cortex-m4)
+
+set(CMAKE_C_COMPILER arm-none-eabi-gcc)
+
+set(CMAKE_C_FLAGS_INIT "-mcpu=cortex-m4")
+set(CMAKE_CXX_FLAGS_INIT "-mcpu=cortex-m4")
+set(CMAKE_EXE_LINKER_FLAGS_INIT "-specs=nano.specs -specs=rdimon.specs")

--- a/examples/AllTests/CMakeLists.txt
+++ b/examples/AllTests/CMakeLists.txt
@@ -24,4 +24,6 @@ target_link_libraries(ExampleTests
 )
 
 include(CppUTestBuildTimeDiscoverTests)
-cpputest_buildtime_discover_tests(ExampleTests)
+if(CPPUTEST_TEST_DISCOVERY OR NOT DEFINED CPPUTEST_TEST_DISCOVERY)
+    cpputest_buildtime_discover_tests(ExampleTests)
+endif()

--- a/src/Platforms/Gcc/UtestPlatform.cpp
+++ b/src/Platforms/Gcc/UtestPlatform.cpp
@@ -204,7 +204,7 @@ static long TimeInMillisImplementation()
     struct timeval tv;
     struct timezone tz;
     gettimeofday(&tv, &tz);
-    return (tv.tv_sec * 1000) + (long)((double)tv.tv_usec * 0.001);
+    return (long)((tv.tv_sec * 1000) + (time_t)((double)tv.tv_usec * 0.001));
 #else
     return 0;
 #endif

--- a/tests/CppUTestExt/MockReturnValueTest.cpp
+++ b/tests/CppUTestExt/MockReturnValueTest.cpp
@@ -145,7 +145,7 @@ TEST(MockReturnValueTest, UnsignedLongIntReturnValueCanBeRetrievedAsUnsignedLong
 
 TEST(MockReturnValueTest, UnsignedLongLongIntReturnValueCanBeRetrieved)
 {
-    unsigned long long int expected_value = ULLONG_MAX;
+    unsigned long long int expected_value = 2ULL;
     mock().expectOneCall("foo").andReturnValue(expected_value);
     UNSIGNED_LONGLONGS_EQUAL(expected_value, mock().actualCall("foo").returnValue().getUnsignedLongLongIntValue());
 }
@@ -180,7 +180,7 @@ TEST(MockReturnValueTest, UnsignedLongIntReturnValueCanBeRetrievedAsLongLongInt)
 
 TEST(MockReturnValueTest, LongLongIntReturnValueCanBeRetrieved)
 {
-    long long int expected_value = LLONG_MAX;
+    long long int expected_value = 2LL;
     mock().expectOneCall("foo").andReturnValue(expected_value);
     LONGLONGS_EQUAL(expected_value, mock().actualCall("foo").returnValue().getLongLongIntValue());
 }
@@ -288,7 +288,7 @@ TEST(MockReturnValueTest, WhenNoLongIntegerReturnValueIsExpectedButThereIsADefau
 
 TEST(MockReturnValueTest, WhenAUnsignedLongLongIntegerReturnValueIsExpectedAndAlsoThereIsADefaultShouldlIgnoreTheDefault)
 {
-    unsigned long long int default_return_value = ULLONG_MAX;
+    unsigned long long int default_return_value = 2ULL;
     unsigned long long int expected_return_value = default_return_value - 1;
     mock().expectOneCall("foo").andReturnValue(expected_return_value);
     LONGS_EQUAL(expected_return_value, mock().actualCall("foo").returnUnsignedLongLongIntValueOrDefault(default_return_value));
@@ -297,7 +297,7 @@ TEST(MockReturnValueTest, WhenAUnsignedLongLongIntegerReturnValueIsExpectedAndAl
 
 TEST(MockReturnValueTest, WhenNoUnsignedLongLongIntegerReturnValueIsExpectedButThereIsADefaultShouldlUseTheDefaultValue)
 {
-    unsigned long long int default_return_value = ULLONG_MAX;
+    unsigned long long int default_return_value = 2ULL;
     mock().expectOneCall("foo");
     LONGS_EQUAL(default_return_value, mock().actualCall("foo").returnUnsignedLongLongIntValueOrDefault(default_return_value));
     LONGS_EQUAL(default_return_value, mock().returnUnsignedLongLongIntValueOrDefault(default_return_value));
@@ -305,7 +305,7 @@ TEST(MockReturnValueTest, WhenNoUnsignedLongLongIntegerReturnValueIsExpectedButT
 
 TEST(MockReturnValueTest, WhenALongLongIntegerReturnValueIsExpectedAndAlsoThereIsADefaultShouldlIgnoreTheDefault)
 {
-    long long int default_return_value = LLONG_MAX;
+    long long int default_return_value = 2LL;
     long long int expected_return_value = default_return_value - 1;
     mock().expectOneCall("foo").andReturnValue(expected_return_value);
     LONGS_EQUAL(expected_return_value, mock().actualCall("foo").returnLongLongIntValueOrDefault(default_return_value));
@@ -314,7 +314,7 @@ TEST(MockReturnValueTest, WhenALongLongIntegerReturnValueIsExpectedAndAlsoThereI
 
 TEST(MockReturnValueTest, WhenNoLongLongIntegerReturnValueIsExpectedButThereIsADefaultShouldlUseTheDefaultValue)
 {
-    long long int default_return_value = LLONG_MAX;
+    long long int default_return_value = 2LL;
     mock().expectOneCall("foo");
     LONGS_EQUAL(default_return_value, mock().actualCall("foo").returnLongLongIntValueOrDefault(default_return_value));
     LONGS_EQUAL(default_return_value, mock().returnLongLongIntValueOrDefault(default_return_value));


### PR DESCRIPTION
Test discovery depends on the ability to run the test executables on host. Without an emulator, there's no way to do that.