### PR TITLE
Avoid missing include directory warnings

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -78,7 +78,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@main
-      - run: brew install automake
+      - run: brew install automake libtool
         if: ${{ startswith(matrix.os, 'macos') }}
       - if: ${{ matrix.cxx }}
         run: echo "CXX=${{ matrix.cxx }}" >> $GITHUB_ENV

--- a/CppUTest.vcproj
+++ b/CppUTest.vcproj
@@ -41,7 +41,7 @@
 			<Tool
 				Name="VCCLCompilerTool"
 				Optimization="0"
-				AdditionalIncludeDirectories=".\include\Platforms\VisualCpp,.\include"
+				AdditionalIncludeDirectories=".\include"
 				PreprocessorDefinitions="WIN32;_DEBUG;_LIB;STDC_WANT_SECURE_LIB;CPPUTEST_USE_LONG_LONG"
 				BasicRuntimeChecks="3"
 				RuntimeLibrary="3"
@@ -112,7 +112,7 @@
 				Name="VCCLCompilerTool"
 				Optimization="0"
 				InlineFunctionExpansion="1"
-				AdditionalIncludeDirectories=".\include\Platforms\VisualCpp,.\include"
+				AdditionalIncludeDirectories=".\include"
 				PreprocessorDefinitions="WIN32;NDEBUG;_LIB;STDC_WANT_SECURE_LIB;CPPUTEST_USE_LONG_LONG"
 				StringPooling="true"
 				RuntimeLibrary="0"

--- a/CppUTest.vcxproj
+++ b/CppUTest.vcxproj
@@ -74,7 +74,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>.\include;.\include\Platforms\VisualCpp;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>.\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_LIB;WIN32;_DEBUG;STDC_WANT_SECURE_LIB;CPPUTEST_USE_LONG_LONG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -106,7 +106,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>.\include;.\include\Platforms\VisualCpp;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>.\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_LIB;WIN32;_DEBUG;STDC_WANT_SECURE_LIB;CPPUTEST_USE_LONG_LONG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -138,7 +138,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>.\include;.\include\Platforms\VisualCpp;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>.\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
       <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;STDC_WANT_SECURE_LIB;CPPUTEST_USE_LONG_LONG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
@@ -173,7 +173,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>.\include;.\include\Platforms\VisualCpp;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>.\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
       <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;STDC_WANT_SECURE_LIB;CPPUTEST_USE_LONG_LONG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>

--- a/build/alltests.mmp
+++ b/build/alltests.mmp
@@ -29,7 +29,7 @@ TARGET		  cpputest.exe
 TARGETTYPE	  exe
 UID			 0x00000000 0x03A6305A
 
-USERINCLUDE	 ..\include ..\include\CppUTest ..\include\Platforms\Symbian ..\tests
+USERINCLUDE	 ..\include ..\include\CppUTest ..\tests
 SYSTEMINCLUDE   \epoc32\include \epoc32\include\stdapis
 
 STATICLIBRARY libcrt0.lib 

--- a/build/cpputest.mmp
+++ b/build/cpputest.mmp
@@ -29,7 +29,7 @@ TARGET		  cpputest.lib
 TARGETTYPE	  LIB
 UID			 0x00000000 0x03A6305A
 
-USERINCLUDE	 ..\include ..\include\CppUTest ..\include\Platforms\Symbian
+USERINCLUDE	 ..\include ..\include\CppUTest
 SYSTEMINCLUDE   \epoc32\include \epoc32\include\stdapis
 
 SOURCEPATH ..\src\CppUTest

--- a/cmake/warnings.cmake
+++ b/cmake/warnings.cmake
@@ -16,6 +16,7 @@ if(
         -Wswitch-enum
         -Wconversion
         -Wsign-conversion
+        -Wmissing-include-dirs
         -Wno-padded
         -Wno-disabled-macro-expansion
         -Wno-reserved-id-macro

--- a/examples/AllTests/AllTests.vcproj
+++ b/examples/AllTests/AllTests.vcproj
@@ -45,7 +45,7 @@
 			<Tool
 				Name="VCCLCompilerTool"
 				Optimization="2"
-				AdditionalIncludeDirectories="../../include,../../include/Platforms/VisualCpp,../ApplicationLib"
+				AdditionalIncludeDirectories="../../include,../ApplicationLib"
 				PreprocessorDefinitions="WIN32;NDEBUG;_CONSOLE"
 				BasicRuntimeChecks="0"
 				RuntimeLibrary="3"
@@ -140,7 +140,7 @@
 			<Tool
 				Name="VCCLCompilerTool"
 				Optimization="0"
-				AdditionalIncludeDirectories="../../include,../../include/Platforms/VisualCpp,../ApplicationLib"
+				AdditionalIncludeDirectories="../../include,../ApplicationLib"
 				PreprocessorDefinitions="WIN32;_DEBUG;_CONSOLE"
 				BasicRuntimeChecks="3"
 				RuntimeLibrary="3"

--- a/examples/ApplicationLib/ApplicationLib.vcproj
+++ b/examples/ApplicationLib/ApplicationLib.vcproj
@@ -42,7 +42,7 @@
 			<Tool
 				Name="VCCLCompilerTool"
 				Optimization="0"
-				AdditionalIncludeDirectories="../../include,../../include/Platforms/VisualCpp"
+				AdditionalIncludeDirectories="../../include"
 				PreprocessorDefinitions="WIN32;_DEBUG;_LIB"
 				BasicRuntimeChecks="3"
 				RuntimeLibrary="3"
@@ -116,7 +116,7 @@
 			<Tool
 				Name="VCCLCompilerTool"
 				Optimization="2"
-				AdditionalIncludeDirectories="../../include,../../include/Platforms/VisualCpp"
+				AdditionalIncludeDirectories="../../include"
 				PreprocessorDefinitions="WIN32;NDEBUG;_LIB"
 				BasicRuntimeChecks="0"
 				RuntimeLibrary="3"

--- a/platforms/Dos/Makefile
+++ b/platforms/Dos/Makefile
@@ -18,7 +18,6 @@ COMMONFLAGS := \
   -q -c -os -oc -d0 -we -w=3 -ml -zm \
   -dCPPUTEST_MEM_LEAK_DETECTION_DISABLED=1 -dCPPUTEST_STD_CPP_LIB_DISABLED=1 \
   -i$(call convert_paths,$(CPPUTEST_HOME)/include) \
-  -i$(call convert_paths,$(CPPUTEST_HOME)/include/Platforms/Dos) \
   -i$(call convert_paths,$(WATCOM)/h) -i$(call convert_paths,$(WATCOM)/h/nt) \
 
 # Disable W303 unreferenced parameter - PUNUSED is GNU-specific

--- a/platforms/armcc/Makefile
+++ b/platforms/armcc/Makefile
@@ -29,7 +29,6 @@ COMPONENT_NAME := CppUTest
 
 INCLUDE_DIRS :=\
   $(CPPUTEST_HOME)/include \
-  $(CPPUTEST_HOME)/include/Platforms/armcc \
 
 # armcc system include path
 SYS_INCLUDE_DIRS:=$(KEIL_DIR)/include 

--- a/scripts/VS2010Templates/CppUTest_VS2010.props
+++ b/scripts/VS2010Templates/CppUTest_VS2010.props
@@ -2,9 +2,9 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup Label="UserMacros">
-    <CPPUTEST_INCLUDE_PATHS>$(CPPUTEST_HOME)\include;$(CPPUTEST_HOME)\include\CppUTestExt\CppUTestGTest;$(CPPUTEST_HOME)\include\CppUTestExt\CppUTestGMock;$(CPPUTEST_HOME)\include\Platforms\VisualCpp</CPPUTEST_INCLUDE_PATHS>
+    <CPPUTEST_INCLUDE_PATHS>$(CPPUTEST_HOME)\include;$(CPPUTEST_HOME)\include\CppUTestExt\CppUTestGTest;$(CPPUTEST_HOME)\include\CppUTestExt\CppUTestGMock</CPPUTEST_INCLUDE_PATHS>
     <CPPUTEST_LIB_PATHS>$(CPPUTEST_HOME)\lib</CPPUTEST_LIB_PATHS>
-    <CPPUTEST_FORCED_INCLUDES>$(CPPUTEST_HOME)\include\Platforms\VisualCpp\Platform.h;$(CPPUTEST_HOME)\include\CppUTest\MemoryLeakDetectorMallocMacros.h;</CPPUTEST_FORCED_INCLUDES>
+    <CPPUTEST_FORCED_INCLUDES>$(CPPUTEST_HOME)\include\CppUTest\MemoryLeakDetectorMallocMacros.h;</CPPUTEST_FORCED_INCLUDES>
     <CPPUTEST_LIB_DEPENDENCIES>CppUTest.lib</CPPUTEST_LIB_DEPENDENCIES>
   </PropertyGroup>
   <PropertyGroup />

--- a/scripts/templates/ProjectTemplate/ProjectMakefile
+++ b/scripts/templates/ProjectTemplate/ProjectMakefile
@@ -32,7 +32,6 @@ INCLUDE_DIRS =\
   include \
   include/* \
   $(CPPUTEST_HOME)/include/ \
-  $(CPPUTEST_HOME)/include/Platforms/Gcc\
   mocks
 
 CPPUTEST_WARNINGFLAGS = -Wall -Werror -Wswitch-default 

--- a/src/CppUTest/CMakeLists.txt
+++ b/src/CppUTest/CMakeLists.txt
@@ -53,9 +53,12 @@ if(CPPUTEST_PLATFORM)
         PRIVATE
             ${CMAKE_CURRENT_LIST_DIR}/../Platforms/${CPPUTEST_PLATFORM}/UtestPlatform.cpp
     )
+endif()
+
+if(CPPUTEST_PLATFORM STREQUAL "c2000")
     target_include_directories(CppUTest
         PUBLIC
-            $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/../../include/Platforms/${CPPUTEST_PLATFORM}>
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/../../include/Platforms/c2000>
     )
 endif()
 

--- a/tests/AllTests.vcproj
+++ b/tests/AllTests.vcproj
@@ -45,7 +45,7 @@
 				Name="VCCLCompilerTool"
 				Optimization="0"
 				InlineFunctionExpansion="1"
-				AdditionalIncludeDirectories="..\include,..\include\Platforms\VisualCpp"
+				AdditionalIncludeDirectories="..\include"
 				PreprocessorDefinitions="WIN32;NDEBUG;_CONSOLE;CPPUTEST_USE_LONG_LONG"
 				StringPooling="true"
 				RuntimeLibrary="0"
@@ -129,7 +129,7 @@
 			<Tool
 				Name="VCCLCompilerTool"
 				Optimization="0"
-				AdditionalIncludeDirectories="..\include,..\include\Platforms\VisualCpp"
+				AdditionalIncludeDirectories="..\include"
 				PreprocessorDefinitions="_CONSOLE;WIN32;_DEBUG;CPPUTEST_USE_LONG_LONG"
 				BasicRuntimeChecks="3"
 				RuntimeLibrary="3"

--- a/tests/AllTests.vcxproj
+++ b/tests/AllTests.vcxproj
@@ -92,7 +92,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <WarningLevel>Level3</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalIncludeDirectories>..\include;..\include\CppUTestExt\CppUTestGTest;..\include\CppUTestExt\CppUTestGMock;..\include\Platforms\VisualCpp;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\include;..\include\CppUTestExt\CppUTestGTest;..\include\CppUTestExt\CppUTestGMock;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
       <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
@@ -131,7 +131,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <WarningLevel>Level3</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalIncludeDirectories>..\include;..\include\CppUTestExt\CppUTestGTest;..\include\CppUTestExt\CppUTestGMock;..\include\Platforms\VisualCpp;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\include;..\include\CppUTestExt\CppUTestGTest;..\include\CppUTestExt\CppUTestGMock;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
       <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
@@ -162,7 +162,7 @@
     </Midl>
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\include;..\include\CppUTestExt\CppUTestGTest;..\include\CppUTestExt\CppUTestGMock;..\include\Platforms\VisualCpp;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\include;..\include\CppUTestExt\CppUTestGTest;..\include\CppUTestExt\CppUTestGMock;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CONSOLE;WIN32;_DEBUG;CPPUTEST_USE_LONG_LONG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>


### PR DESCRIPTION
Only c2000 even uses this include path anymore, so we can remove it for everything else.

Closes #1784