### PR TITLE
Delete build directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,6 @@ generated/
 *.LOG
 /console_output
 /exit
+
+# Builds
+/cpputest_build/

--- a/cpputest_build/.gitignore
+++ b/cpputest_build/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/scripts/appveyor_ci_build.ps1
+++ b/scripts/appveyor_ci_build.ps1
@@ -2,6 +2,8 @@
 # Load functions from the helper file
 . (Join-Path (Split-Path $MyInvocation.MyCommand.Path) 'appveyor_helpers.ps1')
 
+mkdir cpputest_build
+
 function Invoke-BuildCommand($command, $directory = '.')
 {
     $command_wrapped = "$command;`$err = `$?"


### PR DESCRIPTION
I frequently delete the build directory when re-configuring builds and it creates very noisy git diffs, since the directory is currently tracked.