### PR TITLE
support very verbose in CompositeTestOutput

### DIFF
--- a/include/CppUTest/TestOutput.h
+++ b/include/CppUTest/TestOutput.h
@@ -198,6 +198,8 @@ public:
     virtual void printFailure(const TestFailure& failure) _override;
     virtual void setProgressIndicator(const char*) _override;
 
+    virtual void printVeryVerbose(const char*) _override;
+
     virtual void flush() _override;
 
 protected:

--- a/src/CppUTest/CommandLineTestRunner.cpp
+++ b/src/CppUTest/CommandLineTestRunner.cpp
@@ -191,7 +191,7 @@ bool CommandLineTestRunner::parseArguments(TestPlugin* plugin)
 
   if (arguments_->isJUnitOutput()) {
     output_= createJUnitOutput(arguments_->getPackageName());
-    if (arguments_->isVerbose())
+    if (arguments_->isVerbose() || arguments_->isVeryVerbose())
       output_ = createCompositeOutput(output_, createConsoleOutput());
   } else if (arguments_->isTeamCityOutput()) {
     output_ = createTeamCityOutput();

--- a/src/CppUTest/TestOutput.cpp
+++ b/src/CppUTest/TestOutput.cpp
@@ -400,6 +400,12 @@ void CompositeTestOutput::setProgressIndicator(const char* indicator)
   if (outputTwo_) outputTwo_->setProgressIndicator(indicator);
 }
 
+void CompositeTestOutput::printVeryVerbose(const char* str)
+{
+  if (outputOne_) outputOne_->printVeryVerbose(str);
+  if (outputTwo_) outputTwo_->printVeryVerbose(str);
+}
+
 void CompositeTestOutput::flush()
 {
   if (outputOne_) outputOne_->flush();

--- a/tests/CppUTest/TestOutputTest.cpp
+++ b/tests/CppUTest/TestOutputTest.cpp
@@ -470,3 +470,11 @@ TEST(CompositeTestOutput, deletePreviousInstanceWhenSettingNew)
 
   // CHECK NO MEMORY LEAKS
 }
+
+TEST(CompositeTestOutput, printVeryVerbose)
+{
+  compositeOutput.verbose(TestOutput::level_veryVerbose);
+  compositeOutput.printVeryVerbose("very-verbose");
+  STRCMP_EQUAL("very-verbose", output1->getOutput().asCharString());
+  STRCMP_EQUAL("very-verbose", output2->getOutput().asCharString());
+}


### PR DESCRIPTION
This PR fixes an empty console output when the "JUnit" and "very verbose" options are selected at the same time