### PR TITLE
Omit tests from coverage

### DIFF
--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -44,7 +44,9 @@ jobs:
       - name: Test
         run: ctest --test-dir cpputest_build
       - name: Coverage
-        run: lcov --capture --directory . --no-external --output-file lcov.info
+        run: |
+          lcov --capture --directory . --no-external --output-file lcov.info
+          lcov --remove lcov.info --output-file lcov.info '*/tests/*'
       - name: Coveralls
         uses: coverallsapp/github-action@master
         with:


### PR DESCRIPTION
This is in line with behavior from before CI broke: https://coveralls.io/builds/44525666