### PR TITLE
Delete extraneous install configs

### DIFF
--- a/cmake/install.cmake
+++ b/cmake/install.cmake
@@ -2,9 +2,6 @@ set(INCLUDE_INSTALL_DIR "${CMAKE_INSTALL_INCLUDEDIR}")
 set(LIB_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}")
 set(INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/include")
 
-# Pkg-config file
-set(CppUTest_PKGCONFIG_FILE ${CMAKE_CURRENT_BINARY_DIR}/cpputest.pc)
-
 # Pkg-config file.
 set(prefix "${CMAKE_INSTALL_PREFIX}")
 set(exec_prefix "\${prefix}")
@@ -12,9 +9,9 @@ set(libdir "\${exec_prefix}/${LIB_INSTALL_DIR}")
 set(includedir "\${prefix}/${INCLUDE_INSTALL_DIR}")
 set(PACKAGE_VERSION "${PROJECT_VERSION}")
 
-configure_file(cpputest.pc.in "${CppUTest_PKGCONFIG_FILE}" @ONLY)
+configure_file(cpputest.pc.in cpputest.pc @ONLY)
 install(
-    FILES "${CppUTest_PKGCONFIG_FILE}"
+    FILES "${CMAKE_CURRENT_BINARY_DIR}/cpputest.pc"
     DESTINATION ${LIB_INSTALL_DIR}/pkgconfig
 )
 
@@ -23,20 +20,7 @@ install(
     DESTINATION "${INCLUDE_INSTALL_DIR}/generated"
 )
 
-# Try to include helper module
-include(CMakePackageConfigHelpers OPTIONAL
-    RESULT_VARIABLE PkgHelpers_AVAILABLE
-)
-
-# guard against older versions of cmake which do not provide it
-if(NOT PkgHelpers_AVAILABLE)
-    message(WARNING
-        "If you wish to use find_package(CppUTest) in your own project to find CppUTest library"
-        " please update cmake to version which provides CMakePackageConfighelpers module"
-        " or write generators for CppUTestConfig.cmake by yourself."
-    )
-    return()
-endif()
+include(CMakePackageConfigHelpers)
 
 set(CPPUTEST_CONFIG_DEST "${LIB_INSTALL_DIR}/CppUTest/cmake")
 
@@ -46,13 +30,14 @@ configure_package_config_file(CppUTestConfig.cmake.install.in
     PATH_VARS INCLUDE_INSTALL_DIR LIB_INSTALL_DIR)
 write_basic_package_version_file(
     ${CMAKE_CURRENT_BINARY_DIR}/install/CppUTestConfigVersion.cmake
-    VERSION ${PROJECT_VERSION}
-    COMPATIBILITY SameMajorVersion )
+    COMPATIBILITY SameMajorVersion
+)
 install(
     FILES
         ${CMAKE_CURRENT_BINARY_DIR}/install/CppUTestConfig.cmake
         ${CMAKE_CURRENT_BINARY_DIR}/install/CppUTestConfigVersion.cmake
-    DESTINATION "${CPPUTEST_CONFIG_DEST}" )
+    DESTINATION "${CPPUTEST_CONFIG_DEST}"
+)
 install(
     EXPORT CppUTestTargets
     NAMESPACE CppUTest::
@@ -76,6 +61,5 @@ configure_package_config_file(CppUTestConfig.cmake.build.in
 )
 write_basic_package_version_file(
     ${CMAKE_CURRENT_BINARY_DIR}/CppUTestConfigVersion.cmake
-    VERSION ${PROJECT_VERSION}
     COMPATIBILITY SameMajorVersion
 )


### PR DESCRIPTION
- `VERSION` is implied by the arguments to `project()`
- `CMakePackageConfigHelpers` is guaranteed to exist by the minimum CMake version (3.8)