### PR TITLE
Remove `CPPUTEST_LIBNAME_POSTFIX_DEBUG`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,8 +70,6 @@ option(CPPUTEST_VERBOSE_CONFIG "Print configuration to stdout during generation"
 
 cmake_dependent_option(CPPUTEST_LIBNAME_POSTFIX_BITSIZE "Add architecture bitsize (32/64) to the library name?"
   OFF "PROJECT_IS_TOP_LEVEL" OFF)
-cmake_dependent_option(CPPUTEST_LIBNAME_POSTFIX_DEBUG "Add indication of debug compilation to the library name?"
-  OFF "PROJECT_IS_TOP_LEVEL" OFF)
 
 include(CheckCXXSymbolExists)
 check_cxx_symbol_exists(fopen_s "stdio.h" CPPUTEST_HAVE_SECURE_STDLIB)
@@ -271,7 +269,6 @@ Features configured in CppUTest:
 
 Library name options:
     Add architecture bitsize (32/64)    ${CPPUTEST_LIBNAME_POSTFIX_BITSIZE}
-    Add debug compilation indicator     ${CPPUTEST_LIBNAME_POSTFIX_DEBUG}
 
 -------------------------------------------------------
 ")

--- a/src/CppUTest/CMakeLists.txt
+++ b/src/CppUTest/CMakeLists.txt
@@ -47,10 +47,6 @@ add_library(${CppUTestLibName}
         ${PROJECT_SOURCE_DIR}/include/CppUTest/SimpleMutex.h
 )
 
-if(CPPUTEST_LIBNAME_POSTFIX_DEBUG)
-    set_target_properties(${CppUTestLibName} PROPERTIES DEBUG_POSTFIX "d")
-endif()
-
 #[[Set CPP_PLATFORM in a parent CMakeLists.txt if reusing one of the provided platforms, else supply the missing definitions]]
 if (CPP_PLATFORM)
     target_sources(${CppUTestLibName}

--- a/src/CppUTestExt/CMakeLists.txt
+++ b/src/CppUTestExt/CMakeLists.txt
@@ -39,10 +39,6 @@ add_library(${CppUTestExtLibName} STATIC
 
 target_link_libraries(${CppUTestExtLibName} PUBLIC ${CppUTestLibName})
 
-if(CPPUTEST_LIBNAME_POSTFIX_DEBUG)
-    set_target_properties(${CppUTestExtLibName} PROPERTIES DEBUG_POSTFIX "d")
-endif()
-
 #[[Arrange for the include directory to be added to the include paths of any CMake target depending on CppUTestExt.]]
 target_include_directories(${CppUTestExtLibName}
     PUBLIC


### PR DESCRIPTION
This duplicates the natively supported [`CMAKE_DEBUG_POSTFIX`](https://cmake.org/cmake/help/latest/variable/CMAKE_DEBUG_POSTFIX.html).