### PR TITLE
Remove qemu from CI

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -270,13 +270,6 @@ jobs:
 
       - uses: carlosperate/arm-none-eabi-gcc-action@v1
         if: ${{ matrix.name == 'GCC ARM embedded' }}
-      - name: Install QEMU
-        # The version in the ubuntu repositories (6.2) is broken.
-        run: |
-          wget -nv http://ftp.de.debian.org/debian/pool/main/q/qemu/qemu-user-static_7.1+dfsg-2+b3_amd64.deb -O qemu.deb
-          sudo dpkg --install qemu.deb
-          rm -f qemu.deb
-        if: ${{ matrix.name == 'GCC ARM embedded' }}
 
       - name: Install OpenWatcom
         uses: open-watcom/setup-watcom@v0

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -67,10 +67,7 @@
     {
       "name": "arm-embedded",
       "inherits": ["defaults"],
-      "toolchainFile": "${sourceDir}/cmake/Toolchains/arm-none-eabi-gcc.toolchain.cmake",
-      "cacheVariables": {
-        "CMAKE_CROSSCOMPILING_EMULATOR": "qemu-arm-static;-cpu;cortex-m4"
-      }
+      "toolchainFile": "${sourceDir}/cmake/Toolchains/arm-none-eabi-gcc.toolchain.cmake"
     },
     {
       "name": "coverage",


### PR DESCRIPTION
Our workaround to download a new version on Ubuntu keeps breaking because the Debian URL is not stable.

- #1700
- #1738