### PR TITLE
Correct pthreads dependency

### DIFF
--- a/src/CppUTest/CMakeLists.txt
+++ b/src/CppUTest/CMakeLists.txt
@@ -78,9 +78,14 @@ target_compile_definitions(${CppUTestLibName}
         $<$<BOOL:${HAVE_STRUCT_TIMESPEC}>:_TIMESPEC_DEFINED>
 )
 
-if (WIN32)
-    target_link_libraries(${CppUTestLibName} winmm)
-endif (WIN32)
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads)
+
+target_link_libraries(${CppUTestLibName}
+    PRIVATE
+        $<$<BOOL:${WIN32}>:winmm>
+        $<$<BOOL:${CMAKE_USE_PTHREADS_INIT}>:${CMAKE_THREAD_LIBS_INIT}>
+)
 
 add_library(CppUTest::CppUTest ALIAS ${CppUTestLibName})
 

--- a/tests/CppUTest/CMakeLists.txt
+++ b/tests/CppUTest/CMakeLists.txt
@@ -43,14 +43,6 @@ if(CPPUTEST_STD_C_LIB_DISABLED)
     )
 endif()
 
-if(MINGW OR (${CMAKE_HOST_SYSTEM_NAME} MATCHES "OpenBSD"))
-    set(THREADS_PREFER_PTHREAD_FLAG ON)
-    find_package(Threads)
-    if(CMAKE_USE_PTHREADS_INIT)
-        target_link_libraries(CppUTestTests PRIVATE Threads::Threads)
-    endif()
-endif()
-
 target_link_libraries(CppUTestTests PRIVATE ${CppUTestLibName})
 
 if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.13")

--- a/tests/CppUTestExt/CMakeLists.txt
+++ b/tests/CppUTestExt/CMakeLists.txt
@@ -60,14 +60,6 @@ if(CPPUTEST_TEST_GTEST)
     target_compile_definitions(CppUTestExtTests PRIVATE CPPUTEST_INCLUDE_GTEST_TESTS)
 endif()
 
-if(MINGW)
-    set(THREADS_PREFER_PTHREAD_FLAG ON)
-    find_package(Threads)
-    if(CMAKE_USE_PTHREADS_INIT)
-        target_link_libraries(CppUTestExtTests PRIVATE Threads::Threads)
-    endif()
-endif()
-
 target_link_libraries(CppUTestExtTests
     PRIVATE
         ${CppUTestLibName}


### PR DESCRIPTION
CppUTest itself depends on pthreads (when used), not just the tests.