### PR TITLE
Fix undefined behavior in case of time overflow on 32-bit platforms

### DIFF
--- a/include/CppUTest/PlatformSpecificFunctions_c.h
+++ b/include/CppUTest/PlatformSpecificFunctions_c.h
@@ -47,7 +47,7 @@ extern void (*PlatformSpecificLongJmp)(void);
 extern void (*PlatformSpecificRestoreJumpBuffer)(void);
 
 /* Time operations */
-extern long (*GetPlatformSpecificTimeInMillis)(void);
+extern unsigned long (*GetPlatformSpecificTimeInMillis)(void);
 extern const char* (*GetPlatformSpecificTimeString)(void);
 
 /* String operations */

--- a/src/Platforms/Borland/UtestPlatform.cpp
+++ b/src/Platforms/Borland/UtestPlatform.cpp
@@ -193,13 +193,12 @@ void (*PlatformSpecificRestoreJumpBuffer)() = PlatformSpecificRestoreJumpBufferI
 
 ///////////// Time in millis
 
-static long TimeInMillisImplementation()
+static unsigned long TimeInMillisImplementation()
 {
 #ifdef CPPUTEST_HAVE_GETTIMEOFDAY
     struct timeval tv;
-    struct timezone tz;
-    gettimeofday(&tv, &tz);
-    return (tv.tv_sec * 1000) + (long)((double)tv.tv_usec * 0.001);
+    gettimeofday(&tv, NULL);
+    return ((unsigned long)tv.tv_sec * 1000) + ((unsigned long)tv.tv_usec / 1000));
 #else
     return 0;
 #endif
@@ -214,7 +213,7 @@ static const char* TimeStringImplementation()
     return dateTime;
 }
 
-long (*GetPlatformSpecificTimeInMillis)() = TimeInMillisImplementation;
+unsigned long (*GetPlatformSpecificTimeInMillis)() = TimeInMillisImplementation;
 const char* (*GetPlatformSpecificTimeString)() = TimeStringImplementation;
 
 static int BorlandVSNprintf(char *str, size_t size, const char* format, va_list args)

--- a/src/Platforms/C2000/UtestPlatform.cpp
+++ b/src/Platforms/C2000/UtestPlatform.cpp
@@ -100,7 +100,7 @@ int (*PlatformSpecificSetJmp)(void (*function) (void*), void*) = C2000SetJmp;
 void (*PlatformSpecificLongJmp)(void) = C2000LongJmp;
 void (*PlatformSpecificRestoreJumpBuffer)(void) = C2000RestoreJumpBuffer;
 
-static long C2000TimeInMillis()
+static unsigned long C2000TimeInMillis()
 {
     /* The TI c2000 platform does not have Posix support and thus lacks struct timespec.
      * Also, clock() always returns 0 in the simulator. Hence we work with struct tm.tm_hour
@@ -112,7 +112,7 @@ static long C2000TimeInMillis()
      */
     time_t t        = time((time_t*)0);
     struct tm * ptm = gmtime(&t);
-    long result = (long)
+    unsigned long result = (unsigned long)
         ((ptm->tm_sec + ptm->tm_min * (time_t)60 + ptm->tm_hour * (time_t)3600) * (time_t)1000);
     return result;
 }
@@ -123,7 +123,7 @@ static const char* TimeStringImplementation()
     return ctime(&tm);
 }
 
-long (*GetPlatformSpecificTimeInMillis)() = C2000TimeInMillis;
+unsigned long (*GetPlatformSpecificTimeInMillis)() = C2000TimeInMillis;
 const char* (*GetPlatformSpecificTimeString)() = TimeStringImplementation;
 
 extern int vsnprintf(char*, size_t, const char*, va_list); // not std::vsnprintf()

--- a/src/Platforms/Dos/UtestPlatform.cpp
+++ b/src/Platforms/Dos/UtestPlatform.cpp
@@ -104,9 +104,9 @@ int (*PlatformSpecificSetJmp)(void (*function) (void*), void*) = DosSetJmp;
 void (*PlatformSpecificLongJmp)(void) = DosLongJmp;
 void (*PlatformSpecificRestoreJumpBuffer)(void) = DosRestoreJumpBuffer;
 
-static long DosTimeInMillis()
+static unsigned long DosTimeInMillis()
 {
-    return clock() * 1000 / CLOCKS_PER_SEC;
+    return (unsigned long)(clock() * 1000 / CLOCKS_PER_SEC);
 }
 
 static const char* DosTimeString()
@@ -119,7 +119,7 @@ static int DosVSNprintf(char* str, size_t size, const char* format, va_list args
     return vsnprintf(str, size, format, args);
 }
 
-long (*GetPlatformSpecificTimeInMillis)() = DosTimeInMillis;
+unsigned long (*GetPlatformSpecificTimeInMillis)() = DosTimeInMillis;
 const char* (*GetPlatformSpecificTimeString)() = DosTimeString;
 int (*PlatformSpecificVSNprintf)(char *, size_t, const char*, va_list) = DosVSNprintf;
 

--- a/src/Platforms/Gcc/UtestPlatform.cpp
+++ b/src/Platforms/Gcc/UtestPlatform.cpp
@@ -198,13 +198,12 @@ void (*PlatformSpecificRestoreJumpBuffer)() = PlatformSpecificRestoreJumpBufferI
 
 ///////////// Time in millis
 
-static long TimeInMillisImplementation()
+static unsigned long TimeInMillisImplementation()
 {
 #ifdef CPPUTEST_HAVE_GETTIMEOFDAY
     struct timeval tv;
-    struct timezone tz;
-    gettimeofday(&tv, &tz);
-    return (long)((tv.tv_sec * 1000) + (time_t)((double)tv.tv_usec * 0.001));
+    gettimeofday(&tv, NULL);
+    return (((unsigned long)tv.tv_sec * 1000) + ((unsigned long)tv.tv_usec / 1000));
 #else
     return 0;
 #endif
@@ -225,7 +224,7 @@ static const char* TimeStringImplementation()
     return dateTime;
 }
 
-long (*GetPlatformSpecificTimeInMillis)() = TimeInMillisImplementation;
+unsigned long (*GetPlatformSpecificTimeInMillis)() = TimeInMillisImplementation;
 const char* (*GetPlatformSpecificTimeString)() = TimeStringImplementation;
 
 /* Wish we could add an attribute to the format for discovering mis-use... but the __attribute__(format) seems to not work on va_list */

--- a/src/Platforms/GccNoStdC/UtestPlatform.cpp
+++ b/src/Platforms/GccNoStdC/UtestPlatform.cpp
@@ -48,7 +48,7 @@ void (*PlatformSpecificLongJmp)() = NULLPTR;
 int (*PlatformSpecificSetJmp)(void (*)(void*), void*) = NULLPTR;
 void (*PlatformSpecificRestoreJumpBuffer)() = NULLPTR;
 
-long (*GetPlatformSpecificTimeInMillis)() = NULLPTR;
+unsigned long (*GetPlatformSpecificTimeInMillis)() = NULLPTR;
 const char* (*GetPlatformSpecificTimeString)() = NULLPTR;
 
 /* IO operations */

--- a/src/Platforms/Iar/UtestPlatform.cpp
+++ b/src/Platforms/Iar/UtestPlatform.cpp
@@ -101,13 +101,13 @@ void (*PlatformSpecificRestoreJumpBuffer)() = PlatformSpecificRestoreJumpBufferI
 
 ///////////// Time in millis
 
-static long TimeInMillisImplementation()
+static unsigned long TimeInMillisImplementation()
 {
     clock_t t = clock();
 
     t = t * 10;
 
-    return t;
+    return (unsigned long)t;
 }
 
 ///////////// Time in String
@@ -121,7 +121,7 @@ static const char* TimeStringImplementation()
     return (pTimeStr);
 }
 
-long (*GetPlatformSpecificTimeInMillis)() = TimeInMillisImplementation;
+unsigned long (*GetPlatformSpecificTimeInMillis)() = TimeInMillisImplementation;
 const char* (*GetPlatformSpecificTimeString)() = TimeStringImplementation;
 
 int (*PlatformSpecificVSNprintf)(char *str, size_t size, const char* format, va_list args) = vsnprintf;

--- a/src/Platforms/Keil/UtestPlatform.cpp
+++ b/src/Platforms/Keil/UtestPlatform.cpp
@@ -108,16 +108,16 @@ extern "C"
     *  In Keil MDK-ARM, clock() default implementation used semihosting.
     *  Resolutions is user adjustable (1 ms for now)
     */
-    static long TimeInMillisImplementation()
+    static unsigned long TimeInMillisImplementation()
     {
         clock_t t = clock();
 
-       t = t * 10;
+        t = t * 10;
 
-        return t;
+        return (unsigned long)t;
     }
 
-    long (*GetPlatformSpecificTimeInMillis)() = TimeInMillisImplementation;
+    unsigned long (*GetPlatformSpecificTimeInMillis)() = TimeInMillisImplementation;
 
     static const char* TimeStringImplementation()
     {

--- a/src/Platforms/Symbian/UtestPlatform.cpp
+++ b/src/Platforms/Symbian/UtestPlatform.cpp
@@ -67,14 +67,14 @@ void PlatformSpecificRunTestInASeperateProcess(UtestShell* shell, TestPlugin* pl
    shell->runOneTest(plugin, *result);
 }
 
-static long TimeInMillisImplementation() {
+static unsigned long TimeInMillisImplementation() {
     struct timeval tv;
     struct timezone tz;
     ::gettimeofday(&tv, &tz);
-    return (tv.tv_sec * 1000) + (long)(tv.tv_usec * 0.001);
+    return ((unsigned long)tv.tv_sec * 1000) + ((unsigned long)tv.tv_usec / 1000);
 }
 
-long (*GetPlatformSpecificTimeInMillis)() = TimeInMillisImplementation;
+unsigned long (*GetPlatformSpecificTimeInMillis)() = TimeInMillisImplementation;
 
 TestOutput::WorkingEnvironment PlatformSpecificGetWorkingEnvironment()
 {

--- a/src/Platforms/VisualCpp/UtestPlatform.cpp
+++ b/src/Platforms/VisualCpp/UtestPlatform.cpp
@@ -75,7 +75,7 @@ TestOutput::WorkingEnvironment PlatformSpecificGetWorkingEnvironment()
 
 ///////////// Time in millis
 
-static long VisualCppTimeInMillis()
+static unsigned long VisualCppTimeInMillis()
 {
 	static LARGE_INTEGER s_frequency;
 	static const BOOL s_use_qpc = QueryPerformanceFrequency(&s_frequency);
@@ -83,23 +83,23 @@ static long VisualCppTimeInMillis()
 	{
 		LARGE_INTEGER now;
 		QueryPerformanceCounter(&now);
-		return (long)((now.QuadPart * 1000) / s_frequency.QuadPart);
-	} 
-	else 
+		return (unsigned long)((now.QuadPart * 1000) / s_frequency.QuadPart);
+	}
+	else
 	{
 	#ifdef TIMERR_NOERROR
-		return (long)timeGetTime();
+		return (unsigned long)timeGetTime();
 	#else
 		#if !defined(_WIN32_WINNT) || !defined(_WIN32_WINNT_VISTA) || (_WIN32_WINNT < _WIN32_WINNT_VISTA)
-			return (long)GetTickCount();
+			return (unsigned long)GetTickCount();
 		#else
-			return (long)GetTickCount64();
+			return (unsigned long)GetTickCount64();
 		#endif
 	#endif
 	}
 }
 
-long (*GetPlatformSpecificTimeInMillis)() = VisualCppTimeInMillis;
+unsigned long (*GetPlatformSpecificTimeInMillis)() = VisualCppTimeInMillis;
 
 ///////////// Time in String
 

--- a/src/Platforms/armcc/UtestPlatform.cpp
+++ b/src/Platforms/armcc/UtestPlatform.cpp
@@ -107,10 +107,10 @@ void (*PlatformSpecificRestoreJumpBuffer)() = PlatformSpecificRestoreJumpBufferI
 *  In Keil MDK-ARM, clock() default implementation used semihosting.
 *  Resolutions is user adjustable (1 ms for now)
 */
-static long TimeInMillisImplementation()
+static unsigned long TimeInMillisImplementation()
 {
     clock_t t = clock();
-    return t;
+    return (unsigned long)t;
 }
 
 ///////////// Time in String
@@ -121,7 +121,7 @@ static const char* DummyTimeStringImplementation()
     return ctime(&tm);
 }
 
-long (*GetPlatformSpecificTimeInMillis)() = TimeInMillisImplementation;
+unsigned long (*GetPlatformSpecificTimeInMillis)() = TimeInMillisImplementation;
 const char* (*GetPlatformSpecificTimeString)() = DummyTimeStringImplementation;
 
 int (*PlatformSpecificVSNprintf)(char *str, size_t size, const char* format, va_list args) = vsnprintf;

--- a/tests/CppUTest/JUnitOutputTest.cpp
+++ b/tests/CppUTest/JUnitOutputTest.cpp
@@ -135,10 +135,10 @@ public:
 };
 
 extern "C" {
-    static long millisTime = 0;
+    static unsigned long millisTime = 0;
     static const char* theTime = "";
 
-    static long MockGetPlatformSpecificTimeInMillis()
+    static unsigned long MockGetPlatformSpecificTimeInMillis()
     {
         return millisTime;
     }
@@ -156,7 +156,7 @@ class JUnitTestOutputTestRunner
     const char* currentGroupName_;
     UtestShell* currentTest_;
     bool firstTestInGroup_;
-    int timeTheTestTakes_;
+    unsigned int timeTheTestTakes_;
     unsigned int numberOfChecksInTest_;
     TestFailure* testFailure_;
 
@@ -279,7 +279,7 @@ public:
         return *this;
     }
 
-    JUnitTestOutputTestRunner& thatTakes(int timeElapsed)
+    JUnitTestOutputTestRunner& thatTakes(unsigned int timeElapsed)
     {
         timeTheTestTakes_ = timeElapsed;
         return *this;

--- a/tests/CppUTest/TeamCityOutputTest.cpp
+++ b/tests/CppUTest/TeamCityOutputTest.cpp
@@ -32,11 +32,11 @@ private:
     SimpleString output;
 };
 
-static long millisTime;
+static unsigned long millisTime;
 
 extern "C" {
 
-    static long MockGetPlatformSpecificTimeInMillis()
+    static unsigned long MockGetPlatformSpecificTimeInMillis()
     {
         return millisTime;
     }

--- a/tests/CppUTest/TestOutputTest.cpp
+++ b/tests/CppUTest/TestOutputTest.cpp
@@ -30,11 +30,11 @@
 #include "CppUTest/TestResult.h"
 #include "CppUTest/PlatformSpecificFunctions.h"
 
-static long millisTime;
+static unsigned long millisTime;
 
 extern "C" {
 
-    static long MockGetPlatformSpecificTimeInMillis()
+    static unsigned long MockGetPlatformSpecificTimeInMillis()
     {
         return millisTime;
     }

--- a/tests/CppUTest/TestResultTest.cpp
+++ b/tests/CppUTest/TestResultTest.cpp
@@ -31,7 +31,7 @@
 
 extern "C" {
 
-    static long MockGetPlatformSpecificTimeInMillis()
+    static unsigned long MockGetPlatformSpecificTimeInMillis()
     {
         return 10;
     }

--- a/tests/DummyUTestPlatform/DummyUTestPlatform.cpp
+++ b/tests/DummyUTestPlatform/DummyUTestPlatform.cpp
@@ -41,11 +41,11 @@ static void fakeRestoreJumpBuffer()
 }
 void (*PlatformSpecificRestoreJumpBuffer)(void) = fakeRestoreJumpBuffer;
 
-static long fakeTimeInMillis(void)
+static unsigned long fakeTimeInMillis(void)
 {
     return 0;
 }
-long (*GetPlatformSpecificTimeInMillis)(void) = fakeTimeInMillis;
+unsigned long (*GetPlatformSpecificTimeInMillis)(void) = fakeTimeInMillis;
 
 static const char* fakeTimeString(void)
 {


### PR DESCRIPTION
Fixes https://github.com/cpputest/cpputest/issues/1762

Currently signed long int is used for storing current time in milliseconds (time is calculated by GetPlatformSpecificTimeInMillis()).
But on 32-bit platforms long could be a 32-bit number (e.g. C17 standard declares at 5.2.4.2.1 that long int should be at least 32 bits long).

Current unix timestamp in seconds is 31 bit long and timestamp in milliseconds is at least 41 bit long.

C/C++ standards declare that behavior of signed integer overflow is undefined (e.g. C17 example at 3.4.3).

The platform specific time is used only for calculating difference between end and start time. So, long could be replaced with unsigned long in that case without any negative effects.