### PR TITLE
Remove undefined behavior

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -265,7 +265,9 @@ jobs:
       ### SETUP
 
       - name: Install packages
-        run: sudo apt install -y ${{ matrix.apt_packages }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ${{ matrix.apt_packages }}
         if: ${{ matrix.apt_packages }}
 
       - uses: carlosperate/arm-none-eabi-gcc-action@v1
@@ -404,6 +406,7 @@ jobs:
         uses: actions/checkout@main
       - name: Install tools
         run: |
+          sudo apt-get update
           sudo apt-get install -y dosbox
           git clone https://github.com/cpputest/watcom-compiler.git $WATCOM
           echo "$WATCOM/binl" >> $GITHUB_PATH

--- a/tests/CppUTest/MemoryOperatorOverloadTest.cpp
+++ b/tests/CppUTest/MemoryOperatorOverloadTest.cpp
@@ -14,9 +14,6 @@
 # if __GNUC__ >= 11
 #  define NEEDS_DISABLE_FREE_NON_HEEP_WARNING
 # endif /* GCC >= 11 */
-# if __GNUC__ >= 12
-#  define NEEDS_DISABLE_USE_AFTER_FREE
-# endif /* GCC >= 12 */
 #endif /* GCC */
 
 
@@ -31,29 +28,6 @@ TEST(BasicBehavior, CanDeleteNullPointers)
 }
 
 #if CPPUTEST_USE_MEM_LEAK_DETECTION
-
-#ifdef NEEDS_DISABLE_USE_AFTER_FREE
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wuse-after-free"
-#endif /* NEEDS_DISABLE_USE_AFTER_FREE */
-
-CPPUTEST_DO_NOT_SANITIZE_ADDRESS
-static void deleteArrayInvalidatesMemory()
-{
-    unsigned char* memory = new unsigned char[10];
-    PlatformSpecificMemset(memory, 0xAB, 10);
-    delete [] memory;
-    CHECK(memory[5] != 0xAB);
-}
-
-#ifdef NEEDS_DISABLE_USE_AFTER_FREE
-# pragma GCC diagnostic pop
-#endif /* NEEDS_DISABLE_USE_AFTER_FREE */
-
-TEST(BasicBehavior, deleteArrayInvalidatesMemory)
-{
-    deleteArrayInvalidatesMemory();
-}
 
 #if __cplusplus >= 201402L
 TEST(BasicBehavior, DeleteWithSizeParameterWorks)
@@ -114,23 +88,6 @@ TEST(BasicBehavior, bothMallocAndFreeAreOverloaded)
     cpputest_free_location(memory, "file", 10);
 }
 
-#endif
-
-#if CPPUTEST_USE_MEM_LEAK_DETECTION
-
-CPPUTEST_DO_NOT_SANITIZE_ADDRESS
-static void freeInvalidatesMemory()
-{
-    unsigned char* memory = (unsigned char*) cpputest_malloc(sizeof(unsigned char));
-    *memory = 0xAD;
-    cpputest_free(memory);
-    CHECK(*memory != 0xAD);
-}
-
-TEST(BasicBehavior, freeInvalidatesMemory)
-{
-    freeInvalidatesMemory();
-}
 #endif
 
 TEST_GROUP(MemoryLeakOverridesToBeUsedInProductionCode)

--- a/tests/CppUTest/MemoryOperatorOverloadTest.cpp
+++ b/tests/CppUTest/MemoryOperatorOverloadTest.cpp
@@ -46,15 +46,6 @@ static void deleteArrayInvalidatesMemory()
     CHECK(memory[5] != 0xAB);
 }
 
-CPPUTEST_DO_NOT_SANITIZE_ADDRESS
-static void deleteInvalidatesMemory()
-{
-    unsigned char* memory = new unsigned char;
-    *memory = 0xAD;
-    delete memory;
-    CHECK(*memory != 0xAD);
-}
-
 #ifdef NEEDS_DISABLE_USE_AFTER_FREE
 # pragma GCC diagnostic pop
 #endif /* NEEDS_DISABLE_USE_AFTER_FREE */
@@ -62,11 +53,6 @@ static void deleteInvalidatesMemory()
 TEST(BasicBehavior, deleteArrayInvalidatesMemory)
 {
     deleteArrayInvalidatesMemory();
-}
-
-TEST(BasicBehavior, deleteInvalidatesMemory)
-{
-    deleteInvalidatesMemory();
 }
 
 #if __cplusplus >= 201402L


### PR DESCRIPTION
This is undefined behavior and has been failing very frequently on CI. The custom `delete` implementation calls `free()`.

> The behavior is undefined if after `free()` returns, an access is made through the pointer.

https://en.cppreference.com/w/c/memory/free