### PR TITLE
Repair floating point exception support check

### DIFF
--- a/include/CppUTest/CppUTestConfig.h
+++ b/include/CppUTest/CppUTestConfig.h
@@ -185,7 +185,7 @@
 #endif
 
 #if CPPUTEST_HAVE_FENV
-#if defined(__WATCOMC__) || defined(__ARMEL__) || defined(__m68k__)
+#if defined(__WATCOMC__) || (defined(__arm__) && !__STDC_IEC_559__) || defined(__m68k__)
 #define CPPUTEST_FENV_IS_WORKING_PROPERLY 0
 #else
 #define CPPUTEST_FENV_IS_WORKING_PROPERLY 1


### PR DESCRIPTION
Endianess is not a reliable indicator of support for floating point exception status flags.  Rather, the Arm C Language Extensions specify a macro for indicating support:

> `__STDC_IEC_559__` is defined if the implementation conforms to IEC. This implies support for floating-point exception status flags, including the inexact exception.

https://arm-software.github.io/acle/main/acle.html#floating-point-model