### PR TITLE
Squelch deprecation warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # 2.6.3 is needed for ctest support
 # 3.1 is needed for target_sources
 # 3.8 is needed for try_compile improvements (CMP0067)
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.8...3.31)
 
 project(CppUTest
   VERSION 4.0

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.8...3.31)
 
 project(CppUTestExample)
 

--- a/src/CppUTest/CMakeIntegration-README.md
+++ b/src/CppUTest/CMakeIntegration-README.md
@@ -51,7 +51,7 @@ This is useful for managing a common
 CppUTest installation with the system's package manager.
 
 ```cmake
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.10)
 project(trying_CppUtest)
 
 find_package(CppUTest REQUIRED)
@@ -80,7 +80,7 @@ how an external project can refer to this CMakeLists.txt to build CppUTest as a
 library and include it as a target dependency.
 
 ```cmake
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.10)
 project(trying_CppUtest)
 
 SET(CppUTestRootDirectory /path/to/cpputest)


### PR DESCRIPTION
Most recent CMake started complaining about the pending end of 3.8 support.

> ```
> CMake Deprecation Warning at CMakeLists.txt:4 (cmake_minimum_required):
>   Compatibility with CMake < 3.10 will be removed from a future version of
>   CMake.
>
>   Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
>   to tell CMake that the project requires at least <min> but has been updated
>   to work with policies introduced by <max> or earlier.
> ```

We can retain support by adding a max version. This will not prevent use with newer versions, but indicates forward compatibility.[^1]

[^1]: https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html