### PR TITLE
Memory Sanitizer

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -211,6 +211,9 @@ jobs:
           - name: Address Sanitizer
             os: ubuntu-latest
             preset: asan
+          - name: Memory Sanitizer
+            os: ubuntu-latest
+            preset: msan
           - name: GCC ARM embedded
             os: ubuntu-latest
             preset: arm-embedded

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -141,6 +141,19 @@
       }
     },
     {
+      "name": "msan",
+      "inherits": ["Clang"],
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CPPUTEST_MEM_LEAK_DETECTION_DISABLED": true
+      },
+      "environment": {
+        "CFLAGS": "-fsanitize=memory -fsanitize-memory-track-origins -fno-omit-frame-pointer",
+        "CXXFLAGS": "-fsanitize=memory -fsanitize-memory-track-origins -fno-omit-frame-pointer",
+        "LDFLAGS": "-fsanitize=memory"
+      }
+    },
+    {
       "name": "detailed",
       "inherits": ["defaults"],
       "cacheVariables": {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -145,7 +145,8 @@
       "inherits": ["Clang"],
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
-        "CPPUTEST_MEM_LEAK_DETECTION_DISABLED": true
+        "CPPUTEST_MEM_LEAK_DETECTION_DISABLED": true,
+        "CPPUTEST_STD_CPP_LIB_DISABLED": true
       },
       "environment": {
         "CFLAGS": "-fsanitize=memory -fsanitize-memory-track-origins -fno-omit-frame-pointer",

--- a/include/CppUTest/CppUTestConfig.h
+++ b/include/CppUTest/CppUTestConfig.h
@@ -133,33 +133,42 @@
  * Address sanitizer is a good thing... and it causes some conflicts with the CppUTest tests
  * To check whether it is on or off, we create a CppUTest define here.
 */
-#if defined(__has_feature)
-#if __has_feature(address_sanitizer)
-#define CPPUTEST_SANITIZE_ADDRESS 1
-#endif
+#ifdef __has_feature
+  #if __has_feature(address_sanitizer)
+    #define CPPUTEST_SANITIZE_ADDRESS 1
+    #define CPPUTEST_DO_NOT_SANITIZE_ADDRESS __attribute__((no_sanitize_address))
+  #endif
+  #if __has_feature(memory_sanitizer)
+    #define CPPUTEST_SANITIZE_MEMORY 1
+    #define CPPUTEST_DO_NOT_SANITIZE_MEMORY __attribute__((no_sanitize_memory))
+  #endif
+#elif defined(__SANITIZE_ADDRESS__)
+  #define CPPUTEST_SANITIZE_ADDRESS 1
 #endif
 
-#ifdef __SANITIZE_ADDRESS__
-#define CPPUTEST_SANITIZE_ADDRESS 1
+#if CPPUTEST_USE_MEM_LEAK_DETECTION \
+    && CPPUTEST_SANITIZE_ADDRESS \
+    && (defined(__linux__) \
+    && defined(__clang))
+  #warning Compiling with Address Sanitizer with clang on linux will cause duplicate symbols for operator new. Turning off memory leak detection. Compile with -DCPPUTEST_MEM_LEAK_DETECTION_DISABLED to get rid of this warning.
+  #undef CPPUTEST_USE_MEM_LEAK_DETECTION
+  #define CPPUTEST_USE_MEM_LEAK_DETECTION 0
 #endif
 
 #ifndef CPPUTEST_SANITIZE_ADDRESS
-#define CPPUTEST_SANITIZE_ADDRESS 0
+  #define CPPUTEST_SANITIZE_ADDRESS 0
 #endif
 
-#if CPPUTEST_SANITIZE_ADDRESS
-#define CPPUTEST_SANITIZE_ADDRESS 1
-#define CPPUTEST_DO_NOT_SANITIZE_ADDRESS __attribute__((no_sanitize_address))
-  #if defined(__linux__) && defined(__clang__)
-    #if CPPUTEST_USE_MEM_LEAK_DETECTION
-    #warning Compiling with Address Sanitizer with clang on linux will cause duplicate symbols for operator new. Turning off memory leak detection. Compile with -DCPPUTEST_MEM_LEAK_DETECTION_DISABLED to get rid of this warning.
-    #undef CPPUTEST_USE_MEM_LEAK_DETECTION
-    #define CPPUTEST_USE_MEM_LEAK_DETECTION 0
-    #endif
-  #endif
-#else
-#define CPPUTEST_SANITIZER_ADDRESS 0
-#define CPPUTEST_DO_NOT_SANITIZE_ADDRESS
+#ifndef CPPUTEST_DO_NOT_SANITIZE_ADDRESS
+  #define CPPUTEST_DO_NOT_SANITIZE_ADDRESS
+#endif
+
+#ifndef CPPUTEST_SANITIZE_MEMORY
+  #define CPPUTEST_SANITIZE_MEMORY 0
+#endif
+
+#ifndef CPPUTEST_DO_NOT_SANITIZE_MEMORY
+  #define CPPUTEST_DO_NOT_SANITIZE_MEMORY 0
 #endif
 
 /*

--- a/tests/CppUTest/MemoryLeakDetectorTest.cpp
+++ b/tests/CppUTest/MemoryLeakDetectorTest.cpp
@@ -30,6 +30,12 @@
 #include "CppUTest/TestMemoryAllocator.h"
 #include "CppUTest/PlatformSpecificFunctions.h"
 
+#if CPPUTEST_SANITIZE_MEMORY
+  #define LEAKY_TEST IGNORE_TEST
+#else
+  #define LEAKY_TEST TEST
+#endif
+
 class MemoryLeakFailureForTest: public MemoryLeakFailure
 {
 public:
@@ -129,7 +135,7 @@ TEST_GROUP(MemoryLeakDetectorTest)
     }
 };
 
-TEST(MemoryLeakDetectorTest, OneLeak)
+LEAKY_TEST(MemoryLeakDetectorTest, OneLeak)
 {
     char* mem = detector->allocMemory(testAllocator, 3);
     detector->stopChecking();
@@ -144,7 +150,7 @@ TEST(MemoryLeakDetectorTest, OneLeak)
     LONGS_EQUAL(0, testAllocator->free_called);
 }
 
-TEST(MemoryLeakDetectorTest, sequenceNumbersOfMemoryLeaks)
+LEAKY_TEST(MemoryLeakDetectorTest, sequenceNumbersOfMemoryLeaks)
 {
     char* mem = detector->allocMemory(defaultNewAllocator(), 1);
     char* mem2 = detector->allocMemory(defaultNewAllocator(), 2);
@@ -174,7 +180,7 @@ TEST(MemoryLeakDetectorTest, memoryDumpOutput)
     PlatformSpecificFree(mem);
 }
 
-TEST(MemoryLeakDetectorTest, OneHundredLeaks)
+LEAKY_TEST(MemoryLeakDetectorTest, OneHundredLeaks)
 {
     const int amount_alloc = 100;
     char *mem[amount_alloc];
@@ -193,7 +199,7 @@ TEST(MemoryLeakDetectorTest, OneHundredLeaks)
         PlatformSpecificFree(mem[j]);
 }
 
-TEST(MemoryLeakDetectorTest, OneLeakOutsideCheckingPeriod)
+LEAKY_TEST(MemoryLeakDetectorTest, OneLeakOutsideCheckingPeriod)
 {
     detector->stopChecking();
     char* mem = detector->allocMemory(defaultNewAllocator(), 4);
@@ -212,7 +218,7 @@ TEST(MemoryLeakDetectorTest, NoLeaksWhatsoever)
     STRCMP_CONTAINS("No memory leaks", detector->report(mem_leak_period_all));
 }
 
-TEST(MemoryLeakDetectorTest, TwoLeaksUsingOperatorNew)
+LEAKY_TEST(MemoryLeakDetectorTest, TwoLeaksUsingOperatorNew)
 {
     char* mem = detector->allocMemory(defaultNewAllocator(), 4);
     char* mem2 = detector->allocMemory(defaultNewAllocator(), 8);
@@ -235,7 +241,7 @@ TEST(MemoryLeakDetectorTest, OneAllocButNoLeak)
     LONGS_EQUAL(1, testAllocator->free_called);
 }
 
-TEST(MemoryLeakDetectorTest, TwoAllocOneFreeOneLeak)
+LEAKY_TEST(MemoryLeakDetectorTest, TwoAllocOneFreeOneLeak)
 {
     char* mem = detector->allocMemory(testAllocator, 4);
     char* mem2 = detector->allocMemory(testAllocator, 12);
@@ -250,7 +256,7 @@ TEST(MemoryLeakDetectorTest, TwoAllocOneFreeOneLeak)
     LONGS_EQUAL(1, testAllocator->free_called);
 }
 
-TEST(MemoryLeakDetectorTest, TwoAllocOneFreeOneLeakReverseOrder)
+LEAKY_TEST(MemoryLeakDetectorTest, TwoAllocOneFreeOneLeakReverseOrder)
 {
     char* mem = detector->allocMemory(defaultNewAllocator(), 4);
     char* mem2 = detector->allocMemory(defaultNewAllocator(), 12);
@@ -311,7 +317,7 @@ TEST(MemoryLeakDetectorTest, IgnoreMemoryAllocatedOutsideCheckingPeriodComplicat
     PlatformSpecificFree(mem3);
 }
 
-TEST(MemoryLeakDetectorTest, OneLeakUsingOperatorNewWithFileLine)
+LEAKY_TEST(MemoryLeakDetectorTest, OneLeakUsingOperatorNewWithFileLine)
 {
     char* mem = detector->allocMemory(defaultNewAllocator(), 4, "file.cpp", 1234);
     detector->stopChecking();
@@ -321,7 +327,7 @@ TEST(MemoryLeakDetectorTest, OneLeakUsingOperatorNewWithFileLine)
     PlatformSpecificFree(mem);
 }
 
-TEST(MemoryLeakDetectorTest, OneAllocAndFreeUsingArrayNew)
+LEAKY_TEST(MemoryLeakDetectorTest, OneAllocAndFreeUsingArrayNew)
 {
     char* mem = detector->allocMemory(defaultNewArrayAllocator(), 10, "file.cpp", 1234);
     char* mem2 = detector->allocMemory(defaultNewArrayAllocator(), 12);
@@ -334,7 +340,7 @@ TEST(MemoryLeakDetectorTest, OneAllocAndFreeUsingArrayNew)
     detector->stopChecking();
 }
 
-TEST(MemoryLeakDetectorTest, OneAllocAndFree)
+LEAKY_TEST(MemoryLeakDetectorTest, OneAllocAndFree)
 {
     char* mem = detector->allocMemory(defaultMallocAllocator(), 10, "file.cpp", 1234);
     char* mem2 = detector->allocMemory(defaultMallocAllocator(), 12);
@@ -347,7 +353,7 @@ TEST(MemoryLeakDetectorTest, OneAllocAndFree)
     detector->stopChecking();
 }
 
-TEST(MemoryLeakDetectorTest, OneRealloc)
+LEAKY_TEST(MemoryLeakDetectorTest, OneRealloc)
 {
     char* mem1 = detector->allocMemory(testAllocator, 10, "file.cpp", 1234, true);
 
@@ -396,7 +402,7 @@ TEST(MemoryLeakDetectorTest, AllocOneTypeFreeAnotherTypeWithCheckingDisabled)
     detector->enableAllocationTypeChecking();
 }
 
-TEST(MemoryLeakDetectorTest, mallocLeakGivesAdditionalWarning)
+LEAKY_TEST(MemoryLeakDetectorTest, mallocLeakGivesAdditionalWarning)
 {
     char* mem = detector->allocMemory(defaultMallocAllocator(), 100, "ALLOC.c", 10);
     detector->stopChecking();
@@ -405,7 +411,7 @@ TEST(MemoryLeakDetectorTest, mallocLeakGivesAdditionalWarning)
     PlatformSpecificFree(mem);
 }
 
-TEST(MemoryLeakDetectorTest, newLeakDoesNotGiveAdditionalWarning)
+LEAKY_TEST(MemoryLeakDetectorTest, newLeakDoesNotGiveAdditionalWarning)
 {
     char* mem = detector->allocMemory(defaultNewAllocator(), 100, "ALLOC.c", 10);
     detector->stopChecking();

--- a/tests/CppUTest/TestMemoryAllocatorTest.cpp
+++ b/tests/CppUTest/TestMemoryAllocatorTest.cpp
@@ -125,7 +125,7 @@ TEST(TestMemoryAllocatorTest, NullUnknownNames)
     STRCMP_EQUAL("unknown", allocator->free_name());
 }
 
-#if (! CPPUTEST_SANITIZE_ADDRESS)
+#if !CPPUTEST_SANITIZE_ADDRESS && !CPPUTEST_SANITIZE_MEMORY
 
 #define MAX_SIZE_FOR_ALLOC ((size_t) -1 > (unsigned short)-1) ? (size_t)(-97) : (size_t)(-1)
 

--- a/tests/CppUTest/UtestPlatformTest.cpp
+++ b/tests/CppUTest/UtestPlatformTest.cpp
@@ -122,7 +122,7 @@ TEST(UTestPlatformsTest_PlatformSpecificRunTestInASeperateProcess, FailureInSepa
     fixture.assertPrintContains("Errors (1 failures, 1 tests, 1 ran, 0 checks, 0 ignored, 0 filtered out");
 }
 
-#if (! CPPUTEST_SANITIZE_ADDRESS)
+#if !CPPUTEST_SANITIZE_ADDRESS && !CPPUTEST_SANITIZE_MEMORY
 
 static int accessViolationTestFunction_()
 {


### PR DESCRIPTION
> [MemorySanitizer](https://clang.llvm.org/docs/MemorySanitizer.html) is a detector of uninitialized reads.

* We obviously can't run msan with leak detection enabled.
* We have to disable the C++ standard library for msan. Unless we build it ourselves, it isn't instrumented, so generates false positives.
* I had to disable all the MemoryLeakDetector tests for msan. I was surprised to discover that code is active, even when leak detection is disabled.