### PR TITLE
Suppress Sanitization Warning on Linux When Memory Leak Detection is Disabled

### DIFF
--- a/include/CppUTest/CppUTestConfig.h
+++ b/include/CppUTest/CppUTestConfig.h
@@ -146,7 +146,7 @@
 #endif
 
 #if CPPUTEST_SANITIZE_ADDRESS
-  #if defined(__linux__) && defined(__clang__) && CPPUTEST_USE_STD_CPP_LIB
+  #if defined(__linux__) && defined(__clang__) && CPPUTEST_USE_STD_CPP_LIB && CPPUTEST_USE_MEM_LEAK_DETECTION
     #warning Compiling with Address Sanitizer with clang on linux may cause duplicate symbols for operator new. Turning off memory leak detection. Compile with -DCPPUTEST_MEM_LEAK_DETECTION_DISABLED to get rid of this warning.
   #endif
   #define CPPUTEST_DO_NOT_SANITIZE_ADDRESS __attribute__((no_sanitize_address))


### PR DESCRIPTION
## Suppress Sanitization Warning on Linux When Memory Leak Detection is Disabled

### Overview

There is a warning in the `CppUTestConfig.h` on Linux platforms when building with ASAN. The warning says to disable memory leak detection in order to get rid of the warning with `-DCPPUTEST_MEM_LEAK_DETECTION_DISABLED`. However, providing said define does not get rid of the warning. This prevents compilation on Linux with ASAN + `-Werror`.

### Proposed Change

1. If `CPPUTEST_MEM_LEAK_DETECTION_DISABLED` do not display warning about address sanitization.