### PR TITLE
Mark exception as unused

### DIFF
--- a/src/CppUTest/TestFailure.cpp
+++ b/src/CppUTest/TestFailure.cpp
@@ -426,6 +426,7 @@ UnexpectedExceptionFailure::UnexpectedExceptionFailure(UtestShell* test, const s
 #endif
 )
 {
+    (void) e;
 }
 #endif // CPPUTEST_USE_STD_CPP_LIB
 #endif // CPPUTEST_HAVE_EXCEPTIONS


### PR DESCRIPTION
If compiled without RTTI `e` is unused and issues a warning. Casting to void marks it as intentionally unused.

Should we create eg. an "unused()" for improved documentation (cast-to-void might not be known to everyone)?