### PR TITLE
Bound CheckEqualFailure difference scans

### DIFF
--- a/src/CppUTest/TestFailure.cpp
+++ b/src/CppUTest/TestFailure.cpp
@@ -188,11 +188,20 @@ CheckEqualFailure::CheckEqualFailure(UtestShell* test, const char* fileName, siz
 
     message_ += createButWasString(printableExpected, printableActual);
 
+    const size_t comparisonLength =
+        actual.size() < expected.size() ? actual.size() : expected.size();
     size_t failStart;
-    for (failStart = 0; actual.at(failStart) == expected.at(failStart); failStart++)
+    for (failStart = 0;
+         failStart < comparisonLength && actual.at(failStart) == expected.at(failStart);
+         failStart++)
         ;
+    const size_t printableComparisonLength = printableActual.size() < printableExpected.size()
+                                                 ? printableActual.size()
+                                                 : printableExpected.size();
     size_t failStartPrintable;
-    for (failStartPrintable = 0; printableActual.at(failStartPrintable) == printableExpected.at(failStartPrintable); failStartPrintable++)
+    for (failStartPrintable = 0;
+         failStartPrintable < printableComparisonLength && printableActual.at(failStartPrintable) == printableExpected.at(failStartPrintable);
+         failStartPrintable++)
         ;
     message_ += createDifferenceAtPosString(printableActual, failStartPrintable, failStart);
 }

--- a/tests/CppUTest/TestFailureTest.cpp
+++ b/tests/CppUTest/TestFailureTest.cpp
@@ -107,6 +107,14 @@ TEST(TestFailure, CheckEqualFailure)
                   "\t                                               ^", f);
 }
 
+TEST(TestFailure, CheckEqualFailureStopsAtEndOfEqualRepresentations)
+{
+    const SimpleString representation = "1";
+    CheckEqualFailure f(test, failFileName, failLineNumber, representation, representation, "");
+
+    STRCMP_CONTAINS("difference starts at position 1", f.getMessage().asCharString());
+}
+
 TEST(TestFailure, CheckFailure)
 {
     CheckFailure f(test, failFileName, failLineNumber, "CHECK", "chk");


### PR DESCRIPTION
## Summary

- stop `CheckEqualFailure` difference scans at the end of the shorter representation
- add a regression test for unequal values that format to identical strings

## Problem

`CHECK_EQUAL` decides whether values differ using the values' own comparison, then passes their formatted `SimpleString` representations to `CheckEqualFailure` for diagnostics. Distinct values can format identically, for example when floating-point output rounds both values to the same text.

Both diagnostic loops assumed that the strings must contain a differing byte and kept calling `SimpleString::at()` without a length check. When the representations are identical, the scan reads beyond both buffers while trying to locate a difference that does not exist.

The regression test passes the same `"1"` representation for both sides, matching the diagnostic state produced by such a formatting collision. On the original code, Linux GCC 14 with AddressSanitizer reports a heap-buffer-overflow at `SimpleString::at()` from `CheckEqualFailure`.

## Fix

Bound the original and printable scans by the shorter string length. Existing difference positions are unchanged when the strings differ; identical representations now report the end position without reading beyond either buffer.

## Verification

- regression first reproduced the AddressSanitizer heap-buffer-overflow on the original implementation
- focused regression passes under GCC 14 with ASan/UBSan after the fix
- full plain GCC 14 `CppUTestTests` run: 889 tests, 0 failures
- CMake/CTest including CppUTest and CppUTestExt: 79/79 passed
