### PR TITLE
Resolve new CMake warning

### DIFF
--- a/cmake/Modules/CppUTest.cmake
+++ b/cmake/Modules/CppUTest.cmake
@@ -77,7 +77,6 @@ function(cpputest_discover_tests target)
             -D "CTEST_FILE=${CTEST_GENERATED_FILE}"
             -P "${_CPPUTEST_DISCOVERY_SCRIPT}"
         WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
-        DEPENDS "${_CPPUTEST_DISCOVERY_SCRIPT}"
         VERBATIM
     )
 


### PR DESCRIPTION
CMake 3.31 added a new warning for the added [CMP0175](https://cmake.org/cmake/help/latest/policy/CMP0175.html) policy which uncovered the previously ignored unused `DEPENDS` argument.