### PR TITLE
ci: actually run docker builds

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -421,20 +421,12 @@ jobs:
     runs-on: ubuntu-latest
     name: Docker ${{ matrix.image }}
     steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-        env:
-          TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        if: ${{ env.TOKEN != '' }}
       - name: Build
         uses: docker/build-push-action@v3
         with:
           file: docker/Dockerfile.${{ matrix.image }}
-          tags: cpputest/${{ matrix.image }}
+          tags: cpputest/${{ matrix.image }}:latest
+          push: false
+      - name: Test
+        run: |
+          docker run --rm cpputest/${{ matrix.image }}:latest

--- a/docker/Dockerfile.dos
+++ b/docker/Dockerfile.dos
@@ -4,4 +4,6 @@ RUN apt-get -qq update && apt-get -qq install -y --no-install-recommends dosbox 
 
 WORKDIR /cpputest_build
 
+COPY ../ /cpputest
+
 CMD ["/cpputest/scripts/dos_build_test.sh"]

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -5,4 +5,6 @@ RUN apt-get update && \
 
 WORKDIR /cpputest_build
 
-CMD autoreconf -i ../cpputest && ../cpputest/configure && make tdd
+COPY ../ /cpputest
+
+CMD ["bash", "-c", "autoreconf -i /cpputest && /cpputest/configure && make tdd"]


### PR DESCRIPTION
qemu and buildx didn't do anything for these builds, and because these
aren't pushed or using private deps, authenticating to docker hub
doesn't do anything

related to #1855
