### PR TITLE
CHECK_EQUAL: fix array != array compare under C++26

### DIFF
--- a/include/CppUTest/UtestMacros.h
+++ b/include/CppUTest/UtestMacros.h
@@ -129,20 +129,11 @@
 #define CHECK_EQUAL_TEXT(expected, actual, text)\
   CHECK_EQUAL_LOCATION(expected, actual, text, __FILE__, __LINE__)
 
-namespace CppUTestPrivate
-{
-    template <typename T>
-    bool checkEqualSelfNotEqual(T a, T b)
-    {
-        return a != b;
-    }
-}
-
 #define CHECK_EQUAL_LOCATION(expected, actual, text, file, line)\
   do { if ((expected) != (actual)) { \
-      if (::CppUTestPrivate::checkEqualSelfNotEqual((actual), (actual))) \
+      if (StringFrom(actual) != StringFrom(actual)) \
       	  UtestShell::getCurrent()->print("WARNING:\n\tThe \"Actual Parameter\" parameter is evaluated multiple times resulting in different values.\n\tThus the value in the error message is probably incorrect.", file, line); \
-      if (::CppUTestPrivate::checkEqualSelfNotEqual((expected), (expected))) \
+      if (StringFrom(expected) != StringFrom(expected)) \
       	  UtestShell::getCurrent()->print("WARNING:\n\tThe \"Expected Parameter\" parameter is evaluated multiple times resulting in different values.\n\tThus the value in the error message is probably incorrect.", file, line); \
       UtestShell::getCurrent()->assertEquals(true, StringFrom(expected).asCharString(), StringFrom(actual).asCharString(), text, file, line); \
   } \

--- a/include/CppUTest/UtestMacros.h
+++ b/include/CppUTest/UtestMacros.h
@@ -129,11 +129,20 @@
 #define CHECK_EQUAL_TEXT(expected, actual, text)\
   CHECK_EQUAL_LOCATION(expected, actual, text, __FILE__, __LINE__)
 
+namespace CppUTestPrivate
+{
+    template <typename T>
+    bool checkEqualSelfNotEqual(T a, T b)
+    {
+        return a != b;
+    }
+}
+
 #define CHECK_EQUAL_LOCATION(expected, actual, text, file, line)\
   do { if ((expected) != (actual)) { \
-      if ((actual) != (actual)) \
+      if (::CppUTestPrivate::checkEqualSelfNotEqual((actual), (actual))) \
       	  UtestShell::getCurrent()->print("WARNING:\n\tThe \"Actual Parameter\" parameter is evaluated multiple times resulting in different values.\n\tThus the value in the error message is probably incorrect.", file, line); \
-      if ((expected) != (expected)) \
+      if (::CppUTestPrivate::checkEqualSelfNotEqual((expected), (expected))) \
       	  UtestShell::getCurrent()->print("WARNING:\n\tThe \"Expected Parameter\" parameter is evaluated multiple times resulting in different values.\n\tThus the value in the error message is probably incorrect.", file, line); \
       UtestShell::getCurrent()->assertEquals(true, StringFrom(expected).asCharString(), StringFrom(actual).asCharString(), text, file, line); \
   } \

--- a/tests/CppUTest/TestUTestMacro.cpp
+++ b/tests/CppUTest/TestUTestMacro.cpp
@@ -489,6 +489,13 @@ TEST(UnitTestMacros, failing_CHECK_EQUAL_withParamatersThatDontChangeWillNotGive
     fixture.assertPrintContainsNot("WARNING");
 }
 
+TEST(UnitTestMacros, CHECK_EQUAL_compilesWithArrayOperand)
+{
+    const char buf[] = "hello";
+    const char* actual = buf;
+    CHECK_EQUAL(buf, actual);
+}
+
 TEST(UnitTestMacros, CHECK_EQUALBehavesAsProperMacro)
 {
     if (false) CHECK_EQUAL(1, 2);


### PR DESCRIPTION
## Problem

C++26 [over.match.oper]/p10 makes `array == array` (and `array != array`) ill-formed. `CHECK_EQUAL_LOCATION` expanded its two side-effect-detection probes literally as `(operand) != (operand)`. As soon as either operand was an array — most commonly a string literal in `CHECK_EQUAL("text", x)` — the inner self-compare became a forbidden array-vs-array compare.

The same pattern is also a `-Wdeprecated-array-compare` error under C++20+ when `-Werror` is on. CppUTest's existing tests don't exercise the array-operand path, so this never showed up in CI; it surfaces immediately in any consuming project that does.

## Fix

A small `CppUTestPrivate::checkEqualSelfNotEqual<T>(T, T)` helper that takes both arguments by value, so any array decays to a pointer before the comparison runs. The two side-effect probes (`(actual) != (actual)` and `(expected) != (expected)`) route through it. Both arguments come from the same operand expression, so `T` is identical on both sides — `-Wsign-compare` cannot fire.

The outer `(expected) != (actual)` is intentionally left at the macro call site. Routing it through a function template would lose `-Wsign-compare`'s constant-fits exception that lets idioms like `CHECK_EQUAL(0, some_unsigned)` build clean today.

Behavior is unchanged for every non-array operand. For arrays, the resulting pointer-address self-compare matches the historical C++03 behavior (always false, since the same array's decayed pointer equals itself).

## Test

Added `CHECK_EQUAL_compilesWithArrayOperand` in `TestUTestMacro.cpp`. Without the fix, the test TU emits `-Wdeprecated-array-compare` under C++20+ with `-Werror`, and is ill-formed at C++26 regardless of warning flags. With the fix it compiles at every standard from C++98 through C++26.

## CI coverage

Verified by the existing `-Wall -Werror` jobs (Make Defaults, CMake Linux GNU 17/20/23, etc.) — `-Wdeprecated-array-compare` is on by default at C++20+ and gates the relevant condition. A future PR could add a C++26 job once compiler C++26 support stabilizes; this fix doesn't depend on that addition.

## Compatibility

Works at C++98 through C++26. No new headers included. The helper is a plain function template — no `<type_traits>`, no `if constexpr`, no forwarding refs.