### PR TITLE
Save map files

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -210,6 +210,11 @@ jobs:
         run: cmake --preset ${{ matrix.preset }} ${{ matrix.cmake_args }}
       - name: Build
         run: cmake --build cpputest_build --verbose -j
+      - name: Save map files
+        uses: actions/upload-artifact@v3
+        with:
+          name: "${{ matrix.name }} map files"
+          path: cpputest_build/**/*.map
       - name: Test
         run: ctest --test-dir cpputest_build ${{ matrix.ctest_args }}
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,22 @@
+# Helper to handle generating a map file, which is annoyingly tricky.
+function(add_mapfile target)
+    if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.13")
+        set(mapfile "$<TARGET_FILE:${target}>.map")
+        if(CMAKE_CXX_SIMULATE_ID STREQUAL "MSVC")
+            # ClangCL (lld-link) can't generate map files
+        elseif(CMAKE_CXX_COMPILER_ID STREQUAL "IAR")
+            target_link_options(${target} PRIVATE "SHELL:--map ${mapfile}.map")
+        elseif(MSVC)
+            target_link_options(${target} PRIVATE "/MAP:${mapfile}")
+        elseif(
+            (CMAKE_CXX_COMPILER_ID STREQUAL "GNU") OR
+            (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+        )
+            target_link_options(${target} PRIVATE "LINKER:-Map=${mapfile}")
+        endif()
+    endif()
+endfunction()
+
 add_subdirectory(CppUTest)
 if (CPPUTEST_EXTENSIONS)
     add_subdirectory(CppUTestExt)

--- a/tests/CppUTest/CMakeLists.txt
+++ b/tests/CppUTest/CMakeLists.txt
@@ -53,14 +53,7 @@ endif()
 
 target_link_libraries(CppUTestTests PRIVATE ${CppUTestLibName})
 
-if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.13")
-    target_link_options(CppUTestTests
-        PRIVATE
-            $<$<CXX_COMPILER_ID:GNU,Clang>:LINKER:-Map=$<TARGET_FILE:CppUTestTests>.map>
-            "$<$<CXX_COMPILER_ID:MSVC>:/MAP>"
-            $<$<CXX_COMPILER_ID:IAR>:"SHELL:--map $<TARGET_FILE:CppUTestTests>.map">
-    )
-endif()
+add_mapfile(CppUTestTests)
 
 if(CPPUTEST_TEST_DISCOVERY)
     include(CppUTest)

--- a/tests/CppUTestExt/CMakeLists.txt
+++ b/tests/CppUTestExt/CMakeLists.txt
@@ -50,14 +50,7 @@ target_link_libraries(CppUTestExtTests
         ${CppUTestExtLibName}
 )
 
-if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.13")
-    target_link_options(CppUTestExtTests
-        PRIVATE
-            $<$<CXX_COMPILER_ID:GNU,Clang>:LINKER:-Map=$<TARGET_FILE:CppUTestExtTests>.map>
-            "$<$<CXX_COMPILER_ID:MSVC>:/MAP>"
-            $<$<CXX_COMPILER_ID:IAR>:"SHELL:--map $<TARGET_FILE:CppUTestExtTests>.map">
-    )
-endif()
+add_mapfile(CppUTestExtTests)
 
 if(CPPUTEST_TEST_DISCOVERY)
     include(CppUTest)


### PR DESCRIPTION
I was trying to save map files from the ClangCL build to try to debug the hang in `BasicBehavior.deleteWillNotThrowAnExceptionWhenDeletingUnallocatedMemoryButCanStillCauseTestFailures`. Unfortunately ClangCL's linker (link-lld) can't generate map files (and neither can Mac's ld), but I figured it's worth saving them for the builds that can to make future errors easier to diagnose.

See saved map files listed under "Artifacts" here: https://github.com/cpputest/cpputest/actions/runs/3495321337.

Without a Windows system, I won't be able to pursue the problem with `BasicBehavior.deleteWillNotThrowAnExceptionWhenDeletingUnallocatedMemoryButCanStillCauseTestFailures` and ClangCL any further.