### PR TITLE
update README.md fetchcontent cmake section remove test disable

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,8 +248,6 @@ FetchContent_Declare(
     GIT_REPOSITORY https://github.com/cpputest/cpputest.git
     GIT_TAG        master # or use release tag, eg. v4.0
 )
-# Set this to ON if you want to have the CppUTests in your project as well.
-set(TESTS OFF CACHE BOOL "Switch off CppUTest Test build")
 FetchContent_MakeAvailable(CppUTest)
 ```
 


### PR DESCRIPTION
dd70ae595cdd7374bd8e160e5d53fe9510904478 renamed TESTS to
CPPUTEST_BUILD_TESTING and defaulted it to off, so we no longer need to
set it to off in the example