### PR TITLE
ci: update codeql

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@main
       - name: CodeQL Initialization
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
         with:
           languages: cpp
           queries: +security-and-quality
@@ -34,7 +34,7 @@ jobs:
           cmake -DCMAKE_CXX_STANDARD=17 ..
           make -j2
       - name: CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3
 
   autotools:
     strategy:


### PR DESCRIPTION
v2 is deprecated and causing warnings
https://github.blog/changelog/2025-01-10-code-scanning-codeql-action-v2-is-now-deprecated/
v3 seems to work with no changes
