### PR TITLE
Call abort instead of invoking undefined behavior

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -130,6 +130,10 @@ jobs:
             os: ubuntu-latest
             cpp_version: 98
             preset: no-rtti
+          - name: No C Standard Library
+            os: ubuntu-latest
+            cpp_version: 98
+            preset: no-std-c
           - name: Coverage
             os: ubuntu-latest
             cpp_version: 11

--- a/include/CppUTest/CppUTestConfig.h
+++ b/include/CppUTest/CppUTestConfig.h
@@ -271,10 +271,12 @@
  * CHAR_BIT is defined in limits.h (ANSI C), the user must provide a definition
  * when building without Std C library.
  */
-#if defined(CHAR_BIT) && !defined(CPPUTEST_CHAR_BIT)
-  #define CPPUTEST_CHAR_BIT CHAR_BIT
-#else
-  #error "Provide a definition for CPPUTEST_CHAR_BIT"
+#ifndef CPPUTEST_CHAR_BIT
+  #if defined(CHAR_BIT)
+    #define CPPUTEST_CHAR_BIT CHAR_BIT
+  #else
+    #error "Provide a definition for CPPUTEST_CHAR_BIT"
+  #endif
 #endif
 
 /* Handling of systems with a different int-width (e.g. 16 bit).

--- a/include/CppUTest/PlatformSpecificFunctions_c.h
+++ b/include/CppUTest/PlatformSpecificFunctions_c.h
@@ -88,6 +88,7 @@ extern int (*PlatformSpecificRand)(void);
 extern void (*PlatformSpecificMutexLock)(PlatformSpecificMutex mtx);
 extern void (*PlatformSpecificMutexUnlock)(PlatformSpecificMutex mtx);
 extern void (*PlatformSpecificMutexDestroy)(PlatformSpecificMutex mtx);
+extern void (*PlatformSpecificAbort)(void);
 
 #ifdef __cplusplus
 }

--- a/src/CppUTest/Utest.cpp
+++ b/src/CppUTest/Utest.cpp
@@ -163,12 +163,7 @@ UtestShell::~UtestShell()
 {
 }
 
-static void defaultCrashMethod()
-{
-    abort();
-}
-
-static void (*pleaseCrashMeRightNow) () = defaultCrashMethod;
+static void (*pleaseCrashMeRightNow) () = PlatformSpecificAbort;
 
 void UtestShell::setCrashMethod(void (*crashme)())
 {
@@ -177,7 +172,7 @@ void UtestShell::setCrashMethod(void (*crashme)())
 
 void UtestShell::resetCrashMethod()
 {
-    pleaseCrashMeRightNow = defaultCrashMethod;
+    pleaseCrashMeRightNow = PlatformSpecificAbort;
 }
 
 void UtestShell::crash()

--- a/src/CppUTest/Utest.cpp
+++ b/src/CppUTest/Utest.cpp
@@ -163,22 +163,10 @@ UtestShell::~UtestShell()
 {
 }
 
-// LCOV_EXCL_START - actually covered but not in .gcno due to race condition
-#ifdef NEEDS_DISABLE_NULL_WARNING
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wnonnull"
-#endif /* NEEDS_DISABLE_NULL_WARNING */
-
 static void defaultCrashMethod()
 {
-    UtestShell* ptr = (UtestShell*) NULLPTR;
-    ptr->countTests();
+    abort();
 }
-
-#ifdef NEEDS_DISABLE_NULL_WARNING
-# pragma GCC diagnostic pop
-#endif /* NEEDS_DISABLE_NULL_WARNING */
-// LCOV_EXCL_STOP
 
 static void (*pleaseCrashMeRightNow) () = defaultCrashMethod;
 

--- a/src/Platforms/Borland/UtestPlatform.cpp
+++ b/src/Platforms/Borland/UtestPlatform.cpp
@@ -328,5 +328,6 @@ PlatformSpecificMutex (*PlatformSpecificMutexCreate)(void) = PThreadMutexCreate;
 void (*PlatformSpecificMutexLock)(PlatformSpecificMutex) = PThreadMutexLock;
 void (*PlatformSpecificMutexUnlock)(PlatformSpecificMutex) = PThreadMutexUnlock;
 void (*PlatformSpecificMutexDestroy)(PlatformSpecificMutex) = PThreadMutexDestroy;
+void (*PlatformSpecificAbort)(void) = abort;
 
 }

--- a/src/Platforms/C2000/UtestPlatform.cpp
+++ b/src/Platforms/C2000/UtestPlatform.cpp
@@ -245,5 +245,6 @@ int (*PlatformSpecificRand)(void) = rand;
 void (*PlatformSpecificMutexLock)(PlatformSpecificMutex) = DummyMutexLock;
 void (*PlatformSpecificMutexUnlock)(PlatformSpecificMutex) = DummyMutexUnlock;
 void (*PlatformSpecificMutexDestroy)(PlatformSpecificMutex) = DummyMutexDestroy;
+void (*PlatformSpecificAbort)(void) = abort;
 
 }

--- a/src/Platforms/Dos/UtestPlatform.cpp
+++ b/src/Platforms/Dos/UtestPlatform.cpp
@@ -234,4 +234,11 @@ void (*PlatformSpecificMutexLock)(PlatformSpecificMutex) = DummyMutexLock;
 void (*PlatformSpecificMutexUnlock)(PlatformSpecificMutex) = DummyMutexUnlock;
 void (*PlatformSpecificMutexDestroy)(PlatformSpecificMutex) = DummyMutexDestroy;
 
+static void DosAbort()
+{
+    abort();
+}
+
+void (*PlatformSpecificAbort)(void) = DosAbort;
+
 }

--- a/src/Platforms/Gcc/UtestPlatform.cpp
+++ b/src/Platforms/Gcc/UtestPlatform.cpp
@@ -354,5 +354,6 @@ PlatformSpecificMutex (*PlatformSpecificMutexCreate)(void) = PThreadMutexCreate;
 void (*PlatformSpecificMutexLock)(PlatformSpecificMutex) = PThreadMutexLock;
 void (*PlatformSpecificMutexUnlock)(PlatformSpecificMutex) = PThreadMutexUnlock;
 void (*PlatformSpecificMutexDestroy)(PlatformSpecificMutex) = PThreadMutexDestroy;
+void (*PlatformSpecificAbort)(void) = abort;
 
 }

--- a/src/Platforms/GccNoStdC/UtestPlatform.cpp
+++ b/src/Platforms/GccNoStdC/UtestPlatform.cpp
@@ -80,3 +80,4 @@ void (*PlatformSpecificMutexDestroy)(PlatformSpecificMutex mtx) = NULLPTR;
 
 void (*PlatformSpecificSrand)(unsigned int) = NULLPTR;
 int (*PlatformSpecificRand)(void) = NULLPTR;
+void (*PlatformSpecificAbort)(void) = NULLPTR;

--- a/src/Platforms/Iar/UtestPlatform.cpp
+++ b/src/Platforms/Iar/UtestPlatform.cpp
@@ -202,4 +202,5 @@ void (*PlatformSpecificMutexUnlock)(PlatformSpecificMutex) = DummyMutexUnlock;
 void (*PlatformSpecificMutexDestroy)(PlatformSpecificMutex) = DummyMutexDestroy;
 void (*PlatformSpecificSrand)(unsigned int) = srand;
 int (*PlatformSpecificRand)(void) = rand;
+void (*PlatformSpecificAbort)(void) = abort;
 }

--- a/src/Platforms/Keil/UtestPlatform.cpp
+++ b/src/Platforms/Keil/UtestPlatform.cpp
@@ -216,5 +216,6 @@ extern "C"
     void (*PlatformSpecificMutexLock)(PlatformSpecificMutex) = DummyMutexLock;
     void (*PlatformSpecificMutexUnlock)(PlatformSpecificMutex) = DummyMutexUnlock;
     void (*PlatformSpecificMutexDestroy)(PlatformSpecificMutex) = DummyMutexDestroy;
+    void (*PlatformSpecificAbort)(void) = abort;
 
 }

--- a/src/Platforms/Symbian/UtestPlatform.cpp
+++ b/src/Platforms/Symbian/UtestPlatform.cpp
@@ -177,4 +177,5 @@ PlatformSpecificMutex (*PlatformSpecificMutexCreate)(void) = DummyMutexCreate;
 void (*PlatformSpecificMutexLock)(PlatformSpecificMutex) = DummyMutexLock;
 void (*PlatformSpecificMutexUnlock)(PlatformSpecificMutex) = DummyMutexUnlock;
 void (*PlatformSpecificMutexDestroy)(PlatformSpecificMutex) = DummyMutexDestroy;
+void (*PlatformSpecificAbort)(void) = abort;
 

--- a/src/Platforms/VisualCpp/UtestPlatform.cpp
+++ b/src/Platforms/VisualCpp/UtestPlatform.cpp
@@ -231,3 +231,4 @@ PlatformSpecificMutex (*PlatformSpecificMutexCreate)(void) = VisualCppMutexCreat
 void (*PlatformSpecificMutexLock)(PlatformSpecificMutex) = VisualCppMutexLock;
 void (*PlatformSpecificMutexUnlock)(PlatformSpecificMutex) = VisualCppMutexUnlock;
 void (*PlatformSpecificMutexDestroy)(PlatformSpecificMutex) = VisualCppMutexDestroy;
+void (*PlatformSpecificAbort)(void) = abort;

--- a/src/Platforms/armcc/UtestPlatform.cpp
+++ b/src/Platforms/armcc/UtestPlatform.cpp
@@ -203,5 +203,6 @@ PlatformSpecificMutex (*PlatformSpecificMutexCreate)(void) = DummyMutexCreate;
 void (*PlatformSpecificMutexLock)(PlatformSpecificMutex) = DummyMutexLock;
 void (*PlatformSpecificMutexUnlock)(PlatformSpecificMutex) = DummyMutexUnlock;
 void (*PlatformSpecificMutexDestroy)(PlatformSpecificMutex) = DummyMutexDestroy;
+void (*PlatformSpecificAbort)(void) = abort;
 
 }

--- a/tests/CppUTest/UtestTest.cpp
+++ b/tests/CppUTest/UtestTest.cpp
@@ -401,8 +401,7 @@ TEST(UtestShell, TestDefaultCrashMethodInSeparateProcessTest)
     fixture.runAllTests();
     fixture.assertPrintContains("Failed in separate process - killed by signal");
 
-    /* Signal 11 usually happens, but with clang3.7 on Linux, it produced signal 4. Mac now produces signal 5 */
-    CHECK(fixture.getOutput().contains("signal 11") || fixture.getOutput().contains("signal 4") || fixture.getOutput().contains("signal 5"));
+    CHECK(fixture.getOutput().contains("signal 6"));
 }
 
 #endif

--- a/tests/CppUTest/UtestTest.cpp
+++ b/tests/CppUTest/UtestTest.cpp
@@ -400,8 +400,6 @@ TEST(UtestShell, TestDefaultCrashMethodInSeparateProcessTest)
     fixture.setRunTestsInSeperateProcess();
     fixture.runAllTests();
     fixture.assertPrintContains("Failed in separate process - killed by signal");
-
-    CHECK(fixture.getOutput().contains("signal 6"));
 }
 
 #endif


### PR DESCRIPTION
This started hanging instead of crashing when built with Clang 14.0.6 on my box. Dereferencing a null pointer is not a valid or reliable way to induce a crash.

I also added back the no-std-c build which I guess got lost somewhere. This shook out a bug in my `CPPUTEST_CHAR_BIT` changes.