### PR TITLE
Version bump of github workflow actions to v4.

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -270,7 +270,7 @@ jobs:
       - name: Build
         run: cmake --build cpputest_build --verbose -j
       - name: Save map files
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: "${{ matrix.name }} map files"
           path: cpputest_build/**/*.map
@@ -318,7 +318,7 @@ jobs:
       - run: cmake --preset=defaults -DCPPUTEST_JUNIT_REPORT=TRUE
       - run: cmake --build cpputest_build -j
       - run: ctest --test-dir cpputest_build
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: success() || failure()
         with:
           name: test-results


### PR DESCRIPTION
This PR fixes an issue for github repos that use cpputest as a submodule AND run workflows on github.

[Github has deprecated workflow "actions/upload-artifact@v3" "actions/download-artifact@v3"](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/). Unfortunately, github has a policy of scanning all ".github/workflows/*.yaml" files for deprecated actions, whether those workflows in submodules are run or not. The presence of deprecated actions causes a workflow error.

This PR bumps the actions version to v4.
