### PR TITLE
Fix conflicting declaration of cpputest_strdup_location

### DIFF
--- a/include/CppUTest/StandardCLibrary.h
+++ b/include/CppUTest/StandardCLibrary.h
@@ -14,6 +14,7 @@
 #ifdef __cplusplus
  #if CPPUTEST_USE_STD_CPP_LIB
   #include <cstdlib>
+  #include <cstring>
   #include <string>
  #endif
 #endif


### PR DESCRIPTION
I encountered the exact same issue as what was supposedly resolved in <https://github.com/cpputest/cpputest/pull/1192>, but for C++ code. What resolved it for me is adding `#include <cstring>` to `StandardCLibrary.h`.

Note that this appears to be a regression. <https://github.com/cpputest/cpputest/commit/8dded9ebc21d35c63c4258291e3fed3a35d74c98> is the last commit that builds without adding the extra header. 