### PR TITLE
Keep C++98 compatibility macros out of C

### DIFF
--- a/include/CppUTest/CppUTestConfig.h
+++ b/include/CppUTest/CppUTestConfig.h
@@ -316,29 +316,24 @@ typedef struct
 
 #endif
 
-/* Visual C++ 10.0+ (2010+) supports the override keyword, but doesn't define the C++ version as C++11 */
-#if defined(__cplusplus) && ((__cplusplus >= 201103L) || (defined(_MSC_VER) && (_MSC_VER >= 1600)))
-#if !defined(__ghs__)
-#define CPPUTEST_COMPILER_FULLY_SUPPORTS_CXX11
-#define _override override
-#else
-/* GreenHills is not compatible with other compilers with regards to where
- * it expects the override specifier to be on methods that return function
- * pointers. Given this, it is easiest to not use the override specifier.
- */
-#define _override
-#endif
-#define NULLPTR nullptr
-#else
-#define _override
-#define NULLPTR NULL
+#ifdef __cplusplus
+  /* Visual C++ 10.0+ (2010+) supports the override keyword, but doesn't define the C++ version as C++11 */
+  #if (__cplusplus >= 201103L) || (defined(_MSC_VER) && (_MSC_VER >= 1600))
+    #define _override override
+    #define NULLPTR nullptr
+  #else
+    #define _override
+    #define NULLPTR NULL
+  #endif
 #endif
 
-/* Visual C++ 11.0+ (2012+) supports the override keyword on destructors */
-#if defined(__cplusplus) && ((__cplusplus >= 201103L) || (defined(_MSC_VER) && (_MSC_VER >= 1700)))
-#define _destructor_override override
-#else
-#define _destructor_override
+#ifdef __cplusplus
+  /* Visual C++ 11.0+ (2012+) supports the override keyword on destructors */
+  #if (__cplusplus >= 201103L) || (defined(_MSC_VER) && (_MSC_VER >= 1700))
+    #define _destructor_override override
+  #else
+    #define _destructor_override
+  #endif
 #endif
 
 #ifdef __clang__

--- a/include/CppUTest/TestHarness_c.h
+++ b/include/CppUTest/TestHarness_c.h
@@ -37,85 +37,85 @@
 #include "CppUTestConfig.h"
 
 #define CHECK_EQUAL_C_BOOL(expected,actual) \
-  CHECK_EQUAL_C_BOOL_LOCATION(expected,actual,NULLPTR,__FILE__,__LINE__)
+  CHECK_EQUAL_C_BOOL_LOCATION(expected,actual,NULL,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_BOOL_TEXT(expected,actual,text) \
   CHECK_EQUAL_C_BOOL_LOCATION(expected,actual,text,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_INT(expected,actual) \
-  CHECK_EQUAL_C_INT_LOCATION(expected,actual,NULLPTR,__FILE__,__LINE__)
+  CHECK_EQUAL_C_INT_LOCATION(expected,actual,NULL,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_INT_TEXT(expected,actual,text) \
   CHECK_EQUAL_C_INT_LOCATION(expected,actual,text,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_UINT(expected,actual) \
-  CHECK_EQUAL_C_UINT_LOCATION(expected,actual,NULLPTR,__FILE__,__LINE__)
+  CHECK_EQUAL_C_UINT_LOCATION(expected,actual,NULL,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_UINT_TEXT(expected,actual,text) \
   CHECK_EQUAL_C_UINT_LOCATION(expected,actual,text,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_LONG(expected,actual) \
-  CHECK_EQUAL_C_LONG_LOCATION(expected,actual,NULLPTR,__FILE__,__LINE__)
+  CHECK_EQUAL_C_LONG_LOCATION(expected,actual,NULL,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_LONG_TEXT(expected,actual,text) \
   CHECK_EQUAL_C_LONG_LOCATION(expected,actual,text,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_ULONG(expected,actual) \
-  CHECK_EQUAL_C_ULONG_LOCATION(expected,actual,NULLPTR,__FILE__,__LINE__)
+  CHECK_EQUAL_C_ULONG_LOCATION(expected,actual,NULL,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_ULONG_TEXT(expected,actual,text) \
   CHECK_EQUAL_C_ULONG_LOCATION(expected,actual,text,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_LONGLONG(expected,actual) \
-  CHECK_EQUAL_C_LONGLONG_LOCATION(expected,actual,NULLPTR,__FILE__,__LINE__)
+  CHECK_EQUAL_C_LONGLONG_LOCATION(expected,actual,NULL,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_LONGLONG_TEXT(expected,actual,text) \
   CHECK_EQUAL_C_LONGLONG_LOCATION(expected,actual,text,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_ULONGLONG(expected,actual) \
-  CHECK_EQUAL_C_ULONGLONG_LOCATION(expected,actual,NULLPTR,__FILE__,__LINE__)
+  CHECK_EQUAL_C_ULONGLONG_LOCATION(expected,actual,NULL,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_ULONGLONG_TEXT(expected,actual,text) \
   CHECK_EQUAL_C_ULONGLONG_LOCATION(expected,actual,text,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_REAL(expected,actual,threshold) \
-  CHECK_EQUAL_C_REAL_LOCATION(expected,actual,threshold,NULLPTR,__FILE__,__LINE__)
+  CHECK_EQUAL_C_REAL_LOCATION(expected,actual,threshold,NULL,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_REAL_TEXT(expected,actual,threshold,text) \
   CHECK_EQUAL_C_REAL_LOCATION(expected,actual,threshold,text,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_CHAR(expected,actual) \
-  CHECK_EQUAL_C_CHAR_LOCATION(expected,actual,NULLPTR,__FILE__,__LINE__)
+  CHECK_EQUAL_C_CHAR_LOCATION(expected,actual,NULL,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_CHAR_TEXT(expected,actual,text) \
   CHECK_EQUAL_C_CHAR_LOCATION(expected,actual,text,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_UBYTE(expected,actual) \
-  CHECK_EQUAL_C_UBYTE_LOCATION(expected,actual,NULLPTR,__FILE__,__LINE__)
+  CHECK_EQUAL_C_UBYTE_LOCATION(expected,actual,NULL,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_UBYTE_TEXT(expected,actual,text) \
   CHECK_EQUAL_C_UBYTE_LOCATION(expected,actual,text,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_SBYTE(expected,actual) \
-  CHECK_EQUAL_C_SBYTE_LOCATION(expected,actual,NULLPTR,__FILE__,__LINE__)
+  CHECK_EQUAL_C_SBYTE_LOCATION(expected,actual,NULL,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_SBYTE_TEXT(expected,actual,text) \
   CHECK_EQUAL_C_SBYTE_LOCATION(expected,actual,text,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_STRING(expected,actual) \
-  CHECK_EQUAL_C_STRING_LOCATION(expected,actual,NULLPTR,__FILE__,__LINE__)
+  CHECK_EQUAL_C_STRING_LOCATION(expected,actual,NULL,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_STRING_TEXT(expected,actual,text) \
   CHECK_EQUAL_C_STRING_LOCATION(expected,actual,text,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_POINTER(expected,actual) \
-  CHECK_EQUAL_C_POINTER_LOCATION(expected,actual,NULLPTR,__FILE__,__LINE__)
+  CHECK_EQUAL_C_POINTER_LOCATION(expected,actual,NULL,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_POINTER_TEXT(expected,actual,text) \
   CHECK_EQUAL_C_POINTER_LOCATION(expected,actual,text,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_BITS(expected, actual, mask) \
-  CHECK_EQUAL_C_BITS_LOCATION(expected, actual, mask, sizeof(actual), NULLPTR, __FILE__, __LINE__)
+  CHECK_EQUAL_C_BITS_LOCATION(expected, actual, mask, sizeof(actual), NULL, __FILE__, __LINE__)
 
 #define CHECK_EQUAL_C_BITS_TEXT(expected, actual, mask, text) \
   CHECK_EQUAL_C_BITS_LOCATION(expected, actual, mask, sizeof(actual), text, __FILE__, __LINE__)
@@ -127,7 +127,7 @@
   FAIL_C_LOCATION(__FILE__,__LINE__)
 
 #define CHECK_C(condition) \
-  CHECK_C_LOCATION(condition, #condition, NULLPTR, __FILE__,__LINE__)
+  CHECK_C_LOCATION(condition, #condition, NULL, __FILE__,__LINE__)
 
 #define CHECK_C_TEXT(condition, text) \
   CHECK_C_LOCATION(condition, #condition, text, __FILE__, __LINE__)


### PR DESCRIPTION
- Keep `NULLPTR`, `_override`, and `_destructor_override` macros out of
  C. We had some leak into TestHarness_c.h.
- Drop Green Hills workaround for `override` with function pointers added
  in #1239. This was mitigated in #1605.