### PR TITLE
Target name in README.md "Integration as external CMake project" should match.

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ FetchContent_MakeAvailable(CppUTest)
 It can be used then like so:
 
 ```cmake
-add_executable(run_tests UnitTest1.cpp UnitTest2.cpp)
+add_executable(example_test UnitTest1.cpp UnitTest2.cpp)
 
 target_link_libraries(example_test PRIVATE
     CppUTest::CppUTest


### PR DESCRIPTION
Please see [Integration as external CMake project](https://github.com/cpputest/cpputest?tab=readme-ov-file#integration-as-external-cmake-project) in the README.md.

The target, `example_test`, referenced in `target_link_libraries(example_test ...` , should match the target, `run_tests`, as defined in `add_executable(run_tests ...`.

Since `example_test` is used in other portions of the README.md, `run_tests` should be changed to `example_test` for parity and function.