### PR TITLE
Fix NULLPTR in C harness

### DIFF
--- a/include/CppUTest/TestHarness_c.h
+++ b/include/CppUTest/TestHarness_c.h
@@ -115,7 +115,7 @@
   CHECK_EQUAL_C_POINTER_LOCATION(expected,actual,text,__FILE__,__LINE__)
 
 #define CHECK_EQUAL_C_MEMCMP(expected, actual, size) \
-  CHECK_EQUAL_C_MEMCMP_LOCATION(expected, actual, size, NULLPTR, __FILE__, __LINE__)
+  CHECK_EQUAL_C_MEMCMP_LOCATION(expected, actual, size, NULL, __FILE__, __LINE__)
 
 #define CHECK_EQUAL_C_MEMCMP_TEXT(expected, actual, size, text) \
   CHECK_EQUAL_C_MEMCMP_LOCATION(expected, actual, size, text, __FILE__, __LINE__)


### PR DESCRIPTION
In PR https://github.com/cpputest/cpputest/pull/1773 NULLPTR was used as an argument CHECK_EQUAL_C_MEMCMP_LOCATION instead of NULL.
So, it was impossible to use CHECK_EQUAL_C_MEMCMP in C files.