### PR TITLE
Fix strict prototypes of Clang 15

### DIFF
--- a/examples/ApplicationLib/hello.c
+++ b/examples/ApplicationLib/hello.c
@@ -28,7 +28,7 @@
 #include <stdio.h>
 #include "hello.h"
 
-void printHelloWorld()
+void printHelloWorld(void)
 {
     PrintFormated("Hello World!\n");
 }

--- a/include/CppUTest/TestHarness_c.h
+++ b/include/CppUTest/TestHarness_c.h
@@ -141,19 +141,19 @@
 /* For use in C file */
 #define TEST_GROUP_C_SETUP(group_name) \
     extern void group_##group_name##_setup_wrapper_c(void); \
-    void group_##group_name##_setup_wrapper_c()
+    void group_##group_name##_setup_wrapper_c(void)
 
 #define TEST_GROUP_C_TEARDOWN(group_name) \
     extern void group_##group_name##_teardown_wrapper_c(void); \
-    void group_##group_name##_teardown_wrapper_c()
+    void group_##group_name##_teardown_wrapper_c(void)
 
 #define TEST_C(group_name, test_name) \
     extern void test_##group_name##_##test_name##_wrapper_c(void);\
-    void test_##group_name##_##test_name##_wrapper_c()
+    void test_##group_name##_##test_name##_wrapper_c(void)
 
 #define IGNORE_TEST_C(group_name, test_name) \
     extern void ignore_##group_name##_##test_name##_wrapper_c(void);\
-    void ignore_##group_name##_##test_name##_wrapper_c()
+    void ignore_##group_name##_##test_name##_wrapper_c(void)
 
 
 /* For use in C++ file */

--- a/tests/CppUTest/AllocationInCFile.c
+++ b/tests/CppUTest/AllocationInCFile.c
@@ -4,12 +4,12 @@
 
 /* This file is for simulating overloads of malloc */
 
-char* mallocAllocation()
+char* mallocAllocation(void)
 {
     return (char*) malloc(10UL);
 }
 
-char* strdupAllocation()
+char* strdupAllocation(void)
 {
 #ifdef CPPUTEST_USE_STRDUP_MACROS
     return strdup("0123456789");
@@ -19,7 +19,7 @@ char* strdupAllocation()
 }
 
 
-char* strndupAllocation()
+char* strndupAllocation(void)
 {
 #ifdef CPPUTEST_USE_STRDUP_MACROS
     return strndup("0123456789", 10);

--- a/tests/CppUTestExt/IEEE754PluginTest_c.c
+++ b/tests/CppUTestExt/IEEE754PluginTest_c.c
@@ -58,7 +58,7 @@ void set_nothing_c(void)
 {
 }
 
-void set_everything_c()
+void set_everything_c(void)
 {
     set_divisionbyzero_c();
     set_overflow_c();


### PR DESCRIPTION
Add missing `void`s to C functions.