### PR TITLE
Remove test of undefined behavior

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,14 +29,10 @@ include(CTest)
 include(CMakeDependentOption)
 option(CPPUTEST_STD_C_LIB_DISABLED "Disable the standard C library")
 
-if((CMAKE_CXX_COMPILER_ID STREQUAL "Clang") AND (CMAKE_CXX_SIMULATE_ID STREQUAL "MSVC"))
-  set(is_clang_cl TRUE)
-endif()
-
 cmake_dependent_option(CPPUTEST_STD_CPP_LIB_DISABLED "Use the standard C++ library"
   OFF "NOT CPPUTEST_STD_C_LIB_DISABLED" ON)
 cmake_dependent_option(CPPUTEST_MEM_LEAK_DETECTION_DISABLED "Enable memory leak detection"
-  OFF "NOT BORLAND;NOT CPPUTEST_STD_C_LIB_DISABLED;NOT is_clang_cl" ON)
+  OFF "NOT BORLAND;NOT CPPUTEST_STD_C_LIB_DISABLED" ON)
 option(CPPUTEST_EXTENSIONS "Use the CppUTest extension library" ON)
 include(CheckTypeSize)
 check_type_size("long long" SIZEOF_LONGLONG)

--- a/tests/CppUTest/MemoryOperatorOverloadTest.cpp
+++ b/tests/CppUTest/MemoryOperatorOverloadTest.cpp
@@ -10,12 +10,6 @@
 #include "CppUTest/TestHarness_c.h"
 #include "AllocationInCFile.h"
 
-#if defined(__GNUC__)
-# if __GNUC__ >= 11
-#  define NEEDS_DISABLE_FREE_NON_HEEP_WARNING
-# endif /* GCC >= 11 */
-#endif /* GCC */
-
 
 TEST_GROUP(BasicBehavior)
 {

--- a/tests/CppUTest/MemoryOperatorOverloadTest.cpp
+++ b/tests/CppUTest/MemoryOperatorOverloadTest.cpp
@@ -39,37 +39,6 @@ TEST(BasicBehavior, DeleteWithSizeParameterWorks)
 }
 #endif
 
-#ifdef NEEDS_DISABLE_FREE_NON_HEEP_WARNING
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wfree-nonheap-object"
-#endif /* NEEDS_DISABLE_FREE_NON_HEEP_WARNING */
-
-static void deleteUnallocatedMemory()
-{
-    delete (char*) 0x1234678;
-    FAIL("Should never come here"); // LCOV_EXCL_LINE
-} // LCOV_EXCL_LINE
-
-#ifdef NEEDS_DISABLE_FREE_NON_HEEP_WARNING
-# pragma GCC diagnostic pop
-#endif /* NEEDS_DISABLE_FREE_NON_HEEP_WARNING */
-
-
-TEST(BasicBehavior, deleteWillNotThrowAnExceptionWhenDeletingUnallocatedMemoryButCanStillCauseTestFailures)
-{
-    /*
-     * Test failure might cause an exception. But according to C++ standard, you aren't allowed
-     * to throw exceptions in the delete function. If you do that, it will call std::terminate.
-     * Therefore, the delete will need to fail without exceptions.
-     */
-    MemoryLeakFailure* defaultReporter = MemoryLeakWarningPlugin::getGlobalFailureReporter();
-    TestTestingFixture fixture;
-    fixture.setTestFunction(deleteUnallocatedMemory);
-    fixture.runAllTests();
-    LONGS_EQUAL(1, fixture.getFailureCount());
-    POINTERS_EQUAL(defaultReporter, MemoryLeakWarningPlugin::getGlobalFailureReporter());
-}
-
 #endif
 
 #ifdef CPPUTEST_USE_MALLOC_MACROS


### PR DESCRIPTION
This hangs in ClangCL.  Calling `delete` on a pointer that wasn't created by a `new` expression is undefined behavior.[1]  There are no valid assertions about post conditions here. Removing this test allows us to remove the hack added in #1641 and restore support for memory leak detection.

[1]: https://en.cppreference.com/w/cpp/language/delete.