### PR TITLE
Remove excessive warning suppressions

### DIFF
--- a/build/MakefileWorker.mk
+++ b/build/MakefileWorker.mk
@@ -206,9 +206,8 @@ ifeq ($(COMPILER_NAME),$(CLANG_STR))
 # -Wno-old-style-casts -> We only use old style casts by decision
 # -Wno-c++11-long-long -> When it detects long long, then we can use it and no need for a warning about that
 # -Wno-c++98-compat-pedantic -> Incompatibilities with C++98, these are happening through #define.
-# -Wno-keyword-macro -> new overload
-	CPPUTEST_CXX_WARNINGFLAGS += -Wno-disabled-macro-expansion -Wno-padded -Wno-global-constructors -Wno-exit-time-destructors -Wno-weak-vtables -Wno-old-style-cast -Wno-c++11-long-long -Wno-c++98-compat-pedantic -Wreserved-id-macro -Wno-keyword-macro
-	CPPUTEST_C_WARNINGFLAGS += -Wno-padded
+	CPPUTEST_CXX_WARNINGFLAGS += -Wno-disabled-macro-expansion -Wno-padded -Wno-global-constructors -Wno-exit-time-destructors -Wno-weak-vtables -Wno-old-style-cast -Wno-c++11-long-long -Wno-c++98-compat-pedantic -Wreserved-id-macro
+	CPPUTEST_C_WARNINGFLAGS += -Wno-padded -Wreserved-id-macro
 
 # Clang 7 and 12 introduced new warnings by default that don't exist on previous versions of clang and cause errors when present.
 CLANG_VERSION := $(shell echo $(CC_VERSION_OUTPUT) | sed -n 's/.* \([0-9]*\.[0-9]*\.[0-9]*\).*/\1/p')
@@ -218,9 +217,8 @@ CLANG_VERSION_NUM_GT_1200 := $(shell [ "$(CLANG_VERSION_NUM)" -ge 1200 ] && echo
 CLANG_VERSION_NUM_GT_1205 := $(shell [ "$(CLANG_VERSION_NUM)" -ge 1205 ] && echo Y || echo N)
 
 ifeq ($(CLANG_VERSION_NUM_GT_700), Y)
-# -Wno-keyword-macro -> CppUTest redefines the 'new' keyword for memory leak tracking
-	CPPUTEST_CXX_WARNINGFLAGS += -Wno-keyword-macro
-	CPPUTEST_C_WARNINGFLAGS += -Wno-keyword-macro
+	CPPUTEST_CXX_WARNINGFLAGS += -Wkeyword-macro
+	CPPUTEST_C_WARNINGFLAGS += -Wkeyword-macro
 endif
 
 ifeq ($(UNAME_OS),$(MACOSX_STR))

--- a/build/MakefileWorker.mk
+++ b/build/MakefileWorker.mk
@@ -206,9 +206,8 @@ ifeq ($(COMPILER_NAME),$(CLANG_STR))
 # -Wno-old-style-casts -> We only use old style casts by decision
 # -Wno-c++11-long-long -> When it detects long long, then we can use it and no need for a warning about that
 # -Wno-c++98-compat-pedantic -> Incompatibilities with C++98, these are happening through #define.
-# -Wno-reserved-id-macro -> Macro uses __ in MINGW... can't change that.
 # -Wno-keyword-macro -> new overload
-	CPPUTEST_CXX_WARNINGFLAGS += -Wno-disabled-macro-expansion -Wno-padded -Wno-global-constructors -Wno-exit-time-destructors -Wno-weak-vtables -Wno-old-style-cast -Wno-c++11-long-long -Wno-c++98-compat-pedantic -Wno-reserved-id-macro -Wno-keyword-macro
+	CPPUTEST_CXX_WARNINGFLAGS += -Wno-disabled-macro-expansion -Wno-padded -Wno-global-constructors -Wno-exit-time-destructors -Wno-weak-vtables -Wno-old-style-cast -Wno-c++11-long-long -Wno-c++98-compat-pedantic -Wreserved-id-macro -Wno-keyword-macro
 	CPPUTEST_C_WARNINGFLAGS += -Wno-padded
 
 # Clang 7 and 12 introduced new warnings by default that don't exist on previous versions of clang and cause errors when present.
@@ -219,10 +218,9 @@ CLANG_VERSION_NUM_GT_1200 := $(shell [ "$(CLANG_VERSION_NUM)" -ge 1200 ] && echo
 CLANG_VERSION_NUM_GT_1205 := $(shell [ "$(CLANG_VERSION_NUM)" -ge 1205 ] && echo Y || echo N)
 
 ifeq ($(CLANG_VERSION_NUM_GT_700), Y)
-# -Wno-reserved-id-macro -> Many CppUTest macros start with __, which is a reserved namespace
 # -Wno-keyword-macro -> CppUTest redefines the 'new' keyword for memory leak tracking
-	CPPUTEST_CXX_WARNINGFLAGS += -Wno-reserved-id-macro -Wno-keyword-macro
-	CPPUTEST_C_WARNINGFLAGS += -Wno-reserved-id-macro -Wno-keyword-macro
+	CPPUTEST_CXX_WARNINGFLAGS += -Wno-keyword-macro
+	CPPUTEST_C_WARNINGFLAGS += -Wno-keyword-macro
 endif
 
 ifeq ($(UNAME_OS),$(MACOSX_STR))

--- a/cmake/warnings.cmake
+++ b/cmake/warnings.cmake
@@ -20,7 +20,7 @@ if(
         -Wno-padded
         -Wno-disabled-macro-expansion
         -Wreserved-id-macro
-        -Wkeyword-macro
+        -Wreserved-identifier
         -Wno-long-long
         -Wno-unsafe-buffer-usage
     )

--- a/cmake/warnings.cmake
+++ b/cmake/warnings.cmake
@@ -20,7 +20,7 @@ if(
         -Wno-padded
         -Wno-disabled-macro-expansion
         -Wreserved-id-macro
-        -Wno-keyword-macro
+        -Wkeyword-macro
         -Wno-long-long
         -Wno-unsafe-buffer-usage
     )

--- a/cmake/warnings.cmake
+++ b/cmake/warnings.cmake
@@ -19,7 +19,7 @@ if(
         -Wmissing-include-dirs
         -Wno-padded
         -Wno-disabled-macro-expansion
-        -Wno-reserved-id-macro
+        -Wreserved-id-macro
         -Wno-keyword-macro
         -Wno-long-long
         -Wno-unsafe-buffer-usage

--- a/configure.ac
+++ b/configure.ac
@@ -232,10 +232,10 @@ AC_MSG_CHECKING([whether CC support -Wreserved-id-macro])
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([])], [AC_MSG_RESULT([yes]); CPPUTEST_CWARNINGFLAGS="${CPPUTEST_CWARNINGFLAGS} -Wreserved-id-macro"], [AC_MSG_RESULT([no])])
 CFLAGS="$saved_cflags"
 
-# Flag -Wno-keyword-macro.
-CFLAGS="-Werror -Wkeyword-macro"
-AC_MSG_CHECKING([whether CC supports -Wkeyword-macro])
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([])], [AC_MSG_RESULT([yes]); CPPUTEST_CWARNINGFLAGS="${CPPUTEST_CWARNINGFLAGS} -Wkeyword-macro"; CPPUTEST_CXXWARNINGFLAGS="${CPPUTEST_CXXWARNINGFLAGS} -Wno-keyword-macro" ], [AC_MSG_RESULT([no])])
+# Flag -Wreserved-identifier
+CFLAGS="-Werror -Wreserved-identifier"
+AC_MSG_CHECKING([whether CC supports -Wreserved-identifier])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([])], [AC_MSG_RESULT([yes]); CPPUTEST_CWARNINGFLAGS="${CPPUTEST_CWARNINGFLAGS} -Wreserved-identifier"; CPPUTEST_CXXWARNINGFLAGS="${CPPUTEST_CXXWARNINGFLAGS} -Wreserved-identifier" ], [AC_MSG_RESULT([no])])
 CFLAGS="$saved_cflags"
 
 ##### C++ Warnings

--- a/configure.ac
+++ b/configure.ac
@@ -226,6 +226,12 @@ AC_MSG_CHECKING([whether CC supports -Wsign-conversion])
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([])], [AC_MSG_RESULT([yes]); CPPUTEST_CWARNINGFLAGS="${CPPUTEST_CWARNINGFLAGS} -Wsign-conversion"], [AC_MSG_RESULT([no])])
 CFLAGS="$saved_cflags"
 
+# Flag -Wreserved-id-macro
+CFLAGS="-Werror -Wreserved-id-macro"
+AC_MSG_CHECKING([whether CC support -Wreserved-id-macro])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([])], [AC_MSG_RESULT([yes]); CPPUTEST_CWARNINGFLAGS="${CPPUTEST_CWARNINGFLAGS} -Wreserved-id-macro"], [AC_MSG_RESULT([no])])
+CFLAGS="$saved_cflags"
+
 ##### C++ Warnings
 # Flag -Wsign-conversion (for CXX)
 AC_LANG_PUSH([C++])
@@ -264,12 +270,6 @@ CFLAGS="$saved_cflags"
 CFLAGS="-Werror -Wno-padded"
 AC_MSG_CHECKING([whether CC and CXX supports -Wno-padded])
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([])], [AC_MSG_RESULT([yes]); CPPUTEST_CWARNINGFLAGS="${CPPUTEST_CWARNINGFLAGS} -Wno-padded"; CPPUTEST_CXXWARNINGFLAGS="${CPPUTEST_CXXWARNINGFLAGS} -Wno-padded" ], [AC_MSG_RESULT([no])])
-CFLAGS="$saved_cflags"
-
-# Flag -Wno-reserved-id-macro.
-CFLAGS="-Werror -Wno-reserved-id-macro"
-AC_MSG_CHECKING([whether CC and CXX supports -Wno-reserved-id-macro])
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([])], [AC_MSG_RESULT([yes]); CPPUTEST_CWARNINGFLAGS="${CPPUTEST_CWARNINGFLAGS} -Wno-reserved-id-macro"; CPPUTEST_CXXWARNINGFLAGS="${CPPUTEST_CXXWARNINGFLAGS} -Wno-reserved-id-macro" ], [AC_MSG_RESULT([no])])
 CFLAGS="$saved_cflags"
 
 # Flag -Wno-keyword-macro.

--- a/configure.ac
+++ b/configure.ac
@@ -232,6 +232,12 @@ AC_MSG_CHECKING([whether CC support -Wreserved-id-macro])
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([])], [AC_MSG_RESULT([yes]); CPPUTEST_CWARNINGFLAGS="${CPPUTEST_CWARNINGFLAGS} -Wreserved-id-macro"], [AC_MSG_RESULT([no])])
 CFLAGS="$saved_cflags"
 
+# Flag -Wno-keyword-macro.
+CFLAGS="-Werror -Wkeyword-macro"
+AC_MSG_CHECKING([whether CC supports -Wkeyword-macro])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([])], [AC_MSG_RESULT([yes]); CPPUTEST_CWARNINGFLAGS="${CPPUTEST_CWARNINGFLAGS} -Wkeyword-macro"; CPPUTEST_CXXWARNINGFLAGS="${CPPUTEST_CXXWARNINGFLAGS} -Wno-keyword-macro" ], [AC_MSG_RESULT([no])])
+CFLAGS="$saved_cflags"
+
 ##### C++ Warnings
 # Flag -Wsign-conversion (for CXX)
 AC_LANG_PUSH([C++])
@@ -270,12 +276,6 @@ CFLAGS="$saved_cflags"
 CFLAGS="-Werror -Wno-padded"
 AC_MSG_CHECKING([whether CC and CXX supports -Wno-padded])
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([])], [AC_MSG_RESULT([yes]); CPPUTEST_CWARNINGFLAGS="${CPPUTEST_CWARNINGFLAGS} -Wno-padded"; CPPUTEST_CXXWARNINGFLAGS="${CPPUTEST_CXXWARNINGFLAGS} -Wno-padded" ], [AC_MSG_RESULT([no])])
-CFLAGS="$saved_cflags"
-
-# Flag -Wno-keyword-macro.
-CFLAGS="-Werror -Wno-keyword-macro"
-AC_MSG_CHECKING([whether CC and CXX supports -Wno-keyword-macro])
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([])], [AC_MSG_RESULT([yes]); CPPUTEST_CWARNINGFLAGS="${CPPUTEST_CWARNINGFLAGS} -Wno-keyword-macro"; CPPUTEST_CXXWARNINGFLAGS="${CPPUTEST_CXXWARNINGFLAGS} -Wno-keyword-macro" ], [AC_MSG_RESULT([no])])
 CFLAGS="$saved_cflags"
 
 AC_LANG_PUSH([C++])

--- a/examples/AllTests/FEDemoTest.cpp
+++ b/examples/AllTests/FEDemoTest.cpp
@@ -52,13 +52,13 @@ TEST_GROUP(FE_Demo)
     }
 };
 
-IGNORE_TEST(FE_Demo, should_fail_when__FE_DIVBYZERO__is_set)
+IGNORE_TEST(FE_Demo, should_fail_when_FE_DIVBYZERO_is_set)
 {
     float f = 1.0f;
     CHECK((f /= 0.0f) >= std::numeric_limits<float>::infinity());
 }
 
-IGNORE_TEST(FE_Demo, should_fail_when__FE_UNDERFLOW__is_set)
+IGNORE_TEST(FE_Demo, should_fail_when_FE_UNDERFLOW_is_set)
 {
     volatile float f = 0.01f;
     while (f > 0.0f)
@@ -66,7 +66,7 @@ IGNORE_TEST(FE_Demo, should_fail_when__FE_UNDERFLOW__is_set)
     CHECK(f == 0.0f);
 }
 
-IGNORE_TEST(FE_Demo, should_fail_when__FE_OVERFLOW__is_set)
+IGNORE_TEST(FE_Demo, should_fail_when_FE_OVERFLOW_is_set)
 {
     volatile float f = 1000.0f;
     while (f < std::numeric_limits<float>::infinity())
@@ -74,7 +74,7 @@ IGNORE_TEST(FE_Demo, should_fail_when__FE_OVERFLOW__is_set)
     CHECK(f >= std::numeric_limits<float>::infinity());
 }
 
-IGNORE_TEST(FE_Demo, should_fail_when__FE_INEXACT____is_set)
+IGNORE_TEST(FE_Demo, should_fail_when_FE_INEXACT_is_set)
 {
     IEEE754ExceptionsPlugin::enableInexact();
     float f = 10.0f;

--- a/include/CppUTest/CppUTestConfig.h
+++ b/include/CppUTest/CppUTestConfig.h
@@ -40,13 +40,6 @@
  *
  */
 
-#ifdef __clang__
- #pragma clang diagnostic push
- #if (__clang_major__ == 3 && __clang_minor__ >= 6) || __clang_major__ >= 4
-  #pragma clang diagnostic ignored "-Wreserved-id-macro"
- #endif
-#endif
-
 /*
  * Lib C dependencies that are currently still left:
  *
@@ -350,10 +343,6 @@ typedef struct
   #else
     #define CPPUTEST_DESTRUCTOR_OVERRIDE
   #endif
-#endif
-
-#ifdef __clang__
- #pragma clang diagnostic pop
 #endif
 
 #endif


### PR DESCRIPTION
We removed the last use of reserved macro names in #1800 and have a local suppression for the single keyword macro.