### PR TITLE
Avoid trying to set downstream users' global flags.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ endif()
 
 cmake_dependent_option(CPPUTEST_STD_CPP_LIB_DISABLED "Use the standard C++ library"
   OFF "NOT CPPUTEST_STD_C_LIB_DISABLED;CPPUTEST_HAVE_EXCEPTIONS" ON)
-option(CPPUTEST_FLAGS "Use the CFLAGS/CXXFLAGS/LDFLAGS set by CppUTest" ON)
+option(CPPUTEST_FLAGS "Use the CFLAGS/CXXFLAGS/LDFLAGS set by CppUTest" ${PROJECT_IS_TOP_LEVEL})
 cmake_dependent_option(CPPUTEST_MEM_LEAK_DETECTION_DISABLED "Enable memory leak detection"
   OFF "NOT BORLAND;NOT CPPUTEST_STD_C_LIB_DISABLED;NOT is_clang_cl" ON)
 option(CPPUTEST_EXTENSIONS "Use the CppUTest extension library" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ cmake_dependent_option(CPPUTEST_STD_CPP_LIB_DISABLED "Use the standard C++ libra
   OFF "NOT CPPUTEST_STD_C_LIB_DISABLED;CPPUTEST_HAVE_EXCEPTIONS" ON)
 option(CPPUTEST_FLAGS "Use the CFLAGS/CXXFLAGS/LDFLAGS set by CppUTest" ${PROJECT_IS_TOP_LEVEL})
 cmake_dependent_option(CPPUTEST_MEM_LEAK_DETECTION_DISABLED "Enable memory leak detection"
-  OFF "NOT BORLAND;NOT CPPUTEST_STD_C_LIB_DISABLED;NOT is_clang_cl" ON)
+  OFF "CPPUTEST_FLAGS;NOT BORLAND;NOT CPPUTEST_STD_C_LIB_DISABLED;NOT is_clang_cl" ON)
 option(CPPUTEST_EXTENSIONS "Use the CppUTest extension library" ON)
 
 include(CheckTypeSize)
@@ -52,12 +52,12 @@ cmake_dependent_option(CPPUTEST_USE_LONG_LONG "Support long long"
   YES "HAVE_SIZEOF_LONGLONG" OFF)
 
 cmake_dependent_option(CPPUTEST_MAP_FILE "Enable the creation of a map file"
-  OFF "NOT MSVC" OFF)
+  OFF "CPPUTEST_FLAGS;NOT MSVC" OFF)
 cmake_dependent_option(CPPUTEST_COVERAGE "Enable running with coverage"
-  OFF "NOT MSVC" OFF)
+  OFF "CPPUTEST_FLAGS;NOT MSVC" OFF)
 cmake_dependent_option(CPPUTEST_WERROR
   "Compile with warnings as errors"
-  ON "PROJECT_IS_TOP_LEVEL" OFF
+  ON "CPPUTEST_FLAGS;PROJECT_IS_TOP_LEVEL" OFF
 )
 cmake_dependent_option(CPPUTEST_BUILD_TESTING "Compile and make tests for CppUTest"
   ${PROJECT_IS_TOP_LEVEL} "BUILD_TESTING" OFF)


### PR DESCRIPTION
This didn't actually work anyway; non-cache variables are scoped to the directory in which they are set. I think CMake support for memory leak detection needs some dedicated attention, but this at least avoids surprising users with unexpected flags and broken features.