### PR TITLE
Do not define __has_attribute in a public header

### DIFF
--- a/include/CppUTest/CppUTestConfig.h
+++ b/include/CppUTest/CppUTestConfig.h
@@ -100,12 +100,14 @@
  * This is needed for compiling with clang, without breaking other compilers.
  */
 #ifndef __has_attribute
-  #define __has_attribute(x) 0
+  #define CPPUTEST_HAS_ATTRIBUTE(x) 0
+#else
+  #define CPPUTEST_HAS_ATTRIBUTE(x) __has_attribute(x)
 #endif
 
 #if defined (__cplusplus) && __cplusplus >= 201103L
    #define CPPUTEST_NORETURN [[noreturn]]
-#elif __has_attribute(noreturn)
+#elif CPPUTEST_HAS_ATTRIBUTE(noreturn)
    #define CPPUTEST_NORETURN __attribute__((noreturn))
 #else
    #define CPPUTEST_NORETURN
@@ -117,7 +119,7 @@
 #define CPPUTEST_CHECK_FORMAT_TYPE printf
 #endif
 
-#if __has_attribute(format)
+#if CPPUTEST_HAS_ATTRIBUTE(format)
   #define CPPUTEST_CHECK_FORMAT(type, format_parameter, other_parameters) __attribute__ ((format (type, format_parameter, other_parameters)))
 #else
   #define CPPUTEST_CHECK_FORMAT(type, format_parameter, other_parameters) /* type, format_parameter, other_parameters */


### PR DESCRIPTION
This causes issues with gcc < 5 and gmacros.h from glib >= 2.69.
The glib header thinks the compiler supports __has_attribute, so it uses it instead of doing version checks.
Then macros like G_GNUC_UNUSED become empty, as if no attribute was supported.