### PR TITLE
Document -ri CLI arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ $ vcpkg install cpputest (More information: https://github.com/microsoft/vcpkg)
 * `-v` verbose, print each test name as it runs
 * `-r#` repeat the tests some number of times, default is one, default if # is not specified is 2. This is handy if you are experiencing memory leaks related to statics and caches.
 * `-s#` random shuffle the test execution order. # is an integer used for seeding the random number generator. # is optional, and if omitted, the seed value is chosen automatically, which results in a different order every time. The seed value is printed to console to make it possible to reproduce a previously generated execution order. Handy for detecting problems related to dependencies between tests.
+* `-ri` run ignored tests as if they are not ignored.
 * `-g` group only run test whose group contains the substring group
 * `-n` name only run test whose name contains the substring name
 * `-f` crash on fail, run the tests as normal but, when a test fails, crash rather than report the failure in the normal way

--- a/src/CppUTest/CommandLineArguments.cpp
+++ b/src/CppUTest/CommandLineArguments.cpp
@@ -155,6 +155,7 @@ const char* CommandLineArguments::help() const
       "  -b                - run the tests backwards, reversing the normal way\n"
       "  -s [<seed>]       - shuffle tests randomly (randomization seed is optional, must be greater than 0)\n"
       "  -r[<#>]           - repeat the tests <#> times (or twice if <#> is not specified)\n"
+      "  -ri               - run ignored tests as if they are not ignored\n"
       "  -f                - Cause the tests to crash on failure (to allow the test to be debugged if necessary)\n"
       "  -e                - do not rethrow unexpected exceptions on failure\n"
       "  -ci               - continuous integration mode (equivalent to -e)\n";


### PR DESCRIPTION
# Summary

Add explanation for the run ignored tests cli argument.

I noticed that the -ri argument is in the print usage but not in the verbose help and I was not sure what this option did:

<img width="786" height="90" alt="image" src="https://github.com/user-attachments/assets/815a55a2-aae2-40f3-850c-0a3c5e60f9da" />


## Testing

<img width="770" height="827" alt="image" src="https://github.com/user-attachments/assets/5047ec5a-c724-4a22-b7af-51ed3bef4a0d" />


