### PR TITLE
Decouple C++ standard library and exception support

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -130,6 +130,10 @@ jobs:
             os: ubuntu-latest
             cpp_version: 98
             preset: no-rtti
+          - name: No Exceptions
+            os: ubuntu-latest
+            cpp_version: 98
+            preset: no-exceptions
           - name: No C Standard Library
             os: ubuntu-latest
             cpp_version: 98

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,18 +29,12 @@ include(CTest)
 include(CMakeDependentOption)
 option(CPPUTEST_STD_C_LIB_DISABLED "Disable the standard C library")
 
-include(CheckCXXSourceCompiles)
-check_cxx_source_compiles(
-  "int main(int argc, char ** argv) { throw 20; }"
-  CPPUTEST_HAVE_EXCEPTIONS
-)
-
 if((CMAKE_CXX_COMPILER_ID STREQUAL "Clang") AND (CMAKE_CXX_SIMULATE_ID STREQUAL "MSVC"))
   set(is_clang_cl TRUE)
 endif()
 
 cmake_dependent_option(CPPUTEST_STD_CPP_LIB_DISABLED "Use the standard C++ library"
-  OFF "NOT CPPUTEST_STD_C_LIB_DISABLED;CPPUTEST_HAVE_EXCEPTIONS" ON)
+  OFF "NOT CPPUTEST_STD_C_LIB_DISABLED" ON)
 option(CPPUTEST_FLAGS "Use the CFLAGS/CXXFLAGS/LDFLAGS set by CppUTest" ${PROJECT_IS_TOP_LEVEL})
 cmake_dependent_option(CPPUTEST_MEM_LEAK_DETECTION_DISABLED "Enable memory leak detection"
   OFF "CPPUTEST_FLAGS;NOT BORLAND;NOT CPPUTEST_STD_C_LIB_DISABLED;NOT is_clang_cl" ON)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -81,7 +81,10 @@
       "name": "no-std-cpp",
       "inherits": ["GNU"],
       "environment": {
-        "CXXFLAGS": "-Werror -fno-exceptions -nostdinc++"
+        "CXXFLAGS": "-Werror  -nostdinc++"
+      },
+      "cacheVariables": {
+        "CPPUTEST_STD_CPP_LIB_DISABLED": true
       }
     },
     {
@@ -89,6 +92,13 @@
       "inherits": ["GNU"],
       "environment": {
         "CXXFLAGS": "-Werror -fno-rtti"
+      }
+    },
+    {
+      "name": "no-exceptions",
+      "inherits": ["GNU"],
+      "environment": {
+        "CXXFLAGS": "-Werror -fno-exceptions"
       }
     },
     {

--- a/include/CppUTest/CppUTestConfig.h
+++ b/include/CppUTest/CppUTestConfig.h
@@ -254,6 +254,22 @@
       #define CPPUTEST_HAVE_RTTI 1
     #endif
   #endif
+
+  /*
+   * Detection of exception support. Since it's a standard language feature,
+   * assume it is enabled unless we see otherwise.
+   */
+  #ifndef CPPUTEST_HAVE_EXCEPTIONS
+    #if ((__cplusplus >= 202002L) && !__cpp_exceptions) || \
+        (defined(_MSC_VER) && !_CPPUNWIND) || \
+        (defined(__GNUC__) && !__EXCEPTIONS) || \
+        (defined(__ghs__) && !__EXCEPTION_HANDLING) || \
+        (defined(__WATCOMC__) && !_CPPUNWIND)
+      #define CPPUTEST_HAVE_EXCEPTIONS 0
+    #else
+      #define CPPUTEST_HAVE_EXCEPTIONS 1
+    #endif
+  #endif
 #endif
 
 /*

--- a/include/CppUTest/CppUTestConfig.h
+++ b/include/CppUTest/CppUTestConfig.h
@@ -123,56 +123,10 @@
   #define _check_format_(type, format_parameter, other_parameters) /* type, format_parameter, other_parameters */
 #endif
 
-/*
- * When we don't link Standard C++, then we won't throw exceptions as we assume the compiler might not support that!
- */
-
-#if CPPUTEST_USE_STD_CPP_LIB
-  #if defined(__cplusplus) && __cplusplus >= 201103L
-    #define UT_THROW(exception)
-    #define UT_NOTHROW noexcept
-  #else
-    #define UT_THROW(exception) throw (exception)
-    #define UT_NOTHROW throw()
-  #endif
-#else
-  #define UT_THROW(exception)
-  #ifdef __clang__
-    #define UT_NOTHROW throw()
-  #else
-    #define UT_NOTHROW
-  #endif
-#endif
-
-/*
- * Visual C++ doesn't define __cplusplus as C++11 yet (201103), however it doesn't want the throw(exception) either, but
- * it does want throw().
- */
-
-#ifdef _MSC_VER
-  #undef UT_THROW
-  #define UT_THROW(exception)
-#endif
-
 #if defined(__cplusplus) && __cplusplus >= 201103L
     #define DEFAULT_COPY_CONSTRUCTOR(classname) classname(const classname &) = default;
 #else
     #define DEFAULT_COPY_CONSTRUCTOR(classname)
-#endif
-
-/*
- * g++-4.7 with stdc++11 enabled On MacOSX! will have a different exception specifier for operator new (and thank you!)
- * I assume they'll fix this in the future, but for now, we'll change that here.
- * (This should perhaps also be done in the configure.ac)
- */
-
-#ifdef __GXX_EXPERIMENTAL_CXX0X__
-#ifdef __APPLE__
-#ifdef _GLIBCXX_THROW
-#undef UT_THROW
-#define UT_THROW(exception) _GLIBCXX_THROW(exception)
-#endif
-#endif
 #endif
 
 /*
@@ -269,6 +223,51 @@
     #else
       #define CPPUTEST_HAVE_EXCEPTIONS 1
     #endif
+  #endif
+
+  #if CPPUTEST_HAVE_EXCEPTIONS
+    #if defined(__cplusplus) && __cplusplus >= 201103L
+      #define UT_THROW(exception)
+      #define UT_NOTHROW noexcept
+    #else
+      #define UT_THROW(exception) throw (exception)
+      #define UT_NOTHROW throw()
+    #endif
+  #else
+    #define UT_THROW(exception)
+    #ifdef __clang__
+      #define UT_NOTHROW throw()
+    #else
+      #define UT_NOTHROW
+    #endif
+  #endif
+
+  /*
+   * Visual C++ doesn't define __cplusplus as C++11 yet (201103), however it doesn't want the throw(exception) either, but
+   * it does want throw().
+   */
+  #ifdef _MSC_VER
+    #undef UT_THROW
+    #define UT_THROW(exception)
+  #endif
+
+  /*
+   * g++-4.7 with stdc++11 enabled On MacOSX! will have a different exception specifier for operator new (and thank you!)
+   * I assume they'll fix this in the future, but for now, we'll change that here.
+   * (This should perhaps also be done in the configure.ac)
+   */
+  #if defined(__GXX_EXPERIMENTAL_CXX0X__) && \
+      defined(__APPLE__) && \
+      defined(_GLIBCXX_THROW)
+    #undef UT_THROW
+    #define UT_THROW(exception) _GLIBCXX_THROW(exception)
+  #endif
+
+  #if CPPUTEST_USE_STD_CPP_LIB
+    #define CPPUTEST_BAD_ALLOC std::bad_alloc
+  #else
+    class CppUTestBadAlloc {};
+    #define CPPUTEST_BAD_ALLOC CppUTestBadAlloc
   #endif
 #endif
 

--- a/include/CppUTest/MemoryLeakDetectorNewMacros.h
+++ b/include/CppUTest/MemoryLeakDetectorNewMacros.h
@@ -56,12 +56,12 @@
      * know about all allocations and report freeing of unallocated blocks. Hence, provide both overloads.
      */
 
-    void* operator new(size_t size, const char* file, int line) UT_THROW (std::bad_alloc);
-    void* operator new(size_t size, const char* file, size_t line) UT_THROW (std::bad_alloc);
-    void* operator new[](size_t size, const char* file, int line) UT_THROW (std::bad_alloc);
-    void* operator new[](size_t size, const char* file, size_t line) UT_THROW (std::bad_alloc);
-    void* operator new(size_t size) UT_THROW(std::bad_alloc);
-    void* operator new[](size_t size) UT_THROW(std::bad_alloc);
+    void* operator new(size_t size, const char* file, int line) UT_THROW (CPPUTEST_BAD_ALLOC);
+    void* operator new(size_t size, const char* file, size_t line) UT_THROW (CPPUTEST_BAD_ALLOC);
+    void* operator new[](size_t size, const char* file, int line) UT_THROW (CPPUTEST_BAD_ALLOC);
+    void* operator new[](size_t size, const char* file, size_t line) UT_THROW (CPPUTEST_BAD_ALLOC);
+    void* operator new(size_t size) UT_THROW(CPPUTEST_BAD_ALLOC);
+    void* operator new[](size_t size) UT_THROW(CPPUTEST_BAD_ALLOC);
 
     void operator delete(void* mem, const char* file, int line) UT_NOTHROW;
     void operator delete(void* mem, const char* file, size_t line) UT_NOTHROW;

--- a/include/CppUTest/TestFailure.h
+++ b/include/CppUTest/TestFailure.h
@@ -186,12 +186,14 @@ public:
     FeatureUnsupportedFailure(UtestShell* test, const char* fileName, size_t lineNumber, const SimpleString& featureName, const SimpleString& text);
 };
 
-#if CPPUTEST_USE_STD_CPP_LIB
+#if CPPUTEST_HAVE_EXCEPTIONS
 class UnexpectedExceptionFailure : public TestFailure
 {
 public:
     UnexpectedExceptionFailure(UtestShell* test);
+#if CPPUTEST_USE_STD_CPP_LIB
     UnexpectedExceptionFailure(UtestShell* test, const std::exception &e);
+#endif
 };
 #endif
 

--- a/include/CppUTest/UtestMacros.h
+++ b/include/CppUTest/UtestMacros.h
@@ -363,7 +363,7 @@
 #define UT_PRINT(text) \
    UT_PRINT_LOCATION(text, __FILE__, __LINE__)
 
-#if CPPUTEST_USE_STD_CPP_LIB
+#if CPPUTEST_HAVE_EXCEPTIONS
 #define CHECK_THROWS(expected, expression) \
     do { \
     SimpleString failure_msg("expected to throw "#expected "\nbut threw nothing"); \
@@ -382,7 +382,7 @@
         UtestShell::getCurrent()->countCheck(); \
     } \
     } while(0)
-#endif /* CPPUTEST_USE_STD_CPP_LIB */
+#endif /* CPPUTEST_HAVE_EXCEPTIONS */
 
 #define UT_CRASH() do { UtestShell::crash(); } while(0)
 #define RUN_ALL_TESTS(ac, av) CommandLineTestRunner::RunAllTests(ac, av)

--- a/src/CppUTest/MemoryLeakWarningPlugin.cpp
+++ b/src/CppUTest/MemoryLeakWarningPlugin.cpp
@@ -130,10 +130,12 @@ void cpputest_free_location_with_leak_detection(void* buffer, const char* file, 
 #if CPPUTEST_USE_MEM_LEAK_DETECTION
 #undef new
 
-#if CPPUTEST_USE_STD_CPP_LIB
+#if !CPPUTEST_HAVE_EXCEPTIONS
+#define UT_THROW_BAD_ALLOC_WHEN_NULL(memory)
+#elif CPPUTEST_USE_STD_CPP_LIB
 #define UT_THROW_BAD_ALLOC_WHEN_NULL(memory) if (memory == NULLPTR) throw std::bad_alloc()
 #else
-#define UT_THROW_BAD_ALLOC_WHEN_NULL(memory)
+#define UT_THROW_BAD_ALLOC_WHEN_NULL(memory) if (memory == NULLPTR) throw 7
 #endif
 
 static void* threadsafe_mem_leak_operator_new (size_t size) UT_THROW(std::bad_alloc)

--- a/src/CppUTest/MemoryLeakWarningPlugin.cpp
+++ b/src/CppUTest/MemoryLeakWarningPlugin.cpp
@@ -130,15 +130,13 @@ void cpputest_free_location_with_leak_detection(void* buffer, const char* file, 
 #if CPPUTEST_USE_MEM_LEAK_DETECTION
 #undef new
 
-#if !CPPUTEST_HAVE_EXCEPTIONS
-#define UT_THROW_BAD_ALLOC_WHEN_NULL(memory)
-#elif CPPUTEST_USE_STD_CPP_LIB
-#define UT_THROW_BAD_ALLOC_WHEN_NULL(memory) if (memory == NULLPTR) throw std::bad_alloc()
+#if CPPUTEST_HAVE_EXCEPTIONS
+#define UT_THROW_BAD_ALLOC_WHEN_NULL(memory) if (memory == NULLPTR) throw CPPUTEST_BAD_ALLOC()
 #else
-#define UT_THROW_BAD_ALLOC_WHEN_NULL(memory) if (memory == NULLPTR) throw 7
+#define UT_THROW_BAD_ALLOC_WHEN_NULL(memory)
 #endif
 
-static void* threadsafe_mem_leak_operator_new (size_t size) UT_THROW(std::bad_alloc)
+static void* threadsafe_mem_leak_operator_new (size_t size) UT_THROW(CPPUTEST_BAD_ALLOC)
 {
     MemLeakScopedMutex lock;
     void* memory = MemoryLeakWarningPlugin::getGlobalDetector()->allocMemory(getCurrentNewAllocator(), size);
@@ -152,7 +150,7 @@ static void* threadsafe_mem_leak_operator_new_nothrow (size_t size) UT_NOTHROW
     return MemoryLeakWarningPlugin::getGlobalDetector()->allocMemory(getCurrentNewAllocator(), size);
 }
 
-static void* threadsafe_mem_leak_operator_new_debug (size_t size, const char* file, size_t line) UT_THROW(std::bad_alloc)
+static void* threadsafe_mem_leak_operator_new_debug (size_t size, const char* file, size_t line) UT_THROW(CPPUTEST_BAD_ALLOC)
 {
     MemLeakScopedMutex lock;
     void *memory = MemoryLeakWarningPlugin::getGlobalDetector()->allocMemory(getCurrentNewAllocator(), size, file, line);
@@ -160,7 +158,7 @@ static void* threadsafe_mem_leak_operator_new_debug (size_t size, const char* fi
     return memory;
 }
 
-static void* threadsafe_mem_leak_operator_new_array (size_t size) UT_THROW(std::bad_alloc)
+static void* threadsafe_mem_leak_operator_new_array (size_t size) UT_THROW(CPPUTEST_BAD_ALLOC)
 {
     MemLeakScopedMutex lock;
     void* memory = MemoryLeakWarningPlugin::getGlobalDetector()->allocMemory(getCurrentNewArrayAllocator(), size);
@@ -174,7 +172,7 @@ static void* threadsafe_mem_leak_operator_new_array_nothrow (size_t size) UT_NOT
     return MemoryLeakWarningPlugin::getGlobalDetector()->allocMemory(getCurrentNewArrayAllocator(), size);
 }
 
-static void* threadsafe_mem_leak_operator_new_array_debug (size_t size, const char* file, size_t line) UT_THROW(std::bad_alloc)
+static void* threadsafe_mem_leak_operator_new_array_debug (size_t size, const char* file, size_t line) UT_THROW(CPPUTEST_BAD_ALLOC)
 {
     MemLeakScopedMutex lock;
     void* memory = MemoryLeakWarningPlugin::getGlobalDetector()->allocMemory(getCurrentNewArrayAllocator(), size, file, line);
@@ -197,7 +195,7 @@ static void threadsafe_mem_leak_operator_delete_array (void* mem) UT_NOTHROW
 }
 
 
-static void* mem_leak_operator_new (size_t size) UT_THROW(std::bad_alloc)
+static void* mem_leak_operator_new (size_t size) UT_THROW(CPPUTEST_BAD_ALLOC)
 {
     void* memory = MemoryLeakWarningPlugin::getGlobalDetector()->allocMemory(getCurrentNewAllocator(), size);
     UT_THROW_BAD_ALLOC_WHEN_NULL(memory);
@@ -209,14 +207,14 @@ static void* mem_leak_operator_new_nothrow (size_t size) UT_NOTHROW
     return MemoryLeakWarningPlugin::getGlobalDetector()->allocMemory(getCurrentNewAllocator(), size);
 }
 
-static void* mem_leak_operator_new_debug (size_t size, const char* file, size_t line) UT_THROW(std::bad_alloc)
+static void* mem_leak_operator_new_debug (size_t size, const char* file, size_t line) UT_THROW(CPPUTEST_BAD_ALLOC)
 {
     void *memory = MemoryLeakWarningPlugin::getGlobalDetector()->allocMemory(getCurrentNewAllocator(), size, file, line);
     UT_THROW_BAD_ALLOC_WHEN_NULL(memory);
     return memory;
 }
 
-static void* mem_leak_operator_new_array (size_t size) UT_THROW(std::bad_alloc)
+static void* mem_leak_operator_new_array (size_t size) UT_THROW(CPPUTEST_BAD_ALLOC)
 {
     void* memory = MemoryLeakWarningPlugin::getGlobalDetector()->allocMemory(getCurrentNewArrayAllocator(), size);
     UT_THROW_BAD_ALLOC_WHEN_NULL(memory);
@@ -228,7 +226,7 @@ static void* mem_leak_operator_new_array_nothrow (size_t size) UT_NOTHROW
     return MemoryLeakWarningPlugin::getGlobalDetector()->allocMemory(getCurrentNewArrayAllocator(), size);
 }
 
-static void* mem_leak_operator_new_array_debug (size_t size, const char* file, size_t line) UT_THROW(std::bad_alloc)
+static void* mem_leak_operator_new_array_debug (size_t size, const char* file, size_t line) UT_THROW(CPPUTEST_BAD_ALLOC)
 {
     void* memory = MemoryLeakWarningPlugin::getGlobalDetector()->allocMemory(getCurrentNewArrayAllocator(), size, file, line);
     UT_THROW_BAD_ALLOC_WHEN_NULL(memory);
@@ -247,7 +245,7 @@ static void mem_leak_operator_delete_array (void* mem) UT_NOTHROW
     MemoryLeakWarningPlugin::getGlobalDetector()->deallocMemory(getCurrentNewArrayAllocator(), (char*) mem);
 }
 
-static void* normal_operator_new (size_t size) UT_THROW(std::bad_alloc)
+static void* normal_operator_new (size_t size) UT_THROW(CPPUTEST_BAD_ALLOC)
 {
     void* memory = PlatformSpecificMalloc(size);
     UT_THROW_BAD_ALLOC_WHEN_NULL(memory);
@@ -259,14 +257,14 @@ static void* normal_operator_new_nothrow (size_t size) UT_NOTHROW
     return PlatformSpecificMalloc(size);
 }
 
-static void* normal_operator_new_debug (size_t size, const char* /*file*/, size_t /*line*/) UT_THROW(std::bad_alloc)
+static void* normal_operator_new_debug (size_t size, const char* /*file*/, size_t /*line*/) UT_THROW(CPPUTEST_BAD_ALLOC)
 {
     void* memory = PlatformSpecificMalloc(size);
     UT_THROW_BAD_ALLOC_WHEN_NULL(memory);
     return memory;
 }
 
-static void* normal_operator_new_array (size_t size) UT_THROW(std::bad_alloc)
+static void* normal_operator_new_array (size_t size) UT_THROW(CPPUTEST_BAD_ALLOC)
 {
     void* memory = PlatformSpecificMalloc(size);
     UT_THROW_BAD_ALLOC_WHEN_NULL(memory);
@@ -278,7 +276,7 @@ static void* normal_operator_new_array_nothrow (size_t size) UT_NOTHROW
     return PlatformSpecificMalloc(size);
 }
 
-static void* normal_operator_new_array_debug (size_t size, const char* /*file*/, size_t /*line*/) UT_THROW(std::bad_alloc)
+static void* normal_operator_new_array_debug (size_t size, const char* /*file*/, size_t /*line*/) UT_THROW(CPPUTEST_BAD_ALLOC)
 {
     void* memory = PlatformSpecificMalloc(size);
     UT_THROW_BAD_ALLOC_WHEN_NULL(memory);
@@ -295,36 +293,36 @@ static void normal_operator_delete_array (void* mem) UT_NOTHROW
     PlatformSpecificFree(mem);
 }
 
-static void *(*operator_new_fptr)(size_t size) UT_THROW(std::bad_alloc) = mem_leak_operator_new;
+static void *(*operator_new_fptr)(size_t size) UT_THROW(CPPUTEST_BAD_ALLOC) = mem_leak_operator_new;
 static void *(*operator_new_nothrow_fptr)(size_t size) UT_NOTHROW = mem_leak_operator_new_nothrow;
-static void *(*operator_new_debug_fptr)(size_t size, const char* file, size_t line) UT_THROW(std::bad_alloc) = mem_leak_operator_new_debug;
-static void *(*operator_new_array_fptr)(size_t size) UT_THROW(std::bad_alloc) = mem_leak_operator_new_array;
+static void *(*operator_new_debug_fptr)(size_t size, const char* file, size_t line) UT_THROW(CPPUTEST_BAD_ALLOC) = mem_leak_operator_new_debug;
+static void *(*operator_new_array_fptr)(size_t size) UT_THROW(CPPUTEST_BAD_ALLOC) = mem_leak_operator_new_array;
 static void *(*operator_new_array_nothrow_fptr)(size_t size) UT_NOTHROW = mem_leak_operator_new_array_nothrow;
-static void *(*operator_new_array_debug_fptr)(size_t size, const char* file, size_t line) UT_THROW(std::bad_alloc) = mem_leak_operator_new_array_debug;
+static void *(*operator_new_array_debug_fptr)(size_t size, const char* file, size_t line) UT_THROW(CPPUTEST_BAD_ALLOC) = mem_leak_operator_new_array_debug;
 static void (*operator_delete_fptr)(void* mem) UT_NOTHROW = mem_leak_operator_delete;
 static void (*operator_delete_array_fptr)(void* mem) UT_NOTHROW = mem_leak_operator_delete_array;
 
-static void *(*saved_operator_new_fptr)(size_t size) UT_THROW(std::bad_alloc) = mem_leak_operator_new;
+static void *(*saved_operator_new_fptr)(size_t size) UT_THROW(CPPUTEST_BAD_ALLOC) = mem_leak_operator_new;
 static void *(*saved_operator_new_nothrow_fptr)(size_t size) UT_NOTHROW = mem_leak_operator_new_nothrow;
-static void *(*saved_operator_new_debug_fptr)(size_t size, const char* file, size_t line) UT_THROW(std::bad_alloc) = mem_leak_operator_new_debug;
-static void *(*saved_operator_new_array_fptr)(size_t size) UT_THROW(std::bad_alloc) = mem_leak_operator_new_array;
+static void *(*saved_operator_new_debug_fptr)(size_t size, const char* file, size_t line) UT_THROW(CPPUTEST_BAD_ALLOC) = mem_leak_operator_new_debug;
+static void *(*saved_operator_new_array_fptr)(size_t size) UT_THROW(CPPUTEST_BAD_ALLOC) = mem_leak_operator_new_array;
 static void *(*saved_operator_new_array_nothrow_fptr)(size_t size) UT_NOTHROW = mem_leak_operator_new_array_nothrow;
-static void *(*saved_operator_new_array_debug_fptr)(size_t size, const char* file, size_t line) UT_THROW(std::bad_alloc) = mem_leak_operator_new_array_debug;
+static void *(*saved_operator_new_array_debug_fptr)(size_t size, const char* file, size_t line) UT_THROW(CPPUTEST_BAD_ALLOC) = mem_leak_operator_new_array_debug;
 static void (*saved_operator_delete_fptr)(void* mem) UT_NOTHROW = mem_leak_operator_delete;
 static void (*saved_operator_delete_array_fptr)(void* mem) UT_NOTHROW = mem_leak_operator_delete_array;
 static int save_counter = 0;
 
-void* operator new(size_t size) UT_THROW(std::bad_alloc)
+void* operator new(size_t size) UT_THROW(CPPUTEST_BAD_ALLOC)
 {
     return operator_new_fptr(size);
 }
 
-void* operator new(size_t size, const char* file, int line) UT_THROW(std::bad_alloc)
+void* operator new(size_t size, const char* file, int line) UT_THROW(CPPUTEST_BAD_ALLOC)
 {
     return operator_new_debug_fptr(size, file, (size_t)line);
 }
 
-void* operator new(size_t size, const char* file, size_t line) UT_THROW(std::bad_alloc)
+void* operator new(size_t size, const char* file, size_t line) UT_THROW(CPPUTEST_BAD_ALLOC)
 {
     return operator_new_debug_fptr(size, file, line);
 }
@@ -351,17 +349,17 @@ void operator delete (void* mem, size_t) UT_NOTHROW
 }
 #endif
 
-void* operator new[](size_t size) UT_THROW(std::bad_alloc)
+void* operator new[](size_t size) UT_THROW(CPPUTEST_BAD_ALLOC)
 {
     return operator_new_array_fptr(size);
 }
 
-void* operator new [](size_t size, const char* file, int line) UT_THROW(std::bad_alloc)
+void* operator new [](size_t size, const char* file, int line) UT_THROW(CPPUTEST_BAD_ALLOC)
 {
     return operator_new_array_debug_fptr(size, file, (size_t)line);
 }
 
-void* operator new [](size_t size, const char* file, size_t line) UT_THROW(std::bad_alloc)
+void* operator new [](size_t size, const char* file, size_t line) UT_THROW(CPPUTEST_BAD_ALLOC)
 {
     return operator_new_array_debug_fptr(size, file, line);
 }

--- a/src/CppUTest/TestFailure.cpp
+++ b/src/CppUTest/TestFailure.cpp
@@ -387,12 +387,13 @@ FeatureUnsupportedFailure::FeatureUnsupportedFailure(UtestShell* test, const cha
     message_ += StringFromFormat("The feature \"%s\" is not supported in this environment or with the feature set selected when building the library.", featureName.asCharString());
 }
 
-#if CPPUTEST_USE_STD_CPP_LIB
+#if CPPUTEST_HAVE_EXCEPTIONS
 UnexpectedExceptionFailure::UnexpectedExceptionFailure(UtestShell* test)
 : TestFailure(test, "Unexpected exception of unknown type was thrown.")
 {
 }
 
+#if CPPUTEST_USE_STD_CPP_LIB
 #if CPPUTEST_HAVE_RTTI
 static SimpleString getExceptionTypeName(const std::exception &e)
 {
@@ -427,3 +428,4 @@ UnexpectedExceptionFailure::UnexpectedExceptionFailure(UtestShell* test, const s
 {
 }
 #endif // CPPUTEST_USE_STD_CPP_LIB
+#endif // CPPUTEST_HAVE_EXCEPTIONS

--- a/src/CppUTest/Utest.cpp
+++ b/src/CppUTest/Utest.cpp
@@ -216,7 +216,7 @@ void UtestShell::runOneTestInCurrentProcess(TestPlugin* plugin, TestResult& resu
 
     Utest* testToRun = NULLPTR;
 
-#if CPPUTEST_USE_STD_CPP_LIB
+#if CPPUTEST_HAVE_EXCEPTIONS
     try
     {
 #endif
@@ -230,7 +230,7 @@ void UtestShell::runOneTestInCurrentProcess(TestPlugin* plugin, TestResult& resu
 
         UtestShell::setCurrentTest(savedTest);
         UtestShell::setTestResult(savedResult);
-#if CPPUTEST_USE_STD_CPP_LIB
+#if CPPUTEST_HAVE_EXCEPTIONS
     }
     catch(...)
     {
@@ -639,7 +639,7 @@ Utest::~Utest()
 {
 }
 
-#if CPPUTEST_USE_STD_CPP_LIB
+#if CPPUTEST_HAVE_EXCEPTIONS
 
 void Utest::run()
 {
@@ -660,6 +660,7 @@ void Utest::run()
     {
         PlatformSpecificRestoreJumpBuffer();
     }
+#if CPPUTEST_USE_STD_CPP_LIB
     catch (const std::exception &e)
     {
         current->addFailure(UnexpectedExceptionFailure(current, e));
@@ -669,6 +670,7 @@ void Utest::run()
             throw;
         }
     }
+#endif
     catch (...)
     {
         current->addFailure(UnexpectedExceptionFailure(current));
@@ -688,6 +690,7 @@ void Utest::run()
     {
         PlatformSpecificRestoreJumpBuffer();
     }
+#if CPPUTEST_USE_STD_CPP_LIB
     catch (const std::exception &e)
     {
         current->addFailure(UnexpectedExceptionFailure(current, e));
@@ -697,6 +700,7 @@ void Utest::run()
             throw;
         }
     }
+#endif
     catch (...)
     {
         current->addFailure(UnexpectedExceptionFailure(current));
@@ -740,7 +744,7 @@ TestTerminator::~TestTerminator()
 
 void NormalTestTerminator::exitCurrentTest() const
 {
-    #if CPPUTEST_USE_STD_CPP_LIB
+    #if CPPUTEST_HAVE_EXCEPTIONS
         throw CppUTestFailedException();
     #else
         TestTerminatorWithoutExceptions().exitCurrentTest();

--- a/tests/CppUTest/AllocationInCppFile.cpp
+++ b/tests/CppUTest/AllocationInCppFile.cpp
@@ -27,7 +27,7 @@ char* newArrayAllocationWithoutMacro()
     return new char[100];
 }
 
-#if CPPUTEST_USE_STD_CPP_LIB
+#if CPPUTEST_HAVE_EXCEPTIONS
 
 ClassThatThrowsAnExceptionInTheConstructor::ClassThatThrowsAnExceptionInTheConstructor()
 {

--- a/tests/CppUTest/AllocationInCppFile.h
+++ b/tests/CppUTest/AllocationInCppFile.h
@@ -7,7 +7,7 @@ char* newArrayAllocation();
 char* newAllocationWithoutMacro();
 char* newArrayAllocationWithoutMacro();
 
-#if CPPUTEST_USE_STD_CPP_LIB
+#if CPPUTEST_HAVE_EXCEPTIONS
 
 class ClassThatThrowsAnExceptionInTheConstructor
 {

--- a/tests/CppUTest/MemoryOperatorOverloadTest.cpp
+++ b/tests/CppUTest/MemoryOperatorOverloadTest.cpp
@@ -421,20 +421,14 @@ TEST_GROUP(OutOfMemoryTestsForOperatorNew)
 
 #if CPPUTEST_HAVE_EXCEPTIONS
 
-#if CPPUTEST_USE_STD_CPP_LIB
-#define BAD_ALLOC std::bad_alloc
-#else
-#define BAD_ALLOC int
-#endif
-
 TEST(OutOfMemoryTestsForOperatorNew, FailingNewOperatorThrowsAnExceptionWhenUsingStdCppNew)
 {
-    CHECK_THROWS(BAD_ALLOC, new char);
+    CHECK_THROWS(CPPUTEST_BAD_ALLOC, new char);
 }
 
 TEST(OutOfMemoryTestsForOperatorNew, FailingNewArrayOperatorThrowsAnExceptionWhenUsingStdCppNew)
 {
-    CHECK_THROWS(BAD_ALLOC, new char[10]);
+    CHECK_THROWS(CPPUTEST_BAD_ALLOC, new char[10]);
 }
 
 TEST_GROUP(TestForExceptionsInConstructor)
@@ -506,12 +500,12 @@ char* some_memory;
 
 TEST(OutOfMemoryTestsForOperatorNew, FailingNewOperatorThrowsAnExceptionWhenUsingStdCppNewWithoutOverride)
 {
-    CHECK_THROWS(BAD_ALLOC, some_memory = new char);
+    CHECK_THROWS(CPPUTEST_BAD_ALLOC, some_memory = new char);
 }
 
 TEST(OutOfMemoryTestsForOperatorNew, FailingNewArrayOperatorThrowsAnExceptionWhenUsingStdCppNewWithoutOverride)
 {
-    CHECK_THROWS(BAD_ALLOC, some_memory = new char[10]);
+    CHECK_THROWS(CPPUTEST_BAD_ALLOC, some_memory = new char[10]);
 }
 
 #if CPPUTEST_USE_STD_CPP_LIB

--- a/tests/CppUTest/MemoryOperatorOverloadTest.cpp
+++ b/tests/CppUTest/MemoryOperatorOverloadTest.cpp
@@ -419,16 +419,22 @@ TEST_GROUP(OutOfMemoryTestsForOperatorNew)
 
 #if CPPUTEST_USE_MEM_LEAK_DETECTION
 
+#if CPPUTEST_HAVE_EXCEPTIONS
+
 #if CPPUTEST_USE_STD_CPP_LIB
+#define BAD_ALLOC std::bad_alloc
+#else
+#define BAD_ALLOC int
+#endif
 
 TEST(OutOfMemoryTestsForOperatorNew, FailingNewOperatorThrowsAnExceptionWhenUsingStdCppNew)
 {
-    CHECK_THROWS(std::bad_alloc, new char);
+    CHECK_THROWS(BAD_ALLOC, new char);
 }
 
 TEST(OutOfMemoryTestsForOperatorNew, FailingNewArrayOperatorThrowsAnExceptionWhenUsingStdCppNew)
 {
-    CHECK_THROWS(std::bad_alloc, new char[10]);
+    CHECK_THROWS(BAD_ALLOC, new char[10]);
 }
 
 TEST_GROUP(TestForExceptionsInConstructor)
@@ -461,7 +467,7 @@ TEST(OutOfMemoryTestsForOperatorNew, FailingNewArrayOperatorReturnsNull)
 
 #undef new
 
-#if CPPUTEST_USE_STD_CPP_LIB
+#if CPPUTEST_HAVE_EXCEPTIONS
 
 
 /*
@@ -500,14 +506,15 @@ char* some_memory;
 
 TEST(OutOfMemoryTestsForOperatorNew, FailingNewOperatorThrowsAnExceptionWhenUsingStdCppNewWithoutOverride)
 {
-    CHECK_THROWS(std::bad_alloc, some_memory = new char);
+    CHECK_THROWS(BAD_ALLOC, some_memory = new char);
 }
 
 TEST(OutOfMemoryTestsForOperatorNew, FailingNewArrayOperatorThrowsAnExceptionWhenUsingStdCppNewWithoutOverride)
 {
-    CHECK_THROWS(std::bad_alloc, some_memory = new char[10]);
+    CHECK_THROWS(BAD_ALLOC, some_memory = new char[10]);
 }
 
+#if CPPUTEST_USE_STD_CPP_LIB
 TEST(OutOfMemoryTestsForOperatorNew, FailingNewOperatorReturnsNullWithoutOverride)
 {
     POINTERS_EQUAL(NULLPTR, new (std::nothrow) char);
@@ -517,6 +524,7 @@ TEST(OutOfMemoryTestsForOperatorNew, FailingNewArrayOperatorReturnsNullWithoutOv
 {
     POINTERS_EQUAL(NULLPTR, new (std::nothrow) char[10]);
 }
+#endif
 
 #else
 

--- a/tests/CppUTest/TestFailureTest.cpp
+++ b/tests/CppUTest/TestFailureTest.cpp
@@ -427,13 +427,15 @@ TEST(TestFailure, FeatureUnsupported)
     FAILURE_EQUAL("The feature \"SOME_FEATURE\" is not supported in this environment or with the feature set selected when building the library.", f);
 }
 
-#if CPPUTEST_USE_STD_CPP_LIB
+#if CPPUTEST_HAVE_EXCEPTIONS
 TEST(TestFailure, UnexpectedExceptionFailure_UnknownException)
 {
     UnexpectedExceptionFailure f(test);
     FAILURE_EQUAL("Unexpected exception of unknown type was thrown.", f);
 }
+#endif
 
+#if CPPUTEST_HAVE_EXCEPTIONS && CPPUTEST_USE_STD_CPP_LIB
 TEST(TestFailure, UnexpectedExceptionFailure_StandardException)
 {
     std::runtime_error e("Some error");
@@ -446,4 +448,4 @@ TEST(TestFailure, UnexpectedExceptionFailure_StandardException)
     FAILURE_EQUAL("Unexpected exception of unknown type was thrown.", f);
 #endif
 }
-#endif // CPPUTEST_USE_STD_CPP_LIB
+#endif

--- a/tests/CppUTest/TestUTestMacro.cpp
+++ b/tests/CppUTest/TestUTestMacro.cpp
@@ -1318,7 +1318,7 @@ IGNORE_TEST(UnitTestMacros, ENUMS_EQUAL_EQUAL_INT_TEXTWithUnscopedEnumWorksInAnI
     ENUMS_EQUAL_INT_TEXT(UNSCOPED_ENUM_B, UNSCOPED_ENUM_A, "Failed because it failed"); // LCOV_EXCL_LINE
 } // LCOV_EXCL_LINE
 
-#if CPPUTEST_USE_STD_CPP_LIB
+#if CPPUTEST_HAVE_EXCEPTIONS
 static void failingTestMethod_NoThrowWithCHECK_THROWS_()
 {
     CHECK_THROWS(int, (void) (1+2));

--- a/tests/CppUTest/UtestTest.cpp
+++ b/tests/CppUTest/UtestTest.cpp
@@ -217,7 +217,7 @@ TEST(UtestShell, TestStopsAfterSetupFailure)
     LONGS_EQUAL(0, stopAfterFailure);
 }
 
-#if CPPUTEST_USE_STD_CPP_LIB
+#if CPPUTEST_HAVE_EXCEPTIONS
 
 // Prevents -Wunreachable-code; should always be 'true'
 static bool shouldThrowException = true;
@@ -227,15 +227,6 @@ static void thrownUnknownExceptionMethod_()
     if (shouldThrowException)
     {
         throw 33;
-    }
-    stopAfterFailure++;
-}
-
-static void thrownStandardExceptionMethod_()
-{
-    if (shouldThrowException)
-    {
-        throw std::runtime_error("exception text");
     }
     stopAfterFailure++;
 }
@@ -250,26 +241,6 @@ TEST(UtestShell, TestStopsAfterUnknownExceptionIsThrown)
     fixture.runAllTests();
     LONGS_EQUAL(1, fixture.getFailureCount());
     fixture.assertPrintContains("Unexpected exception of unknown type was thrown");
-    LONGS_EQUAL(0, stopAfterFailure);
-    UtestShell::setRethrowExceptions(initialRethrowExceptions);
-}
-
-TEST(UtestShell, TestStopsAfterStandardExceptionIsThrown)
-{
-    bool initialRethrowExceptions = UtestShell::isRethrowingExceptions();
-    UtestShell::setRethrowExceptions(false);
-    stopAfterFailure = 0;
-    shouldThrowException = true;
-    fixture.setTestFunction(thrownStandardExceptionMethod_);
-    fixture.runAllTests();
-    LONGS_EQUAL(1, fixture.getFailureCount());
-#if CPPUTEST_HAVE_RTTI
-    fixture.assertPrintContains("Unexpected exception of type '");
-    fixture.assertPrintContains("runtime_error");
-    fixture.assertPrintContains("' was thrown: exception text");
-#else
-    fixture.assertPrintContains("Unexpected exception of unknown type was thrown");
-#endif
     LONGS_EQUAL(0, stopAfterFailure);
     UtestShell::setRethrowExceptions(initialRethrowExceptions);
 }
@@ -320,6 +291,36 @@ TEST(UtestShell, UnknownExceptionIsRethrownIfEnabled)
     UtestShell::setRethrowExceptions(initialRethrowExceptions);
 }
 
+#if CPPUTEST_USE_STD_CPP_LIB
+static void thrownStandardExceptionMethod_()
+{
+    if (shouldThrowException)
+    {
+        throw std::runtime_error("exception text");
+    }
+    stopAfterFailure++;
+}
+
+TEST(UtestShell, TestStopsAfterStandardExceptionIsThrown)
+{
+    bool initialRethrowExceptions = UtestShell::isRethrowingExceptions();
+    UtestShell::setRethrowExceptions(false);
+    stopAfterFailure = 0;
+    shouldThrowException = true;
+    fixture.setTestFunction(thrownStandardExceptionMethod_);
+    fixture.runAllTests();
+    LONGS_EQUAL(1, fixture.getFailureCount());
+#if CPPUTEST_HAVE_RTTI
+    fixture.assertPrintContains("Unexpected exception of type '");
+    fixture.assertPrintContains("runtime_error");
+    fixture.assertPrintContains("' was thrown: exception text");
+#else
+    fixture.assertPrintContains("Unexpected exception of unknown type was thrown");
+#endif
+    LONGS_EQUAL(0, stopAfterFailure);
+    UtestShell::setRethrowExceptions(initialRethrowExceptions);
+}
+
 TEST(UtestShell, StandardExceptionIsRethrownIfEnabled)
 {
     bool initialRethrowExceptions = UtestShell::isRethrowingExceptions();
@@ -345,7 +346,8 @@ TEST(UtestShell, StandardExceptionIsRethrownIfEnabled)
     LONGS_EQUAL(0, stopAfterFailure);
     UtestShell::setRethrowExceptions(initialRethrowExceptions);
 }
-#endif
+#endif // CPPUTEST_USE_STD_CPP_LIB
+#endif // CPPUTEST_HAVE_EXCEPTIONS
 
 TEST(UtestShell, veryVebose)
 {
@@ -406,7 +408,7 @@ TEST(UtestShell, TestDefaultCrashMethodInSeparateProcessTest)
 
 #endif
 
-#if CPPUTEST_USE_STD_CPP_LIB
+#if CPPUTEST_HAVE_EXCEPTIONS
 
 static bool destructorWasCalledOnFailedTest = false;
 


### PR DESCRIPTION
Like RTTI, exceptions can be disabled independently of the C++ standard library. It is common to disable one or both of RTTI and exceptions while continuing to use remaining supported parts of the standard library in space- or time-constrained embedded systems.