### PR TITLE
Prevent attempts to discover cross compiled tests without an emulator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,8 +43,6 @@ cmake_dependent_option(CPPUTEST_BUILD_TESTING "Compile and make tests for CppUTe
   ${PROJECT_IS_TOP_LEVEL} "BUILD_TESTING" OFF)
 cmake_dependent_option(CPPUTEST_SPLIT_TESTS "Split tests into small executables"
   OFF "CPPUTEST_BUILD_TESTING" OFF)
-cmake_dependent_option(CPPUTEST_TEST_DISCOVERY "Build time test discover"
-  ON "CPPUTEST_BUILD_TESTING;CMAKE_CROSSCOMPILING_EMULATOR OR NOT CMAKE_CROSSCOMPILING" OFF)
 cmake_dependent_option(CPPUTEST_TEST_GTEST "Test GoogleTest integration"
   OFF "CPPUTEST_BUILD_TESTING" OFF)
 cmake_dependent_option(CPPUTEST_EXAMPLES "Compile and make examples?"

--- a/cmake/Modules/CppUTest.cmake
+++ b/cmake/Modules/CppUTest.cmake
@@ -35,6 +35,17 @@ function(cpputest_discover_tests target)
         "which is not an executable."
         )
     endif()
+    
+    get_property(emulator
+        TARGET ${target}
+        PROPERTY CROSSCOMPILING_EMULATOR
+    )
+    if(CMAKE_CROSSCOMPILING)
+        if(NOT emulator)
+            message(WARNING "Cannot discover cross compiled tests without an emulator")
+            return()
+        endif()
+    endif()
 
     if(NOT DEFINED _EXTRA_ARGS)
         set(_EXTRA_ARGS -v)
@@ -72,7 +83,7 @@ function(cpputest_discover_tests target)
             "${CMAKE_COMMAND}"
             -D "TESTS_DETAILED:BOOL=${_DETAILED}"
             -D "EXECUTABLE=$<TARGET_FILE:${target}>"
-            -D "EMULATOR=$<TARGET_PROPERTY:${target},CROSSCOMPILING_EMULATOR>"
+            -D "EMULATOR=${emulator}"
             -D "ARGS=${_EXTRA_ARGS}"
             -D "CTEST_FILE=${CTEST_GENERATED_FILE}"
             -P "${_CPPUTEST_DISCOVERY_SCRIPT}"

--- a/examples/AllTests/CMakeLists.txt
+++ b/examples/AllTests/CMakeLists.txt
@@ -23,7 +23,5 @@ target_link_libraries(ExampleTests
         CppUTest::CppUTestExt
 )
 
-if(CPPUTEST_TEST_DISCOVERY OR NOT DEFINED CPPUTEST_TEST_DISCOVERY)
-    include(CppUTest)
-    cpputest_discover_tests(ExampleTests)
-endif()
+include(CppUTest)
+cpputest_discover_tests(ExampleTests)

--- a/tests/CppUTest/CMakeLists.txt
+++ b/tests/CppUTest/CMakeLists.txt
@@ -20,9 +20,7 @@ if(NOT CPPUTEST_SPLIT_TESTS)
 
     add_mapfile(CppUTestTests)
 
-    if(CPPUTEST_TEST_DISCOVERY)
-        cpputest_discover_tests(CppUTestTests)
-    endif()
+    cpputest_discover_tests(CppUTestTests)
 endif()
 
 function(add_cpputest_test number)
@@ -32,9 +30,7 @@ function(add_cpputest_test number)
         string(APPEND name ${number})
         add_executable(${name})
         add_mapfile(${name})
-        if(CPPUTEST_TEST_DISCOVERY)
-            cpputest_discover_tests(${name})
-        endif()
+        cpputest_discover_tests(${name})
     endif()
 
     target_sources(${name}

--- a/tests/CppUTestExt/CMakeLists.txt
+++ b/tests/CppUTestExt/CMakeLists.txt
@@ -44,12 +44,10 @@ if(NOT CPPUTEST_SPLIT_TESTS)
 
     add_mapfile(CppUTestExtTests)
 
-    if(CPPUTEST_TEST_DISCOVERY)
-        include(CppUTest)
-        cpputest_discover_tests(CppUTestExtTests
-            DETAILED FALSE
-        )
-    endif()
+    include(CppUTest)
+    cpputest_discover_tests(CppUTestExtTests
+        DETAILED FALSE
+    )
 endif()
 
 function(add_cpputestext_test number)
@@ -59,9 +57,7 @@ function(add_cpputestext_test number)
         string(APPEND name ${number})
         add_executable(${name})
         add_mapfile(${name})
-        if(CPPUTEST_TEST_DISCOVERY)
-            cpputest_discover_tests(${name})
-        endif()
+        cpputest_discover_tests(${name})
     endif()
 
     target_sources(${name}


### PR DESCRIPTION
Test discovery depends on being able to run the test executables. When cross compiling, that means using an emulator. There's no reason to try discovering tests when cross compiling without an emulator. This lets users (and us) avoid noisy guards at call sites in cross-platform projects.

I've added a warning for such cases so users get a useful explanation instead of the confusing errors that used to occur. (e.g. https://github.com/cpputest/cpputest/actions/runs/11062997988/job/30738413966?pr=1820#step:8:56)