### PR TITLE
Fixing the IAR scramble issue

### DIFF
--- a/src/Platforms/Iar/UtestPlatform.cpp
+++ b/src/Platforms/Iar/UtestPlatform.cpp
@@ -137,9 +137,10 @@ static PlatformSpecificFile PlatformSpecificFOpenImplementation(const char* file
 
 static void PlatformSpecificFPutsImplementation(const char* str, PlatformSpecificFile file)
 {
-    (void)str;
-    (void)file;
-    printf("FILE%d:%s",(int)file, str);
+    if (file == PlatformSpecificStdOut)
+        printf("%s", str);
+    else
+        printf("FILE%d:%s", (int)file, str);
 }
 
 static void PlatformSpecificFCloseImplementation(PlatformSpecificFile file)


### PR DESCRIPTION
Fix for IAR console scrambled issue. Due to fputs now also being used for stdout

Fixes issue: https://github.com/cpputest/cpputest/issues/1888