### PR TITLE
Automate coverage via CTest post-test hooks

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -298,15 +298,10 @@ jobs:
           ctest --test-dir build
         if: ${{ matrix.install }}
 
-      - name: Coverage
-        run: |
-          lcov --ignore-errors mismatch --capture --directory . --no-external --output-file lcov.info
-          lcov --remove lcov.info --output-file lcov.info '*/tests/*'
-        if: ${{ matrix.name == 'Coverage' }}
       - name: Coveralls
         uses: coverallsapp/github-action@master
         with:
-          path-to-lcov: lcov.info
+          path-to-lcov: cpputest_build/coverage.lcov
           github-token: ${{ secrets.GITHUB_TOKEN }}
         if: ${{ matrix.name == 'Coverage' }}
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -81,6 +81,7 @@
       },
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_PROJECT_CppUTest_INCLUDE": "${sourceDir}/cmake/lcov.cmake",
         "CMAKE_CXX_STANDARD": "11",
         "CPPUTEST_EXAMPLES": false
       }

--- a/cmake/CTestCustom.cmake.in
+++ b/cmake/CTestCustom.cmake.in
@@ -1,0 +1,6 @@
+set(CTEST_CUSTOM_POST_TEST
+    "@LCOV@ --capture --directory @CMAKE_BINARY_DIR@ --base-directory @CMAKE_SOURCE_DIR@ --no-external --ignore-errors mismatch,inconsistent --output-file @CMAKE_BINARY_DIR@/coverage.lcov"
+    "@LCOV@ --remove @CMAKE_BINARY_DIR@/coverage.lcov --output-file @CMAKE_BINARY_DIR@/coverage.lcov */tests/*"
+    "@CMAKE_COMMAND@ -E rm -rf @CMAKE_BINARY_DIR@/coverage"
+    "@GENHTML@ @CMAKE_BINARY_DIR@/coverage.lcov --output-directory @CMAKE_BINARY_DIR@/coverage"
+)

--- a/cmake/lcov.cmake
+++ b/cmake/lcov.cmake
@@ -1,0 +1,13 @@
+if(NOT CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    message(FATAL_ERROR
+        "Coverage requires GCC or Clang (got ${CMAKE_CXX_COMPILER_ID})")
+endif()
+
+find_program(LCOV lcov REQUIRED)
+find_program(GENHTML genhtml REQUIRED)
+
+configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/CTestCustom.cmake.in"
+    "${CMAKE_BINARY_DIR}/CTestCustom.cmake"
+    @ONLY
+)


### PR DESCRIPTION
Add configs so that lcov capture, filtering, and genhtml run automatically after ctest completes. Wire the coverage preset to load these configs, and update the CI workflow to drop the manual lcov shell steps and point coverallsapp at the new output path. This means the exact coverage workflow used in CI to feed coveralls can now also be run locally to produce HTML reports.