### PR TITLE
Fix QEMU compabiltity

### DIFF
--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -139,15 +139,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@main
       - uses: carlosperate/arm-none-eabi-gcc-action@v1
-      - name: Install QEMU
-        run: sudo apt-get install -y --no-install-recommends qemu-user-static
       - name: Configure
         run: >
           cmake
           -B cpputest_build
           -D CMAKE_TOOLCHAIN_FILE=cmake/arm-none-eabi-gcc.toolchain.cmake
-          -D CMAKE_CROSSCOMPILING_EMULATOR="qemu-user-static;-cpu;cortex-m4"
       - name: Build
         run: cmake --build cpputest_build
       - name: Test
+        # This won't do anything, because there is no way to run the tests.
         run: ctest --test-dir cpputest_build

--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -139,13 +139,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@main
       - uses: carlosperate/arm-none-eabi-gcc-action@v1
+      - name: Install QEMU
+        run: sudo apt-get install -y --no-install-recommends qemu-user-static
       - name: Configure
         run: >
           cmake
           -B cpputest_build
           -D CMAKE_TOOLCHAIN_FILE=cmake/arm-none-eabi-gcc.toolchain.cmake
+          -D CMAKE_CROSSCOMPILING_EMULATOR="qemu-user-static;-cpu;cortex-m4"
       - name: Build
         run: cmake --build cpputest_build
       - name: Test
-        # This won't do anything, because there is no way to run the tests.
         run: ctest --test-dir cpputest_build

--- a/cmake/arm-none-eabi-gcc.toolchain.cmake
+++ b/cmake/arm-none-eabi-gcc.toolchain.cmake
@@ -5,4 +5,4 @@ set(CMAKE_C_COMPILER arm-none-eabi-gcc)
 
 set(CMAKE_C_FLAGS_INIT "-mcpu=cortex-m4")
 set(CMAKE_CXX_FLAGS_INIT "-mcpu=cortex-m4")
-set(CMAKE_EXE_LINKER_FLAGS_INIT "-specs=nano.specs -specs=rdimon.specs")
+set(CMAKE_EXE_LINKER_FLAGS_INIT "-specs=rdimon.specs")


### PR DESCRIPTION
This lets tests for ARM/GCC run with `-DCMAKE_CROSSCOMPILING_EMULATOR=qemu-arm-static;-cpu;cortex-m4`.

I can run this locally with qemu-arm v7.1, but the version of the `qemu-user-static` package available in CI (6.2 from Ubuntu) does not pass command line arguments to the executable.