### PR TITLE
Don't guess CHAR_BIT

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -88,8 +88,8 @@
       "name": "no-std-c",
       "inherits": ["GNU"],
       "environment": {
-        "CXXFLAGS": "-Werror -nostdinc",
-        "CFLAGS": "-Werror -nostdinc"
+        "CXXFLAGS": "-DCHAR_BIT=8 -Werror -nostdinc",
+        "CFLAGS": "-DCHAR_BIT=8 -Werror -nostdinc"
       },
       "cacheVariables": {
         "CMAKE_SYSTEM_NAME": "Generic",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -88,8 +88,8 @@
       "name": "no-std-c",
       "inherits": ["GNU"],
       "environment": {
-        "CXXFLAGS": "-DCHAR_BIT=8 -Werror -nostdinc",
-        "CFLAGS": "-DCHAR_BIT=8 -Werror -nostdinc"
+        "CXXFLAGS": "-DCPPUTEST_CHAR_BIT=8 -Werror -nostdinc",
+        "CFLAGS": "-DCPPUTEST_CHAR_BIT=8 -Werror -nostdinc"
       },
       "cacheVariables": {
         "CMAKE_SYSTEM_NAME": "Generic",

--- a/include/CppUTest/CppUTestConfig.h
+++ b/include/CppUTest/CppUTestConfig.h
@@ -249,13 +249,12 @@
 #endif
 #endif
 
-/* Handling of systems with a different byte-width (e.g. 16 bit).
- * Since CHAR_BIT is defined in limits.h (ANSI C), use default of 8 when building without Std C library.
+/* Handling of systems with a different byte-width (e.g. 16 bit). Since
+ * CHAR_BIT is defined in limits.h (ANSI C), the user must provide a definition
+ * when building without Std C library.
  */
-#if CPPUTEST_USE_STD_C_LIB
-#define CPPUTEST_CHAR_BIT CHAR_BIT
-#else
-#define CPPUTEST_CHAR_BIT 8
+#if !CPPUTEST_USE_STD_C_LIB && !defined(CHAR_BIT)
+  #error "Provide a definition for CHAR_BIT"
 #endif
 
 /* Handling of systems with a different int-width (e.g. 16 bit).

--- a/include/CppUTest/CppUTestConfig.h
+++ b/include/CppUTest/CppUTestConfig.h
@@ -253,8 +253,10 @@
  * CHAR_BIT is defined in limits.h (ANSI C), the user must provide a definition
  * when building without Std C library.
  */
-#if !CPPUTEST_USE_STD_C_LIB && !defined(CHAR_BIT)
-  #error "Provide a definition for CHAR_BIT"
+#if defined(CHAR_BIT) && !defined(CPPUTEST_CHAR_BIT)
+  #define CPPUTEST_CHAR_BIT CHAR_BIT
+#else
+  #error "Provide a definition for CPPUTEST_CHAR_BIT"
 #endif
 
 /* Handling of systems with a different int-width (e.g. 16 bit).

--- a/src/CppUTest/SimpleString.cpp
+++ b/src/CppUTest/SimpleString.cpp
@@ -723,7 +723,7 @@ SimpleString HexStringFrom(signed char value)
     SimpleString result = StringFromFormat("%x", value);
     if(value < 0) {
         size_t size = result.size();
-        result = result.subString(size-(CPPUTEST_CHAR_BIT/4));
+        result = result.subString(size-(CHAR_BIT/4));
     }
     return result;
 }
@@ -1007,7 +1007,7 @@ SimpleString StringFromBinaryWithSizeOrNull(const unsigned char* value, size_t s
 SimpleString StringFromMaskedBits(unsigned long value, unsigned long mask, size_t byteCount)
 {
     SimpleString result;
-    size_t bitCount = (byteCount > sizeof(unsigned long)) ? (sizeof(unsigned long) * CPPUTEST_CHAR_BIT) : (byteCount * CPPUTEST_CHAR_BIT);
+    size_t bitCount = (byteCount > sizeof(unsigned long)) ? (sizeof(unsigned long) * CHAR_BIT) : (byteCount * CHAR_BIT);
     const unsigned long msbMask = (((unsigned long) 1) << (bitCount - 1));
 
     for (size_t i = 0; i < bitCount; i++) {

--- a/src/CppUTest/SimpleString.cpp
+++ b/src/CppUTest/SimpleString.cpp
@@ -723,7 +723,7 @@ SimpleString HexStringFrom(signed char value)
     SimpleString result = StringFromFormat("%x", value);
     if(value < 0) {
         size_t size = result.size();
-        result = result.subString(size-(CHAR_BIT/4));
+        result = result.subString(size-(CPPUTEST_CHAR_BIT/4));
     }
     return result;
 }
@@ -1007,7 +1007,7 @@ SimpleString StringFromBinaryWithSizeOrNull(const unsigned char* value, size_t s
 SimpleString StringFromMaskedBits(unsigned long value, unsigned long mask, size_t byteCount)
 {
     SimpleString result;
-    size_t bitCount = (byteCount > sizeof(unsigned long)) ? (sizeof(unsigned long) * CHAR_BIT) : (byteCount * CHAR_BIT);
+    size_t bitCount = (byteCount > sizeof(unsigned long)) ? (sizeof(unsigned long) * CPPUTEST_CHAR_BIT) : (byteCount * CPPUTEST_CHAR_BIT);
     const unsigned long msbMask = (((unsigned long) 1) << (bitCount - 1));
 
     for (size_t i = 0; i < bitCount; i++) {

--- a/tests/CppUTest/SimpleStringTest.cpp
+++ b/tests/CppUTest/SimpleStringTest.cpp
@@ -1130,7 +1130,7 @@ TEST(SimpleString, MemCmpFirstLastNotMatching)
     CHECK(0 != SimpleString::MemCmp(base, lastNotMatching, sizeof(base)));
 }
 
-#if (CHAR_BIT == 16)
+#if (CPPUTEST_CHAR_BIT == 16)
 TEST(SimpleString, MaskedBitsChar)
 {
     STRCMP_EQUAL("xxxxxxxx xxxxxxxx", StringFromMaskedBits(0x00, 0x00, 1).asCharString());
@@ -1140,7 +1140,7 @@ TEST(SimpleString, MaskedBitsChar)
     STRCMP_EQUAL("xxxxxxxx xxxxxxx1", StringFromMaskedBits(0x01, 0x01, 1).asCharString());
     STRCMP_EQUAL("xxxxxxxx 11xx11xx", StringFromMaskedBits(0xFF, 0xCC, 1).asCharString());
 }
-#elif (CHAR_BIT == 8)
+#elif (CPPUTEST_CHAR_BIT == 8)
 TEST(SimpleString, MaskedBitsChar)
 {
     STRCMP_EQUAL("xxxxxxxx", StringFromMaskedBits(0x00, 0x00, 1).asCharString());
@@ -1154,22 +1154,22 @@ TEST(SimpleString, MaskedBitsChar)
 
 TEST(SimpleString, MaskedBits16Bit)
 {
-    STRCMP_EQUAL("xxxxxxxx xxxxxxxx", StringFromMaskedBits(0x0000, 0x0000, 2*8/CHAR_BIT).asCharString());
-    STRCMP_EQUAL("00000000 00000000", StringFromMaskedBits(0x0000, 0xFFFF, 2*8/CHAR_BIT).asCharString());
-    STRCMP_EQUAL("11111111 11111111", StringFromMaskedBits(0xFFFF, 0xFFFF, 2*8/CHAR_BIT).asCharString());
-    STRCMP_EQUAL("1xxxxxxx xxxxxxxx", StringFromMaskedBits(0x8000, 0x8000, 2*8/CHAR_BIT).asCharString());
-    STRCMP_EQUAL("xxxxxxxx xxxxxxx1", StringFromMaskedBits(0x0001, 0x0001, 2*8/CHAR_BIT).asCharString());
-    STRCMP_EQUAL("11xx11xx 11xx11xx", StringFromMaskedBits(0xFFFF, 0xCCCC, 2*8/CHAR_BIT).asCharString());
+    STRCMP_EQUAL("xxxxxxxx xxxxxxxx", StringFromMaskedBits(0x0000, 0x0000, 2*8/CPPUTEST_CHAR_BIT).asCharString());
+    STRCMP_EQUAL("00000000 00000000", StringFromMaskedBits(0x0000, 0xFFFF, 2*8/CPPUTEST_CHAR_BIT).asCharString());
+    STRCMP_EQUAL("11111111 11111111", StringFromMaskedBits(0xFFFF, 0xFFFF, 2*8/CPPUTEST_CHAR_BIT).asCharString());
+    STRCMP_EQUAL("1xxxxxxx xxxxxxxx", StringFromMaskedBits(0x8000, 0x8000, 2*8/CPPUTEST_CHAR_BIT).asCharString());
+    STRCMP_EQUAL("xxxxxxxx xxxxxxx1", StringFromMaskedBits(0x0001, 0x0001, 2*8/CPPUTEST_CHAR_BIT).asCharString());
+    STRCMP_EQUAL("11xx11xx 11xx11xx", StringFromMaskedBits(0xFFFF, 0xCCCC, 2*8/CPPUTEST_CHAR_BIT).asCharString());
 }
 
 TEST(SimpleString, MaskedBits32Bit)
 {
-    STRCMP_EQUAL("xxxxxxxx xxxxxxxx xxxxxxxx xxxxxxxx", StringFromMaskedBits(0x00000000, 0x00000000, 4*8/CHAR_BIT).asCharString());
-    STRCMP_EQUAL("00000000 00000000 00000000 00000000", StringFromMaskedBits(0x00000000, 0xFFFFFFFF, 4*8/CHAR_BIT).asCharString());
-    STRCMP_EQUAL("11111111 11111111 11111111 11111111", StringFromMaskedBits(0xFFFFFFFF, 0xFFFFFFFF, 4*8/CHAR_BIT).asCharString());
-    STRCMP_EQUAL("1xxxxxxx xxxxxxxx xxxxxxxx xxxxxxxx", StringFromMaskedBits(0x80000000, 0x80000000, 4*8/CHAR_BIT).asCharString());
-    STRCMP_EQUAL("xxxxxxxx xxxxxxxx xxxxxxxx xxxxxxx1", StringFromMaskedBits(0x00000001, 0x00000001, 4*8/CHAR_BIT).asCharString());
-    STRCMP_EQUAL("11xx11xx 11xx11xx 11xx11xx 11xx11xx", StringFromMaskedBits(0xFFFFFFFF, 0xCCCCCCCC, 4*8/CHAR_BIT).asCharString());
+    STRCMP_EQUAL("xxxxxxxx xxxxxxxx xxxxxxxx xxxxxxxx", StringFromMaskedBits(0x00000000, 0x00000000, 4*8/CPPUTEST_CHAR_BIT).asCharString());
+    STRCMP_EQUAL("00000000 00000000 00000000 00000000", StringFromMaskedBits(0x00000000, 0xFFFFFFFF, 4*8/CPPUTEST_CHAR_BIT).asCharString());
+    STRCMP_EQUAL("11111111 11111111 11111111 11111111", StringFromMaskedBits(0xFFFFFFFF, 0xFFFFFFFF, 4*8/CPPUTEST_CHAR_BIT).asCharString());
+    STRCMP_EQUAL("1xxxxxxx xxxxxxxx xxxxxxxx xxxxxxxx", StringFromMaskedBits(0x80000000, 0x80000000, 4*8/CPPUTEST_CHAR_BIT).asCharString());
+    STRCMP_EQUAL("xxxxxxxx xxxxxxxx xxxxxxxx xxxxxxx1", StringFromMaskedBits(0x00000001, 0x00000001, 4*8/CPPUTEST_CHAR_BIT).asCharString());
+    STRCMP_EQUAL("11xx11xx 11xx11xx 11xx11xx 11xx11xx", StringFromMaskedBits(0xFFFFFFFF, 0xCCCCCCCC, 4*8/CPPUTEST_CHAR_BIT).asCharString());
 }
 
 TEST(SimpleString, StringFromOrdinalNumberOnes)

--- a/tests/CppUTest/SimpleStringTest.cpp
+++ b/tests/CppUTest/SimpleStringTest.cpp
@@ -1130,7 +1130,7 @@ TEST(SimpleString, MemCmpFirstLastNotMatching)
     CHECK(0 != SimpleString::MemCmp(base, lastNotMatching, sizeof(base)));
 }
 
-#if (CPPUTEST_CHAR_BIT == 16)
+#if (CHAR_BIT == 16)
 TEST(SimpleString, MaskedBitsChar)
 {
     STRCMP_EQUAL("xxxxxxxx xxxxxxxx", StringFromMaskedBits(0x00, 0x00, 1).asCharString());
@@ -1140,7 +1140,7 @@ TEST(SimpleString, MaskedBitsChar)
     STRCMP_EQUAL("xxxxxxxx xxxxxxx1", StringFromMaskedBits(0x01, 0x01, 1).asCharString());
     STRCMP_EQUAL("xxxxxxxx 11xx11xx", StringFromMaskedBits(0xFF, 0xCC, 1).asCharString());
 }
-#else
+#elif (CHAR_BIT == 8)
 TEST(SimpleString, MaskedBitsChar)
 {
     STRCMP_EQUAL("xxxxxxxx", StringFromMaskedBits(0x00, 0x00, 1).asCharString());
@@ -1154,22 +1154,22 @@ TEST(SimpleString, MaskedBitsChar)
 
 TEST(SimpleString, MaskedBits16Bit)
 {
-    STRCMP_EQUAL("xxxxxxxx xxxxxxxx", StringFromMaskedBits(0x0000, 0x0000, 2*8/CPPUTEST_CHAR_BIT).asCharString());
-    STRCMP_EQUAL("00000000 00000000", StringFromMaskedBits(0x0000, 0xFFFF, 2*8/CPPUTEST_CHAR_BIT).asCharString());
-    STRCMP_EQUAL("11111111 11111111", StringFromMaskedBits(0xFFFF, 0xFFFF, 2*8/CPPUTEST_CHAR_BIT).asCharString());
-    STRCMP_EQUAL("1xxxxxxx xxxxxxxx", StringFromMaskedBits(0x8000, 0x8000, 2*8/CPPUTEST_CHAR_BIT).asCharString());
-    STRCMP_EQUAL("xxxxxxxx xxxxxxx1", StringFromMaskedBits(0x0001, 0x0001, 2*8/CPPUTEST_CHAR_BIT).asCharString());
-    STRCMP_EQUAL("11xx11xx 11xx11xx", StringFromMaskedBits(0xFFFF, 0xCCCC, 2*8/CPPUTEST_CHAR_BIT).asCharString());
+    STRCMP_EQUAL("xxxxxxxx xxxxxxxx", StringFromMaskedBits(0x0000, 0x0000, 2*8/CHAR_BIT).asCharString());
+    STRCMP_EQUAL("00000000 00000000", StringFromMaskedBits(0x0000, 0xFFFF, 2*8/CHAR_BIT).asCharString());
+    STRCMP_EQUAL("11111111 11111111", StringFromMaskedBits(0xFFFF, 0xFFFF, 2*8/CHAR_BIT).asCharString());
+    STRCMP_EQUAL("1xxxxxxx xxxxxxxx", StringFromMaskedBits(0x8000, 0x8000, 2*8/CHAR_BIT).asCharString());
+    STRCMP_EQUAL("xxxxxxxx xxxxxxx1", StringFromMaskedBits(0x0001, 0x0001, 2*8/CHAR_BIT).asCharString());
+    STRCMP_EQUAL("11xx11xx 11xx11xx", StringFromMaskedBits(0xFFFF, 0xCCCC, 2*8/CHAR_BIT).asCharString());
 }
 
 TEST(SimpleString, MaskedBits32Bit)
 {
-    STRCMP_EQUAL("xxxxxxxx xxxxxxxx xxxxxxxx xxxxxxxx", StringFromMaskedBits(0x00000000, 0x00000000, 4*8/CPPUTEST_CHAR_BIT).asCharString());
-    STRCMP_EQUAL("00000000 00000000 00000000 00000000", StringFromMaskedBits(0x00000000, 0xFFFFFFFF, 4*8/CPPUTEST_CHAR_BIT).asCharString());
-    STRCMP_EQUAL("11111111 11111111 11111111 11111111", StringFromMaskedBits(0xFFFFFFFF, 0xFFFFFFFF, 4*8/CPPUTEST_CHAR_BIT).asCharString());
-    STRCMP_EQUAL("1xxxxxxx xxxxxxxx xxxxxxxx xxxxxxxx", StringFromMaskedBits(0x80000000, 0x80000000, 4*8/CPPUTEST_CHAR_BIT).asCharString());
-    STRCMP_EQUAL("xxxxxxxx xxxxxxxx xxxxxxxx xxxxxxx1", StringFromMaskedBits(0x00000001, 0x00000001, 4*8/CPPUTEST_CHAR_BIT).asCharString());
-    STRCMP_EQUAL("11xx11xx 11xx11xx 11xx11xx 11xx11xx", StringFromMaskedBits(0xFFFFFFFF, 0xCCCCCCCC, 4*8/CPPUTEST_CHAR_BIT).asCharString());
+    STRCMP_EQUAL("xxxxxxxx xxxxxxxx xxxxxxxx xxxxxxxx", StringFromMaskedBits(0x00000000, 0x00000000, 4*8/CHAR_BIT).asCharString());
+    STRCMP_EQUAL("00000000 00000000 00000000 00000000", StringFromMaskedBits(0x00000000, 0xFFFFFFFF, 4*8/CHAR_BIT).asCharString());
+    STRCMP_EQUAL("11111111 11111111 11111111 11111111", StringFromMaskedBits(0xFFFFFFFF, 0xFFFFFFFF, 4*8/CHAR_BIT).asCharString());
+    STRCMP_EQUAL("1xxxxxxx xxxxxxxx xxxxxxxx xxxxxxxx", StringFromMaskedBits(0x80000000, 0x80000000, 4*8/CHAR_BIT).asCharString());
+    STRCMP_EQUAL("xxxxxxxx xxxxxxxx xxxxxxxx xxxxxxx1", StringFromMaskedBits(0x00000001, 0x00000001, 4*8/CHAR_BIT).asCharString());
+    STRCMP_EQUAL("11xx11xx 11xx11xx 11xx11xx 11xx11xx", StringFromMaskedBits(0xFFFFFFFF, 0xCCCCCCCC, 4*8/CHAR_BIT).asCharString());
 }
 
 TEST(SimpleString, StringFromOrdinalNumberOnes)

--- a/tests/CppUTest/TestFailureTest.cpp
+++ b/tests/CppUTest/TestFailureTest.cpp
@@ -390,18 +390,18 @@ TEST(TestFailure, BinaryEqualExpectedNull)
 
 TEST(TestFailure, BitsEqualWithText)
 {
-    BitsEqualFailure f(test, failFileName, failLineNumber, 0x0001, 0x0003, 0x00FF, 2*8/CHAR_BIT, "text");
+    BitsEqualFailure f(test, failFileName, failLineNumber, 0x0001, 0x0003, 0x00FF, 2*8/CPPUTEST_CHAR_BIT, "text");
     FAILURE_EQUAL("Message: text\n"
                   "\texpected <xxxxxxxx 00000001>\n\tbut was  <xxxxxxxx 00000011>", f);
 }
 
-#if (CHAR_BIT == 16)
+#if (CPPUTEST_CHAR_BIT == 16)
 TEST(TestFailure, BitsEqualChar)
 {
     BitsEqualFailure f(test, failFileName, failLineNumber, 0x01, 0x03, 0xFF, sizeof(char), "");
     FAILURE_EQUAL("expected <xxxxxxxx 00000001>\n\tbut was  <xxxxxxxx 00000011>", f);
 }
-#elif (CHAR_BIT == 8)
+#elif (CPPUTEST_CHAR_BIT == 8)
 TEST(TestFailure, BitsEqualChar)
 {
     BitsEqualFailure f(test, failFileName, failLineNumber, 0x01, 0x03, 0xFF, sizeof(char), "");
@@ -411,13 +411,13 @@ TEST(TestFailure, BitsEqualChar)
 
 TEST(TestFailure, BitsEqual16Bit)
 {
-    BitsEqualFailure f(test, failFileName, failLineNumber, 0x0001, 0x0003, 0xFFFF, 2*8/CHAR_BIT, "");
+    BitsEqualFailure f(test, failFileName, failLineNumber, 0x0001, 0x0003, 0xFFFF, 2*8/CPPUTEST_CHAR_BIT, "");
     FAILURE_EQUAL("expected <00000000 00000001>\n\tbut was  <00000000 00000011>", f);
 }
 
 TEST(TestFailure, BitsEqual32Bit)
 {
-    BitsEqualFailure f(test, failFileName, failLineNumber, 0x00000001, 0x00000003, 0xFFFFFFFF, 4*8/CHAR_BIT, "");
+    BitsEqualFailure f(test, failFileName, failLineNumber, 0x00000001, 0x00000003, 0xFFFFFFFF, 4*8/CPPUTEST_CHAR_BIT, "");
     FAILURE_EQUAL("expected <00000000 00000000 00000000 00000001>\n\tbut was  <00000000 00000000 00000000 00000011>", f);
 }
 

--- a/tests/CppUTest/TestFailureTest.cpp
+++ b/tests/CppUTest/TestFailureTest.cpp
@@ -390,18 +390,18 @@ TEST(TestFailure, BinaryEqualExpectedNull)
 
 TEST(TestFailure, BitsEqualWithText)
 {
-    BitsEqualFailure f(test, failFileName, failLineNumber, 0x0001, 0x0003, 0x00FF, 2*8/CPPUTEST_CHAR_BIT, "text");
+    BitsEqualFailure f(test, failFileName, failLineNumber, 0x0001, 0x0003, 0x00FF, 2*8/CHAR_BIT, "text");
     FAILURE_EQUAL("Message: text\n"
                   "\texpected <xxxxxxxx 00000001>\n\tbut was  <xxxxxxxx 00000011>", f);
 }
 
-#if (CPPUTEST_CHAR_BIT == 16)
+#if (CHAR_BIT == 16)
 TEST(TestFailure, BitsEqualChar)
 {
     BitsEqualFailure f(test, failFileName, failLineNumber, 0x01, 0x03, 0xFF, sizeof(char), "");
     FAILURE_EQUAL("expected <xxxxxxxx 00000001>\n\tbut was  <xxxxxxxx 00000011>", f);
 }
-#else
+#elif (CHAR_BIT == 8)
 TEST(TestFailure, BitsEqualChar)
 {
     BitsEqualFailure f(test, failFileName, failLineNumber, 0x01, 0x03, 0xFF, sizeof(char), "");
@@ -411,13 +411,13 @@ TEST(TestFailure, BitsEqualChar)
 
 TEST(TestFailure, BitsEqual16Bit)
 {
-    BitsEqualFailure f(test, failFileName, failLineNumber, 0x0001, 0x0003, 0xFFFF, 2*8/CPPUTEST_CHAR_BIT, "");
+    BitsEqualFailure f(test, failFileName, failLineNumber, 0x0001, 0x0003, 0xFFFF, 2*8/CHAR_BIT, "");
     FAILURE_EQUAL("expected <00000000 00000001>\n\tbut was  <00000000 00000011>", f);
 }
 
 TEST(TestFailure, BitsEqual32Bit)
 {
-    BitsEqualFailure f(test, failFileName, failLineNumber, 0x00000001, 0x00000003, 0xFFFFFFFF, 4*8/CPPUTEST_CHAR_BIT, "");
+    BitsEqualFailure f(test, failFileName, failLineNumber, 0x00000001, 0x00000003, 0xFFFFFFFF, 4*8/CHAR_BIT, "");
     FAILURE_EQUAL("expected <00000000 00000000 00000000 00000001>\n\tbut was  <00000000 00000000 00000000 00000011>", f);
 }
 

--- a/tests/CppUTest/TestUTestMacro.cpp
+++ b/tests/CppUTest/TestUTestMacro.cpp
@@ -724,10 +724,10 @@ static void failingTestMethodWithSIGNED_BYTES_EQUAL_()
 TEST(UnitTestMacros, FailureWithSIGNED_BYTES_EQUAL)
 {
     fixture.runTestWithMethod(failingTestMethodWithSIGNED_BYTES_EQUAL_);
-#if CHAR_BIT == 16
+#if CPPUTEST_CHAR_BIT == 16
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <-1 (0xffff)>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <-2 (0xfffe)>");
-#elif CHAR_BIT == 8
+#elif CPPUTEST_CHAR_BIT == 8
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <-1 (0xff)>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <-2 (0xfe)>");
 #endif

--- a/tests/CppUTest/TestUTestMacro.cpp
+++ b/tests/CppUTest/TestUTestMacro.cpp
@@ -724,10 +724,10 @@ static void failingTestMethodWithSIGNED_BYTES_EQUAL_()
 TEST(UnitTestMacros, FailureWithSIGNED_BYTES_EQUAL)
 {
     fixture.runTestWithMethod(failingTestMethodWithSIGNED_BYTES_EQUAL_);
-#if CPPUTEST_CHAR_BIT == 16
+#if CHAR_BIT == 16
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <-1 (0xffff)>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <-2 (0xfffe)>");
-#else
+#elif CHAR_BIT == 8
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("expected <-1 (0xff)>");
     CHECK_TEST_FAILS_PROPER_WITH_TEXT("but was  <-2 (0xfe)>");
 #endif


### PR DESCRIPTION
This change requires use-cases without the standard library to provide their appropriate byte size. Given the commitment to maintain support for use without standard C, I think we need to be more prudent about the assumptions we're making about those environments.