### PR TITLE
Minor readme fix for autoconf install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Building from source (Unix-based, Cygwin, MacOS):
 
 ```bash
 git clone https://github.com/cpputest/cpputest.git
-cd cpputest_build
+cd cpputest/build
 autoreconf .. -i
 ../configure
 make


### PR DESCRIPTION
I copied/pasted the install instructions and it failed. Seems like there's just a typo in the readme.