### PR TITLE
Use the currently configured Test Terminator rather than a hard coded version

### DIFF
--- a/src/CppUTest/MemoryLeakWarningPlugin.cpp
+++ b/src/CppUTest/MemoryLeakWarningPlugin.cpp
@@ -545,7 +545,7 @@ public:
     virtual void fail(char* fail_string) _override
     {
         UtestShell* currentTest = UtestShell::getCurrent();
-        currentTest->failWith(FailFailure(currentTest, currentTest->getName().asCharString(), currentTest->getLineNumber(), fail_string), TestTerminatorWithoutExceptions());
+        currentTest->failWith(FailFailure(currentTest, currentTest->getName().asCharString(), currentTest->getLineNumber(), fail_string), UtestShell::getCurrentTestTerminatorWithoutExceptions());
     } // LCOV_EXCL_LINE
 };
 


### PR DESCRIPTION
This is the fix for #1709