### PR TITLE
Don't error on OSX when __STDC_IEC_559__ isn't defined

### DIFF
--- a/include/CppUTest/CppUTestConfig.h
+++ b/include/CppUTest/CppUTestConfig.h
@@ -167,7 +167,7 @@
  * Predominantly works on non-Visual C++ compilers and Visual C++ 2008 and newer
  */
 #ifndef CPPUTEST_HAVE_FENV
-  #if __STDC_IEC_559__ && CPPUTEST_USE_STD_C_LIB
+  #if (defined(__STDC_IEC_559__) && __STDC_IEC_559__) && CPPUTEST_USE_STD_C_LIB
     #define CPPUTEST_HAVE_FENV 1
   #else
     #define CPPUTEST_HAVE_FENV 0


### PR DESCRIPTION
6ee9aba75afa413bcd0e8089da71e6a8644ac177 started using` __STDC_IEC_559__`
to detect if IEC 60559 is supported, but with apple clang 14.0.0 it was
undefined and throwing -Wundef
This commit just adds a check for if it's defined before using it.

We use the MakefileWorker.mk interface
Full error:
```
In file included from /Users/user/projectDir/cpputest/include/CppUTest/MemoryLeakDetectorNewMacros.h:22:
/Users/user/projectDir/cpputest/include/CppUTest/CppUTestConfig.h:170:7: error: ‘__STDC_IEC_559__’ is not defined, evaluates to 0 [-Werror,-Wundef]
  #if __STDC_IEC_559__ && CPPUTEST_USE_STD_C_LIB
      ^
1 error generated.
```

