### PR TITLE
Fix new ClangCL warnings

### DIFF
--- a/src/CppUTest/SimpleString.cpp
+++ b/src/CppUTest/SimpleString.cpp
@@ -710,12 +710,12 @@ SimpleString StringFrom(void (*value)())
 
 SimpleString HexStringFrom(long value)
 {
-    return StringFromFormat("%lx", value);
+    return HexStringFrom((unsigned long)value);
 }
 
 SimpleString HexStringFrom(int value)
 {
-    return StringFromFormat("%x", value);
+    return HexStringFrom((unsigned int)value);
 }
 
 SimpleString HexStringFrom(signed char value)
@@ -795,7 +795,7 @@ SimpleString StringFrom(cpputest_ulonglong value)
 
 SimpleString HexStringFrom(cpputest_longlong value)
 {
-    return StringFromFormat("%llx", value);
+    return HexStringFrom((cpputest_ulonglong)value);
 }
 
 SimpleString HexStringFrom(cpputest_ulonglong value)

--- a/src/CppUTestExt/MockExpectedCall.cpp
+++ b/src/CppUTestExt/MockExpectedCall.cpp
@@ -423,7 +423,7 @@ SimpleString MockCheckedExpectedCall::callToString()
             str += ", other parameters are ignored";
     }
 
-    str += StringFromFormat(" (expected %d call%s, called %d time%s)",
+    str += StringFromFormat(" (expected %u call%s, called %u time%s)",
                             expectedCalls_, (expectedCalls_ == 1) ? "" : "s", actualCalls_, (actualCalls_ == 1) ? "" : "s" );
 
     return str;


### PR DESCRIPTION
`x` and `X` format specifiers are only defined for unsigned types.

https://en.cppreference.com/w/cpp/io/c/fprintf