### PR TITLE
STRING_H: Gate string.h inclusion on STRDUP

### DIFF
--- a/include/CppUTest/StandardCLibrary.h
+++ b/include/CppUTest/StandardCLibrary.h
@@ -45,7 +45,7 @@
 #include <limits.h>
 
 /* Needed to ensure that string.h is included prior to strdup redefinition */
-#ifdef CPPUTEST_HAVE_STRING_H
+#ifdef CPPUTEST_HAVE_STRDUP
 #include <string.h>
 #endif
 


### PR DESCRIPTION
Replace `CPPUTEST_HAVE_STRING_H` with `CPPUTEST_HAVE_STRDUP` in `StandardCLibrary.h`

PR #1192 resolved a build issue related to projects including string.h for autoconf-based projects but not CMake-based projects. The autoconf projects have `CPPUTEST_HAVE_STRING_H` defined as part of `AC_CHECK_HEADERS` check for `string.h` but CMake projects do not have this same check.

The CMake projects *do* have a call to `check_cxx_symbol_exists` for `strdup` which is used to set `CPPUTEST_HAVE_STRDUP` in `config.h`. The autoconf project has the equivalent check via `AC_CHECK_FUNCS` for `strdup`, so gating the `string.h` inclusion in `StandardCLibrary.h` on `CPPUTEST_HAVE_STRDUP` is both functionally equivalent for autoconf projects and more precise.

Based on CppUTest git history, it seems like @thetic maintains a lot of the CMake tooling, so pinging here for awareness.