### PR TITLE
Allow redirection of PlatformSpecificStdOut.

### DIFF
--- a/include/CppUTest/PlatformSpecificFunctions_c.h
+++ b/include/CppUTest/PlatformSpecificFunctions_c.h
@@ -62,7 +62,7 @@ extern int (*PlatformSpecificAtExit)(void(*func)(void));
 /* IO operations */
 typedef void* PlatformSpecificFile;
 
-extern const PlatformSpecificFile PlatformSpecificStdOut;
+extern PlatformSpecificFile PlatformSpecificStdOut;
 
 extern PlatformSpecificFile (*PlatformSpecificFOpen)(const char* filename, const char* flag);
 extern void (*PlatformSpecificFPuts)(const char* str, PlatformSpecificFile file);

--- a/src/Platforms/Borland/UtestPlatform.cpp
+++ b/src/Platforms/Borland/UtestPlatform.cpp
@@ -246,7 +246,7 @@ static void PlatformSpecificFlushImplementation()
   fflush(stdout);
 }
 
-const PlatformSpecificFile PlatformSpecificStdOut = stdout;
+PlatformSpecificFile PlatformSpecificStdOut = stdout;
 PlatformSpecificFile (*PlatformSpecificFOpen)(const char*, const char*) = PlatformSpecificFOpenImplementation;
 void (*PlatformSpecificFPuts)(const char*, PlatformSpecificFile) = PlatformSpecificFPutsImplementation;
 void (*PlatformSpecificFClose)(PlatformSpecificFile) = PlatformSpecificFCloseImplementation;

--- a/src/Platforms/C2000/UtestPlatform.cpp
+++ b/src/Platforms/C2000/UtestPlatform.cpp
@@ -155,7 +155,7 @@ static void C2000FClose(PlatformSpecificFile file)
    fclose((FILE*)file);
 }
 
-const PlatformSpecificFile PlatformSpecificStdOut = stdout;
+PlatformSpecificFile PlatformSpecificStdOut = stdout;
 PlatformSpecificFile (*PlatformSpecificFOpen)(const char* filename, const char* flag) = C2000FOpen;
 void (*PlatformSpecificFPuts)(const char* str, PlatformSpecificFile file) = C2000FPuts;
 void (*PlatformSpecificFClose)(PlatformSpecificFile file) = C2000FClose;

--- a/src/Platforms/Dos/UtestPlatform.cpp
+++ b/src/Platforms/Dos/UtestPlatform.cpp
@@ -138,7 +138,7 @@ static void DosFClose(PlatformSpecificFile file)
    fclose((FILE*)file);
 }
 
-const PlatformSpecificFile PlatformSpecificStdOut = stdout;
+PlatformSpecificFile PlatformSpecificStdOut = stdout;
 PlatformSpecificFile (*PlatformSpecificFOpen)(const char* filename, const char* flag) = DosFOpen;
 void (*PlatformSpecificFPuts)(const char* str, PlatformSpecificFile file) = DosFPuts;
 void (*PlatformSpecificFClose)(PlatformSpecificFile file) = DosFClose;

--- a/src/Platforms/Gcc/UtestPlatform.cpp
+++ b/src/Platforms/Gcc/UtestPlatform.cpp
@@ -264,7 +264,7 @@ static void PlatformSpecificFlushImplementation()
   fflush(stdout);
 }
 
-const PlatformSpecificFile PlatformSpecificStdOut = stdout;
+PlatformSpecificFile PlatformSpecificStdOut = stdout;
 
 PlatformSpecificFile (*PlatformSpecificFOpen)(const char*, const char*) = PlatformSpecificFOpenImplementation;
 void (*PlatformSpecificFPuts)(const char*, PlatformSpecificFile) = PlatformSpecificFPutsImplementation;

--- a/src/Platforms/GccNoStdC/UtestPlatform.cpp
+++ b/src/Platforms/GccNoStdC/UtestPlatform.cpp
@@ -52,7 +52,7 @@ long (*GetPlatformSpecificTimeInMillis)() = NULLPTR;
 const char* (*GetPlatformSpecificTimeString)() = NULLPTR;
 
 /* IO operations */
-const PlatformSpecificFile PlatformSpecificStdOut = NULLPTR;
+PlatformSpecificFile PlatformSpecificStdOut = NULLPTR;
 PlatformSpecificFile (*PlatformSpecificFOpen)(const char* filename, const char* flag) = NULLPTR;
 void (*PlatformSpecificFPuts)(const char* str, PlatformSpecificFile file) = NULLPTR;
 void (*PlatformSpecificFClose)(PlatformSpecificFile file) = NULLPTR;

--- a/src/Platforms/Iar/UtestPlatform.cpp
+++ b/src/Platforms/Iar/UtestPlatform.cpp
@@ -151,7 +151,7 @@ static void PlatformSpecificFlushImplementation()
 {
 }
 
-const PlatformSpecificFile PlatformSpecificStdOut = stdout;
+PlatformSpecificFile PlatformSpecificStdOut = stdout;
 PlatformSpecificFile (*PlatformSpecificFOpen)(const char*, const char*) = PlatformSpecificFOpenImplementation;
 void (*PlatformSpecificFPuts)(const char*, PlatformSpecificFile) = PlatformSpecificFPutsImplementation;
 void (*PlatformSpecificFClose)(PlatformSpecificFile) = PlatformSpecificFCloseImplementation;

--- a/src/Platforms/Keil/UtestPlatform.cpp
+++ b/src/Platforms/Keil/UtestPlatform.cpp
@@ -155,7 +155,7 @@ extern "C"
     {
     }
 
-    const PlatformSpecificFile PlatformSpecificStdOut = stdout;
+    PlatformSpecificFile PlatformSpecificStdOut = stdout;
     PlatformSpecificFile (*PlatformSpecificFOpen)(const char*, const char*) = PlatformSpecificFOpenImplementation;
     void (*PlatformSpecificFPuts)(const char*, PlatformSpecificFile) = PlatformSpecificFPutsImplementation;
     void (*PlatformSpecificFClose)(PlatformSpecificFile) = PlatformSpecificFCloseImplementation;

--- a/src/Platforms/Symbian/UtestPlatform.cpp
+++ b/src/Platforms/Symbian/UtestPlatform.cpp
@@ -121,7 +121,7 @@ void* PlatformSpecificMemset(void* mem, int c, size_t size)
     return memset(mem, c, size);
 }
 
-const PlatformSpecificFile PlatformSpecificStdOut = stdout;
+PlatformSpecificFile PlatformSpecificStdOut = stdout;
 
 PlatformSpecificFile PlatformSpecificFOpen(const char* filename, const char* flag) {
     return fopen(filename, flag);

--- a/src/Platforms/VisualCpp/UtestPlatform.cpp
+++ b/src/Platforms/VisualCpp/UtestPlatform.cpp
@@ -158,7 +158,7 @@ static void VisualCppFClose(PlatformSpecificFile file)
     fclose((FILE*)file);
 }
 
-const PlatformSpecificFile PlatformSpecificStdOut = stdout;
+PlatformSpecificFile PlatformSpecificStdOut = stdout;
 PlatformSpecificFile (*PlatformSpecificFOpen)(const char* filename, const char* flag) = VisualCppFOpen;
 void (*PlatformSpecificFPuts)(const char* str, PlatformSpecificFile file) = VisualCppFPuts;
 void (*PlatformSpecificFClose)(PlatformSpecificFile file) = VisualCppFClose;

--- a/src/Platforms/armcc/UtestPlatform.cpp
+++ b/src/Platforms/armcc/UtestPlatform.cpp
@@ -146,7 +146,7 @@ static void PlatformSpecificFlushImplementation()
     fflush(stdout);
 }
 
-const PlatformSpecificFile PlatformSpecificStdOut = stdout;
+PlatformSpecificFile PlatformSpecificStdOut = stdout;
 PlatformSpecificFile (*PlatformSpecificFOpen)(const char*, const char*) = PlatformSpecificFOpenImplementation;
 void (*PlatformSpecificFPuts)(const char*, PlatformSpecificFile) = PlatformSpecificFPutsImplementation;
 void (*PlatformSpecificFClose)(PlatformSpecificFile) = PlatformSpecificFCloseImplementation;


### PR DESCRIPTION
When putchar support was dropped by 80d807c1de79ee7307beae923ba2ad382bd17cd5 commit it became impossible to redirect log output to some arbitrary logging function without removing the `const` specifier of `PlatformSpecificStdOut`.

Consider the following usage example (pseudocode):
```cpp
static void LogRedirectorPuts(const char* str, PlatformSpecificFile file)
{
#ifdef _UTEST_IMMEDIATE_LOG
    Log.Warning("%s", str);
#else
    ((std::string *)file)->append(str);
#endif
}

static void RunTests()
{
    std::string log_buffer;

    PlatformSpecificStdOut = &log_buffer;
    PlatformSpecificFPuts  = LogRedirectorPuts;

    char **tmp = NULL;
    int result = RUN_ALL_TESTS(0, tmp);

    if (result != 0)
    {	
        Log.ErrorSrc(TEST_LOG, "failure:\n--//--\n%s--//--", log_buffer.c_str());
    }
    else
    {
        Log.VerboseSrc(TEST_LOG, "success:\n--//--\n%s--//--", log_buffer.c_str());
    }

    PlatformSpecificStdOut = NULL;
}
```

This PR makes log redirection possible again and drops `const` specifier of `PlatformSpecificStdOut` for all platform implementations.