### PR TITLE
Put use without RTTI under test

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -126,6 +126,10 @@ jobs:
             os: ubuntu-latest
             cpp_version: 98
             preset: no-std-cpp
+          - name: No RTTI
+            os: ubuntu-latest
+            cpp_version: 98
+            preset: no-rtti
           - name: Coverage
             os: ubuntu-latest
             cpp_version: 11

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -81,7 +81,14 @@
       "name": "no-std-cpp",
       "inherits": ["GNU"],
       "environment": {
-        "CXXFLAGS": "-Werror -fno-exceptions -fno-rtti -nostdinc++"
+        "CXXFLAGS": "-Werror -fno-exceptions -nostdinc++"
+      }
+    },
+    {
+      "name": "no-rtti",
+      "inherits": ["GNU"],
+      "environment": {
+        "CXXFLAGS": "-Werror -fno-rtti"
       }
     },
     {

--- a/include/CppUTest/CppUTestConfig.h
+++ b/include/CppUTest/CppUTestConfig.h
@@ -238,14 +238,21 @@
 #endif
 #endif
 
-/*
- * Detection of run-time type information (RTTI) presence
- */
-#ifndef CPPUTEST_HAVE_RTTI
-  #if defined(_CPPRTTI) || defined(__GXX_RTTI) || defined(__RTTI) || (defined(__cpp_rtti) && __cpp_rtti)
-    #define CPPUTEST_HAVE_RTTI 1
-  #else
-    #define CPPUTEST_HAVE_RTTI 0
+#ifdef __cplusplus
+  /*
+   * Detection of run-time type information (RTTI) presence. Since it's a
+   * standard language feature, assume it is enabled unless we see otherwise.
+   */
+  #ifndef CPPUTEST_HAVE_RTTI
+    #if ((__cplusplus >= 202002L) && !defined(__cpp_rtti)) || \
+        (defined(_MSC_VER) && !defined(_CPPRTTI)) || \
+        (defined(__GNUC__) && !defined(__GXX_RTTI)) || \
+        (defined(__ghs__) && !defined(__RTTI)) || \
+        (defined(__WATCOMC__) && !defined(_CPPRTTI))
+      #define CPPUTEST_HAVE_RTTI 0
+    #else
+      #define CPPUTEST_HAVE_RTTI 1
+    #endif
   #endif
 #endif
 

--- a/src/CppUTest/TestFailure.cpp
+++ b/src/CppUTest/TestFailure.cpp
@@ -393,9 +393,9 @@ UnexpectedExceptionFailure::UnexpectedExceptionFailure(UtestShell* test)
 {
 }
 
+#if CPPUTEST_HAVE_RTTI
 static SimpleString getExceptionTypeName(const std::exception &e)
 {
-#if CPPUTEST_HAVE_RTTI
     const char *name = typeid(e).name();
 #if defined(__GNUC__) && (__cplusplus >= 201103L)
     int status = -1;
@@ -408,13 +408,22 @@ static SimpleString getExceptionTypeName(const std::exception &e)
 #else
     return name;
 #endif
-#else
-    return "unknown-no-RTTI";
-#endif
 }
+#endif // CPPUTEST_HAVE_RTTI
 
 UnexpectedExceptionFailure::UnexpectedExceptionFailure(UtestShell* test, const std::exception &e)
-: TestFailure(test, StringFromFormat("Unexpected exception of type '%s' was thrown: %s", getExceptionTypeName(e).asCharString(), e.what()))
+: TestFailure(
+    test,
+#if CPPUTEST_HAVE_RTTI
+    StringFromFormat(
+        "Unexpected exception of type '%s' was thrown: %s",
+        getExceptionTypeName(e).asCharString(),
+        e.what()
+    )
+#else
+    "Unexpected exception of unknown type was thrown."
+#endif
+)
 {
 }
-#endif
+#endif // CPPUTEST_USE_STD_CPP_LIB

--- a/tests/CppUTest/TestFailureTest.cpp
+++ b/tests/CppUTest/TestFailureTest.cpp
@@ -438,8 +438,12 @@ TEST(TestFailure, UnexpectedExceptionFailure_StandardException)
 {
     std::runtime_error e("Some error");
     UnexpectedExceptionFailure f(test, e);
+#if CPPUTEST_HAVE_RTTI
     STRCMP_CONTAINS("Unexpected exception of type '", f.getMessage().asCharString());
     STRCMP_CONTAINS("runtime_error", f.getMessage().asCharString());
     STRCMP_CONTAINS("' was thrown: Some error", f.getMessage().asCharString());
-}
+#else
+    FAILURE_EQUAL("Unexpected exception of unknown type was thrown.", f);
 #endif
+}
+#endif // CPPUTEST_USE_STD_CPP_LIB

--- a/tests/CppUTest/UtestTest.cpp
+++ b/tests/CppUTest/UtestTest.cpp
@@ -263,9 +263,13 @@ TEST(UtestShell, TestStopsAfterStandardExceptionIsThrown)
     fixture.setTestFunction(thrownStandardExceptionMethod_);
     fixture.runAllTests();
     LONGS_EQUAL(1, fixture.getFailureCount());
+#if CPPUTEST_HAVE_RTTI
     fixture.assertPrintContains("Unexpected exception of type '");
     fixture.assertPrintContains("runtime_error");
     fixture.assertPrintContains("' was thrown: exception text");
+#else
+    fixture.assertPrintContains("Unexpected exception of unknown type was thrown");
+#endif
     LONGS_EQUAL(0, stopAfterFailure);
     UtestShell::setRethrowExceptions(initialRethrowExceptions);
 }


### PR DESCRIPTION
- test new feature introduced in #1670
- resolve test failures when RTTI is disabled
- swap the detection logic so that it falls back to standard C++ features when an unrecognized compiler is used
- tweak the logging to mirror the existing behavior for unrecognized exceptions