### PR TITLE
CI use one DOS script for docker/make workflows

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -350,7 +350,6 @@ jobs:
     name: Make OpenWatcom DOS
     runs-on: ubuntu-latest
     env:
-      WATCOM: "./watcom"
       TERM: linux
     steps:
       - name: Checkout
@@ -359,12 +358,8 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y dosbox
-          git clone https://github.com/cpputest/watcom-compiler.git $WATCOM
-          echo "$WATCOM/binl" >> $GITHUB_PATH
-      - name: Build
-        run: make -f platforms/Dos/Makefile
-      - name: Test
-        run: make -f platforms/Dos/Makefile test
+      - name: Build & Test
+        run: ./scripts/dos_build_test.sh
 
   cmake_msys:
     name: CMake MSYS

--- a/docker/Dockerfile.dos
+++ b/docker/Dockerfile.dos
@@ -4,4 +4,4 @@ RUN apt-get -qq update && apt-get -qq install -y --no-install-recommends dosbox 
 
 WORKDIR /cpputest_build
 
-CMD BUILD=make_dos /cpputest/scripts/travis_ci_build.sh
+CMD ["/cpputest/scripts/dos_build_test.sh"]

--- a/scripts/dos_build_test.sh
+++ b/scripts/dos_build_test.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# get current dir even if the script is sourced
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+export CPPUTEST_HOME="$DIR/../"
+export WATCOM=./watcom
+export PATH=$PATH:$WATCOM/binl
+
+if [ ! -d "$WATCOM" ]; then
+    git clone https://github.com/cpputest/watcom-compiler.git "$WATCOM"
+fi
+
+make -f "$CPPUTEST_HOME/platforms/Dos/Makefile" clean
+make -f "$CPPUTEST_HOME/platforms/Dos/Makefile"
+make -f "$CPPUTEST_HOME/platforms/Dos/Makefile" test


### PR DESCRIPTION
Stop using a small part of travis_ci_build.sh

part of #1855
