### PR TITLE
Switch from putchar to fputs

### DIFF
--- a/include/CppUTest/PlatformSpecificFunctions_c.h
+++ b/include/CppUTest/PlatformSpecificFunctions_c.h
@@ -68,7 +68,6 @@ extern PlatformSpecificFile (*PlatformSpecificFOpen)(const char* filename, const
 extern void (*PlatformSpecificFPuts)(const char* str, PlatformSpecificFile file);
 extern void (*PlatformSpecificFClose)(PlatformSpecificFile file);
 
-extern int (*PlatformSpecificPutchar)(int c);
 extern void (*PlatformSpecificFlush)(void);
 
 /* Random operations */

--- a/include/CppUTest/PlatformSpecificFunctions_c.h
+++ b/include/CppUTest/PlatformSpecificFunctions_c.h
@@ -62,6 +62,8 @@ extern int (*PlatformSpecificAtExit)(void(*func)(void));
 /* IO operations */
 typedef void* PlatformSpecificFile;
 
+extern const PlatformSpecificFile PlatformSpecificStdOut;
+
 extern PlatformSpecificFile (*PlatformSpecificFOpen)(const char* filename, const char* flag);
 extern void (*PlatformSpecificFPuts)(const char* str, PlatformSpecificFile file);
 extern void (*PlatformSpecificFClose)(PlatformSpecificFile file);

--- a/src/CppUTest/TestOutput.cpp
+++ b/src/CppUTest/TestOutput.cpp
@@ -274,10 +274,7 @@ void TestOutput::printVeryVerbose(const char* str)
 
 void ConsoleTestOutput::printBuffer(const char* s)
 {
-    while (*s) {
-        PlatformSpecificPutchar(*s);
-        s++;
-    }
+    PlatformSpecificFPuts(s, PlatformSpecificStdOut);
     flush();
 }
 

--- a/src/Platforms/Borland/UtestPlatform.cpp
+++ b/src/Platforms/Borland/UtestPlatform.cpp
@@ -251,7 +251,6 @@ PlatformSpecificFile (*PlatformSpecificFOpen)(const char*, const char*) = Platfo
 void (*PlatformSpecificFPuts)(const char*, PlatformSpecificFile) = PlatformSpecificFPutsImplementation;
 void (*PlatformSpecificFClose)(PlatformSpecificFile) = PlatformSpecificFCloseImplementation;
 
-int (*PlatformSpecificPutchar)(int) = putchar;
 void (*PlatformSpecificFlush)() = PlatformSpecificFlushImplementation;
 
 void* (*PlatformSpecificMalloc)(size_t size) = malloc;

--- a/src/Platforms/Borland/UtestPlatform.cpp
+++ b/src/Platforms/Borland/UtestPlatform.cpp
@@ -246,6 +246,7 @@ static void PlatformSpecificFlushImplementation()
   fflush(stdout);
 }
 
+const PlatformSpecificFile PlatformSpecificStdOut = stdout;
 PlatformSpecificFile (*PlatformSpecificFOpen)(const char*, const char*) = PlatformSpecificFOpenImplementation;
 void (*PlatformSpecificFPuts)(const char*, PlatformSpecificFile) = PlatformSpecificFPutsImplementation;
 void (*PlatformSpecificFClose)(PlatformSpecificFile) = PlatformSpecificFCloseImplementation;

--- a/src/Platforms/C2000/UtestPlatform.cpp
+++ b/src/Platforms/C2000/UtestPlatform.cpp
@@ -150,29 +150,11 @@ PlatformSpecificFile (*PlatformSpecificFOpen)(const char* filename, const char* 
 void (*PlatformSpecificFPuts)(const char* str, PlatformSpecificFile file) = C2000FPuts;
 void (*PlatformSpecificFClose)(PlatformSpecificFile file) = C2000FClose;
 
-static int CL2000Putchar(int c)
-{
-#if USE_BUFFER_OUTPUT
-    if(idx < BUFFER_SIZE) {
-        buffer[idx] = (char) c;
-        idx++;
-        /* "buffer[idx]" instead of "c" eliminates "never used" warning */
- 		return (buffer[idx]);
-    }
-    else {
-        return EOF;
-    }
-#else
-    return putchar(c);
-#endif
-}
-
 static void CL2000Flush()
 {
   fflush(stdout);
 }
 
-extern int (*PlatformSpecificPutchar)(int c) = CL2000Putchar;
 extern void (*PlatformSpecificFlush)(void) = CL2000Flush;
 
 static void* C2000Malloc(size_t size)

--- a/src/Platforms/C2000/UtestPlatform.cpp
+++ b/src/Platforms/C2000/UtestPlatform.cpp
@@ -145,6 +145,7 @@ static void C2000FClose(PlatformSpecificFile file)
    fclose((FILE*)file);
 }
 
+const PlatformSpecificFile PlatformSpecificStdOut = stdout;
 PlatformSpecificFile (*PlatformSpecificFOpen)(const char* filename, const char* flag) = C2000FOpen;
 void (*PlatformSpecificFPuts)(const char* str, PlatformSpecificFile file) = C2000FPuts;
 void (*PlatformSpecificFClose)(PlatformSpecificFile file) = C2000FClose;

--- a/src/Platforms/C2000/UtestPlatform.cpp
+++ b/src/Platforms/C2000/UtestPlatform.cpp
@@ -137,7 +137,17 @@ PlatformSpecificFile C2000FOpen(const char* filename, const char* flag)
 
 static void C2000FPuts(const char* str, PlatformSpecificFile file)
 {
-   fputs(str, (FILE*)file);
+#if USE_BUFFER_OUTPUT
+    if (file == PlatformSpecificStdOut) {
+        while (*str && (idx < BUFFER_SIZE)) {
+            buf[idx++] = *str++;
+        }
+    }
+    else
+#endif
+    { 
+        fputs(str, (FILE*)file);
+    }
 }
 
 static void C2000FClose(PlatformSpecificFile file)

--- a/src/Platforms/Dos/UtestPlatform.cpp
+++ b/src/Platforms/Dos/UtestPlatform.cpp
@@ -143,17 +143,11 @@ PlatformSpecificFile (*PlatformSpecificFOpen)(const char* filename, const char* 
 void (*PlatformSpecificFPuts)(const char* str, PlatformSpecificFile file) = DosFPuts;
 void (*PlatformSpecificFClose)(PlatformSpecificFile file) = DosFClose;
 
-static int DosPutchar(int c)
-{
-    return putchar(c);
-}
-
 static void DosFlush()
 {
   fflush(stdout);
 }
 
-extern int (*PlatformSpecificPutchar)(int c) = DosPutchar;
 extern void (*PlatformSpecificFlush)(void) = DosFlush;
 
 static void* DosMalloc(size_t size)

--- a/src/Platforms/Dos/UtestPlatform.cpp
+++ b/src/Platforms/Dos/UtestPlatform.cpp
@@ -138,6 +138,7 @@ static void DosFClose(PlatformSpecificFile file)
    fclose((FILE*)file);
 }
 
+const PlatformSpecificFile PlatformSpecificStdOut = stdout;
 PlatformSpecificFile (*PlatformSpecificFOpen)(const char* filename, const char* flag) = DosFOpen;
 void (*PlatformSpecificFPuts)(const char* str, PlatformSpecificFile file) = DosFPuts;
 void (*PlatformSpecificFClose)(PlatformSpecificFile file) = DosFClose;

--- a/src/Platforms/Gcc/UtestPlatform.cpp
+++ b/src/Platforms/Gcc/UtestPlatform.cpp
@@ -264,6 +264,8 @@ static void PlatformSpecificFlushImplementation()
   fflush(stdout);
 }
 
+const PlatformSpecificFile PlatformSpecificStdOut = stdout;
+
 PlatformSpecificFile (*PlatformSpecificFOpen)(const char*, const char*) = PlatformSpecificFOpenImplementation;
 void (*PlatformSpecificFPuts)(const char*, PlatformSpecificFile) = PlatformSpecificFPutsImplementation;
 void (*PlatformSpecificFClose)(PlatformSpecificFile) = PlatformSpecificFCloseImplementation;

--- a/src/Platforms/Gcc/UtestPlatform.cpp
+++ b/src/Platforms/Gcc/UtestPlatform.cpp
@@ -270,7 +270,6 @@ PlatformSpecificFile (*PlatformSpecificFOpen)(const char*, const char*) = Platfo
 void (*PlatformSpecificFPuts)(const char*, PlatformSpecificFile) = PlatformSpecificFPutsImplementation;
 void (*PlatformSpecificFClose)(PlatformSpecificFile) = PlatformSpecificFCloseImplementation;
 
-int (*PlatformSpecificPutchar)(int) = putchar;
 void (*PlatformSpecificFlush)() = PlatformSpecificFlushImplementation;
 
 void* (*PlatformSpecificMalloc)(size_t size) = malloc;

--- a/src/Platforms/GccNoStdC/UtestPlatform.cpp
+++ b/src/Platforms/GccNoStdC/UtestPlatform.cpp
@@ -57,7 +57,6 @@ PlatformSpecificFile (*PlatformSpecificFOpen)(const char* filename, const char* 
 void (*PlatformSpecificFPuts)(const char* str, PlatformSpecificFile file) = NULLPTR;
 void (*PlatformSpecificFClose)(PlatformSpecificFile file) = NULLPTR;
 
-int (*PlatformSpecificPutchar)(int c) = NULLPTR;
 void (*PlatformSpecificFlush)(void) = NULLPTR;
 
 int (*PlatformSpecificVSNprintf)(char *str, size_t size, const char* format, va_list va_args_list) = NULLPTR;

--- a/src/Platforms/GccNoStdC/UtestPlatform.cpp
+++ b/src/Platforms/GccNoStdC/UtestPlatform.cpp
@@ -52,6 +52,7 @@ long (*GetPlatformSpecificTimeInMillis)() = NULLPTR;
 const char* (*GetPlatformSpecificTimeString)() = NULLPTR;
 
 /* IO operations */
+const PlatformSpecificFile PlatformSpecificStdOut = NULLPTR;
 PlatformSpecificFile (*PlatformSpecificFOpen)(const char* filename, const char* flag) = NULLPTR;
 void (*PlatformSpecificFPuts)(const char* str, PlatformSpecificFile file) = NULLPTR;
 void (*PlatformSpecificFClose)(PlatformSpecificFile file) = NULLPTR;

--- a/src/Platforms/Iar/UtestPlatform.cpp
+++ b/src/Platforms/Iar/UtestPlatform.cpp
@@ -156,7 +156,6 @@ PlatformSpecificFile (*PlatformSpecificFOpen)(const char*, const char*) = Platfo
 void (*PlatformSpecificFPuts)(const char*, PlatformSpecificFile) = PlatformSpecificFPutsImplementation;
 void (*PlatformSpecificFClose)(PlatformSpecificFile) = PlatformSpecificFCloseImplementation;
 
-int (*PlatformSpecificPutchar)(int) = putchar;
 void (*PlatformSpecificFlush)() = PlatformSpecificFlushImplementation;
 
 void* (*PlatformSpecificMalloc)(size_t size) = malloc;

--- a/src/Platforms/Iar/UtestPlatform.cpp
+++ b/src/Platforms/Iar/UtestPlatform.cpp
@@ -151,6 +151,7 @@ static void PlatformSpecificFlushImplementation()
 {
 }
 
+const PlatformSpecificFile PlatformSpecificStdOut = stdout;
 PlatformSpecificFile (*PlatformSpecificFOpen)(const char*, const char*) = PlatformSpecificFOpenImplementation;
 void (*PlatformSpecificFPuts)(const char*, PlatformSpecificFile) = PlatformSpecificFPutsImplementation;
 void (*PlatformSpecificFClose)(PlatformSpecificFile) = PlatformSpecificFCloseImplementation;

--- a/src/Platforms/Keil/UtestPlatform.cpp
+++ b/src/Platforms/Keil/UtestPlatform.cpp
@@ -160,7 +160,6 @@ extern "C"
     void (*PlatformSpecificFPuts)(const char*, PlatformSpecificFile) = PlatformSpecificFPutsImplementation;
     void (*PlatformSpecificFClose)(PlatformSpecificFile) = PlatformSpecificFCloseImplementation;
 
-    int (*PlatformSpecificPutchar)(int) = putchar;
     void (*PlatformSpecificFlush)() = PlatformSpecificFlushImplementation;
     void* (*PlatformSpecificMalloc)(size_t) = malloc;
     void* (*PlatformSpecificRealloc) (void*, size_t) = realloc;

--- a/src/Platforms/Keil/UtestPlatform.cpp
+++ b/src/Platforms/Keil/UtestPlatform.cpp
@@ -155,6 +155,7 @@ extern "C"
     {
     }
 
+    const PlatformSpecificFile PlatformSpecificStdOut = stdout;
     PlatformSpecificFile (*PlatformSpecificFOpen)(const char*, const char*) = PlatformSpecificFOpenImplementation;
     void (*PlatformSpecificFPuts)(const char*, PlatformSpecificFile) = PlatformSpecificFPutsImplementation;
     void (*PlatformSpecificFClose)(PlatformSpecificFile) = PlatformSpecificFCloseImplementation;

--- a/src/Platforms/Symbian/UtestPlatform.cpp
+++ b/src/Platforms/Symbian/UtestPlatform.cpp
@@ -96,10 +96,6 @@ void PlatformSpecificFlush() {
     fflush(stdout);
 }
 
-int PlatformSpecificPutchar(int c) {
-    return putchar(c);
-}
-
 double PlatformSpecificFabs(double d) {
     return fabs(d);
 }

--- a/src/Platforms/Symbian/UtestPlatform.cpp
+++ b/src/Platforms/Symbian/UtestPlatform.cpp
@@ -125,6 +125,8 @@ void* PlatformSpecificMemset(void* mem, int c, size_t size)
     return memset(mem, c, size);
 }
 
+const PlatformSpecificFile PlatformSpecificStdOut = stdout;
+
 PlatformSpecificFile PlatformSpecificFOpen(const char* filename, const char* flag) {
     return fopen(filename, flag);
 }

--- a/src/Platforms/VisualCpp/UtestPlatform.cpp
+++ b/src/Platforms/VisualCpp/UtestPlatform.cpp
@@ -168,7 +168,6 @@ static void VisualCppFlush()
     fflush(stdout);
 }
 
-int (*PlatformSpecificPutchar)(int c) = putchar;
 void (*PlatformSpecificFlush)(void) = VisualCppFlush;
 
 static void* VisualCppMalloc(size_t size)

--- a/src/Platforms/VisualCpp/UtestPlatform.cpp
+++ b/src/Platforms/VisualCpp/UtestPlatform.cpp
@@ -158,6 +158,7 @@ static void VisualCppFClose(PlatformSpecificFile file)
     fclose((FILE*)file);
 }
 
+const PlatformSpecificFile PlatformSpecificStdOut = stdout;
 PlatformSpecificFile (*PlatformSpecificFOpen)(const char* filename, const char* flag) = VisualCppFOpen;
 void (*PlatformSpecificFPuts)(const char* str, PlatformSpecificFile file) = VisualCppFPuts;
 void (*PlatformSpecificFClose)(PlatformSpecificFile file) = VisualCppFClose;

--- a/src/Platforms/armcc/UtestPlatform.cpp
+++ b/src/Platforms/armcc/UtestPlatform.cpp
@@ -151,7 +151,6 @@ PlatformSpecificFile (*PlatformSpecificFOpen)(const char*, const char*) = Platfo
 void (*PlatformSpecificFPuts)(const char*, PlatformSpecificFile) = PlatformSpecificFPutsImplementation;
 void (*PlatformSpecificFClose)(PlatformSpecificFile) = PlatformSpecificFCloseImplementation;
 
-int (*PlatformSpecificPutchar)(int) = putchar;
 void (*PlatformSpecificFlush)() = PlatformSpecificFlushImplementation;
 
 void* (*PlatformSpecificMalloc)(size_t size) = malloc;

--- a/src/Platforms/armcc/UtestPlatform.cpp
+++ b/src/Platforms/armcc/UtestPlatform.cpp
@@ -146,6 +146,7 @@ static void PlatformSpecificFlushImplementation()
     fflush(stdout);
 }
 
+const PlatformSpecificFile PlatformSpecificStdOut = stdout;
 PlatformSpecificFile (*PlatformSpecificFOpen)(const char*, const char*) = PlatformSpecificFOpenImplementation;
 void (*PlatformSpecificFPuts)(const char*, PlatformSpecificFile) = PlatformSpecificFPutsImplementation;
 void (*PlatformSpecificFClose)(PlatformSpecificFile) = PlatformSpecificFCloseImplementation;

--- a/tests/CppUTest/CommandLineTestRunnerTest.cpp
+++ b/tests/CppUTest/CommandLineTestRunnerTest.cpp
@@ -302,13 +302,12 @@ extern "C" {
     typedef PlatformSpecificFile (*FOpenFunc)(const char*, const char*);
     typedef void (*FPutsFunc)(const char*, PlatformSpecificFile);
     typedef void (*FCloseFunc)(PlatformSpecificFile);
-    typedef int (*PutcharFunc)(int);
 }
 
 struct FakeOutput
 {
     FakeOutput() : SaveFOpen(PlatformSpecificFOpen), SaveFPuts(PlatformSpecificFPuts),
-        SaveFClose(PlatformSpecificFClose), SavePutchar(PlatformSpecificPutchar)
+        SaveFClose(PlatformSpecificFClose)
     {
         installFakes();
         currentFake = this;
@@ -325,12 +324,10 @@ struct FakeOutput
         PlatformSpecificFOpen = (FOpenFunc)fopen_fake;
         PlatformSpecificFPuts = (FPutsFunc)fputs_fake;
         PlatformSpecificFClose = (FCloseFunc)fclose_fake;
-        PlatformSpecificPutchar = (PutcharFunc)putchar_fake;
     }
 
     void restoreOriginals()
     {
-        PlatformSpecificPutchar = SavePutchar;
         PlatformSpecificFOpen = SaveFOpen;
         PlatformSpecificFPuts = SaveFPuts;
         PlatformSpecificFClose = SaveFClose;
@@ -355,12 +352,6 @@ struct FakeOutput
     {
     }
 
-    static int putchar_fake(int c)
-    {
-        currentFake->console += StringFrom((char)c);
-        return c;
-    }
-
     SimpleString file;
     SimpleString console;
 
@@ -369,7 +360,6 @@ private:
     FOpenFunc SaveFOpen;
     FPutsFunc SaveFPuts;
     FCloseFunc SaveFClose;
-    PutcharFunc SavePutchar;
 };
 
 FakeOutput* FakeOutput::currentFake = NULLPTR;

--- a/tests/CppUTest/CommandLineTestRunnerTest.cpp
+++ b/tests/CppUTest/CommandLineTestRunnerTest.cpp
@@ -341,9 +341,14 @@ struct FakeOutput
         return (PlatformSpecificFile) NULLPTR;
     }
 
-    static void fputs_fake(const char* str, PlatformSpecificFile)
+    static void fputs_fake(const char* str, PlatformSpecificFile f)
     {
-        currentFake->file += str;
+        if (f == PlatformSpecificStdOut) {
+            currentFake->console += str;
+        }
+        else {
+            currentFake->file += str;
+        }
     }
 
     static void fclose_fake(PlatformSpecificFile)


### PR DESCRIPTION
When semihosting, repeatedly calling `fputs` for each character drives very high syscall overhead.

Since this was the only use of `PlatformSpecificPutchar`, I've removed it entirely.