### PR TITLE
Fix leak detection with CMake

### DIFF
--- a/cmake/Modules/CppUTestConfigurationOptions.cmake
+++ b/cmake/Modules/CppUTestConfigurationOptions.cmake
@@ -1,18 +1,3 @@
-if (NOT CPPUTEST_MEM_LEAK_DETECTION_DISABLED)
-    if (MSVC)
-        set(CPPUTEST_C_FLAGS "${CPPUTEST_C_FLAGS} /FI \"${CppUTest_SOURCE_DIR}/include/CppUTest/MemoryLeakDetectorMallocMacros.h\"")
-        set(CPPUTEST_CXX_FLAGS "${CPPUTEST_CXX_FLAGS} /FI \"${CppUTest_SOURCE_DIR}/include/CppUTest/MemoryLeakDetectorMallocMacros.h\"")
-    elseif (CMAKE_CXX_COMPILER_ID STREQUAL "IAR")
-        set(CPPUTEST_C_FLAGS "${CPPUTEST_C_FLAGS} --preinclude \"${CppUTest_SOURCE_DIR}/include/CppUTest/MemoryLeakDetectorMallocMacros.h\"")
-        set(CPPUTEST_CXX_FLAGS "${CPPUTEST_CXX_FLAGS} --preinclude \"${CppUTest_SOURCE_DIR}/include/CppUTest/MemoryLeakDetectorNewMacros.h\"")
-        set(CPPUTEST_CXX_FLAGS "${CPPUTEST_CXX_FLAGS} --preinclude \"${CppUTest_SOURCE_DIR}/include/CppUTest/MemoryLeakDetectorMallocMacros.h\"")
-    else (MSVC)
-        set(CPPUTEST_C_FLAGS "${CPPUTEST_C_FLAGS} -include \"${CppUTest_SOURCE_DIR}/include/CppUTest/MemoryLeakDetectorMallocMacros.h\"")
-        set(CPPUTEST_CXX_FLAGS "${CPPUTEST_CXX_FLAGS} -include \"${CppUTest_SOURCE_DIR}/include/CppUTest/MemoryLeakDetectorNewMacros.h\"")
-        set(CPPUTEST_CXX_FLAGS "${CPPUTEST_CXX_FLAGS} -include \"${CppUTest_SOURCE_DIR}/include/CppUTest/MemoryLeakDetectorMallocMacros.h\"")
-    endif (MSVC)
-endif ()
-
 set(GMOCK_HOME $ENV{GMOCK_HOME})
 if (DEFINED ENV{GMOCK_HOME})
     # GMock pulls in gtest.

--- a/src/CppUTest/CMakeLists.txt
+++ b/src/CppUTest/CMakeLists.txt
@@ -84,6 +84,22 @@ endif (WIN32)
 
 add_library(CppUTest::CppUTest ALIAS ${CppUTestLibName})
 
+if(NOT CPPUTEST_MEM_LEAK_DETECTION_DISABLED)
+    if(MSVC)
+        set(force_include "/FI")
+    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "IAR")
+        set(force_include "--preinclude ")
+    else()
+        set(force_include "-include")
+    endif()
+    target_compile_options(${CppUTestLibName}
+        PUBLIC
+            "$<$<COMPILE_LANGUAGE:C,CXX>:${force_include}CppUTest/MemoryLeakDetectorMallocMacros.h>"
+            "$<$<COMPILE_LANGUAGE:CXX>:${force_include}CppUTest/MemoryLeakDetectorNewMacros.h>"
+    )
+endif()
+
+# Installation
 if(PROJECT_IS_TOP_LEVEL)
     install(
         TARGETS ${CppUTestLibName}


### PR DESCRIPTION
Variables do not propagate outside a CMake project; settings have to be attached to targets. This moves the force include flags from the global variables (that never exit the project) to the `CppUTest::CppUTest` target so that anything that links to it will get the includes.