### PR TITLE
fix expectedCallsLeft after actual call

### DIFF
--- a/src/CppUTestExt/MockSupport.cpp
+++ b/src/CppUTestExt/MockSupport.cpp
@@ -254,6 +254,7 @@ const char* MockSupport::getTraceOutput()
 
 bool MockSupport::expectedCallsLeft()
 {
+    checkExpectationsOfLastActualCall();
     int callsLeft = expectations_.hasUnfulfilledExpectations();
 
     for (MockNamedValueListNode* p = data_.begin(); p; p = p->next())

--- a/tests/CppUTestExt/MockCallTest.cpp
+++ b/tests/CppUTestExt/MockCallTest.cpp
@@ -500,3 +500,14 @@ TEST(MockCallTest, mockExpectationShouldIncreaseNumberOfChecks)
     fixture.runAllTests();
     LONGS_EQUAL(3, fixture.getCheckCount());
 }
+
+TEST(MockCallTest, expectationsLeftBeforCheckExpectations)
+{
+    CHECK(!mock().expectedCallsLeft());
+    mock().expectOneCall("boo");
+    CHECK(mock().expectedCallsLeft());
+    mock().actualCall("boo");
+    CHECK(!mock().expectedCallsLeft());
+    mock().checkExpectations();
+    CHECK(!mock().expectedCallsLeft());
+}


### PR DESCRIPTION
I want to check if all expected calls were called without failing test. `expectedCallsLeft`  returns true between `actualCall` and `checkExpectations`:

```c++
mock().expectedCallsLeft(); // false
mock().expectOneCall("boo");
mock().expectedCallsLeft()); //true
mock().actualCall("boo");
mock().expectedCallsLeft()); //TRUE BUT SHOULD BE FALSE
mock().checkExpectations();
mock().expectedCallsLeft()); //false
```

This PR fixes it by evaluating last actuall call inside `expectedCallsLeft`.