### PR TITLE
Fixed compilation when exceptions are enabled but RTTI not.

### DIFF
--- a/src/CppUTest/TestFailure.cpp
+++ b/src/CppUTest/TestFailure.cpp
@@ -395,6 +395,7 @@ UnexpectedExceptionFailure::UnexpectedExceptionFailure(UtestShell* test)
 
 static SimpleString getExceptionTypeName(const std::exception &e)
 {
+#if defined(_CPPRTTI) || defined(__GXX_RTTI)
     const char *name = typeid(e).name();
 #if defined(__GNUC__) && (__cplusplus >= 201103L)
     int status = -1;
@@ -406,6 +407,9 @@ static SimpleString getExceptionTypeName(const std::exception &e)
     return (status==0) ? demangledName.get() : name;
 #else
     return name;
+#endif
+#else
+    return "unknown-no-RTTI";
 #endif
 }
 


### PR DESCRIPTION
This PR fixes regression introduced by 3756d31e09e039662ee81e4672634ba8d7b15bea by excluding `typeid()` RTTI function from the compilation if compiler settings did not enable RTTI support that is a fairly common case for Embedded development when C++ exceptions are enabled while RTTI not to balance between functionality and binary size.