### PR TITLE
Improve performance of CHECK_COMPARE_LOCATION.

### DIFF
--- a/include/CppUTest/UtestMacros.h
+++ b/include/CppUTest/UtestMacros.h
@@ -153,11 +153,15 @@
   CHECK_COMPARE_LOCATION(first, relop, second, text, __FILE__, __LINE__)
 
 #define CHECK_COMPARE_LOCATION(first, relop, second, text, file, line)\
- do { SimpleString conditionString;\
-      conditionString += StringFrom(first); conditionString += " ";\
-      conditionString += #relop; conditionString += " ";\
-      conditionString += StringFrom(second);\
-      UtestShell::getCurrent()->assertCompare((first) relop (second), "CHECK_COMPARE", conditionString.asCharString(), text, __FILE__, __LINE__);\
+ do {\
+      bool success = (first) relop (second);\
+      if (!success) {\
+          SimpleString conditionString;\
+          conditionString += StringFrom(first); conditionString += " ";\
+          conditionString += #relop; conditionString += " ";\
+          conditionString += StringFrom(second);\
+          UtestShell::getCurrent()->assertCompare(false, "CHECK_COMPARE", conditionString.asCharString(), text, __FILE__, __LINE__);\
+      }\
  } while(0)
 
 //This check checks for char* string equality using strcmp.


### PR DESCRIPTION
Improve performance of CHECK_COMPARE_LOCATION by moving comparison result check above the SimpleString instantiation.

Performance drop of the test suite will occur if CHECK_COMPARE_LOCATION() is called inside some tight loop which is checking many multiple variants of values. SimpleString instantiation and filling with error message takes time and in case of a large loop may block execution for a long time. Proposed improvement eliminates this problem while keeping logic of the check intact.