### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,13 +64,9 @@ TEST(FirstTestGroup, FirstTest)
 
 You can build and install cpputest using [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
 
-* git clone https://github.com/Microsoft/vcpkg.git
-* cd vcpkg
-* ./bootstrap-vcpkg.sh  # ./bootstrap-vcpkg.bat for Windows
-* ./vcpkg integrate install
-* ./vcpkg install cpputest
-
-The cpputest port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+```console
+$ vcpkg install cpputest (More information: https://github.com/microsoft/vcpkg)
+```
 
 
 ## Command line switches

--- a/README.md
+++ b/README.md
@@ -62,6 +62,17 @@ TEST(FirstTestGroup, FirstTest)
 }
 ```
 
+You can build and install cpputest using [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
+
+* git clone https://github.com/Microsoft/vcpkg.git
+* cd vcpkg
+* ./bootstrap-vcpkg.sh  # ./bootstrap-vcpkg.bat for Windows
+* ./vcpkg integrate install
+* ./vcpkg install cpputest
+
+The cpputest port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
+
 ## Command line switches
 
 * -h help, shows the latest help, including the parameters we've implemented after updating this README page.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ You can build and install cpputest using [vcpkg](https://github.com/Microsoft/vc
 $ vcpkg install cpputest (More information: https://github.com/microsoft/vcpkg)
 ```
 
-
 ## Command line switches
 
 * -h help, shows the latest help, including the parameters we've implemented after updating this README page.


### PR DESCRIPTION
Cpputest is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for cpputest and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build cpputest, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/cpputest/portfile.cmake). We try to keep the library maintained as close as possible to the original library.