### PR TITLE
Force include only in C/C++

### DIFF
--- a/src/CppUTest/CMakeLists.txt
+++ b/src/CppUTest/CMakeLists.txt
@@ -108,7 +108,7 @@ if(NOT CPPUTEST_MEM_LEAK_DETECTION_DISABLED)
     endif()
     target_compile_options(CppUTest
         PUBLIC
-            ${force_include}CppUTest/MemoryLeakDetectorForceInclude.h
+            $<$<COMPILE_LANGUAGE:C,CXX>:${force_include}CppUTest/MemoryLeakDetectorForceInclude.h>
     )
 endif()
 


### PR DESCRIPTION
Previous implementation added the force include flag (e.g. `-include`) to _all_ compile commands.  This would break compilation of assembly and other languages for which the header is invalid.