### PR TITLE
Add TEST_PROPERTY macro for JUnit per-test-case properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ $ vcpkg install cpputest (More information: https://github.com/microsoft/vcpkg)
 * `TEST_SETUP()` - Declare a void setup method in a `TEST_GROUP` - this is the same as declaring void `setup()`
 * `TEST_TEARDOWN()` - Declare a void setup method in a `TEST_GROUP`
 * `IMPORT_TEST_GROUP(group)` - Export the name of a test group so it can be linked in from a library. Needs to be done in `main`.
+* `TEST_PROPERTY(name, value)` - Attach a key-value string property to the current test. Properties appear as `<property>` elements inside the `<testcase>` block in JUnit XML output. For use in C files, use `TEST_PROPERTY_C(name, value)` instead.
 
 ## Set up and tear down support
 

--- a/include/CppUTest/JUnitTestOutput.h
+++ b/include/CppUTest/JUnitTestOutput.h
@@ -52,6 +52,7 @@ public:
     virtual void print(long) CPPUTEST_OVERRIDE;
     virtual void print(size_t) CPPUTEST_OVERRIDE;
     virtual void printFailure(const TestFailure& failure) CPPUTEST_OVERRIDE;
+    virtual void printTestProperty(const char* name, const char* value) CPPUTEST_OVERRIDE;
 
     virtual void flush() CPPUTEST_OVERRIDE;
 

--- a/include/CppUTest/TestHarness_c.h
+++ b/include/CppUTest/TestHarness_c.h
@@ -138,6 +138,9 @@
 #define CHECK_C_TEXT(condition, text) \
   CHECK_C_LOCATION(condition, #condition, text, __FILE__, __LINE__)
 
+#define TEST_PROPERTY_C(name, value) \
+  cpputest_add_test_property(name, value)
+
 /******************************************************************************
  *
  * TEST macros for in C.
@@ -216,6 +219,7 @@ extern void CHECK_EQUAL_C_BITS_LOCATION(unsigned int expected, unsigned int actu
 extern void FAIL_TEXT_C_LOCATION(const char* text, const char* fileName, size_t lineNumber);
 extern void FAIL_C_LOCATION(const char* fileName, size_t lineNumber);
 extern void CHECK_C_LOCATION(int condition, const char* conditionString, const char* text, const char* fileName, size_t lineNumber);
+extern void cpputest_add_test_property(const char* name, const char* value);
 
 extern void* cpputest_malloc(size_t size);
 extern char* cpputest_strdup(const char* str);

--- a/include/CppUTest/TestHarness_c.h
+++ b/include/CppUTest/TestHarness_c.h
@@ -138,9 +138,6 @@
 #define CHECK_C_TEXT(condition, text) \
   CHECK_C_LOCATION(condition, #condition, text, __FILE__, __LINE__)
 
-#define TEST_PROPERTY_C(name, value) \
-  cpputest_add_test_property(name, value)
-
 /******************************************************************************
  *
  * TEST macros for in C.
@@ -219,7 +216,7 @@ extern void CHECK_EQUAL_C_BITS_LOCATION(unsigned int expected, unsigned int actu
 extern void FAIL_TEXT_C_LOCATION(const char* text, const char* fileName, size_t lineNumber);
 extern void FAIL_C_LOCATION(const char* fileName, size_t lineNumber);
 extern void CHECK_C_LOCATION(int condition, const char* conditionString, const char* text, const char* fileName, size_t lineNumber);
-extern void cpputest_add_test_property(const char* name, const char* value);
+extern void TEST_PROPERTY_C(const char* name, const char* value);
 
 extern void* cpputest_malloc(size_t size);
 extern char* cpputest_strdup(const char* str);

--- a/include/CppUTest/TestOutput.h
+++ b/include/CppUTest/TestOutput.h
@@ -71,6 +71,7 @@ public:
     virtual void setProgressIndicator(const char*);
 
     virtual void printVeryVerbose(const char*);
+    virtual void printTestProperty(const char* name, const char* value);
 
     virtual void flush()=0;
 
@@ -199,6 +200,7 @@ public:
     virtual void setProgressIndicator(const char*) CPPUTEST_OVERRIDE;
 
     virtual void printVeryVerbose(const char*) CPPUTEST_OVERRIDE;
+    virtual void printTestProperty(const char* name, const char* value) CPPUTEST_OVERRIDE;
 
     virtual void flush() CPPUTEST_OVERRIDE;
 

--- a/include/CppUTest/TestResult.h
+++ b/include/CppUTest/TestResult.h
@@ -58,6 +58,7 @@ public:
     virtual void countFilteredOut();
     virtual void countIgnored();
     virtual void addFailure(const TestFailure& failure);
+    virtual void addProperty(const char* name, const char* value);
     virtual void print(const char* text);
     virtual void printVeryVerbose(const char* text);
 

--- a/include/CppUTest/Utest.h
+++ b/include/CppUTest/Utest.h
@@ -152,6 +152,7 @@ public:
     virtual void print(const char *text, const char *fileName, size_t lineNumber);
     virtual void print(const SimpleString & text, const char *fileName, size_t lineNumber);
     virtual void printVeryVerbose(const char* text);
+    virtual void addTestProperty(const char* name, const char* value);
 
     void setFileName(const char *fileName);
     void setLineNumber(size_t lineNumber);

--- a/include/CppUTest/UtestMacros.h
+++ b/include/CppUTest/UtestMacros.h
@@ -387,4 +387,7 @@
 #define UT_CRASH() do { UtestShell::crash(); } while(0)
 #define RUN_ALL_TESTS(ac, av) CommandLineTestRunner::RunAllTests(ac, av)
 
+#define TEST_PROPERTY(name, value) \
+  do { UtestShell::getCurrent()->addTestProperty(name, value); } while(0)
+
 #endif /*D_UTestMacros_h*/

--- a/src/CppUTest/JUnitTestOutput.cpp
+++ b/src/CppUTest/JUnitTestOutput.cpp
@@ -31,10 +31,19 @@
 #include "CppUTest/TestFailure.h"
 #include "CppUTest/PlatformSpecificFunctions.h"
 
+struct TestPropertyResultNode
+{
+    TestPropertyResultNode() : next_(NULLPTR) {}
+    SimpleString name_;
+    SimpleString value_;
+    TestPropertyResultNode* next_;
+};
+
 struct JUnitTestCaseResultNode
 {
     JUnitTestCaseResultNode() :
-        execTime_(0), failure_(NULLPTR), ignored_(false), lineNumber_ (0), checkCount_ (0), next_(NULLPTR)
+        execTime_(0), failure_(NULLPTR), ignored_(false), lineNumber_ (0), checkCount_ (0),
+        properties_(NULLPTR), propertiesTail_(NULLPTR), next_(NULLPTR)
     {
     }
 
@@ -45,6 +54,8 @@ struct JUnitTestCaseResultNode
     SimpleString file_;
     size_t lineNumber_;
     size_t checkCount_;
+    TestPropertyResultNode* properties_;
+    TestPropertyResultNode* propertiesTail_;
     JUnitTestCaseResultNode* next_;
 };
 
@@ -93,6 +104,12 @@ void JUnitTestOutput::resetTestGroupResult()
     while (cur) {
         JUnitTestCaseResultNode* tmp = cur->next_;
         delete cur->failure_;
+        TestPropertyResultNode* prop = cur->properties_;
+        while (prop) {
+            TestPropertyResultNode* tmpProp = prop->next_;
+            delete prop;
+            prop = tmpProp;
+        }
         delete cur;
         cur = tmp;
     }
@@ -233,6 +250,20 @@ void JUnitTestOutput::writeTestCases()
 
         impl_->results_.totalCheckCount_ = cur->checkCount_;
 
+        if (cur->properties_) {
+            writeToFile("<properties>\n");
+            TestPropertyResultNode* prop = cur->properties_;
+            while (prop) {
+                SimpleString propBuf = StringFromFormat(
+                    "<property name=\"%s\" value=\"%s\"/>\n",
+                    encodeXmlText(prop->name_).asCharString(),
+                    encodeXmlText(prop->value_).asCharString());
+                writeToFile(propBuf.asCharString());
+                prop = prop->next_;
+            }
+            writeToFile("</properties>\n");
+        }
+
         if (cur->failure_) {
             writeFailure(cur);
         }
@@ -306,6 +337,22 @@ void JUnitTestOutput::printFailure(const TestFailure& failure)
     if (impl_->results_.tail_->failure_ == NULLPTR) {
         impl_->results_.failureCount_++;
         impl_->results_.tail_->failure_ = new TestFailure(failure);
+    }
+}
+
+void JUnitTestOutput::printTestProperty(const char* name, const char* value)
+{
+    TestPropertyResultNode* node = new TestPropertyResultNode;
+    node->name_ = name;
+    node->value_ = value;
+
+    if (impl_->results_.tail_->propertiesTail_ == NULLPTR) {
+        impl_->results_.tail_->properties_ = node;
+        impl_->results_.tail_->propertiesTail_ = node;
+    }
+    else {
+        impl_->results_.tail_->propertiesTail_->next_ = node;
+        impl_->results_.tail_->propertiesTail_ = node;
     }
 }
 

--- a/src/CppUTest/TestHarness_c.cpp
+++ b/src/CppUTest/TestHarness_c.cpp
@@ -124,6 +124,11 @@ void CHECK_C_LOCATION(int condition, const char* conditionString, const char* te
     UtestShell::getCurrent()->assertTrue(condition != 0, "CHECK_C", conditionString, text, fileName, lineNumber, UtestShell::getCurrentTestTerminatorWithoutExceptions());
 }
 
+void cpputest_add_test_property(const char* name, const char* value)
+{
+    UtestShell::getCurrent()->addTestProperty(name, value);
+}
+
 enum { NO_COUNTDOWN = -1, OUT_OF_MEMORRY = 0 };
 static int malloc_out_of_memory_counter = NO_COUNTDOWN;
 static int malloc_count = 0;

--- a/src/CppUTest/TestHarness_c.cpp
+++ b/src/CppUTest/TestHarness_c.cpp
@@ -124,7 +124,7 @@ void CHECK_C_LOCATION(int condition, const char* conditionString, const char* te
     UtestShell::getCurrent()->assertTrue(condition != 0, "CHECK_C", conditionString, text, fileName, lineNumber, UtestShell::getCurrentTestTerminatorWithoutExceptions());
 }
 
-void cpputest_add_test_property(const char* name, const char* value)
+void TEST_PROPERTY_C(const char* name, const char* value)
 {
     UtestShell::getCurrent()->addTestProperty(name, value);
 }

--- a/src/CppUTest/TestOutput.cpp
+++ b/src/CppUTest/TestOutput.cpp
@@ -271,6 +271,10 @@ void TestOutput::printVeryVerbose(const char* str)
         printBuffer(str);
 }
 
+void TestOutput::printTestProperty(const char*, const char*)
+{
+}
+
 
 void ConsoleTestOutput::printBuffer(const char* s)
 {
@@ -404,6 +408,12 @@ void CompositeTestOutput::printVeryVerbose(const char* str)
 {
   if (outputOne_) outputOne_->printVeryVerbose(str);
   if (outputTwo_) outputTwo_->printVeryVerbose(str);
+}
+
+void CompositeTestOutput::printTestProperty(const char* name, const char* value)
+{
+  if (outputOne_) outputOne_->printTestProperty(name, value);
+  if (outputTwo_) outputTwo_->printTestProperty(name, value);
 }
 
 void CompositeTestOutput::flush()

--- a/src/CppUTest/TestResult.cpp
+++ b/src/CppUTest/TestResult.cpp
@@ -82,6 +82,11 @@ void TestResult::addFailure(const TestFailure& failure)
     failureCount_++;
 }
 
+void TestResult::addProperty(const char* name, const char* value)
+{
+    output_.printTestProperty(name, value);
+}
+
 void TestResult::countTest()
 {
     testCount_++;

--- a/src/CppUTest/Utest.cpp
+++ b/src/CppUTest/Utest.cpp
@@ -576,6 +576,11 @@ void UtestShell::printVeryVerbose(const char* text)
     getTestResult()->printVeryVerbose(text);
 }
 
+void UtestShell::addTestProperty(const char* name, const char* value)
+{
+    getTestResult()->addProperty(name, value);
+}
+
 TestResult* UtestShell::testResult_ = NULLPTR;
 UtestShell* UtestShell::currentTest_ = NULLPTR;
 

--- a/tests/CppUTest/JUnitOutputTest.cpp
+++ b/tests/CppUTest/JUnitOutputTest.cpp
@@ -149,6 +149,14 @@ extern "C" {
     }
 }
 
+struct PendingProperty
+{
+    const char* name_;
+    const char* value_;
+    PendingProperty* next_;
+    PendingProperty(const char* n, const char* v, PendingProperty* nx) : name_(n), value_(v), next_(nx) {}
+};
+
 class JUnitTestOutputTestRunner
 {
     TestResult result_;
@@ -159,11 +167,13 @@ class JUnitTestOutputTestRunner
     unsigned int timeTheTestTakes_;
     unsigned int numberOfChecksInTest_;
     TestFailure* testFailure_;
+    PendingProperty* pendingProperties_;
+    PendingProperty* pendingPropertiesTail_;
 
 public:
 
     explicit JUnitTestOutputTestRunner(const TestResult& result) :
-        result_(result), currentGroupName_(NULLPTR), currentTest_(NULLPTR), firstTestInGroup_(true), timeTheTestTakes_(0), numberOfChecksInTest_(0), testFailure_(NULLPTR)
+        result_(result), currentGroupName_(NULLPTR), currentTest_(NULLPTR), firstTestInGroup_(true), timeTheTestTakes_(0), numberOfChecksInTest_(0), testFailure_(NULLPTR), pendingProperties_(NULLPTR), pendingPropertiesTail_(NULLPTR)
     {
         millisTime = 0;
         theTime =  "1978-10-03T00:00:00";
@@ -264,6 +274,16 @@ public:
         }
         numberOfChecksInTest_ = 0;
 
+        PendingProperty* prop = pendingProperties_;
+        pendingProperties_ = NULLPTR;
+        pendingPropertiesTail_ = NULLPTR;
+        while (prop) {
+            PendingProperty* next = prop->next_;
+            result_.addProperty(prop->name_, prop->value_);
+            delete prop;
+            prop = next;
+        }
+
         if (testFailure_) {
             result_.addFailure(*testFailure_);
             delete testFailure_;
@@ -306,6 +326,20 @@ public:
     {
         runPreviousTest();
         result_.print(output);
+        return *this;
+    }
+
+    JUnitTestOutputTestRunner& withProperty(const char* name, const char* value)
+    {
+        PendingProperty* node = new PendingProperty(name, value, NULLPTR);
+        if (pendingPropertiesTail_ == NULLPTR) {
+            pendingProperties_ = node;
+            pendingPropertiesTail_ = node;
+        }
+        else {
+            pendingPropertiesTail_->next_ = node;
+            pendingPropertiesTail_ = node;
+        }
         return *this;
     }
 };
@@ -766,4 +800,85 @@ TEST(JUnitOutputTest, UTPRINTOutputInJUnitOutputWithSpecials)
 
     outputFile = fileSystem.file("cpputest_groupname.xml");
     STRCMP_EQUAL("<system-out>The &lt;rain&gt; in &quot;Spain&quot;&#10;Goes&#13; \\mainly\\ down the Dr&amp;in&#10;</system-out>\n", outputFile->lineFromTheBack(3));
+}
+
+TEST(JUnitOutputTest, TestCaseWithOneProperty)
+{
+    testCaseRunner->start()
+            .withGroup("groupname").withTest("testname").withProperty("key", "val")
+            .end();
+
+    outputFile = fileSystem.file("cpputest_groupname.xml");
+    STRCMP_EQUAL("<testcase classname=\"groupname\" name=\"testname\" assertions=\"0\" time=\"0.000\" file=\"file\" line=\"1\">\n", outputFile->line(5));
+    STRCMP_EQUAL("<properties>\n", outputFile->line(6));
+    STRCMP_EQUAL("<property name=\"key\" value=\"val\"/>\n", outputFile->line(7));
+    STRCMP_EQUAL("</properties>\n", outputFile->line(8));
+    STRCMP_EQUAL("</testcase>\n", outputFile->line(9));
+}
+
+TEST(JUnitOutputTest, TestCaseWithMultiplePropertiesInInsertionOrder)
+{
+    testCaseRunner->start()
+            .withGroup("groupname").withTest("testname")
+                .withProperty("first", "one").withProperty("second", "two")
+            .end();
+
+    outputFile = fileSystem.file("cpputest_groupname.xml");
+    STRCMP_EQUAL("<property name=\"first\" value=\"one\"/>\n", outputFile->line(7));
+    STRCMP_EQUAL("<property name=\"second\" value=\"two\"/>\n", outputFile->line(8));
+}
+
+TEST(JUnitOutputTest, TestCaseWithNoPropertiesHasNoPropertiesBlock)
+{
+    testCaseRunner->start()
+            .withGroup("groupname").withTest("testname")
+            .end();
+
+    outputFile = fileSystem.file("cpputest_groupname.xml");
+    STRCMP_EQUAL("<testcase classname=\"groupname\" name=\"testname\" assertions=\"0\" time=\"0.000\" file=\"file\" line=\"1\">\n", outputFile->line(5));
+    STRCMP_EQUAL("</testcase>\n", outputFile->line(6));
+}
+
+TEST(JUnitOutputTest, TestCasePropertyValuesAreXmlEncoded)
+{
+    testCaseRunner->start()
+            .withGroup("groupname").withTest("testname")
+                .withProperty("a&b", "<val>")
+            .end();
+
+    outputFile = fileSystem.file("cpputest_groupname.xml");
+    STRCMP_EQUAL("<property name=\"a&amp;b\" value=\"&lt;val&gt;\"/>\n", outputFile->line(7));
+}
+
+TEST(JUnitOutputTest, PropertiesOnlyAppearOnCorrectTestInGroup)
+{
+    testCaseRunner->start()
+            .withGroup("groupname")
+                .withTest("firstTest")
+                .withTest("secondTest").withProperty("k", "v")
+            .end();
+
+    outputFile = fileSystem.file("cpputest_groupname.xml");
+    // firstTest: lines 5-6 (no properties block)
+    STRCMP_EQUAL("<testcase classname=\"groupname\" name=\"firstTest\" assertions=\"0\" time=\"0.000\" file=\"file\" line=\"1\">\n", outputFile->line(5));
+    STRCMP_EQUAL("</testcase>\n", outputFile->line(6));
+    // secondTest: lines 7-11 (with properties)
+    STRCMP_EQUAL("<testcase classname=\"groupname\" name=\"secondTest\" assertions=\"0\" time=\"0.000\" file=\"file\" line=\"1\">\n", outputFile->line(7));
+    STRCMP_EQUAL("<properties>\n", outputFile->line(8));
+    STRCMP_EQUAL("<property name=\"k\" value=\"v\"/>\n", outputFile->line(9));
+    STRCMP_EQUAL("</properties>\n", outputFile->line(10));
+    STRCMP_EQUAL("</testcase>\n", outputFile->line(11));
+}
+
+TEST(JUnitOutputTest, PropertiesDontLeakAcrossGroups)
+{
+    testCaseRunner->start()
+            .withGroup("groupOne").withTest("testA").withProperty("x", "1")
+            .endGroupAndClearTest()
+            .withGroup("groupTwo").withTest("testB")
+            .end();
+
+    outputFile = fileSystem.file("cpputest_groupTwo.xml");
+    STRCMP_EQUAL("<testcase classname=\"groupTwo\" name=\"testB\" assertions=\"0\" time=\"0.000\" file=\"file\" line=\"1\">\n", outputFile->line(5));
+    STRCMP_EQUAL("</testcase>\n", outputFile->line(6));
 }

--- a/tests/CppUTest/TestHarness_cTest.cpp
+++ b/tests/CppUTest/TestHarness_cTest.cpp
@@ -28,6 +28,7 @@
 #include "CppUTest/TestHarness_c.h"
 
 #include "CppUTest/TestHarness.h"
+#include "CppUTest/TestPlugin.h"
 #include "CppUTest/TestRegistry.h"
 #include "CppUTest/TestOutput.h"
 #include "CppUTest/TestTestingFixture.h"
@@ -882,3 +883,59 @@ TEST(TestHarness_c, callocShouldReturnNULLWhenOutOfMemory)
     cpputest_malloc_set_not_out_of_memory();
 }
 #endif
+
+class PropertySpyOutput : public StringBufferTestOutput
+{
+public:
+    SimpleString lastPropertyName_;
+    SimpleString lastPropertyValue_;
+    int callCount_;
+
+    PropertySpyOutput() : lastPropertyName_(""), lastPropertyValue_(""), callCount_(0) {}
+
+    virtual void printTestProperty(const char* name, const char* value) CPPUTEST_OVERRIDE
+    {
+        lastPropertyName_ = name;
+        lastPropertyValue_ = value;
+        callCount_++;
+    }
+};
+
+static void callTestPropertyMacro_()
+{
+    TEST_PROPERTY("propname", "propval");
+}
+
+extern "C" void cpputest_test_property_c_caller(void);
+
+TEST(TestHarness_c, testPropertyMacroRoutesToOutput)
+{
+    PropertySpyOutput spy;
+    TestResult spyResult(spy);
+    ExecFunctionTestShell shell;
+    shell.testFunction_ = new ExecFunctionWithoutParameters(callTestPropertyMacro_);
+    NullTestPlugin plugin;
+    shell.runOneTestInCurrentProcess(&plugin, spyResult);
+    delete shell.testFunction_;
+    shell.testFunction_ = NULLPTR;
+
+    LONGS_EQUAL(1, spy.callCount_);
+    STRCMP_EQUAL("propname", spy.lastPropertyName_.asCharString());
+    STRCMP_EQUAL("propval", spy.lastPropertyValue_.asCharString());
+}
+
+TEST(TestHarness_c, testPropertyCMacroRoutesToOutput)
+{
+    PropertySpyOutput spy;
+    TestResult spyResult(spy);
+    ExecFunctionTestShell shell;
+    shell.testFunction_ = new ExecFunctionWithoutParameters(cpputest_test_property_c_caller);
+    NullTestPlugin plugin;
+    shell.runOneTestInCurrentProcess(&plugin, spyResult);
+    delete shell.testFunction_;
+    shell.testFunction_ = NULLPTR;
+
+    LONGS_EQUAL(1, spy.callCount_);
+    STRCMP_EQUAL("ckey", spy.lastPropertyName_.asCharString());
+    STRCMP_EQUAL("cval", spy.lastPropertyValue_.asCharString());
+}

--- a/tests/CppUTest/TestHarness_cTestCFile.c
+++ b/tests/CppUTest/TestHarness_cTestCFile.c
@@ -34,3 +34,8 @@ IGNORE_TEST_C(TestGroupInC, ignoreMacroForCFile)
 {
     test_was_called_in_test_group_in_C++;
 }
+
+void cpputest_test_property_c_caller(void)
+{
+    TEST_PROPERTY_C("ckey", "cval");
+}

--- a/tests/CppUTest/TestHarness_cTestCFile.c
+++ b/tests/CppUTest/TestHarness_cTestCFile.c
@@ -9,6 +9,13 @@ void functionWithUnusedParameter(void* PUNUSED(unlessParamater))
 
 }
 
+extern void cpputest_test_property_c_caller(void);
+
+void cpputest_test_property_c_caller(void)
+{
+    TEST_PROPERTY_C("ckey", "cval");
+}
+
 /* Declared in the cpp file */
 extern int setup_teardown_was_called_in_test_group_in_C;
 extern int test_was_called_in_test_group_in_C;
@@ -33,9 +40,4 @@ TEST_C(TestGroupInC, checkThatTheTestHasRun)
 IGNORE_TEST_C(TestGroupInC, ignoreMacroForCFile)
 {
     test_was_called_in_test_group_in_C++;
-}
-
-void cpputest_test_property_c_caller(void)
-{
-    TEST_PROPERTY_C("ckey", "cval");
 }

--- a/tests/CppUTest/TestOutputTest.cpp
+++ b/tests/CppUTest/TestOutputTest.cpp
@@ -282,6 +282,12 @@ TEST(TestOutput, printTestsEndedWithNoTestsRunOrIgnored)
         mock->getOutput().asCharString());
 }
 
+TEST(TestOutput, printTestPropertyIsNoOp)
+{
+    printer->printTestProperty("key", "value");
+    STRCMP_EQUAL("", mock->getOutput().asCharString());
+}
+
 class CompositeTestOutputTestStringBufferTestOutput : public StringBufferTestOutput
 {
   public:
@@ -477,4 +483,11 @@ TEST(CompositeTestOutput, printVeryVerbose)
   compositeOutput.printVeryVerbose("very-verbose");
   STRCMP_EQUAL("very-verbose", output1->getOutput().asCharString());
   STRCMP_EQUAL("very-verbose", output2->getOutput().asCharString());
+}
+
+TEST(CompositeTestOutput, printTestProperty)
+{
+  compositeOutput.printTestProperty("key", "value");
+  STRCMP_EQUAL("", output1->getOutput().asCharString());
+  STRCMP_EQUAL("", output2->getOutput().asCharString());
 }


### PR DESCRIPTION
## Summary

- Adds `TEST_PROPERTY(name, value)` (C++) and `TEST_PROPERTY_C(name, value)` (C) macros that attach key-value string properties to the current test case
- Properties appear as `<properties><property name="..." value="..."/></properties>` inside the `<testcase>` element in JUnit XML output ([standard JUnit XML format](https://github.com/testmoapp/junitxml#properties-for-suites-and-cases)); the block is omitted entirely when no properties are set
- Property names and values are XML-encoded

The feature routes through the existing `UtestShell → TestResult → TestOutput` call chain: `JUnitTestOutput` overrides `printTestProperty` to store properties on per-test-case result nodes and emit them when writing XML. All other `TestOutput` subclasses get a default no-op, but the feature is available to extend existing or future output implementations.