### PR TITLE
Moved the allocation outside the compile unit to avoid optimising the new away

### DIFF
--- a/tests/CppUTest/AllocationInCppFile.cpp
+++ b/tests/CppUTest/AllocationInCppFile.cpp
@@ -27,6 +27,26 @@ char* newArrayAllocationWithoutMacro()
     return new char[100];
 }
 
+int* newIntAllocationWithoutMacro()
+{
+    return new int;
+}
+
+int* newIntNoThowAllocationWithoutMacro()
+{
+    return new (std::nothrow) int;
+}
+
+char* newCharArrayAllocationWithoutMacro()
+{
+    return new char[20];
+}
+
+char* newCharArrayNoThrowAllocationWithoutMacro()
+{
+    return new (std::nothrow) char[20];
+}
+
 #if CPPUTEST_HAVE_EXCEPTIONS
 
 ClassThatThrowsAnExceptionInTheConstructor::ClassThatThrowsAnExceptionInTheConstructor()

--- a/tests/CppUTest/AllocationInCppFile.h
+++ b/tests/CppUTest/AllocationInCppFile.h
@@ -7,6 +7,11 @@ char* newArrayAllocation();
 char* newAllocationWithoutMacro();
 char* newArrayAllocationWithoutMacro();
 
+int* newIntAllocationWithoutMacro();
+int* newIntNoThowAllocationWithoutMacro();
+char* newCharArrayAllocationWithoutMacro();
+char* newCharArrayNoThrowAllocationWithoutMacro();
+
 #if CPPUTEST_HAVE_EXCEPTIONS
 
 class ClassThatThrowsAnExceptionInTheConstructor

--- a/tests/CppUTest/MemoryLeakWarningTest.cpp
+++ b/tests/CppUTest/MemoryLeakWarningTest.cpp
@@ -35,6 +35,7 @@
 #include "CppUTest/TestHarness_c.h"
 #include "CppUTest/SimpleMutex.h"
 #include "DummyMemoryLeakDetector.h"
+#include "AllocationInCppFile.h"
 
 TEST_GROUP(MemoryLeakWarningLocalDetectorTest)
 {
@@ -471,17 +472,6 @@ TEST(MemoryLeakWarningThreadSafe, turnOnThreadSafeNewDeleteOverloadsDebug)
     MemoryLeakWarningPlugin::turnOnDefaultNotThreadSafeNewDeleteOverloads();
 }
 
-#ifdef __clang__
-
-IGNORE_TEST(MemoryLeakWarningThreadSafe, turnOnThreadSafeNewDeleteOverloads)
-{
-    /*  Clang misbehaves with -O2 - it will not overload operator new or
-     *  operator new[] no matter what. Therefore, this test is must be ignored.
-     */
-}
-
-#else
-
 TEST(MemoryLeakWarningThreadSafe, turnOnThreadSafeNewDeleteOverloads)
 {
 #undef new
@@ -489,10 +479,10 @@ TEST(MemoryLeakWarningThreadSafe, turnOnThreadSafeNewDeleteOverloads)
     size_t storedAmountOfLeaks = MemoryLeakWarningPlugin::getGlobalDetector()->totalMemoryLeaks(mem_leak_period_all);
     MemoryLeakWarningPlugin::turnOnThreadSafeNewDeleteOverloads();
 
-    int *n = new int;
-    int *n_nothrow = new (std::nothrow) int;
-    char *str = new char[20];
-    char *str_nothrow = new (std::nothrow) char[20];
+    int *n = newIntAllocationWithoutMacro();
+    int *n_nothrow = newIntNoThowAllocationWithoutMacro();
+    char *str = newCharArrayAllocationWithoutMacro();
+    char *str_nothrow = newCharArrayNoThrowAllocationWithoutMacro();
 
     LONGS_EQUAL(storedAmountOfLeaks + 4, MemoryLeakWarningPlugin::getGlobalDetector()->totalMemoryLeaks(mem_leak_period_all));
     CHECK_EQUAL(4, mutexLockCount);
@@ -512,8 +502,6 @@ TEST(MemoryLeakWarningThreadSafe, turnOnThreadSafeNewDeleteOverloads)
     #include "CppUTest/MemoryLeakDetectorNewMacros.h"
 #endif
 }
-
-#endif
 
 #endif
 


### PR DESCRIPTION

Moved the allocations outside the compile unit so that the compiler cannot optimise the new/delete pair away. This fixes the test to fail in clang and some newer g++ compilers.