### PR TITLE
Drop confusing *LibName variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,8 +51,6 @@ cmake_dependent_option(CPPUTEST_TEST_GTEST "Test GoogleTest integration"
   OFF "CPPUTEST_BUILD_TESTING" OFF)
 cmake_dependent_option(CPPUTEST_EXAMPLES "Compile and make examples?"
   ${PROJECT_IS_TOP_LEVEL} "CPPUTEST_EXTENSIONS;NOT CPPUTEST_STD_CPP_LIB_DISABLED" OFF)
-cmake_dependent_option(CPPUTEST_LIBNAME_POSTFIX_BITSIZE "Add architecture bitsize (32/64) to the library name?"
-  OFF "PROJECT_IS_TOP_LEVEL" OFF)
 
 if(NOT DEFINED CPPUTEST_PLATFORM)
   if(DEFINED CPP_PLATFORM)
@@ -92,19 +90,6 @@ check_cxx_symbol_exists(fopen_s "stdio.h" CPPUTEST_HAVE_SECURE_STDLIB)
 cmake_dependent_option(CPPUTEST_USE_SECURE_STDLIB "Use MSVC safe functions"
   ON "WIN32;CPPUTEST_HAVE_SECURE_STDLIB" OFF)
 
-set( CppUTestLibName "CppUTest" )
-set( CppUTestExtLibName "CppUTestExt" )
-
-if(CPPUTEST_LIBNAME_POSTFIX_BITSIZE)
-  if( "${CMAKE_SIZEOF_VOID_P}" STREQUAL "8" )
-      set( CppUTestLibName "${CppUTestLibName}64" )
-      set( CppUTestExtLibName "${CppUTestExtLibName}64" )
-  elseif( "${CMAKE_SIZEOF_VOID_P}" STREQUAL "4" )
-      set( CppUTestLibName "${CppUTestLibName}32" )
-      set( CppUTestExtLibName "${CppUTestExtLibName}32" )
-  endif()
-endif()
-
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules")
 if(NOT PROJECT_IS_TOP_LEVEL)
   set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" PARENT_SCOPE)
@@ -139,11 +124,11 @@ configure_file (
 
 add_subdirectory(src)
 
-target_include_directories(${CppUTestLibName}
+target_include_directories(CppUTest
     PUBLIC
         $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
 )
-target_compile_definitions(${CppUTestLibName}
+target_compile_definitions(CppUTest
   PUBLIC
     HAVE_CONFIG_H
 )

--- a/src/CppUTest/CMakeLists.txt
+++ b/src/CppUTest/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(${CppUTestLibName}
+add_library(CppUTest
         CommandLineArguments.cpp
         MemoryLeakWarningPlugin.cpp
         TestHarness_c.cpp
@@ -49,11 +49,11 @@ add_library(${CppUTestLibName}
 
 #[[Set CPPUTEST_PLATFORM in a parent CMakeLists.txt if reusing one of the provided platforms, else supply the missing definitions]]
 if(CPPUTEST_PLATFORM)
-    target_sources(${CppUTestLibName}
+    target_sources(CppUTest
         PRIVATE
             ${CMAKE_CURRENT_LIST_DIR}/../Platforms/${CPPUTEST_PLATFORM}/UtestPlatform.cpp
     )
-    target_include_directories(${CppUTestLibName}
+    target_include_directories(CppUTest
         PUBLIC
             $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/../../include/Platforms/${CPPUTEST_PLATFORM}>
     )
@@ -65,13 +65,13 @@ if (MINGW)
 endif()
 
 #[[Arrange for the include directory to be added to the include paths of any CMake target depending on CppUTest.]]
-target_include_directories(${CppUTestLibName}
+target_include_directories(CppUTest
     PUBLIC
         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
-target_compile_definitions(${CppUTestLibName}
+target_compile_definitions(CppUTest
     PRIVATE
         $<$<BOOL:${CPPUTEST_USE_SECURE_STDLIB}>:STDC_WANT_SECURE_LIB>
         # Apply workaround for MinGW timespec redefinition (pthread.h / time.h).
@@ -81,13 +81,13 @@ target_compile_definitions(${CppUTestLibName}
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads)
 
-target_link_libraries(${CppUTestLibName}
+target_link_libraries(CppUTest
     PRIVATE
         $<$<BOOL:${WIN32}>:winmm>
         $<$<BOOL:${CMAKE_USE_PTHREADS_INIT}>:${CMAKE_THREAD_LIBS_INIT}>
 )
 
-add_library(CppUTest::CppUTest ALIAS ${CppUTestLibName})
+add_library(CppUTest::CppUTest ALIAS CppUTest)
 
 if(NOT CPPUTEST_MEM_LEAK_DETECTION_DISABLED)
     if(MSVC)
@@ -97,7 +97,7 @@ if(NOT CPPUTEST_MEM_LEAK_DETECTION_DISABLED)
     else()
         set(force_include "-include")
     endif()
-    target_compile_options(${CppUTestLibName}
+    target_compile_options(CppUTest
         PUBLIC
             "$<$<COMPILE_LANGUAGE:C,CXX>:${force_include}CppUTest/MemoryLeakDetectorMallocMacros.h>"
             "$<$<COMPILE_LANGUAGE:CXX>:${force_include}CppUTest/MemoryLeakDetectorNewMacros.h>"
@@ -107,7 +107,7 @@ endif()
 # Installation
 if(PROJECT_IS_TOP_LEVEL)
     install(
-        TARGETS ${CppUTestLibName}
+        TARGETS CppUTest
         EXPORT CppUTestTargets
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/src/CppUTestExt/CMakeLists.txt
+++ b/src/CppUTestExt/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(${CppUTestExtLibName} STATIC
+add_library(CppUTestExt STATIC
     CodeMemoryReportFormatter.cpp
     GTest.cpp
     IEEE754ExceptionsPlugin.cpp
@@ -37,20 +37,20 @@ add_library(${CppUTestExtLibName} STATIC
     ${PROJECT_SOURCE_DIR}/include/CppUTestExt/MockSupport.h
 )
 
-target_link_libraries(${CppUTestExtLibName} PUBLIC ${CppUTestLibName})
+target_link_libraries(CppUTestExt PUBLIC CppUTest)
 
 #[[Arrange for the include directory to be added to the include paths of any CMake target depending on CppUTestExt.]]
-target_include_directories(${CppUTestExtLibName}
+target_include_directories(CppUTestExt
     PUBLIC
         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
-add_library(CppUTest::CppUTestExt ALIAS ${CppUTestExtLibName})
+add_library(CppUTest::CppUTestExt ALIAS CppUTestExt)
 
 if(PROJECT_IS_TOP_LEVEL)
     install(
-        TARGETS ${CppUTestExtLibName}
+        TARGETS CppUTestExt
         EXPORT CppUTestTargets
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/tests/CppUTest/CMakeLists.txt
+++ b/tests/CppUTest/CMakeLists.txt
@@ -43,7 +43,7 @@ if(CPPUTEST_STD_C_LIB_DISABLED)
     )
 endif()
 
-target_link_libraries(CppUTestTests PRIVATE ${CppUTestLibName})
+target_link_libraries(CppUTestTests PRIVATE CppUTest)
 
 add_mapfile(CppUTestTests)
 

--- a/tests/CppUTestExt/CMakeLists.txt
+++ b/tests/CppUTestExt/CMakeLists.txt
@@ -62,8 +62,8 @@ endif()
 
 target_link_libraries(CppUTestExtTests
     PRIVATE
-        ${CppUTestLibName}
-        ${CppUTestExtLibName}
+        CppUTest
+        CppUTestExt
 )
 
 add_mapfile(CppUTestExtTests)


### PR DESCRIPTION
These make the code very confusing and I cannot understand the use case. Multiple architectures cannot exist in the same CMake project. When installing, multiple architectures should probably be installed to different locations, not have different names. The native [`CMAKE_<CONFIG>_POSTFIX`](https://cmake.org/cmake/help/latest/variable/CMAKE_CONFIG_POSTFIX.html) variable can be used to append arbitrary suffixes to installed libraries.

This removes changes from #1538. I may not have all the context here. So I'd appreciate any insight @jgonzalezdr has on what this was originally intended to support.