### PR TITLE
Test Windows install

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -55,11 +55,11 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: MSVC defaults
+          - name: MSVC install
             os: windows-latest
             cpp_version: 17
             preset: MSVC
-            # install: true
+            install: true
           - name: MSVC 20
             os: windows-latest
             cpp_version: 20
@@ -195,9 +195,12 @@ jobs:
 
       # POST PROCESSING
 
-      - name: Install
+      - name: Install (*nix)
         run: sudo cmake --install cpputest_build/
-        if: ${{ matrix.install }}
+        if: ${{ matrix.install && !startswith(matrix.os, 'windows')}}
+      - name: Install (Windows)
+        run: cmake --install cpputest_build/ --config=Debug
+        if: ${{ matrix.install && startswith(matrix.os, 'windows')}}
       - name: Use install
         run: |
           cmake -B build -S examples

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -196,7 +196,9 @@ jobs:
       # POST PROCESSING
 
       - name: Install (*nix)
-        run: sudo cmake --install cpputest_build/
+        run: |
+          sudo cmake --install cpputest_build/
+          pkg-config --print-provides cpputest
         if: ${{ matrix.install && !startswith(matrix.os, 'windows')}}
       - name: Install (Windows)
         run: cmake --install cpputest_build/ --config=Debug


### PR DESCRIPTION
Visual Studio is a multi-config generator. Though [test discovery currently ignores this](https://github.com/cpputest/cpputest/pull/1673), installation does not, so we need to pass the config type to the `cmake --install` command.