### PR TITLE
Change codegen for gcc 15.1+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,17 @@ if(NOT PROJECT_IS_TOP_LEVEL)
   set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" PARENT_SCOPE)
 endif()
 
+
+if(
+  (NOT CPPUTEST_MEM_LEAK_DETECTION_DISABLED)
+  AND (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  AND (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "15.1")
+)
+  # Leak detection macros are not sane.
+  message(NOTICE "Disabling -fassume-sane-operators-new-delete which breaks leak detection")
+  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fno-assume-sane-operators-new-delete>)
+endif()
+
 if(PROJECT_IS_TOP_LEVEL)
   include(cmake/warnings.cmake)
 endif()

--- a/configure.ac
+++ b/configure.ac
@@ -303,6 +303,15 @@ AC_MSG_CHECKING([whether CXX supports -Wno-old-style-cast])
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([])], [AC_MSG_RESULT([yes]); CPPUTEST_CXXWARNINGFLAGS="${CPPUTEST_CXXWARNINGFLAGS} -Wno-old-style-cast" ], [AC_MSG_RESULT([no])])
 CXXFLAGS="$saved_cxxflags"
 
+if test "x${memory_leak_detection}" = xyes; then
+	# GCC's default optimization breaks leak detection:
+	# https://gcc.gnu.org/onlinedocs/gcc/C_002b_002b-Dialect-Options.html#index-fassume-sane-operators-new-delete
+	CXXFLAGS="-Werror -fno-assume-sane-operators-new-delete"
+	AC_MSG_CHECKING([whether CXX supports -fno-assume-sane-operators-new-delete])
+	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([])], [AC_MSG_RESULT([yes]); CPPUTEST_CXXWARNINGFLAGS="${CPPUTEST_CXXWARNINGFLAGS} -fno-assume-sane-operators-new-delete" ], [AC_MSG_RESULT([no])])
+	CXXFLAGS="$saved_cxxflags"
+fi
+
 AC_LANG_POP
 
 #####################################################


### PR DESCRIPTION
Leak detection requires modification of global state during allocation which GCC 15.1 now optimizes out by default[^1]:

> The `-fassume-sane-operators-new-delete` option has been added and enabled by default. This option allows control over some optimizations around calls to replaceable global operators new and delete. **If a program overrides those replaceable global operators and the replaced definitions read or modify global state visible to the rest of the program, programs might need to be compiled with `-fno-assume-sane-operators-new-delete`.**

  This change detects GCC 15.1 and disables that optimization. The CMake build only affects the CppUTest project, not user builds. We have no way of injecting such a flag in users' projects.

Mitigates #1851.

[^1]: https://gcc.gnu.org/gcc-15/changes.html