### PR TITLE
Test without C standard library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,6 @@ option(CPPUTEST_FLAGS "Use the CFLAGS/CXXFLAGS/LDFLAGS set by CppUTest" ${PROJEC
 cmake_dependent_option(CPPUTEST_MEM_LEAK_DETECTION_DISABLED "Enable memory leak detection"
   OFF "CPPUTEST_FLAGS;NOT BORLAND;NOT CPPUTEST_STD_C_LIB_DISABLED;NOT is_clang_cl" ON)
 option(CPPUTEST_EXTENSIONS "Use the CppUTest extension library" ON)
-
 include(CheckTypeSize)
 check_type_size("long long" SIZEOF_LONGLONG)
 cmake_dependent_option(CPPUTEST_USE_LONG_LONG "Support long long"
@@ -60,43 +59,37 @@ cmake_dependent_option(CPPUTEST_EXAMPLES "Compile and make examples?"
 cmake_dependent_option(CPPUTEST_LIBNAME_POSTFIX_BITSIZE "Add architecture bitsize (32/64) to the library name?"
   OFF "PROJECT_IS_TOP_LEVEL" OFF)
 
-if(DEFINED CPP_PLATFORM)
-  message(DEPRECATION
-    "The CPP_PLATFORM variable has been deprecated. "
-    "Use CPPUTEST_PLATFORM instead."
-  )
-else()
-  if(MSVC)
-    set(CPP_PLATFORM VisualCpp)
-  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "IAR")
-    set(CPP_PLATFORM Iar)
-  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "ARMCC")
-    set(CPP_PLATFORM armcc)
-  elseif(DOS)
-    set(CPP_PLATFORM Dos)
-  elseif(BORLAND)
-    set(CPP_PLATFORM Borland)
-  elseif(CPPUTEST_STD_C_LIB_DISABLED)
-    set(CPP_PLATFORM GccNoStdC)
+if(NOT DEFINED CPPUTEST_PLATFORM)
+  if(DEFINED CPP_PLATFORM)
+    message(DEPRECATION
+      "The CPP_PLATFORM variable has been deprecated. "
+      "Use CPPUTEST_PLATFORM instead."
+    )
+    set(CPPUTEST_PLATFORM ${CPP_PLATFORM})
   else()
-    set(CPP_PLATFORM Gcc)
+    if(CPPUTEST_STD_C_LIB_DISABLED)
+      set(CPPUTEST_PLATFORM OFF)
+    elseif(MSVC)
+      set(CPPUTEST_PLATFORM VisualCpp)
+    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "IAR")
+      set(CPPUTEST_PLATFORM Iar)
+    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "ARMCC")
+      set(CPPUTEST_PLATFORM armcc)
+    elseif(DOS)
+      set(CPPUTEST_PLATFORM Dos)
+    elseif(BORLAND)
+      set(CPPUTEST_PLATFORM Borland)
+    else()
+      set(CPPUTEST_PLATFORM Gcc)
+    endif()
   endif()
+  message(STATUS "Setting CPPUTEST_PLATFORM: ${CPPUTEST_PLATFORM}")
 endif()
-set(CPPUTEST_PLATFORM "${CPP_PLATFORM}" CACHE STRING "Platform implementation")
+set(CPPUTEST_PLATFORM "${CPPUTEST_PLATFORM}" CACHE STRING "Platform implementation")
 set_property(
   CACHE CPPUTEST_PLATFORM
   PROPERTY STRINGS
-    armcc
-    Borland
-    C2000
-    Dos
-    Gcc
-    GccNoStdC
-    Iar
-    Keil
-    Symbian
-    VisualCpp
-    OFF
+    armcc Borland C2000 Dos Gcc Iar Keil Symbian VisualCpp OFF
 )
 
 include(CheckCXXSymbolExists)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -99,7 +99,6 @@
         "CFLAGS": "-DCPPUTEST_CHAR_BIT=8 -Werror -nostdinc"
       },
       "cacheVariables": {
-        "CMAKE_SYSTEM_NAME": "Generic",
         "CPPUTEST_STD_C_LIB_DISABLED": true
       }
     },

--- a/include/CppUTest/StandardCLibrary.h
+++ b/include/CppUTest/StandardCLibrary.h
@@ -79,8 +79,15 @@ typedef long unsigned int size_t;
 #endif
 
 #define NULL (0)
+#ifdef __cplusplus
+extern "C" {
+#endif
 extern void*	malloc(size_t);
 extern void     free(void *);
+#ifdef __cplusplus
+}
+#endif
+
 
 #define _bnd(X, bnd)            (((sizeof (X)) + (bnd)) & (~(bnd)))
 

--- a/tests/CppUTest/CMakeLists.txt
+++ b/tests/CppUTest/CMakeLists.txt
@@ -36,6 +36,13 @@ add_executable(CppUTestTests
     TeamCityOutputTest.cpp
 )
 
+if(CPPUTEST_STD_C_LIB_DISABLED)
+    target_sources(CppUTestTests
+        PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/../DummyUTestPlatform/DummyUTestPlatform.cpp
+    )
+endif()
+
 if(MINGW OR (${CMAKE_HOST_SYSTEM_NAME} MATCHES "OpenBSD"))
     set(THREADS_PREFER_PTHREAD_FLAG ON)
     find_package(Threads)

--- a/tests/CppUTestExt/CMakeLists.txt
+++ b/tests/CppUTestExt/CMakeLists.txt
@@ -29,6 +29,13 @@ add_executable(CppUTestExtTests
     OrderedTestTest.cpp
 )
 
+if(CPPUTEST_STD_C_LIB_DISABLED)
+    target_sources(CppUTestExtTests
+        PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/../DummyUTestPlatform/DummyUTestPlatform.cpp
+    )
+endif()
+
 if(MINGW)
     set(THREADS_PREFER_PTHREAD_FLAG ON)
     find_package(Threads)

--- a/tests/DummyUTestPlatform/DummyUTestPlatform.cpp
+++ b/tests/DummyUTestPlatform/DummyUTestPlatform.cpp
@@ -1,0 +1,140 @@
+#include <CppUTest/PlatformSpecificFunctions.h>
+
+typedef char jmp_buf[200];
+
+TestOutput::WorkingEnvironment PlatformSpecificGetWorkingEnvironment()
+{
+    return TestOutput::eclipse;
+}
+
+void (*PlatformSpecificRunTestInASeperateProcess)(UtestShell* shell, TestPlugin* plugin, TestResult* result) = NULLPTR;
+int (*PlatformSpecificFork)(void) = NULLPTR;
+int (*PlatformSpecificWaitPid)(int pid, int* status, int options) = NULLPTR;
+
+static jmp_buf test_exit_jmp_buf[10];
+static int jmp_buf_index = 0;
+
+extern "C" int setjmp(jmp_buf);
+static int fakeSetJmp(void (*function)(void* data), void* data)
+{
+    if (0 == setjmp(test_exit_jmp_buf[jmp_buf_index])) {
+        jmp_buf_index++;
+        function(data);
+        jmp_buf_index--;
+        return 1;
+    }
+    return 0;
+}
+int (*PlatformSpecificSetJmp)(void (*function)(void*), void* data) = fakeSetJmp;
+
+extern "C" void longjmp(jmp_buf, int);
+static void fakeLongJmp(void)
+{
+    jmp_buf_index--;
+    longjmp(test_exit_jmp_buf[jmp_buf_index], 1);
+}
+void (*PlatformSpecificLongJmp)(void) = fakeLongJmp;
+
+static void fakeRestoreJumpBuffer()
+{
+    jmp_buf_index--;
+}
+void (*PlatformSpecificRestoreJumpBuffer)(void) = fakeRestoreJumpBuffer;
+
+static long fakeTimeInMillis(void)
+{
+    return 0;
+}
+long (*GetPlatformSpecificTimeInMillis)(void) = fakeTimeInMillis;
+
+static const char* fakeTimeString(void)
+{
+    return "";
+}
+const char* (*GetPlatformSpecificTimeString)() = fakeTimeString;
+
+extern "C" int vsnprintf(char*, size_t, const char*, va_list);
+int (*PlatformSpecificVSNprintf)(char* str, size_t size, const char* format, va_list va_args_list) = vsnprintf;
+
+extern "C" double fabs(double);
+double (*PlatformSpecificFabs)(double d) = fabs;
+
+static int fakeIsNan(double d)
+{
+    return d != d;
+}
+int (*PlatformSpecificIsNan)(double d) = fakeIsNan;
+
+static int fakeIsInf(double d)
+{
+    return !fakeIsNan(d) && fakeIsNan(d - d);
+}
+int (*PlatformSpecificIsInf)(double d) = fakeIsInf;
+
+extern "C" int atexit(void (*func)(void));
+int (*PlatformSpecificAtExit)(void (*func)(void)) = atexit;
+
+extern "C" void* stdout;
+PlatformSpecificFile PlatformSpecificStdOut = stdout;
+
+extern "C" void* fopen(const char*, const char*);
+PlatformSpecificFile (*PlatformSpecificFOpen)(const char* filename, const char* flag) = fopen;
+
+extern "C" int fputs(const char*, void*);
+static void fakeFPuts(const char* str, PlatformSpecificFile file)
+{
+    fputs(str, file);
+}
+void (*PlatformSpecificFPuts)(const char* str, PlatformSpecificFile file) = fakeFPuts;
+
+extern "C" int fclose(void* stream);
+static void fakeFClose(PlatformSpecificFile file)
+{
+    fclose(file);
+}
+void (*PlatformSpecificFClose)(PlatformSpecificFile file) = fakeFClose;
+
+extern "C" int fflush(void* stream);
+static void fakeFlush(void)
+{
+    fflush(stdout);
+}
+void (*PlatformSpecificFlush)(void) = fakeFlush;
+
+static void fakeSrand(unsigned int){};
+void (*PlatformSpecificSrand)(unsigned int) = fakeSrand;
+
+static int fakeRand(void)
+{
+    return 0;
+}
+int (*PlatformSpecificRand)(void) = fakeRand;
+
+extern "C" void* malloc(size_t);
+void* (*PlatformSpecificMalloc)(size_t) = malloc;
+
+extern "C" void* realloc(void* ptr, size_t new_size);
+void* (*PlatformSpecificRealloc)(void* memory, size_t size) = realloc;
+
+extern "C" void free(void*);
+void (*PlatformSpecificFree)(void* memory) = free;
+
+extern "C" void* memcpy(void* dest, const void* src, size_t count);
+void* (*PlatformSpecificMemCpy)(void* s1, const void* s2, size_t size) = memcpy;
+
+extern "C" void* memset(void* dest, int ch, size_t count);
+void* (*PlatformSpecificMemset)(void* mem, int c, size_t size) = memset;
+
+static PlatformSpecificMutex fakeMutexCreate(void)
+{
+    return 0;
+}
+PlatformSpecificMutex (*PlatformSpecificMutexCreate)(void) = fakeMutexCreate;
+
+static void fakeMutexFunc(PlatformSpecificMutex mtx) {}
+void (*PlatformSpecificMutexLock)(PlatformSpecificMutex mtx) = fakeMutexFunc;
+void (*PlatformSpecificMutexUnlock)(PlatformSpecificMutex mtx) = fakeMutexFunc;
+void (*PlatformSpecificMutexDestroy)(PlatformSpecificMutex mtx) = fakeMutexFunc;
+
+extern "C" void abort(void);
+void (*PlatformSpecificAbort)(void) = abort;


### PR DESCRIPTION
This gets the build without the C standard library under test by cheating at link time. None of CppUTest is built with libc (i.e. passing `-nostdinc`), but for testing we link to standard implementations of platform-specific functions.

Closes #1656
Closes #378