### PR TITLE
Added memory to StandardCLibrary.h

### DIFF
--- a/include/CppUTest/StandardCLibrary.h
+++ b/include/CppUTest/StandardCLibrary.h
@@ -16,6 +16,7 @@
   #include <cstdlib>
   #include <cstring>
   #include <string>
+  #include <memory>
  #endif
 #endif
 


### PR DESCRIPTION
Added memory include to the StandardCLibrary.h which then prevents a conflict when using malloc replacement for Alphine docker image.

This should resolve Issue #1862  