### PR TITLE
Allow detailed tests to be set at call site

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -96,6 +96,10 @@ jobs:
             os: ubuntu-latest
             cpp_version: 98
             preset: no-long-long
+          - name: Detailed
+            os: ubuntu-latest
+            cpp_version: 98
+            preset: detailed
           - name: Linux GNU Install
             os: ubuntu-latest
             cpp_version: 11

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,6 @@ cmake_dependent_option(CPPUTEST_USE_LONG_LONG "Support long long"
 
 cmake_dependent_option(CPPUTEST_BUILD_TESTING "Compile and make tests for CppUTest"
   ${PROJECT_IS_TOP_LEVEL} "BUILD_TESTING" OFF)
-option(CPPUTEST_TESTS_DETAILED "Run each test separately instead of grouped?" OFF)
 cmake_dependent_option(CPPUTEST_TEST_DISCOVERY "Build time test discover"
   ON "CPPUTEST_BUILD_TESTING;CMAKE_CROSSCOMPILING_EMULATOR OR NOT CMAKE_CROSSCOMPILING" OFF)
 cmake_dependent_option(CPPUTEST_EXAMPLES "Compile and make examples?"

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -98,9 +98,16 @@
     },
     {
       "name": "no-long-long",
-      "inherits":["GNU"],
+      "inherits": ["GNU"],
       "cacheVariables": {
         "CPPUTEST_USE_LONG_LONG": false
+      }
+    },
+    {
+      "name": "detailed",
+      "inherits": ["defaults"],
+      "cacheVariables": {
+        "CPPUTEST_TESTS_DETAILED": true
       }
     },
     {

--- a/cmake/Modules/CppUTestBuildTimeDiscoverTests.cmake
+++ b/cmake/Modules/CppUTestBuildTimeDiscoverTests.cmake
@@ -1,7 +1,23 @@
+option(CPPUTEST_TESTS_DETAILED "Run discovered tests individually")
+
 set(_DISCOVER_SCRIPT "${CMAKE_CURRENT_LIST_DIR}/../Scripts/CppUTestBuildTimeDiscoverTests.cmake")
 
 # Create target to discover tests
 function (cpputest_buildtime_discover_tests tgt)
+  set(options)
+  set(oneValueArgs DETAILED)
+  set(multiValueArgs)
+  cmake_parse_arguments(
+    ""
+    "${options}"
+    "${oneValueArgs}"
+    "${multiValueArgs}"
+    ${ARGN}
+  )
+  if(NOT DEFINED _DETAILED)
+    set(_DETAILED ${CPPUTEST_TESTS_DETAILED})
+  endif()
+
   if(NOT TARGET ${tgt})
     message(FATAL_ERROR
       "Cannot discover tests for target \"${tgt}\" "
@@ -24,7 +40,7 @@ function (cpputest_buildtime_discover_tests tgt)
     TARGET ${tgt} POST_BUILD
     COMMAND
       ${CMAKE_COMMAND}
-      -D "TESTS_DETAILED:BOOL=${CPPUTEST_TESTS_DETAILED}"
+      -D "TESTS_DETAILED:BOOL=${_DETAILED}"
       -D "EXECUTABLE=$<TARGET_FILE:${tgt}>"
       -D "EMULATOR=$<TARGET_PROPERTY:${tgt},CROSSCOMPILING_EMULATOR>"
       -P "${_DISCOVER_SCRIPT}"

--- a/examples/AllTests/CMakeLists.txt
+++ b/examples/AllTests/CMakeLists.txt
@@ -25,5 +25,7 @@ target_link_libraries(ExampleTests
 
 include(CppUTestBuildTimeDiscoverTests)
 if(CPPUTEST_TEST_DISCOVERY OR NOT DEFINED CPPUTEST_TEST_DISCOVERY)
-    cpputest_buildtime_discover_tests(ExampleTests)
+    cpputest_buildtime_discover_tests(ExampleTests
+        DETAILED TRUE
+    )
 endif()

--- a/tests/CppUTestExt/CMakeLists.txt
+++ b/tests/CppUTestExt/CMakeLists.txt
@@ -54,5 +54,8 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.13")
 endif()
 
 if (CPPUTEST_TEST_DISCOVERY)
-    cpputest_buildtime_discover_tests(CppUTestExtTests)
+    cpputest_buildtime_discover_tests(CppUTestExtTests
+        # TestOrderedTestMacros must run together
+        DETAILED FALSE
+    )
 endif()


### PR DESCRIPTION
When `DETAILED` is passed to `cpputest_buildtime_discover_tests`, that value will take precedence over the `CPPUTEST_TESTS_DETAILED` variable.

For the following invocations:

```cmake
cpputest_buildtime_discover_tests(A)
cpputest_buildtime_discover_tests(B DETAILED TRUE)
cpputest_buildtime_discover_tests(C DETAILED FALSE)
```

- When `CPPUTEST_TESTS_DETAILED` is falsey, _B_ tests will be detailed.
- When `CPPUTEST_TESTS_DETAILED` is truthy, _A_ and _B_ tests will be detailed.

This is useful in cases like `TestOrderedTestMacros`, which fail when run in detailed-mode.