### PR TITLE
Fix new clang warnings

### DIFF
--- a/tests/CppUTestExt/MockActualCallTest.cpp
+++ b/tests/CppUTestExt/MockActualCallTest.cpp
@@ -85,7 +85,7 @@ TEST(MockCheckedActualCall, unExpectedCallWithAnOutputParameter)
 
 TEST(MockCheckedActualCall, unExpectedCallOnObject)
 {
-    int object;
+    int object = 0;
 
     MockCheckedActualCall actualCall(1, reporter, *emptyList);
     actualCall.withName("unexpected").onObject(&object);
@@ -186,7 +186,7 @@ TEST(MockCheckedActualCall, MockIgnoredActualCallWorksAsItShould)
 
 TEST(MockCheckedActualCall, remainderOfMockActualCallTraceWorksAsItShould)
 {
-    int value;
+    int value = 0;
     const int const_value = 1;
     const unsigned char mem_buffer[] = { 0xFE, 0x15 };
     void (*function_value)() = (void (*)())0xDEAD;

--- a/tests/CppUTestExt/MockFailureTest.cpp
+++ b/tests/CppUTestExt/MockFailureTest.cpp
@@ -177,8 +177,8 @@ TEST(MockFailureTest, MockUnexpectedInputParameterFailure)
 
 TEST(MockFailureTest, MockUnexpectedOutputParameterFailure)
 {
-    int out1;
-    int out2;
+    int out1 = 0;
+    int out2 = 0;
     call1->withName("foo").withOutputParameterReturning("boo", &out1, sizeof(out1));
     call2->withName("foo").withOutputParameterReturning("boo", &out2, sizeof(out2));
     call3->withName("unrelated");
@@ -200,7 +200,7 @@ TEST(MockFailureTest, MockUnexpectedOutputParameterFailure)
 
 TEST(MockFailureTest, MockUnexpectedUnmodifiedOutputParameterFailure)
 {
-    int out1;
+    int out1 = 0;
     call1->withName("foo").withOutputParameterReturning("boo", &out1, sizeof(out1));
     call2->withName("foo").withUnmodifiedOutputParameter("boo");
     call3->withName("unrelated");

--- a/tests/CppUTestExt/MockParameterTest.cpp
+++ b/tests/CppUTestExt/MockParameterTest.cpp
@@ -650,7 +650,7 @@ TEST(MockParameterTest, noActualCallForOutputParameter)
 {
     MockFailureReporterInstaller failureReporterInstaller;
 
-    int output;
+    int output = 0;
     MockExpectedCallsListForTest expectations;
     mock().expectOneCall("foo").withOutputParameterReturning("output", &output, sizeof(output));
 
@@ -697,7 +697,7 @@ TEST(MockParameterTest, outputParameterMissing)
 {
     MockFailureReporterInstaller failureReporterInstaller;
 
-    int output;
+    int output = 0;
     MockExpectedCallsListForTest expectations;
     mock().expectOneCall("foo").withOutputParameterReturning("output", &output, sizeof(output));
     mock().actualCall("foo");


### PR DESCRIPTION
Found with clang 21.1.14:

```
error: variable 'out1' is uninitialized when passed as a const pointer argument here [-Werror,-Wuninitialized-const-pointer]
```