### PR TITLE
Add support for long int and unsigned long int in Mock setData functions

### DIFF
--- a/include/CppUTestExt/MockSupport.h
+++ b/include/CppUTestExt/MockSupport.h
@@ -81,6 +81,8 @@ public:
     void setData(const SimpleString& name, bool value);
     void setData(const SimpleString& name, int value);
     void setData(const SimpleString& name, unsigned int value);
+    void setData(const SimpleString& name, long int value);
+    void setData(const SimpleString& name, unsigned long int value);
     void setData(const SimpleString& name, const char* value);
     void setData(const SimpleString& name, double value);
     void setData(const SimpleString& name, void* value);

--- a/include/CppUTestExt/MockSupport_c.h
+++ b/include/CppUTestExt/MockSupport_c.h
@@ -204,6 +204,8 @@ struct SMockSupport_c
     void (*setBoolData) (const char* name, int value);
     void (*setIntData) (const char* name, int value);
     void (*setUnsignedIntData) (const char* name, unsigned int value);
+    void (*setLongIntData) (const char* name, long int value);
+    void (*setUnsignedLongIntData) (const char* name, unsigned long int value);
     void (*setStringData) (const char* name, const char* value);
     void (*setDoubleData) (const char* name, double value);
     void (*setPointerData) (const char* name, void* value);

--- a/src/CppUTestExt/MockSupport.cpp
+++ b/src/CppUTestExt/MockSupport.cpp
@@ -381,6 +381,18 @@ void MockSupport::setData(const SimpleString& name, int value)
     newData->setValue(value);
 }
 
+void MockSupport::setData(const SimpleString& name, long int value)
+{
+    MockNamedValue* newData = retrieveDataFromStore(name);
+    newData->setValue(value);
+}
+
+void MockSupport::setData(const SimpleString& name, unsigned long int value)
+{
+    MockNamedValue* newData = retrieveDataFromStore(name);
+    newData->setValue(value);
+}
+
 void MockSupport::setData(const SimpleString& name, const char* value)
 {
     MockNamedValue* newData = retrieveDataFromStore(name);

--- a/src/CppUTestExt/MockSupport_c.cpp
+++ b/src/CppUTestExt/MockSupport_c.cpp
@@ -128,6 +128,8 @@ void ignoreOtherCalls_c();
 void setBoolData_c(const char* name, int value);
 void setIntData_c(const char* name, int value);
 void setUnsignedIntData_c(const char* name, unsigned int value);
+void setLongIntData_c(const char* name, long int value);
+void setUnsignedLongIntData_c(const char* name, unsigned long int value);
 void setDoubleData_c(const char* name, double value);
 void setStringData_c(const char* name, const char* value);
 void setPointerData_c(const char* name, void* value);
@@ -358,6 +360,8 @@ static MockSupport_c gMockSupport = {
         setBoolData_c,
         setIntData_c,
         setUnsignedIntData_c,
+        setLongIntData_c,
+        setUnsignedLongIntData_c,
         setStringData_c,
         setDoubleData_c,
         setPointerData_c,
@@ -1027,6 +1031,16 @@ void setIntData_c(const char* name, int value)
 }
 
 void setUnsignedIntData_c(const char* name, unsigned int value)
+{
+    currentMockSupport->setData(name, value);
+}
+
+void setLongIntData_c(const char* name, long int value)
+{
+    currentMockSupport->setData(name, value);
+}
+
+void setUnsignedLongIntData_c(const char* name, unsigned long int value)
 {
     currentMockSupport->setData(name, value);
 }

--- a/tests/CppUTestExt/MockSupportTest.cpp
+++ b/tests/CppUTestExt/MockSupportTest.cpp
@@ -107,6 +107,20 @@ TEST(MockSupportTest, setDataDouble)
     DOUBLES_EQUAL(1.0, mock().getData("data").getDoubleValue(), 0.05);
 }
 
+TEST(MockSupportTest, setDataLongInt)
+{
+    long int i = 100;
+    mock().setData("data", i);
+    LONGS_EQUAL(i, mock().getData("data").getLongIntValue());
+}
+
+TEST(MockSupportTest, setDataUnsignedLongInt)
+{
+    unsigned long int i = 100;
+    mock().setData("data", i);
+    UNSIGNED_LONGS_EQUAL(i, mock().getData("data").getUnsignedLongIntValue());
+}
+
 TEST(MockSupportTest, setDataPointer)
 {
     void * ptr = (void*) 0x001;

--- a/tests/CppUTestExt/MockSupport_cTest.cpp
+++ b/tests/CppUTestExt/MockSupport_cTest.cpp
@@ -567,6 +567,20 @@ TEST(MockSupport_c, MockSupportSetIntData)
     LONGS_EQUAL(10, mock_c()->getData("integer").value.intValue);
 }
 
+TEST(MockSupport_c, MockSupportSetLongIntData)
+{
+    long int i = 100;
+    mock_c()->setLongIntData("long integer", i);
+    LONGS_EQUAL(i, mock_c()->getData("long integer").value.longIntValue);
+}
+
+TEST(MockSupport_c, MockSupportSetUnsignedLongIntData)
+{
+    unsigned long int i = 100;
+    mock_c()->setUnsignedLongIntData("unsigned long integer", i);
+    UNSIGNED_LONGS_EQUAL(i, mock_c()->getData("unsigned long integer").value.unsignedLongIntValue);
+}
+
 TEST(MockSupport_c, MockSupportSetDoubleData)
 {
     mock_c()->setDoubleData("double", 1.0);


### PR DESCRIPTION
For MockSupport getData functions, MockNamedValue and MockValue_c already support long int and unsigned long int.

However, there is no equivalent setData function that accepts these types. I have added support for long int and unsigned long int (in C++ and C), following the exact format and structure of the existing types.

Personally, this was useful when trying to pass a time_t as data to a mocked time() function, without running the risk of lossy typecasting / year 2038 problem.