### PR TITLE
Add C version of MEMCMP_EQUAL

### DIFF
--- a/include/CppUTest/TestHarness_c.h
+++ b/include/CppUTest/TestHarness_c.h
@@ -114,6 +114,12 @@
 #define CHECK_EQUAL_C_POINTER_TEXT(expected,actual,text) \
   CHECK_EQUAL_C_POINTER_LOCATION(expected,actual,text,__FILE__,__LINE__)
 
+#define CHECK_EQUAL_C_MEMCMP(expected, actual, size) \
+  CHECK_EQUAL_C_MEMCMP_LOCATION(expected, actual, size, NULLPTR, __FILE__, __LINE__)
+
+#define CHECK_EQUAL_C_MEMCMP_TEXT(expected, actual, size, text) \
+  CHECK_EQUAL_C_MEMCMP_LOCATION(expected, actual, size, text, __FILE__, __LINE__)
+
 #define CHECK_EQUAL_C_BITS(expected, actual, mask) \
   CHECK_EQUAL_C_BITS_LOCATION(expected, actual, mask, sizeof(actual), NULL, __FILE__, __LINE__)
 
@@ -205,6 +211,7 @@ extern void CHECK_EQUAL_C_UBYTE_LOCATION(unsigned char expected, unsigned char a
 extern void CHECK_EQUAL_C_SBYTE_LOCATION(signed char expected, signed char actual, const char* text, const char* fileName, size_t lineNumber);
 extern void CHECK_EQUAL_C_STRING_LOCATION(const char* expected, const char* actual, const char* text, const char* fileName, size_t lineNumber);
 extern void CHECK_EQUAL_C_POINTER_LOCATION(const void* expected, const void* actual, const char* text, const char* fileName, size_t lineNumber);
+extern void CHECK_EQUAL_C_MEMCMP_LOCATION(const void* expected, const void* actual, size_t size, const char* text, const char* fileName, size_t lineNumber);
 extern void CHECK_EQUAL_C_BITS_LOCATION(unsigned int expected, unsigned int actual, unsigned int mask, size_t size, const char* text, const char* fileName, size_t lineNumber);
 extern void FAIL_TEXT_C_LOCATION(const char* text, const char* fileName, size_t lineNumber);
 extern void FAIL_C_LOCATION(const char* fileName, size_t lineNumber);

--- a/src/CppUTest/TestHarness_c.cpp
+++ b/src/CppUTest/TestHarness_c.cpp
@@ -99,6 +99,11 @@ void CHECK_EQUAL_C_POINTER_LOCATION(const void* expected, const void* actual, co
     UtestShell::getCurrent()->assertPointersEqual(expected, actual, text, fileName, lineNumber, UtestShell::getCurrentTestTerminatorWithoutExceptions());
 }
 
+extern void CHECK_EQUAL_C_MEMCMP_LOCATION(const void* expected, const void* actual, size_t size, const char* text, const char* fileName, size_t lineNumber)
+{
+    UtestShell::getCurrent()->assertBinaryEqual(expected, actual, size, text, fileName, lineNumber, UtestShell::getCurrentTestTerminatorWithoutExceptions());
+}
+
 extern void CHECK_EQUAL_C_BITS_LOCATION(unsigned int expected, unsigned int actual, unsigned int mask, size_t size, const char* text, const char* fileName, size_t lineNumber)
 {
     UtestShell::getCurrent()->assertBitsEqual(expected, actual, mask, size, text, fileName, lineNumber, UtestShell::getCurrentTestTerminatorWithoutExceptions());

--- a/tests/CppUTest/TestHarness_cTest.cpp
+++ b/tests/CppUTest/TestHarness_cTest.cpp
@@ -581,6 +581,45 @@ TEST(TestHarness_c, checkPointerText)
     CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
 }
 
+static void failMemcmpMethod_()
+{
+    HasTheDestructorBeenCalledChecker checker;
+    unsigned char expectedData[] = { 0x00, 0x01, 0x02, 0x03 };
+    unsigned char actualData[] = { 0x00, 0x01, 0x03, 0x03 };
+
+    CHECK_EQUAL_C_MEMCMP(expectedData, actualData, sizeof(expectedData));
+}
+
+TEST(TestHarness_c, checkMemcmp)
+{
+    CHECK_EQUAL_C_MEMCMP("TEST", "TEST", 5);
+    fixture->setTestFunction(failMemcmpMethod_);
+    fixture->runAllTests();
+    fixture->assertPrintContains("expected <00 01 02 03>\n\tbut was  <00 01 03 03>");
+    fixture->assertPrintContains("arness_c");
+    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
+}
+
+static void failMemcmpTextMethod_()
+{
+    HasTheDestructorBeenCalledChecker checker;
+    unsigned char expectedData[] = { 0x00, 0x01, 0x02, 0x03 };
+    unsigned char actualData[] = { 0x00, 0x01, 0x03, 0x03 };
+
+    CHECK_EQUAL_C_MEMCMP_TEXT(expectedData, actualData, sizeof(expectedData), "MemcmpTestText");
+}
+
+TEST(TestHarness_c, checkMemcmpText)
+{
+    CHECK_EQUAL_C_MEMCMP_TEXT("TEST", "TEST", 5, "Text");
+    fixture->setTestFunction(failMemcmpTextMethod_);
+    fixture->runAllTests();
+    fixture->assertPrintContains("expected <00 01 02 03>\n\tbut was  <00 01 03 03>");
+    fixture->assertPrintContains("arness_c");
+    fixture->assertPrintContains("Message: MemcmpTestText");
+    CHECK(!hasDestructorOfTheDestructorCheckedBeenCalled);
+}
+
 static void failBitsMethod_()
 {
     HasTheDestructorBeenCalledChecker checker;


### PR DESCRIPTION
Currently there is no MEMCMP in the C harness.
So, new CHECK_EQUAL_C_MEMCMP macro could be useful in tests where we process binary data.