### PR TITLE
Clean up DOS build

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -420,27 +420,22 @@ jobs:
   make_dos:
     name: Make OpenWatcom DOS
     runs-on: ubuntu-latest
+    env:
+      WATCOM: "./watcom"
     steps:
       - name: Checkout
         uses: actions/checkout@main
       - name: Install tools
         run: |
           sudo apt-get install -y dosbox
-          git clone https://github.com/cpputest/watcom-compiler.git watcom
-          echo "WATCOM=$GITHUB_WORKSPACE/watcom" >> $GITHUB_ENV
-          echo "CC=wcl" >> $GITHUB_ENV
-          echo "CXX=wcl" >> $GITHUB_ENV
-          echo "$GITHUB_WORKSPACE/watcom/binl" >> $GITHUB_PATH
-          echo "CPPUTEST_HOME=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+          git clone https://github.com/cpputest/watcom-compiler.git $WATCOM
+          echo "$WATCOM/binl" >> $GITHUB_PATH
       - name: Build
-        run: |
-          $CC --version
-          make -f $CPPUTEST_HOME/platforms/Dos/Makefile clean
-          make -f $CPPUTEST_HOME/platforms/Dos/Makefile
+        run: make -f platforms/Dos/Makefile
       - name: Test
         env:
           TERM: linux
-        run: $CPPUTEST_HOME/platforms/Dos/alltests.sh
+        run: platforms/Dos/alltests.sh
 
   cmake_msys:
     name: CMake MSYS

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -422,6 +422,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       WATCOM: "./watcom"
+      TERM: linux
     steps:
       - name: Checkout
         uses: actions/checkout@main
@@ -433,9 +434,7 @@ jobs:
       - name: Build
         run: make -f platforms/Dos/Makefile
       - name: Test
-        env:
-          TERM: linux
-        run: platforms/Dos/alltests.sh
+        run: make -f platforms/Dos/Makefile test
 
   cmake_msys:
     name: CMake MSYS

--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,8 @@ generated/
 #IAR automatically generated files
 *.dep
 *.ewt
+
+# Watcom
+*.LIB
+*.LST
+*.EXE

--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,6 @@ generated/
 *.LIB
 *.LST
 *.EXE
+*.LOG
+/console_output
+/exit

--- a/platforms/Dos/Makefile
+++ b/platforms/Dos/Makefile
@@ -9,7 +9,7 @@ comma := ,
 path_separator := /
 drive = $(subst $(CYGDRIVE),$(lastword $(subst /, ,$(CYGDRIVE))):/,$(1))
 convert_paths = $(if $(CYGDRIVE),$(subst /,$(path_separator),$(call drive,$(1))),$(1))
-CPPUTEST_HOME ?= .
+export CPPUTEST_HOME ?= .
 
 -include $(CPPUTEST_HOME)/platforms/Dos/platform.mk
 include $(CPPUTEST_HOME)/platforms/Dos/sources.mk
@@ -63,3 +63,7 @@ clean:
 %.EXE: $$($$*_OBJECTS) | CPPU.LIB CPPUX.LIB
 	$(LINK) opt q,map,st=50k sys dos lib CPPU.LIB,CPPUX.LIB \
     file $(subst $(space),$(comma),$(call convert_paths,$?)) name $@
+
+.PHONY:
+test:
+	$(CPPUTEST_HOME)/platforms/Dos/alltests.sh

--- a/platforms/Dos/Makefile
+++ b/platforms/Dos/Makefile
@@ -9,23 +9,34 @@ comma := ,
 path_separator := /
 drive = $(subst $(CYGDRIVE),$(lastword $(subst /, ,$(CYGDRIVE))):/,$(1))
 convert_paths = $(if $(CYGDRIVE),$(subst /,$(path_separator),$(call drive,$(1))),$(1))
+CPPUTEST_HOME ?= .
 
 -include $(CPPUTEST_HOME)/platforms/Dos/platform.mk
 include $(CPPUTEST_HOME)/platforms/Dos/sources.mk
 
-# Disable W013 unreachable code - it overreacts to CHECK_EQUAL macros
-# Disable W367 conditional expression in if statement is always true - same
-# Disable W368 conditional expression in if statement is always false - same
-# Disable W391 assignment found in boolean expression - we don't care
-
-CFLAGS := \
-  -q -c -os -oc -d0 -we -w=3 -wcd=13 -wcd=367 -wcd=368 -wcd391 -wcd=472 -ml -zm \
+COMMONFLAGS := \
+  -q -c -os -oc -d0 -we -w=3 -ml -zm \
   -dCPPUTEST_MEM_LEAK_DETECTION_DISABLED=1 -dCPPUTEST_STD_CPP_LIB_DISABLED=1 \
   -i$(call convert_paths,$(CPPUTEST_HOME)/include) \
   -i$(call convert_paths,$(CPPUTEST_HOME)/include/Platforms/Dos) \
   -i$(call convert_paths,$(WATCOM)/h) -i$(call convert_paths,$(WATCOM)/h/nt) \
 
-CXXFLAGS := $(CFLAGS) -xds
+# Disable W303 unreferenced parameter - PUNUSED is GNU-specific
+CFLAGS := \
+  $(COMMONFLAGS) \
+  -wcd=303
+
+# Disable W013 unreachable code - it overreacts to CHECK_EQUAL macros
+# Disable W367 conditional expression in if statement is always true - same
+# Disable W368 conditional expression in if statement is always false - same
+# Disable W391 assignment found in boolean expression - we don't care
+CXXFLAGS := \
+  $(COMMONFLAGS) \
+  -wcd=13 \
+  -wcd=367 \
+  -wcd=368 \
+  -wcd=391 \
+  -xds
 
 .PHONY: all clean
 
@@ -36,7 +47,7 @@ all: CPPU.LIB CPPUX.LIB \
 clean:
 	rm -rf ../src/CppUTest/*.o ../src/CppUTestExt/*.o \
     ../src/Platforms/dos/*.o ../tests/*.o ../tests/CppUTestExt/*.o \
-    *.o *.map *.txt *.LOG *.EXE *.err *.LIB *.LST
+    *.o *.map *.LOG *.EXE *.err *.LIB *.LST
 
 %.o: %.cpp
 	$(CXX) $(CXXFLAGS) -fo=$(call convert_paths,$@) $(call convert_paths,$<)

--- a/platforms/Dos/alltests.sh
+++ b/platforms/Dos/alltests.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+: "${CPPUTEST_HOME:=.}"
+
 checkForCppUTestToolsEnvVariable() {
 	if [ -z "$CPPUTEST_HOME" ] ; then
 	   echo "CPPUTEST_HOME not set. You must set CPPUTEST_HOME to the top level CppUTest directory"


### PR DESCRIPTION
* Default `CPPUTEST_HOME` variable
* Add outputs to .gitignore
* Run tests from Makefile
* Repair language-specific warning suppressions.