### PR TITLE
Allow for splitting test executables

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -265,7 +265,9 @@ jobs:
       ### SETUP
 
       - name: Install packages
-        run: sudo apt install -y ${{ matrix.apt_packages }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ${{ matrix.apt_packages }}
         if: ${{ matrix.apt_packages }}
 
       - uses: carlosperate/arm-none-eabi-gcc-action@v1
@@ -404,6 +406,7 @@ jobs:
         uses: actions/checkout@main
       - name: Install tools
         run: |
+          sudo apt-get update
           sudo apt-get install -y dosbox
           git clone https://github.com/cpputest/watcom-compiler.git $WATCOM
           echo "$WATCOM/binl" >> $GITHUB_PATH

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,8 @@ cmake_dependent_option(CPPUTEST_USE_LONG_LONG "Support long long"
 
 cmake_dependent_option(CPPUTEST_BUILD_TESTING "Compile and make tests for CppUTest"
   ${PROJECT_IS_TOP_LEVEL} "BUILD_TESTING" OFF)
+cmake_dependent_option(CPPUTEST_SPLIT_TESTS "Split tests into small executables"
+  OFF "CPPUTEST_BUILD_TESTING" OFF)
 cmake_dependent_option(CPPUTEST_TEST_DISCOVERY "Build time test discover"
   ON "CPPUTEST_BUILD_TESTING;CMAKE_CROSSCOMPILING_EMULATOR OR NOT CMAKE_CROSSCOMPILING" OFF)
 cmake_dependent_option(CPPUTEST_TEST_GTEST "Test GoogleTest integration"

--- a/tests/CppUTest/CMakeLists.txt
+++ b/tests/CppUTest/CMakeLists.txt
@@ -13,21 +13,32 @@ target_link_libraries(CppUTestTests_main
     PUBLIC CppUTest
 )
 
+include(CppUTest)
 
-add_executable(CppUTestTests)
+if(NOT CPPUTEST_SPLIT_TESTS)
+    add_executable(CppUTestTests)
 
-add_mapfile(CppUTestTests)
+    add_mapfile(CppUTestTests)
 
-if(CPPUTEST_TEST_DISCOVERY)
-    include(CppUTest)
-    cpputest_discover_tests(CppUTestTests)
+    if(CPPUTEST_TEST_DISCOVERY)
+        cpputest_discover_tests(CppUTestTests)
+    endif()
 endif()
 
-function(add_cpputest_test name)
-    target_sources(CppUTestTests
+function(add_cpputest_test number)
+    set(name CppUTestTests)
+    
+    if(CPPUTEST_SPLIT_TESTS)
+        string(APPEND name ${number})
+        add_executable(${name})
+        add_mapfile(${name})
+        cpputest_discover_tests(${name})
+    endif()
+
+    target_sources(${name}
         PRIVATE ${ARGN}
     )
-    target_link_libraries(CppUTestTests
+    target_link_libraries(${name}
         PRIVATE CppUTestTests_main
     )
 endfunction()

--- a/tests/CppUTest/CMakeLists.txt
+++ b/tests/CppUTest/CMakeLists.txt
@@ -32,7 +32,9 @@ function(add_cpputest_test number)
         string(APPEND name ${number})
         add_executable(${name})
         add_mapfile(${name})
-        cpputest_discover_tests(${name})
+        if(CPPUTEST_TEST_DISCOVERY)
+            cpputest_discover_tests(${name})
+        endif()
     endif()
 
     target_sources(${name}

--- a/tests/CppUTest/CMakeLists.txt
+++ b/tests/CppUTest/CMakeLists.txt
@@ -1,49 +1,20 @@
-add_executable(CppUTestTests
+add_library(CppUTestTests_main OBJECT
     AllTests.cpp
-    SetPluginTest.cpp
-    CheatSheetTest.cpp
-    SimpleStringTest.cpp
-    SimpleStringCacheTest.cpp
-    CompatabilityTests.cpp
-    CommandLineArgumentsTest.cpp
-    TestFailureTest.cpp
-    TestFailureNaNTest.cpp
-    CommandLineTestRunnerTest.cpp
-    TestFilterTest.cpp
-    TestHarness_cTest.cpp
-    JUnitOutputTest.cpp
-    TestHarness_cTestCFile.c
-    DummyMemoryLeakDetector.cpp
-    MemoryLeakDetectorTest.cpp
-    TestInstallerTest.cpp
-    AllocLetTestFree.c
-    MemoryOperatorOverloadTest.cpp
-    TestMemoryAllocatorTest.cpp
-    MemoryLeakWarningTest.cpp
-    TestOutputTest.cpp
-    AllocLetTestFreeTest.cpp
-    TestRegistryTest.cpp
-    AllocationInCFile.c
-    PluginTest.cpp
-    TestResultTest.cpp
-    PreprocessorTest.cpp
-    TestUTestMacro.cpp
-    TestUTestStringMacro.cpp
-    AllocationInCppFile.cpp
-    UtestTest.cpp
-    SimpleMutexTest.cpp
-    UtestPlatformTest.cpp
-    TeamCityOutputTest.cpp
 )
 
 if(CPPUTEST_STD_C_LIB_DISABLED)
-    target_sources(CppUTestTests
+    target_sources(CppUTestTests_main
         PRIVATE
             ${CMAKE_CURRENT_SOURCE_DIR}/../DummyUTestPlatform/DummyUTestPlatform.cpp
     )
 endif()
 
-target_link_libraries(CppUTestTests PRIVATE CppUTest)
+target_link_libraries(CppUTestTests_main
+    PUBLIC CppUTest
+)
+
+
+add_executable(CppUTestTests)
 
 add_mapfile(CppUTestTests)
 
@@ -51,3 +22,71 @@ if(CPPUTEST_TEST_DISCOVERY)
     include(CppUTest)
     cpputest_discover_tests(CppUTestTests)
 endif()
+
+function(add_cpputest_test name)
+    target_sources(CppUTestTests
+        PRIVATE ${ARGN}
+    )
+    target_link_libraries(CppUTestTests
+        PRIVATE CppUTestTests_main
+    )
+endfunction()
+
+add_cpputest_test(1
+    AllocLetTestFree.c
+    AllocLetTestFreeTest.cpp
+    CheatSheetTest.cpp
+    CompatabilityTests.cpp
+    CommandLineArgumentsTest.cpp
+    CommandLineTestRunnerTest.cpp
+    JUnitOutputTest.cpp
+)
+
+add_cpputest_test(2
+    DummyMemoryLeakDetector.cpp
+    MemoryLeakWarningTest.cpp
+    PluginTest.cpp
+    PreprocessorTest.cpp
+    SetPluginTest.cpp
+    SimpleMutexTest.cpp
+    TeamCityOutputTest.cpp
+    TestFailureNaNTest.cpp
+    TestFailureTest.cpp
+    TestResultTest.cpp
+)
+
+add_cpputest_test(3
+    MemoryLeakDetectorTest.cpp
+    SimpleStringTest.cpp
+    SimpleStringCacheTest.cpp
+)
+
+add_cpputest_test(4
+    TestOutputTest.cpp
+    TestRegistryTest.cpp
+)
+
+add_cpputest_test(5
+    AllocationInCFile.c
+    AllocationInCppFile.cpp
+    MemoryOperatorOverloadTest.cpp
+    TeamCityOutputTest.cpp
+)
+
+add_cpputest_test(6
+    TestFilterTest.cpp
+    TestHarness_cTest.cpp
+    TestHarness_cTestCFile.c
+    TestInstallerTest.cpp
+)
+
+add_cpputest_test(7
+    TestMemoryAllocatorTest.cpp
+    TestUTestMacro.cpp
+)
+
+add_cpputest_test(8
+    UtestPlatformTest.cpp
+    UtestTest.cpp
+    TestUTestStringMacro.cpp
+)

--- a/tests/CppUTestExt/CMakeLists.txt
+++ b/tests/CppUTestExt/CMakeLists.txt
@@ -39,23 +39,33 @@ target_link_libraries(CppUTestExtTests_main
         CppUTestExt
 )
 
-add_executable(CppUTestExtTests)
+if(NOT CPPUTEST_SPLIT_TESTS)
+    add_executable(CppUTestExtTests)
 
-add_mapfile(CppUTestExtTests)
+    add_mapfile(CppUTestExtTests)
 
-if(CPPUTEST_TEST_DISCOVERY)
-    include(CppUTest)
-    cpputest_discover_tests(CppUTestExtTests
-        DETAILED FALSE
-    )
+    if(CPPUTEST_TEST_DISCOVERY)
+        include(CppUTest)
+        cpputest_discover_tests(CppUTestExtTests
+            DETAILED FALSE
+        )
+    endif()
 endif()
 
+function(add_cpputestext_test number)
+    set(name CppUTestExtTests)
 
-function(add_cpputestext_test name)
-    target_sources(CppUTestExtTests
+    if(CPPUTEST_SPLIT_TESTS)
+        string(APPEND name ${number})
+        add_executable(${name})
+        add_mapfile(${name})
+        cpputest_discover_tests(${name})
+    endif()
+
+    target_sources(${name}
         PRIVATE ${ARGN}
     )
-    target_link_libraries(CppUTestExtTests
+    target_link_libraries(${name}
         PRIVATE CppUTestExtTests_main
     )
 endfunction()

--- a/tests/CppUTestExt/CMakeLists.txt
+++ b/tests/CppUTestExt/CMakeLists.txt
@@ -1,36 +1,9 @@
-add_executable(CppUTestExtTests
+add_library(CppUTestExtTests_main OBJECT
     AllTests.cpp
-    CodeMemoryReporterTest.cpp
-    GMockTest.cpp
-    GTest1Test.cpp
-    IEEE754PluginTest.cpp
-    IEEE754PluginTest_c.c
-    MemoryReportAllocatorTest.cpp
-    MemoryReporterPluginTest.cpp
-    MemoryReportFormatterTest.cpp
-    MockActualCallTest.cpp
-    MockCheatSheetTest.cpp
-    MockCallTest.cpp
-    MockComparatorCopierTest.cpp
-    MockExpectedCallTest.cpp
-    ExpectedFunctionsListTest.cpp
-    MockFailureReporterForTest.cpp
-    MockFailureTest.cpp
-    MockHierarchyTest.cpp
-    MockNamedValueTest.cpp
-    MockParameterTest.cpp
-    MockPluginTest.cpp
-    MockSupportTest.cpp
-    MockSupport_cTestCFile.c
-    MockSupport_cTest.cpp
-    MockStrictOrderTest.cpp
-    MockReturnValueTest.cpp
-    OrderedTestTest_c.c
-    OrderedTestTest.cpp
 )
 
 if(CPPUTEST_STD_C_LIB_DISABLED)
-    target_sources(CppUTestExtTests
+    target_sources(CppUTestExtTests_main
         PRIVATE
             ${CMAKE_CURRENT_SOURCE_DIR}/../DummyUTestPlatform/DummyUTestPlatform.cpp
     )
@@ -56,15 +29,17 @@ if(CPPUTEST_TEST_GTEST)
             )
         endif()
     endif()
-    target_link_libraries(CppUTestExtTests PRIVATE ${GTEST_LIBRARIES})
-    target_compile_definitions(CppUTestExtTests PRIVATE CPPUTEST_INCLUDE_GTEST_TESTS)
+    target_link_libraries(CppUTestExtTests_main PUBLIC ${GTEST_LIBRARIES})
+    target_compile_definitions(CppUTestExtTests_main PUBLIC CPPUTEST_INCLUDE_GTEST_TESTS)
 endif()
 
-target_link_libraries(CppUTestExtTests
-    PRIVATE
+target_link_libraries(CppUTestExtTests_main
+    PUBLIC
         CppUTest
         CppUTestExt
 )
+
+add_executable(CppUTestExtTests)
 
 add_mapfile(CppUTestExtTests)
 
@@ -74,3 +49,83 @@ if(CPPUTEST_TEST_DISCOVERY)
         DETAILED FALSE
     )
 endif()
+
+
+function(add_cpputestext_test name)
+    target_sources(CppUTestExtTests
+        PRIVATE ${ARGN}
+    )
+    target_link_libraries(CppUTestExtTests
+        PRIVATE CppUTestExtTests_main
+    )
+endfunction()
+
+add_cpputestext_test(1
+    MockFailureReporterForTest.cpp
+    ExpectedFunctionsListTest.cpp
+    GMockTest.cpp
+    GTest1Test.cpp
+    GTest2ConvertorTest.cpp
+)
+
+add_cpputestext_test(2
+    MockFailureReporterForTest.cpp
+    MemoryReportAllocatorTest.cpp
+    MemoryReportFormatterTest.cpp
+    MemoryReporterPluginTest.cpp
+    MockActualCallTest.cpp
+    MockCheatSheetTest.cpp
+    MockComparatorCopierTest.cpp
+    MockExpectedCallTest.cpp
+    MockHierarchyTest.cpp
+)
+
+add_cpputestext_test(3
+    MockFailureReporterForTest.cpp
+    CodeMemoryReporterTest.cpp
+    OrderedTestTest.cpp
+    OrderedTestTest_c.c
+)
+
+add_cpputestext_test(4
+    MockFailureReporterForTest.cpp
+    MockReturnValueTest.cpp
+    MockNamedValueTest.cpp
+)
+
+add_cpputestext_test(5
+    MockFailureReporterForTest.cpp
+    MockPluginTest.cpp
+    MockSupport_cTest.cpp
+    MockSupport_cTestCFile.c
+)
+
+add_cpputestext_test(6
+    MockFailureReporterForTest.cpp
+    ExpectedFunctionsListTest.cpp
+    MockCallTest.cpp
+)
+
+add_cpputestext_test(7
+    MockFailureReporterForTest.cpp
+    MockComparatorCopierTest.cpp
+    MockHierarchyTest.cpp
+    MockParameterTest.cpp
+)
+
+add_cpputestext_test(8
+    MockFailureReporterForTest.cpp
+    IEEE754PluginTest.cpp
+    IEEE754PluginTest_c.c
+    MockComparatorCopierTest.cpp
+)
+
+add_cpputestext_test(9
+    MockFailureReporterForTest.cpp
+    MockFailureTest.cpp
+    MockHierarchyTest.cpp
+    MockPluginTest.cpp
+    MockReturnValueTest.cpp
+    MockStrictOrderTest.cpp
+    MockSupportTest.cpp
+)

--- a/tests/CppUTestExt/CMakeLists.txt
+++ b/tests/CppUTestExt/CMakeLists.txt
@@ -59,7 +59,9 @@ function(add_cpputestext_test number)
         string(APPEND name ${number})
         add_executable(${name})
         add_mapfile(${name})
-        cpputest_discover_tests(${name})
+        if(CPPUTEST_TEST_DISCOVERY)
+            cpputest_discover_tests(${name})
+        endif()
     endif()
 
     target_sources(${name}


### PR DESCRIPTION
This borrows the strategy (and source lists) from the DOS Make build to split tests into smaller executables. This is prep for translating a 16-bit DOS build with CMake, but is also valuable for running tests on other small devices.